### PR TITLE
dbt: use column-level catalog metadata

### DIFF
--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -145,3 +145,25 @@ class OutputStatisticsOutputDatasetFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return SCHEMA_URI + "#/definitions/OutputStatisticsOutputDatasetFacet"
+
+
+@attr.s
+class ColumnMetric:
+    nullCount: Optional[int] = attr.ib(default=None)
+    distinctCount: Optional[int] = attr.ib(default=None)
+    sum: Optional[float] = attr.ib(default=None)
+    count: Optional[int] = attr.ib(default=None)
+    min: Optional[float] = attr.ib(default=None)
+    max: Optional[float] = attr.ib(default=None)
+    quantiles: Optional[Dict[str, float]] = attr.ib(default=None)
+
+
+@attr.s
+class DataQualityMetricsInputDatasetFacet(BaseFacet):
+    rowCount: Optional[int] = attr.ib(default=None)
+    bytes: Optional[int] = attr.ib(default=None)
+    columnMetrics: Dict[str, ColumnMetric] = attr.ib(factory=dict)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/DataQualityMetricsInputDatasetFacet"

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -135,3 +135,13 @@ class DataSourceDatasetFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return SCHEMA_URI + "#/definitions/DataSourceDatasetFacet"
+
+
+@attr.s
+class OutputStatisticsOutputDatasetFacet(BaseFacet):
+    rowCount: int = attr.ib()
+    size: Optional[int] = attr.ib(default=None)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/OutputStatisticsOutputDatasetFacet"

--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -58,6 +58,16 @@ class Dataset:
 
 
 @attr.s
+class InputDataset(Dataset):
+    inputFacets: Dict = attr.ib(factory=dict)
+
+
+@attr.s
+class OutputDataset(Dataset):
+    outputFacets: Dict = attr.ib(factory=dict)
+
+
+@attr.s
 class RunEvent:
     eventType: RunState = attr.ib(validator=attr.validators.in_(RunState))
     eventTime: str = attr.ib()  # TODO: validate dates

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -163,6 +163,9 @@ class GreatExpectationsExtractorImpl(BaseExtractor):
                 custom_facets={
                     'dataQuality': data_quality_facet,
                     'greatExpectations_assertions': assertions_facet
+                },
+                input_facets={
+                    'dataQualityMetrics': data_quality_facet.to_openlineage()
                 }
             )
 

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -1,7 +1,7 @@
 import attr
 from airflow.version import version as AIRFLOW_VERSION
 from openlineage.airflow import __version__ as OPENLINEAGE_AIRFLOW_VERSION
-from openlineage.client.facet import BaseFacet
+from openlineage.client.facet import BaseFacet, DataQualityMetricsInputDatasetFacet
 from typing import Optional, Dict
 
 
@@ -43,6 +43,13 @@ class DataQualityDatasetFacet(BaseFacet):
     rowCount: Optional[int] = attr.ib(default=None)
     bytes: Optional[int] = attr.ib(default=None)
     columnMetrics: Dict[str, ColumnMetric] = attr.ib(factory=dict)
+
+    def to_openlineage(self) -> DataQualityMetricsInputDatasetFacet:
+        return DataQualityMetricsInputDatasetFacet(
+            rowCount=self.rowCount,
+            bytes=self.bytes,
+            columnMetrics=self.columnMetrics
+        )
 
     @staticmethod
     def _get_schema() -> str:

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -24,6 +24,7 @@ from airflow.models import TaskInstance, DAG
 from airflow.utils.state import State
 
 from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
+from openlineage.client.facet import OutputStatisticsOutputDatasetFacet
 from openlineage.common.provider.bigquery import BigQueryJobRunFacet, \
     BigQueryStatisticsDatasetFacet, BigQueryErrorRunFacet
 from openlineage.common.utils import get_from_nullable_chain
@@ -111,6 +112,11 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             rowCount=20,
             size=321
         ) == step_meta.outputs[0].custom_facets['stats']
