### PR TITLE
python: remove usage of OPENLINAGE_PRODUCER environment variable

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -11,7 +11,6 @@ $ python setup.py install
 OpenLineage client depends on environment variables:
 
 * `OPENLINEAGE_URL` - point to service which will consume OpenLineage events
-* `OPENLINEAGE_PRODUCER` - name of producer that client will send along with your events
 * `OPENLINEAGE_API_KEY` - set if consumer of OpenLineage events requires `Bearer` authentication key
 
 `OPENLINEAGE_URL` and `OPENLINEAGE_API_KEY` can also be set up manually when creating client instance.

--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -1,1 +1,2 @@
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
+from openlineage.client.facet import set_producer

--- a/client/python/openlineage/client/constants.py
+++ b/client/python/openlineage/client/constants.py
@@ -10,7 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__version__ = "0.0.1"
+
 DEFAULT_TIMEOUT_MS = 10000
 DEFAULT_NAMESPACE_NAME = 'default'
 DEFAULT_OPENLINEAGE_URL = 'http://localhost:5000'
-DEFAULT_PRODUCER = "openlineage-python"
+DEFAULT_PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}/client/python"

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -18,8 +18,14 @@ import attr
 from openlineage.client.constants import DEFAULT_PRODUCER
 
 
-PRODUCER = os.getenv("OPENLINEAGE_PRODUCER", DEFAULT_PRODUCER)
 SCHEMA_URI = "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json"
+
+PRODUCER = DEFAULT_PRODUCER
+
+
+def set_producer(producer):
+    global PRODUCER
+    PRODUCER = producer
 
 
 @attr.s

--- a/client/python/tests/nominal_time_without_end.json
+++ b/client/python/tests/nominal_time_without_end.json
@@ -1,5 +1,5 @@
 {
-  "_producer": "openlineage-python",
+  "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python",
   "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/NominalTimeRunFacet",
   "nominalStartTime": "2020-01-01"
 }

--- a/client/python/tests/serde_example.json
+++ b/client/python/tests/serde_example.json
@@ -4,7 +4,7 @@
 	"run": {
 		"facets": {
 			"nominalTime": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/NominalTimeRunFacet",
 				"nominalEndTime": "2020-01-02",
 				"nominalStartTime": "2020-01-01"
@@ -19,5 +19,5 @@
 	},
 	"inputs": [],
 	"outputs": [],
-	"producer": "openlineage-python"
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python"
 }

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -18,7 +18,12 @@ import attr
 import pytest
 
 from openlineage.client.serde import Serde
-from openlineage.client import run, facet
+from openlineage.client import run, facet, set_producer
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_producer():
+    set_producer('https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python')
 
 
 def get_sorted_json(file_name: str) -> str:
@@ -48,7 +53,7 @@ def test_full_core_event_serializes_properly():
         ),
         inputs=[],
         outputs=[],
-        producer="openlineage-python"
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python"
     )
 
     assert Serde.to_json(runEvent) == get_sorted_json('serde_example.json')

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -50,7 +50,6 @@ $ python3 setup.py install
 OpenLineage client depends on environment variables:
 
 * `OPENLINEAGE_URL` - point to service which will consume OpenLineage events
-* `OPENLINEAGE_PRODUCER` - name of producer that client will send along with your events. This will be dropped in future versions.
 * `OPENLINEAGE_API_KEY` - set if consumer of OpenLineage events requires `Bearer` authentication key
 * `OPENLINEAGE_NAMESPACE` - set if you are using something other than the `default` namespace for job namespace.
 

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, Type
 from openlineage.airflow import __version__ as OPENLINEAGE_AIRFLOW_VERSION
 from openlineage.airflow.extractors import StepMetadata
 
-from openlineage.client import OpenLineageClient, OpenLineageClientOptions
+from openlineage.client import OpenLineageClient, OpenLineageClientOptions, set_producer
 from openlineage.client.facet import DocumentationJobFacet, SourceCodeLocationJobFacet, \
     SqlJobFacet, NominalTimeRunFacet, ParentRunFacet, BaseFacet
 from openlineage.client.run import RunEvent, RunState, Run, Job
@@ -19,7 +19,11 @@ if not _DAG_NAMESPACE:
         'MARQUEZ_NAMESPACE', _DAG_DEFAULT_NAMESPACE
     )
 
-_PRODUCER = f"openlineage-airflow/{OPENLINEAGE_AIRFLOW_VERSION}"
+_PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/" \
+            f"{OPENLINEAGE_AIRFLOW_VERSION}/integration/airflow"
+
+set_producer(_PRODUCER)
+
 
 log = logging.getLogger(__name__)
 
