### PR TITLE
Add mechanism to enforce spec versioning

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -52,24 +52,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
-def gitBranchName() {
-    def branch = "unknown_branch"
-    def proc = "git rev-parse --abbrev-ref HEAD".execute()
-    proc.in.eachLine { line -> branch = line }
-    proc.err.eachLine { line -> println line }
-    proc.waitFor()
-    branch
-}
-
 task generateCode(type: JavaExec) {
-    description 'generate java code from spec. Use -PgenerateFromLocal to generate from the local file instead of the published version'
+    description 'generate java code from spec.'
     classpath configurations.codeGenerator
     main = 'io.openlineage.client.Generator'
-    if (project.hasProperty('generateFromLocal')) {
-        args "file:$rootDir/../../spec/OpenLineage.json".toString()
-    } else {
-        args "https://raw.githubusercontent.com/OpenLineage/OpenLineage/" + gitBranchName() + "/spec/OpenLineage.json"
-    }
+    args "file:$rootDir/../../spec/OpenLineage.json".toString()
 }
 
 openApiGenerate {

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -57,20 +57,15 @@ public class Generator {
       JsonNode schema = mapper.readValue(input, JsonNode.class);
       if (schema.has("$id") && schema.get("$id").isTextual()) {
         String idURL = schema.get("$id").asText();
-        try {
-          InputStream openStream = new URL(idURL).openStream();
-          JsonNode published;
-          try {
-            published = mapper.readValue(openStream, JsonNode.class);
-          } finally {
-            openStream.close();
-          }
+        try (InputStream openStream = new URL(idURL).openStream();) {
+          JsonNode published = mapper.readValue(openStream, JsonNode.class);
           if (!published.equals(schema)) {
             throw new RuntimeException("You must increment the version when modifying the schema. The current schema at " + baseURL + " has the $id " + idURL + " but the version at that URL does not match.");
           }
-          baseURL = idURL;
         } catch (FileNotFoundException e) {
           logger.warn("This version of the spec is not published yet: " + e.toString());
+        } finally {
+          baseURL = idURL;
         }
       }
       TypeResolver typeResolver = new TypeResolver(schema);

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/0-0-1/OpenLineage.json",
+  "$id": "https://openlineage.io/spec/1-0-0/OpenLineage.json",
   "definitions": {
     "RunEvent": {
       "type": "object",


### PR DESCRIPTION
This modifies the code generator to:
 - always use the local version of the spec
 - issue a warning if the spec is not public at $id
 - verify that the spec matches the one published at $id if available
 - fail the build if the spec does not match to require changing the version.

This will guarantee that we don't reuse published specs.
It also removes the need for the code to be pushed to the repo for the build to work.

Signed-off-by: Julien Le Dem <julien@apache.org>