### PR TITLE
dbt wrapper: fix dependencies

### DIFF
--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         "google-crc32c>=1.1.2"
     ],
     "dbt": [
-        "dbt-core>=0.19.1",
+        "dbt-core>=0.20.0",
         "pyyaml>=5.3.1"
     ],
     "tests": [

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -23,8 +23,9 @@ from setuptools import setup
 __version__ = '0.0.1'
 
 requirements = [
-    "attrs>=20.3.0",
+    "attrs>=19.3.0",
     "requests>=2.20.0",
+    "pyyaml>=5.3.1",
     f"openlineage-python=={__version__}",
 ]
 

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -23,8 +23,6 @@ from setuptools import setup
 __version__ = '0.0.1'
 
 requirements = [
-    "attrs>=19.3.0",
-    "requests>=2.20.0",
     "pyyaml>=5.3.1",
     f"openlineage-python=={__version__}",
 ]

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -23,8 +23,8 @@ from setuptools import setup
 __version__ = '0.0.1'
 
 requirements = [
-    "pyyaml>=5.3.1",
-    f"openlineage-python=={__version__}",
+    f"sqlparse>=0.2.3,<0.4",
+    f"openlineage-integration-common[dbt]=={__version__}",
 ]
 
 


### PR DESCRIPTION
- properly refer to integration-common
- remove transient dependencies
- force sqlparse < 4 when using dbt script