@@ -85,13 +89,13 @@ class OpenLineageAdapter:
             job=self._build_job(
                 job_name, job_description, code_location, sql
             ),
-            producer=_PRODUCER,
             inputs=[
                 dataset.to_openlineage_dataset() for dataset in step.inputs
             ] if step else None,
             outputs=[
                 dataset.to_openlineage_dataset() for dataset in step.outputs
-            ] if step else None
+            ] if step else None,
+            producer=_PRODUCER
         )
         self.get_or_create_openlineage_client().emit(event)
         return event.run.runId

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -43,7 +43,7 @@ from openlineage.airflow.facets import AirflowRunArgsRunFacet, \
 from openlineage.airflow.utils import get_location, get_job_name, new_lineage_run_id
 from openlineage.client.facet import NominalTimeRunFacet, SourceCodeLocationJobFacet, \
     DocumentationJobFacet, DataSourceDatasetFacet, SchemaDatasetFacet, \
-    SchemaField, ParentRunFacet, SqlJobFacet
+    SchemaField, ParentRunFacet, SqlJobFacet, set_producer
 from openlineage.client.run import RunEvent, RunState, Job, Run, \
     Dataset as OpenLineageDataset
 
@@ -76,7 +76,14 @@ DAG_DEFAULT_ARGS = {
 TASK_ID_COMPLETED = 'test_task_completed'
 TASK_ID_FAILED = 'test_task_failed'
 
-PRODUCER = f"openlineage-airflow/{OPENLINEAGE_AIRFLOW_VERSION}"
+
+PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/" \
+            f"{OPENLINEAGE_AIRFLOW_VERSION}/integration/airflow"
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_producer():
+    set_producer(PRODUCER)
 
 
 @pytest.fixture

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -9,11 +9,8 @@ import attr
 
 from openlineage.client.facet import DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField, \
     SqlJobFacet
-from openlineage.common import __version__
 from openlineage.client.run import RunEvent, RunState, Run, Job, Dataset
 from openlineage.common.utils import get_from_nullable_chain
-
-PRODUCER = f"openlineage-dbt/{__version__}"
 
 
 @attr.s
@@ -46,7 +43,8 @@ class DbtRunResult:
 
 
 class DbtArtifactProcessor:
-    def __init__(self, project: str = 'dbt_project.yml', skip_errors: bool = False):
+    def __init__(self, producer: str, project: str = 'dbt_project.yml', skip_errors: bool = False):
+        self.producer = producer
         self.dir = os.path.abspath(os.path.dirname(project))
         self.project = self.load_yaml(project)
         self.namespace = ""
@@ -183,7 +181,7 @@ class DbtArtifactProcessor:
                 namespace=self.namespace,
                 name=run.job_name
             ),
-            producer=PRODUCER,
+            producer=self.producer,
             inputs=[self.node_to_dataset(node) for node in run.inputs],
             outputs=[self.node_to_dataset(run.output)]
         )
@@ -204,7 +202,7 @@ class DbtArtifactProcessor:
                             'sql': SqlJobFacet(run.output['compiled_sql'])
                         }
                     ),
-                    producer=PRODUCER,
+                    producer=self.producer,
                     inputs=[self.node_to_dataset(node, has_facets=True) for node in run.inputs],
                     outputs=[self.node_to_dataset(run.output, has_facets=True)]
                 )
@@ -225,7 +223,7 @@ class DbtArtifactProcessor:
                             'sql': SqlJobFacet(run.output['compiled_sql'])
                         }
                     ),
-                    producer=PRODUCER,
+                    producer=self.producer,
                     inputs=[self.node_to_dataset(node, has_facets=True) for node in run.inputs],
                     outputs=[]
                 )

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -10,7 +10,7 @@
 		"name": "model.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.source_table",
@@ -33,7 +33,7 @@
 		"name": "model.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "bigquery",
@@ -52,7 +52,7 @@
 		"name": "model.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
@@ -75,26 +75,26 @@
 		"name": "model.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
@@ -116,25 +116,25 @@
 		"name": "model.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\nwhere id = 1"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
@@ -149,13 +149,13 @@
 		"name": "speedy-vim-308516.dbt_test1.test_second_dbt_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
@@ -177,25 +177,25 @@
 		"name": "model.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1\nbork bork fail"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": []
 			}

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -10,7 +10,7 @@
 		"name": "model.jaffle_shop.stg_orders",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
@@ -29,7 +29,7 @@
 		"name": "model.jaffle_shop.stg_payments",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
@@ -48,7 +48,7 @@
 		"name": "model.jaffle_shop.stg_customers",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
@@ -67,7 +67,7 @@
 		"name": "model.jaffle_shop.orders",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_orders",
