### PR TITLE
Fix a few minor typos

### DIFF
--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -80,7 +80,7 @@ Facets are pieces of metadata that can be attached to the core entities:
 - Job
 - Dataset (Inputs or Outputs)
 
-A facet is an atomic piece of metadata identified by its name. This means that emiting a new facet whith the same name for the same entity replaces the previous facet instance for that entity entirely). It is defined as a JSON object that can be either part of the spec or custom facets defined in a different project.
+A facet is an atomic piece of metadata identified by its name. This means that emiting a new facet with the same name for the same entity replaces the previous facet instance for that entity entirely). It is defined as a JSON object that can be either part of the spec or custom facets defined in a different project.
 
 Custom facets must use a distinct prefix named after the project defining them to avoid colision with standard facets defined in the [OpenLineage.json](OpenLineage.json) spec.
 They have a \_schemaURL field pointing to the corresponding version of the facet schema (as a JSONPointer: [$ref URL location](https://swagger.io/docs/specification/using-ref/) ).

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -13,7 +13,7 @@ It allows extensions to the spec using `Custom Facets` as described in this docu
 
 ![Open Lineage model](OpenLineageModel.svg)
 
-- **Run Event**: and event describing an observed state of a job run. It is required to at least send one event for a START transition and a COMPLETE/FAIL/ABORT transition. Aditional events are optional.
+- **Run Event**: an event describing an observed state of a job run. It is required to at least send one event for a START transition and a COMPLETE/FAIL/ABORT transition. Aditional events are optional.
 
 - **Job**: a process definition that consumes and produces datasets (defined as its inputs and outputs). It is identified by a unique name within a namespace (which is typicaly assigned to the scheduler starting the jobs). The *Job* evolves over time and this change is captured when the job runs.
 

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -113,8 +113,8 @@ Custom facets can be promoted to the standard by including them in the spec.
 
 #### Input Dataset Facets
 
-*Note: for now there no input facets defined*
+*Note: for now there are no input facets defined*
 
 #### Output Dataset Facets
 
-*Note: for now there no output facets defined*
+*Note: for now there are no output facets defined*

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -13,11 +13,11 @@ It allows extensions to the spec using `Custom Facets` as described in this docu
 
 ![Open Lineage model](OpenLineageModel.svg)
 
-- **Run Event**: an event describing an observed state of a job run. It is required to at least send one event for a START transition and a COMPLETE/FAIL/ABORT transition. Aditional events are optional.
+- **Run Event**: and event describing an observed state of a job run. It is required to at least send one event for a START transition and a COMPLETE/FAIL/ABORT transition. Additional events are optional.
 
-- **Job**: a process definition that consumes and produces datasets (defined as its inputs and outputs). It is identified by a unique name within a namespace (which is typicaly assigned to the scheduler starting the jobs). The *Job* evolves over time and this change is captured when the job runs.
+- **Job**: a process definition that consumes and produces datasets (defined as its inputs and outputs). It is identified by a unique name within a namespace (which is typically assigned to the scheduler starting the jobs). The *Job* evolves over time and this change is captured when the job runs.
 
-- **Dataset**: an abstract representation of data. It has a unique name within a namespace derived from its physical location (for example db.host.database.schema.table). Typicaly, a *Dataset* changes when a job writing to it completes. Similarly to the *Job* and *Run* distinction, metadata that is more static from run to run is captured in a DatasetFacet (for example, the schema that does not change every run), what changes every *Run* is captured as an *InputFacet* or an *OutputFacet* (for example, what subset of the data set was read or written, like a time partition).
+- **Dataset**: an abstract representation of data. It has a unique name within a namespace derived from its physical location (for example db.host.database.schema.table). Typically, a *Dataset* changes when a job writing to it completes. Similarly to the *Job* and *Run* distinction, metadata that is more static from run to run is captured in a DatasetFacet (for example, the schema that does not change every run), what changes every *Run* is captured as an *InputFacet* or an *OutputFacet* (for example, what subset of the data set was read or written, like a time partition).
 
 - **Run**: An instance of a running job with a start and completion (or failure) time. It is uniquely identified by an id relative to its job definition.
 
@@ -56,8 +56,8 @@ Here is an example of a simple start run event not adding any facet information:
 
 The OpenLineage API defines events to capture the lifecycle of a *Run* for a given *Job*.
 When a *job* is being *run*, we capture metadata by sending run events when the state of the job transitions to a different state.
-We might observe different aspects of the job run at different stages. This means that different metadata might be collected in each event during the lyfecycle of a run.
-All metadata is additive. for example, if more inputs or outputs are detected as the job is running we might send additional events specifically for those datasets without re-emiting previously observed inputs or outputs.
+We might observe different aspects of the job run at different stages. This means that different metadata might be collected in each event during the lifecycle of a run.
+All metadata is additive. for example, if more inputs or outputs are detected as the job is running we might send additional events specifically for those datasets without re-emitting previously observed inputs or outputs.
 Example:
  - When the run starts, we collect the following Metadata:
     - Run Id
@@ -80,9 +80,9 @@ Facets are pieces of metadata that can be attached to the core entities:
 - Job
 - Dataset (Inputs or Outputs)
 
-A facet is an atomic piece of metadata identified by its name. This means that emiting a new facet with the same name for the same entity replaces the previous facet instance for that entity entirely). It is defined as a JSON object that can be either part of the spec or custom facets defined in a different project.
+A facet is an atomic piece of metadata identified by its name. This means that emitting a new facet with the same name for the same entity replaces the previous facet instance for that entity entirely). It is defined as a JSON object that can be either part of the spec or custom facets defined in a different project.
 
-Custom facets must use a distinct prefix named after the project defining them to avoid colision with standard facets defined in the [OpenLineage.json](OpenLineage.json) spec.
+Custom facets must use a distinct prefix named after the project defining them to avoid collision with standard facets defined in the [OpenLineage.json](OpenLineage.json) spec.
 They have a \_schemaURL field pointing to the corresponding version of the facet schema (as a JSONPointer: [$ref URL location](https://swagger.io/docs/specification/using-ref/) ).
 
 Example: https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/MyCustomJobFacet
@@ -113,8 +113,8 @@ Custom facets can be promoted to the standard by including them in the spec.
 
 #### Input Dataset Facets
 
-*Note: for now there are no input facets defined*
+*Note: for now there no input facets defined*
 
 #### Output Dataset Facets
 
-*Note: for now there are no output facets defined*
+*Note: for now there no output facets defined*


### PR DESCRIPTION
These changes fix typos in the documentation like 

* Changing an instance of "and" to "an"
* Spelling