+
+        assert OutputStatisticsOutputDatasetFacet(
+            rowCount=20,
+            size=321
+        ) == step_meta.outputs[0].output_facets['outputStatistics']
 
         assert len(step_meta.run_facets) == 1
         assert BigQueryJobRunFacet(

--- a/integration/airflow/tests/extractors/test_great_expectations_extractor.py
+++ b/integration/airflow/tests/extractors/test_great_expectations_extractor.py
@@ -21,6 +21,7 @@ from openlineage.airflow.extractors.great_expectations_extractor import \
 from great_expectations_provider.operators.great_expectations import GreatExpectationsOperator
 
 from openlineage.airflow.facets import DataQualityDatasetFacet, ColumnMetric
+from openlineage.client.facet import DataQualityMetricsInputDatasetFacet
 from openlineage.client.serde import Serde
 
 log = logging.getLogger(__name__)
@@ -66,6 +67,12 @@ def test_great_expectations_operator_batch_kwargs_success():
                 quantiles={"0": -52.8, "0.333": 9.3, "0.6667": 14.16, "1": 3004.8}
             )
         }
+    )
+
+    ol_dq_metrics = DataQualityMetricsInputDatasetFacet(
+        rowCount=expected_dq.rowCount,
+        bytes=expected_dq.bytes,
+        columnMetrics=expected_dq.columnMetrics
     )
 
     expected_assertions = GreatExpectationsAssertionsDatasetFacet(
@@ -119,6 +126,8 @@ def test_great_expectations_operator_batch_kwargs_success():
 
     assert Serde.to_json(step.inputs[0].custom_facets['dataQuality']) == \
            Serde.to_json(expected_dq)
+    assert Serde.to_json(step.inputs[0].input_facets['dataQualityMetrics']) == \
+           Serde.to_json(ol_dq_metrics)
     assert step.inputs[0].custom_facets['greatExpectations_assertions'] == expected_assertions
 
     assert result['success']
@@ -164,8 +173,16 @@ def test_great_expectations_operator_with_provided_namespace_success(namespace, 
         }
     )
 
+    ol_dq_metrics = DataQualityMetricsInputDatasetFacet(
+        rowCount=expected_dq.rowCount,
+        bytes=expected_dq.bytes,
+        columnMetrics=expected_dq.columnMetrics
+    )
+
     assert Serde.to_json(step.inputs[0].custom_facets['dataQuality']) == \
            Serde.to_json(expected_dq)
+    assert Serde.to_json(step.inputs[0].input_facets['dataQualityMetrics']) == \
+           Serde.to_json(ol_dq_metrics)
     assert step.inputs[0].source.scheme == scheme
     assert step.inputs[0].source.authority == authority
     assert step.inputs[0].name == 'schema.table'

--- a/integration/common/openlineage/common/dataset.py
+++ b/integration/common/openlineage/common/dataset.py
@@ -15,7 +15,7 @@ from typing import List, Optional, Dict
 from openlineage.common.models import DbTableSchema, DbColumn
 from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, \
     DocumentationDatasetFacet, SchemaDatasetFacet, SchemaField
-from openlineage.client.run import Dataset as OpenLineageDataset
+from openlineage.client.run import Dataset as OpenLineageDataset, InputDataset, OutputDataset
 
 
 class Source:
@@ -87,17 +87,25 @@ class Dataset:
             source: Source,
             name: str, fields: List[Field] = None,
             description: Optional[str] = None,
-            custom_facets: Dict[str, BaseFacet] = None
+            custom_facets: Dict[str, BaseFacet] = None,
+            input_facets: Dict[str, BaseFacet] = None,
+            output_facets: Dict[str, BaseFacet] = None
     ):
         if fields is None:
             fields = []
         if custom_facets is None:
             custom_facets = {}
+        if input_facets is None:
+            input_facets = {}
+        if output_facets is None:
+            output_facets = {}
         self.source = source
         self.name = name
         self.fields = fields
         self.description = description
         self.custom_facets = custom_facets
