### PR TITLE
Rename Great Expectation assert property `columnId` -> `column`

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/ge-assertions-dataset-facet.json
+++ b/integration/airflow/openlineage/airflow/extractors/ge-assertions-dataset-facet.json
@@ -17,7 +17,7 @@
                 "properties": {
                   "expectationType": {"type": "string"},
                   "success": {"type":  "bool"},
-                  "columnId": {"type":  "str"}
+                  "column": {"type":  "str"}
                 },
                 "required": ["expectationType", "success"]
               }

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -64,7 +64,7 @@ class ExpectationsParserResult:
 class GreatExpectationsAssertion:
     expectationType: str = attr.ib()
     success: bool = attr.ib()
-    columnId: Optional[str] = attr.ib(default=None)
+    column: Optional[str] = attr.ib(default=None)
 
 
 @attr.s
@@ -211,7 +211,7 @@ class GreatExpectationsExtractorImpl(BaseExtractor):
                 assertions.append(GreatExpectationsAssertion(
                     expectationType=expectation['expectation_config']['expectation_type'],
                     success=expectation['success'],
-                    columnId=expectation['expectation_config']['kwargs'].get('column', None)
+                    column=expectation['expectation_config']['kwargs'].get('column', None)
                 ))
 
             return GreatExpectationsAssertionsDatasetFacet(assertions)

--- a/integration/airflow/tests/extractors/test_great_expectations_extractor.py
+++ b/integration/airflow/tests/extractors/test_great_expectations_extractor.py
@@ -77,42 +77,42 @@ def test_great_expectations_operator_batch_kwargs_success():
             GreatExpectationsAssertion(
                 expectationType='expect_column_values_to_not_be_null',
                 success=True,
-                columnId='vendor_id'
+                column='vendor_id'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_distinct_values_to_be_in_set',
                 success=True,
-                columnId='vendor_id'
+                column='vendor_id'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_unique_value_count_to_be_between',
                 success=True,
-                columnId='vendor_id'
+                column='vendor_id'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_min_to_be_between',
                 success=True,
-                columnId='total_amount'
+                column='total_amount'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_max_to_be_between',
                 success=True,
-                columnId='total_amount'
+                column='total_amount'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_sum_to_be_between',
                 success=True,
-                columnId='total_amount'
+                column='total_amount'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_quantile_values_to_be_between',
                 success=True,
-                columnId='total_amount'
+                column='total_amount'
             ),
             GreatExpectationsAssertion(
                 expectationType='expect_column_distinct_values_to_be_in_set',
                 success=True,
-                columnId='passenger_count'
+                column='passenger_count'
             )
         ]
     )


### PR DESCRIPTION
This PR fixes the property name for the Great Expectation facet used in assertions from `columnId` to `column`. The property name in Great Expectation is `column` and we should keep names the same, see https://github.com/great-expectations/great_expectations/blob/main/great_expectations/core/expectation_configuration.py#L996