### PR TITLE
ci/python: format RC versions compliant to PEP 440, use tag to version if exists, unpin dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ checkout_project_root: &checkout_project_root
 only-on-release: &only-on-release
   filters:
     tags:
-      only: /^[0-9]+(\.[0-9]+){2}(rc[0-9]+)?$/
+      only: /^[0-9]+(\.[0-9]+){2}(-?rc[0-9]+)?$/
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ checkout_project_root: &checkout_project_root
     path: ~/openlineage
 
 
-# Only trigger CI job on release (=X.Y.Z)
+# Only trigger CI job on release (=X.Y.Z) with possible (rcX)
 only-on-release: &only-on-release
   filters:
     tags:
-      only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+      only: /^[0-9]+(\.[0-9]+){2}(rc[0-9]+)?$/
     branches:
       ignore: /.*/
 

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -15,7 +15,6 @@ import os
 import re
 import subprocess
 
-import pkg_resources
 from setuptools import find_packages, setup
 
 

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -12,7 +12,10 @@
 
 import codecs
 import os
+import re
+import subprocess
 
+import pkg_resources
 from setuptools import find_packages, setup
 
 
@@ -22,7 +25,21 @@ def read(rel_path):
         return fp.read()
 
 
+def execute_git(cwd, params):
+    p = subprocess.Popen(['git'] + params,
+                         cwd=cwd, stdout=subprocess.PIPE, stderr=None)
+    p.wait(timeout=0.5)
+    out, err = p.communicate()
+    return out.decode('utf8').strip()
+
+
 def get_version(rel_path):
+    tag = execute_git(None, ['tag', '--points-at', 'HEAD'])
+
+    if tag:
+        if re.match(r'^[0-9]+(\.[0-9]+){2}(rc[0-9]+)?$', tag):
+            return tag
+
     for line in read(rel_path).splitlines():
         if line.startswith('VERSION'):
             delim = '"' if '"' in line else "'"
@@ -48,7 +65,7 @@ setup(
     url="https://github.com/OpenLineage/OpenLineage",
     packages=find_packages(),
     install_requires=[
-        "attrs==20.3.0",
-        "requests==2.25.1"
+        "attrs>=20.3.0",
+        "requests>=2.25.1"
     ]
 )


### PR DESCRIPTION
`0.0.1-rc.1` -> `0.0.1rc1` (or `0.0.1-rc1`)

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>