+        self.input_facets = input_facets
+        self.output_facets = output_facets
 
     @staticmethod
     def from_table(source: Source,
@@ -182,6 +190,21 @@ class Dataset:
 
         if self.custom_facets:
             facets.update(self.custom_facets)
+
+        if len(self.input_facets):
+            return InputDataset(
+                namespace=self.source.name,
+                name=self.name,
+                facets=facets,
+                inputFacets=self.input_facets
+            )
+        if len(self.output_facets):
+            return OutputDataset(
+                namespace=self.source.name,
+                name=self.name,
+                facets=facets,
+                outputFacets=self.output_facets
+            )
 
         return OpenLineageDataset(
             namespace=self.source.name,

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -23,8 +23,7 @@ from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbTableSchema, DbColumn, DbTableName
 from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.utils import get_from_nullable_chain
-from openlineage.client.facet import BaseFacet
-
+from openlineage.client.facet import BaseFacet, OutputStatisticsOutputDatasetFacet
 
 _BIGQUERY_CONN_URL = 'bigquery'
 
@@ -72,6 +71,12 @@ class BigQueryStatisticsDatasetFacet(BaseFacet):
     rowCount: int = attr.ib()
     size: int = attr.ib()
 
+    def to_openlineage(self) -> OutputStatisticsOutputDatasetFacet:
+        return OutputStatisticsOutputDatasetFacet(
+            rowCount=self.rowCount,
+            size=self.size
+        )
+
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "bq-statistics-dataset-facet.json"
@@ -113,9 +118,12 @@ class BigQueryDatasetsProvider:
                 })
                 inputs = self._get_input_from_bq(props)
                 output = self._get_output_from_bq(props)
-                if output:
+                if output and dataset_stat_facet:
                     output.custom_facets.update({
                         "stats": dataset_stat_facet
+                    })
+                    output.output_facets.update({
+                        'outputStatistics': dataset_stat_facet.to_openlineage()
                     })
 
             finally:

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -14,12 +14,17 @@ from openlineage.common.utils import get_from_nullable_chain
 
 
 @attr.s
+class ModelNode:
+    metadata_node: Dict = attr.ib()
+    catalog_node: Optional[Dict] = attr.ib(default=None)
+
+@attr.s
 class DbtRun:
     started_at: str = attr.ib()
     completed_at: str = attr.ib()
     status: str = attr.ib()
-    inputs: List[Dict] = attr.ib()
-    output: Dict = attr.ib()
+    inputs: List[ModelNode] = attr.ib()
+    output: ModelNode = attr.ib()
     job_name: str = attr.ib()
     namespace: str = attr.ib()
     run_id: str = attr.ib(factory=lambda: str(uuid.uuid4()))
@@ -60,6 +65,9 @@ class DbtArtifactProcessor:
         run_result = self.load_run_results(
             os.path.join(self.dir, self.project['target-path'], 'run_results.json')
         )
+        catalog = self.load_catalog(
+            os.path.join(self.dir, self.project['target-path'], 'catalog.json')
+        )
 
         profile_dir = run_result['args']['profiles_dir']
 
@@ -74,7 +82,7 @@ class DbtArtifactProcessor:
 
         self.extract_namespace(profile)
 
-        runs = self.parse_artifacts(manifest, run_result)
+        runs = self.parse_artifacts(manifest, run_result, catalog)
 
         start_events, complete_events, fail_events = [], [], []
         for run in runs:
@@ -89,33 +97,42 @@ class DbtArtifactProcessor:
         return DbtEvents(start_events, complete_events, fail_events)
 
     @staticmethod
-    def load_manifest(path: str) -> Dict:
+    def load_metadata(path: str, desired_schema_version: str) -> Dict:
         with open(path, 'r') as f:
-            manifest = json.load(f)
-            schema_version = get_from_nullable_chain(manifest, ['metadata', 'dbt_schema_version'])
-            if schema_version != "https://schemas.getdbt.com/dbt/manifest/v2.json":
+            metadata = json.load(f)
+            schema_version = get_from_nullable_chain(metadata, ['metadata', 'dbt_schema_version'])
+            if schema_version != desired_schema_version:
                 # Maybe we should accept it and throw exception only if it substantially differs
