### PR TITLE
Set `Run.runId` format as uuid, according to RFC4122

### DIFF
--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -251,6 +252,8 @@ public class JavaPoetGenerator {
               return ClassName.get(URI.class);
             } else if (format.equals("date-time")) {
               return ClassName.get(ZonedDateTime.class);
+            } else if (format.equals("uuid")) {
+            return ClassName.get(UUID.class);
             } else {
               throw new RuntimeException("Unknown format: " + primitiveType.getFormat());
             }

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -253,7 +253,7 @@ public class JavaPoetGenerator {
             } else if (format.equals("date-time")) {
               return ClassName.get(ZonedDateTime.class);
             } else if (format.equals("uuid")) {
-            return ClassName.get(UUID.class);
+              return ClassName.get(UUID.class);
             } else {
               throw new RuntimeException("Unknown format: " + primitiveType.getFormat());
             }

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class OpenLineageTest {
 
     URI producer = URI.create("producer");
     OpenLineage ol = new OpenLineage(producer);
-    String runId = "runId";
+    UUID runId = UUID.randomUUID();
     RunFacets runFacets = ol.newRunFacets(ol.newNominalTimeRunFacet(now, now), null);
     Run run = ol.newRun(runId, runFacets);
     String name = "jobName";
@@ -78,7 +79,7 @@ public class OpenLineageTest {
 
     URI producer = URI.create("producer");
     OpenLineage ol = new OpenLineage(producer);
-    String runId = "runId";
+    UUID runId = UUID.randomUUID();
     RunFacets runFacets =
         ol.newRunFacetsBuilder()
         .setNominalTime(

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -59,8 +59,9 @@
       "type": "object",
       "properties": {
         "runId": {
-          "description": "The id of the run, unique relative to the job",
-          "type": "string"
+	  "description": "The id of the run, unique relative to the job",
+	  "type": "string",
+          "format": "uuid"
         },
         "facets": {
           "description": "The run facets.",

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -59,7 +59,7 @@
       "type": "object",
       "properties": {
         "runId": {
-          "description": "The id of the run, unique relative to the job",
+          "description": "The globally unique ID of the run associated with the job.",
           "type": "string",
           "format": "uuid"
         },
@@ -278,6 +278,7 @@
               "type": "object",
               "properties": {
                 "runId": {
+                  "description": "The globally unique ID of the run associated with the job.",
                   "type": "string",
                   "format": "uuid"
                 }

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -59,8 +59,8 @@
       "type": "object",
       "properties": {
         "runId": {
-	      "description": "The id of the run, unique relative to the job",
-	      "type": "string",
+          "description": "The id of the run, unique relative to the job",
+          "type": "string",
           "format": "uuid"
         },
         "facets": {
@@ -278,7 +278,8 @@
               "type": "object",
               "properties": {
                 "runId": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uuid"
                 }
               },
               "required": [

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -59,8 +59,8 @@
       "type": "object",
       "properties": {
         "runId": {
-	  "description": "The id of the run, unique relative to the job",
-	  "type": "string",
+	      "description": "The id of the run, unique relative to the job",
+	      "type": "string",
           "format": "uuid"
         },
         "facets": {

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -19,7 +19,7 @@ It allows extensions to the spec using `Custom Facets` as described in this docu
 
 - **Dataset**: an abstract representation of data. It has a unique name within a namespace derived from its physical location (for example db.host.database.schema.table). Typically, a *Dataset* changes when a job writing to it completes. Similarly to the *Job* and *Run* distinction, metadata that is more static from run to run is captured in a DatasetFacet (for example, the schema that does not change every run), what changes every *Run* is captured as an *InputFacet* or an *OutputFacet* (for example, what subset of the data set was read or written, like a time partition).
 
-- **Run**: An instance of a running job with a start and completion (or failure) time. It is uniquely identified by an id relative to its job definition.
+- **Run**: An instance of a running job with a start and completion (or failure) time. A run is identified by a globally unique ID relative to its job definition. A run ID **must** be an [UUID](https://datatracker.ietf.org/doc/html/rfc4122).
 
 - **Facet**: A piece of metadata attached to one of the entities defined above.
 
@@ -30,7 +30,7 @@ Here is an example of a simple start run event not adding any facet information:
   "transition": "START",
   "eventTime": "2020-12-09T23:37:31.081Z",
   "run": {
-    "runId": "345",
+    "runId": "3b452093-782c-4ef2-9c0c-aafe2aa6f34d",
   },
   "job": {
     "namespace": "my-scheduler-namespace",


### PR DESCRIPTION
This PR sets the`Run.runId` format as `uuid`, according to [RFC4122](https://datatracker.ietf.org/doc/html/rfc4122). A `uuid` is a valid Json schema resource identifier introduced in `2019-09`, see [section 7.3.5](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.5).

Note, please see #29 outlining the reasoning for using the `uuid` type for `Run.runId`.