@@ -94,7 +94,7 @@
 		"name": "model.jaffle_shop.customers",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
@@ -125,26 +125,26 @@
 		"name": "model.jaffle_shop.stg_orders",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "with source as (\n    select * from DEMO_DB.public.raw_orders\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
@@ -170,26 +170,26 @@
 		"name": "model.jaffle_shop.stg_payments",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "with source as (\n    select * from DEMO_DB.public.raw_payments\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
@@ -215,26 +215,26 @@
 		"name": "model.jaffle_shop.stg_customers",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "with source as (\n    select * from DEMO_DB.public.raw_customers\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "customer_id",
@@ -256,25 +256,25 @@
 		"name": "model.jaffle_shop.orders",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "\n\nwith orders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
@@ -292,13 +292,13 @@
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
@@ -317,13 +317,13 @@
 		"name": "DEMO_DB.public.orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
@@ -377,25 +377,25 @@
 		"name": "model.jaffle_shop.customers",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "with customers as (\n\n    select * from DEMO_DB.public.stg_customers\n\n),\n\norders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "customer_id",
@@ -409,13 +409,13 @@
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
@@ -433,13 +433,13 @@
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
@@ -458,13 +458,13 @@
 		"name": "DEMO_DB.public.customers",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "customer_id",

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -10,7 +10,7 @@
 		"name": "model.dbt_test.test_model",
 		"facets": {}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.source_table",
@@ -33,25 +33,25 @@
 		"name": "model.dbt_test.test_model",
 		"facets": {
 			"sql": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1"
 			}
 		}
 	},
-	"producer": "openlineage-dbt/0.0.1",
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": []
 			}
@@ -62,13 +62,13 @@
 		"name": "speedy-vim-308516.dbt_test1.test_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "openlineage-python",
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -3,8 +3,15 @@ from enum import Enum
 from unittest import mock
 
 import attr
+import pytest
 
 from openlineage.common.provider.dbt import DbtArtifactProcessor
+from openlineage.client import set_producer
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_producer():
+    set_producer('https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt')
 
 
 def serialize(inst, field, value):
@@ -19,7 +26,10 @@ def test_dbt_parse_small_event(mock_uuid):
         '6edf42ed-d8d0-454a-b819-d09b9067ff99',
     ]
 
-    processor = DbtArtifactProcessor('tests/dbt/small/dbt_project.yml')
+    processor = DbtArtifactProcessor(
+        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        'tests/dbt/small/dbt_project.yml'
+    )
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)
@@ -40,7 +50,10 @@ def test_dbt_parse_large_event(mock_uuid):
         'ae0a988e-72ad-4caf-8223-fe9dcb923a3f'
     ]
 
-    processor = DbtArtifactProcessor('tests/dbt/large/dbt_project.yml')
+    processor = DbtArtifactProcessor(
+        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        'tests/dbt/large/dbt_project.yml'
+    )
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)
@@ -63,7 +76,10 @@ def test_dbt_parse_failed_event(mock_datetime, mock_uuid):
         'ae0a988e-72ad-4caf-8223-fe9dcb923a3f'
     ]
 
-    processor = DbtArtifactProcessor('tests/dbt/fail/dbt_project.yml')
+    processor = DbtArtifactProcessor(
+        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        'tests/dbt/fail/dbt_project.yml'
+    )
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -5,6 +5,11 @@ import sys
 from openlineage.common.provider.dbt import DbtArtifactProcessor
 from openlineage.client.client import OpenLineageClient
 
+__version__ = '0.0.1'
+
+PRODUCER = f'https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integration/dbt'
+
+
 def main():
     process = subprocess.Popen(
         ["dbt"] + sys.argv[1:],
@@ -18,7 +23,7 @@ def main():
         return
 
     client = OpenLineageClient.from_environment()
-    processor = DbtArtifactProcessor()
+    processor = DbtArtifactProcessor(PRODUCER)
     events = processor.parse().events()
 
     for event in events:

--- a/integration/dbt/setup.cfg
+++ b/integration/dbt/setup.cfg
@@ -1,12 +1,5 @@
 [bumpversion]
 current_version = 0.0.1
-
-[metadata]
-description-file = README.md
-
-[flake8]
-max-line-length=99
-
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<rc>.*)
@@ -18,6 +11,12 @@ serialize =
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bumpversion:file:openlineage/client/constants.py]
+[bumpversion:file:scripts/dbt-ol]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+
+[flake8]
+max-line-length = 99
+
+[tool:pytest]
+addopts = -p no:warnings


### PR DESCRIPTION
Integrations can change default producer using `set_producer`. This is effectively singleton.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>