-                raise ValueError(f"Wrong version of dbt metadata manifest: {schema_version}")
-            return manifest
+                raise ValueError(f"Wrong version of dbt metadata: {schema_version}, "
+                                 f"should be {desired_schema_version}")
+            return metadata
 
-    @staticmethod
-    def load_run_results(path: str) -> Dict:
-        with open(path, 'r') as f:
-            run_results = json.load(f)
-            schema_version = get_from_nullable_chain(
-                run_results, ['metadata', 'dbt_schema_version']
-            )
-            if schema_version != "https://schemas.getdbt.com/dbt/run-results/v2.json":
-                # Maybe we should accept it and throw exception only if it substantially differs
-                raise ValueError(f"Wrong version of dbt run_results manifest: {schema_version}")
-            return run_results
+    @classmethod
+    def load_manifest(cls, path: str) -> Dict:
+        return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/manifest/v2.json")
+
+    @classmethod
+    def load_run_results(cls, path: str) -> Dict:
+        return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/run-results/v2.json")
+
+    @classmethod
+    def load_catalog(cls, path: str) -> Optional[Dict]:
+        try:
+            return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/catalog/v1.json")
+        except FileNotFoundError:
+            return None
 
     @staticmethod
     def load_yaml(path: str) -> Dict:
         with open(path, 'r') as f:
             return yaml.load(f, Loader=yaml.FullLoader)
 
-    def parse_artifacts(self, manifest: Dict, run_results: Dict) -> List[DbtRun]:
+    def parse_artifacts(
+        self,
+        manifest: Dict,
+        run_results: Dict,
+        catalog: Optional[Dict]
+    ) -> List[DbtRun]:
         nodes = {}
         runs = []
 
@@ -136,24 +153,29 @@ class DbtArtifactProcessor:
                     return timing, timing
 
             started_at, completed_at = get_timings(run['timing'])
-            inputs = [
-                nodes[node]
-                for node
-                in manifest['parent_map'][run['unique_id']]
-                if node.startswith('model.')
-            ] + [
-                manifest['sources'][source]
-                for source
-                in manifest['parent_map'][run['unique_id']]
-                if source.startswith('source.')
-            ]
+
+            inputs = []
+            for node in manifest['parent_map'][run['unique_id']]:
+                if node.startswith('model.'):
+                    inputs.append(ModelNode(
+                        nodes[node],
+                        get_from_nullable_chain(catalog, ['nodes', node])
+                    ))
+                elif node.startswith('source.'):
+                    inputs.append(ModelNode(
+                        manifest['sources'][node],
+                        get_from_nullable_chain(catalog, ['sources', node])
+                    ))
 
             runs.append(DbtRun(
                 started_at,
                 completed_at,
                 run['status'],
                 inputs,
-                nodes[run['unique_id']],
+                ModelNode(
+                    nodes[run['unique_id']],
+                    get_from_nullable_chain(catalog, ['nodes', run['unique_id']])
+                ),
                 run['unique_id'],
                 self.namespace
             ))
@@ -199,7 +221,7 @@ class DbtArtifactProcessor:
                         namespace=self.namespace,
                         name=run.job_name,
                         facets={
-                            'sql': SqlJobFacet(run.output['compiled_sql'])
+                            'sql': SqlJobFacet(run.output.metadata_node['compiled_sql'])
                         }
                     ),
                     producer=self.producer,
@@ -220,7 +242,7 @@ class DbtArtifactProcessor:
                         namespace=self.namespace,
                         name=run.job_name,
                         facets={
-                            'sql': SqlJobFacet(run.output['compiled_sql'])
+                            'sql': SqlJobFacet(run.output.metadata_node['compiled_sql'])
                         }
                     ),
                     producer=self.producer,
@@ -233,7 +255,7 @@ class DbtArtifactProcessor:
             raise ValueError(f"Run status was {run.status}, "
                              f"should be in ['success', 'skipped', 'skipped']")
 
-    def node_to_dataset(self, node: Dict, has_facets: bool = False) -> Dataset:
+    def node_to_dataset(self, node: ModelNode, has_facets: bool = False) -> Dataset:
         if has_facets:
             has_facets = {
                 'dataSource': DataSourceDatasetFacet(
@@ -241,18 +263,25 @@ class DbtArtifactProcessor:
                     uri=self.namespace
                 ),
                 'schema': SchemaDatasetFacet(
-                    fields=self.extract_fields(node['columns'].values())
+                    fields=self.extract_metadata_fields(node.metadata_node['columns'].values())
                 )
             }
+            if node.catalog_node:
+                has_facets['schema'] = SchemaDatasetFacet(
+                        fields=self.extract_catalog_fields(node.catalog_node['columns'].values())
+                )
         else:
             has_facets = {}
         return Dataset(
             namespace=self.namespace,
-            name=f"{node['database']}.{node['schema']}.{node['name']}",
+            name=f"{node.metadata_node['database']}."
+                 f"{node.metadata_node['schema']}."
+                 f"{node.metadata_node['name']}",
             facets=has_facets
         )
 
-    def extract_fields(self, columns: List[Dict]) -> List[SchemaField]:
+    @staticmethod
+    def extract_metadata_fields(columns: List[Dict]) -> List[SchemaField]:
         fields = []
         for field in columns:
             type = None
@@ -260,6 +289,20 @@ class DbtArtifactProcessor:
                 type = field['data_type']
             fields.append(SchemaField(
                 name=field['name'], type=type
+            ))
+        return fields
+
+    @staticmethod
+    def extract_catalog_fields(columns: List[Dict]) -> List[SchemaField]:
+        fields = []
+        for field in columns:
+            type, description = None, None
+            if 'type' in field and field['type'] is not None:
+                type = field['type']
+            if 'column' in field and field['column'] is not None:
+                description = field['column']
+            fields.append(SchemaField(
+                name=field['name'], type=type, description=description
             ))
         return fields
 

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -42,3 +42,11 @@ def get_from_nullable_chain(source: Dict[str, Any], chain: List[str]) -> Optiona
         return source
     except AttributeError:
         return
+
+
+def get_from_multiple_chains(source: Dict[str, Any], chains: List[List[str]]) -> Optional[Any]:
+    for chain in chains:
+        result = get_from_nullable_chain(source, chain)
+        if result:
+            return result
+    return None

--- a/integration/common/tests/dbt/catalog/dbt_project.yml
+++ b/integration/common/tests/dbt/catalog/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/catalog/profiles.yml
+++ b/integration/common/tests/dbt/catalog/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: speedy-vim-308516
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -1,0 +1,85 @@
+[{
+	"eventType": "START",
+	"eventTime": "2021-07-07T12:44:46.069306Z",
+	"run": {
+		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"facets": {}
+	},
+	"job": {
+		"namespace": "bigquery",
+		"name": "model.dbt_test.test_model",
+		"facets": {}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"facets": {}
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"facets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"run": {
+		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"facets": {}
+	},
+	"job": {
+		"namespace": "bigquery",
+		"name": "model.dbt_test.test_model",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "id",
+					"type": "INT64",
+					"description": null
+				}]
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "id",
+					"type": "INT64",
+					"description": null
+				}]
+			}
+		}
+	}]
+}]

--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -19,7 +19,8 @@
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_model",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -79,6 +80,14 @@
 					"type": "INT64",
 					"description": null
 				}]
+			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
+				"rowCount": 1,
+				"size": 16
 			}
 		}
 	}]

--- a/integration/common/tests/dbt/catalog/small/dbt_project.yml
+++ b/integration/common/tests/dbt/catalog/small/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/catalog/small/profiles.yml
+++ b/integration/common/tests/dbt/catalog/small/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: speedy-vim-308516
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/catalog/small/result.json
+++ b/integration/common/tests/dbt/catalog/small/result.json
@@ -1,0 +1,81 @@
+[{
+	"eventType": "START",
+	"eventTime": "2021-07-07T12:44:46.069306Z",
+	"run": {
+		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"facets": {}
+	},
+	"job": {
+		"namespace": "bigquery",
+		"name": "model.dbt_test.test_model",
+		"facets": {}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"facets": {}
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"facets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"run": {
+		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"facets": {}
+	},
+	"job": {
+		"namespace": "bigquery",
+		"name": "model.dbt_test.test_model",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": []
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "id",
+					"type": null,
+					"description": null
+				}]
+			}
+		}
+	}]
+}]

--- a/integration/common/tests/dbt/catalog/small/target/manifest.json
+++ b/integration/common/tests/dbt/catalog/small/target/manifest.json
@@ -1,0 +1,147 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:44.367050Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {},
+		"project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.dbt_test.test_model": {
+			"raw_sql": "select *\nfrom {{ source('dbt_test1', 'source_table') }}\nwhere id = 1",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["source.dbt_test.dbt_test1.source_table"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "speedy-vim-308516",
+			"schema": "dbt_test1",
+			"fqn": ["dbt_test", "example", "test_model"],
+			"unique_id": "model.dbt_test.test_model",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "example/test_second_parallel_dbt_model.sql",
+			"original_file_path": "models/example/test_model.sql",
+			"name": "test_model",
+			"alias": "test_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "318f640067e471c6a2e8d370039786939aaf4197c4be4ee64677e59f1f1a9a34"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [
+				["dbt_test1", "source_table"]
+			],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "dbt_test://models/example/schema.yml",
+			"compiled_path": "target/compiled/dbt_test/models/example/test_model.sql",
+			"build_path": "target/run/dbt_test/models/example/test_model.sql",
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625661884,
+			"compiled_sql": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`speedy-vim-308516`.`dbt_test1`.`test_model`"
+		}
+	},
+  	"sources": {
+		"source.dbt_test.dbt_test1.source_table": {
+			"fqn": ["dbt_test", "example", "dbt_test1", "source_table"],
+			"database": "speedy-vim-308516",
+			"schema": "dbt_test1",
+			"unique_id": "source.dbt_test.dbt_test1.source_table",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "models/example/schema.yml",
+			"original_file_path": "models/example/schema.yml",
+			"name": "source_table",
+			"source_name": "dbt_test1",
+			"source_description": "",
+			"loader": "",
+			"identifier": "source_table",
+			"resource_type": "source",
+			"quoting": {
+				"database": null,
+				"schema": null,
+				"identifier": null,
+				"column": null
+			},
+			"loaded_at_field": null,
+			"freshness": {
+				"warn_after": null,
+				"error_after": null,
+				"filter": null
+			},
+			"external": null,
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"source_meta": {},
+			"tags": [],
+			"config": {
+				"enabled": true
+			},
+			"patch_path": null,
+			"unrendered_config": {},
+			"relation_name": "`speedy-vim-308516`.`dbt_test1`.`source_table`",
+			"created_at": 1625661884
+		}
+	},
+	"macros": {},
+	"docs": {
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.dbt_test.test_model": ["source.dbt_test.dbt_test1.source_table"]
+	},
+	"child_map": {
+		"model.dbt_test.test_model": []
+	}
+}

--- a/integration/common/tests/dbt/catalog/small/target/run_results.json
+++ b/integration/common/tests/dbt/catalog/small/target/run_results.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:51.891863Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-07T12:44:46.053875Z",
+			"completed_at": "2021-07-07T12:44:46.063996Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-07T12:44:46.069306Z",
+			"completed_at": "2021-07-07T12:44:46.972743Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 0.9195568561553955,
+		"adapter_response": {
+			"_message": "OK",
+			"code": "CREATE VIEW"
+		},
+		"message": "OK",
+		"failures": null,
+		"unique_id": "model.dbt_test.test_model"
+	}],
+	"elapsed_time": 7.067806243896484,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/small",
+		"use_cache": true,
+		"version_check": true,
+		"which": "run",
+		"rpc_method": "run"
+	}
+}

--- a/integration/common/tests/dbt/catalog/target/catalog.json
+++ b/integration/common/tests/dbt/catalog/target/catalog.json
@@ -1,0 +1,98 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+		"dbt_version": "0.20.0",
+		"generated_at": "2021-08-02T09:21:26.854116Z",
+		"invocation_id": "4a1602fe-2a65-494b-97fc-c9fd71b5b2c9",
+		"env": {}
+	},
+	"nodes": {
+		"model.dbt_test.test_model": {
+			"metadata": {
+				"type": "table",
+				"schema": "dbt_test1",
+				"name": "test_model",
+				"database": "speedy-vim-308516",
+				"comment": null,
+				"owner": null
+			},
+			"columns": {
+				"id": {
+					"type": "INT64",
+					"index": 1,
+					"name": "id",
+					"comment": null
+				}
+			},
+			"stats": {
+				"num_bytes": {
+					"id": "num_bytes",
+					"label": "Approximate Size",
+					"value": 16.0,
+					"include": true,
+					"description": "Approximate size of table as reported by BigQuery"
+				},
+				"num_rows": {
+					"id": "num_rows",
+					"label": "# Rows",
+					"value": 1.0,
+					"include": true,
+					"description": "Approximate count of rows in this table"
+				},
+				"has_stats": {
+					"id": "has_stats",
+					"label": "Has Stats?",
+					"value": true,
+					"include": false,
+					"description": "Indicates whether there are statistics for this table"
+				}
+			},
+			"unique_id": "model.dbt_test.test_model"
+		}
+	},
+	"sources": {
+		"source.dbt_test.dbt_test1.source_table": {
+			"metadata": {
+				"type": "table",
+				"schema": "dbt_test1",
+				"name": "source_table",
+				"database": "speedy-vim-308516",
+				"comment": null,
+				"owner": null
+			},
+			"columns": {
+				"id": {
+					"type": "INT64",
+					"index": 1,
+					"name": "id",
+					"comment": null
+				}
+			},
+			"stats": {
+				"num_bytes": {
+					"id": "num_bytes",
+					"label": "Approximate Size",
+					"value": 22.0,
+					"include": true,
+					"description": "Approximate size of table as reported by BigQuery"
+				},
+				"num_rows": {
+					"id": "num_rows",
+					"label": "# Rows",
+					"value": 2.0,
+					"include": true,
+					"description": "Approximate count of rows in this table"
+				},
+				"has_stats": {
+					"id": "has_stats",
+					"label": "Has Stats?",
+					"value": true,
+					"include": false,
+					"description": "Indicates whether there are statistics for this table"
+				}
+			},
+			"unique_id": "source.dbt_test.dbt_test1.source_table"
+		}
+	},
+	"errors": null
+}

--- a/integration/common/tests/dbt/catalog/target/manifest.json
+++ b/integration/common/tests/dbt/catalog/target/manifest.json
@@ -1,0 +1,147 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:44.367050Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {},
+		"project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.dbt_test.test_model": {
+			"raw_sql": "select *\nfrom {{ source('dbt_test1', 'source_table') }}\nwhere id = 1",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["source.dbt_test.dbt_test1.source_table"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "speedy-vim-308516",
+			"schema": "dbt_test1",
+			"fqn": ["dbt_test", "example", "test_model"],
+			"unique_id": "model.dbt_test.test_model",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "example/test_second_parallel_dbt_model.sql",
+			"original_file_path": "models/example/test_model.sql",
+			"name": "test_model",
+			"alias": "test_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "318f640067e471c6a2e8d370039786939aaf4197c4be4ee64677e59f1f1a9a34"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [
+				["dbt_test1", "source_table"]
+			],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "dbt_test://models/example/schema.yml",
+			"compiled_path": "target/compiled/dbt_test/models/example/test_model.sql",
+			"build_path": "target/run/dbt_test/models/example/test_model.sql",
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625661884,
+			"compiled_sql": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`speedy-vim-308516`.`dbt_test1`.`test_model`"
+		}
+	},
+  	"sources": {
+		"source.dbt_test.dbt_test1.source_table": {
+			"fqn": ["dbt_test", "example", "dbt_test1", "source_table"],
+			"database": "speedy-vim-308516",
+			"schema": "dbt_test1",
+			"unique_id": "source.dbt_test.dbt_test1.source_table",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "models/example/schema.yml",
+			"original_file_path": "models/example/schema.yml",
+			"name": "source_table",
+			"source_name": "dbt_test1",
+			"source_description": "",
+			"loader": "",
+			"identifier": "source_table",
+			"resource_type": "source",
+			"quoting": {
+				"database": null,
+				"schema": null,
+				"identifier": null,
+				"column": null
+			},
+			"loaded_at_field": null,
+			"freshness": {
+				"warn_after": null,
+				"error_after": null,
+				"filter": null
+			},
+			"external": null,
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"source_meta": {},
+			"tags": [],
+			"config": {
+				"enabled": true
+			},
+			"patch_path": null,
+			"unrendered_config": {},
+			"relation_name": "`speedy-vim-308516`.`dbt_test1`.`source_table`",
+			"created_at": 1625661884
+		}
+	},
+	"macros": {},
+	"docs": {
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.dbt_test.test_model": ["source.dbt_test.dbt_test1.source_table"]
+	},
+	"child_map": {
+		"model.dbt_test.test_model": []
+	}
+}

--- a/integration/common/tests/dbt/catalog/target/run_results.json
+++ b/integration/common/tests/dbt/catalog/target/run_results.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:51.891863Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-07T12:44:46.053875Z",
+			"completed_at": "2021-07-07T12:44:46.063996Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-07T12:44:46.069306Z",
+			"completed_at": "2021-07-07T12:44:46.972743Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 0.9195568561553955,
+		"adapter_response": {
+			"_message": "OK",
+			"code": "CREATE VIEW"
+		},
+		"message": "OK",
+		"failures": null,
+		"unique_id": "model.dbt_test.test_model"
+	}],
+	"elapsed_time": 7.067806243896484,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/small",
+		"use_cache": true,
+		"version_check": true,
+		"which": "run",
+		"rpc_method": "run"
+	}
+}

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -19,7 +19,8 @@
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_second_parallel_dbt_model",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -38,7 +39,8 @@
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -61,7 +63,8 @@
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_second_dbt_model",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -102,7 +105,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -163,7 +167,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "FAIL",

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -15,7 +15,8 @@
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_orders",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -34,7 +35,8 @@
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_payments",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -53,7 +55,8 @@
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -80,7 +83,8 @@
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.orders",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "START",
@@ -111,7 +115,8 @@
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.customers",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -156,7 +161,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -201,7 +207,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -242,7 +249,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -363,7 +371,8 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -496,6 +505,7 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }]

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -19,7 +19,8 @@
 	"outputs": [{
 		"namespace": "bigquery",
 		"name": "speedy-vim-308516.dbt_test1.test_model",
-		"facets": {}
+		"facets": {},
+		"outputFacets": {}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -76,6 +77,7 @@
 					"description": null
 				}]
 			}
-		}
+		},
+		"outputFacets": {}
 	}]
 }]

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -41,6 +41,26 @@ def test_dbt_parse_small_event(mock_uuid):
 
 
 @mock.patch('uuid.uuid4')
+def test_dbt_parse_catalog_event(mock_uuid):
+    mock_uuid.side_effect = [
+        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
+    ]
+
+    processor = DbtArtifactProcessor(
+        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        'tests/dbt/catalog/dbt_project.yml'
+    )
+    dbt_events = processor.parse()
+    events = [
+        attr.asdict(event, value_serializer=serialize)
+        for event
+        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+    ]
+    with open('tests/dbt/catalog/result.json', 'r') as f:
+        assert events == json.load(f)
+
+
+@mock.patch('uuid.uuid4')
 def test_dbt_parse_large_event(mock_uuid):
     mock_uuid.side_effect = [
         '6edf42ed-d8d0-454a-b819-d09b9067ff99',

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -42,3 +42,5 @@ OpenLineage client depends on environment variables:
 ## Usage
 
 To begin collecting dbt metadata with OpenLineage, replace `dbt run` with `dbt-ol run`.
+
+Additional table and column level metadata will be available if `catalog.json`, result of running `dbt docs generate` will be found in target directory.


### PR DESCRIPTION
If file `catalog.json` is found in target directory, use it to gather column and table-level metadata, like column types and `BigQueryStatisticsDatasetFacet`.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>