### PR TITLE
[2 of 2] Cleanup .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ param_build_tag: &param_build_tag
         type: string
 
 jobs:
-  test-client-python:
+  unit-test-client-python:
     working_directory: ~/openlineage/client/python
     docker:
       - image: circleci/python:3.6
@@ -163,7 +163,7 @@ jobs:
           paths:
             - ~/.gradle
 
-  test-integration-common:
+  unit-test-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
       - image: circleci/python:3.6
@@ -230,7 +230,7 @@ jobs:
           paths:
             - ~/.gradle
 
-  test-integration-airflow:
+  unit-test-integration-airflow:
     working_directory: ~/openlineage/integration/airflow
     docker:
       - image: circleci/python:3.6
@@ -310,23 +310,23 @@ workflows:
           context: release
           requires:
             - integration-test-spark
-      - test-client-python
+      - unit-test-client-python
       - build-client-python:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
-            - test-client-python
-      - test-integration-common
+            - unit-test-client-python
+      - unit-test-integration-common
       - build-integration-common:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
-            - test-integration-common
-      - test-integration-airflow
+            - unit-test-integration-common
+      - unit-test-integration-airflow
       - integration-test-airflow:
           <<: *only_on_main
           requires:
-            - test-integration-airflow
+            - unit-test-integration-airflow
       - build-integration-airflow:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,8 @@ jobs:
           keys:
             - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
             - v1-integration-spark-{{ .Branch }}
+      - attach_workspace:
+          at: .
       - run: ./gradlew --no-daemon --stacktrace build
       - run:
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ install_python_client: &install_python_client
 install_integration_common: &install_integration_common
   run: (cd ~/openlineage/integration/common && pip install . --user)
 
-only_main: &only_main
+only_on_main: &only_on_main
   filters:
     branches:
       only: main
@@ -297,7 +297,7 @@ workflows:
     jobs:
       - build-client-java
       - publish-snapshot-client-java:
-          <<: *only_main
+          <<: *only_on_main
           context: release
           requires:
             - build-client-java
@@ -306,37 +306,37 @@ workflows:
           requires:
             - build-integration-spark
       - publish-snapshot-integration-spark:
-          <<: *only_main
+          <<: *only_on_main
           context: release
           requires:
             - integration-test-spark
       - test-client-python
       - build-client-python:
-          <<: *only_main
+          <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
             - test-client-python
       - test-integration-common
       - build-integration-common:
-          <<: *only_main
+          <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
             - test-integration-common
       - test-integration-airflow
       - integration-test-airflow:
-          <<: *only_main
+          <<: *only_on_main
           requires:
             - test-integration-airflow
       - build-integration-airflow:
-          <<: *only_main
+          <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
             - integration-test-airflow
       - build-integration-dbt:
-          <<: *only_main
+          <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
       - publish-snapshot-python:
-          <<: *only_main
+          <<: *only_on_main
           context: release
           requires:
             - build-client-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,34 @@
 version: 2.1
-orbs:
-  gradle: circleci/gradle@2.2.0
 
 checkout_project_root: &checkout_project_root
   # Override checkout path to project root (see: https://circleci.com/docs/2.0/configuration-reference/#checkout)
   checkout:
     path: ~/openlineage
 
+install_python_client: &install_python_client
+  run: (cd ~/openlineage/client/python && pip install . --user)
 
 install_integration_common: &install_integration_common
   run: (cd ~/openlineage/integration/common && pip install . --user)
 
-
-install_python_client: &install_python_client
-  run: (cd ~/openlineage/client/python && pip install . --user)
+only_main: &only_main
+  filters:
+    branches:
+      only: main
 
 # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
-only-on-release: &only-on-release
+only_on_release: &only_on_release
   filters:
     tags:
       only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
     branches:
       ignore: /.*/
 
-only-on-main-without-release-tag: &only-on-main-without-release-tag
-  filters:
-    tags:
-      ignore: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-    branches:
-      only: main
+param_build_tag: &param_build_tag
+    parameters:
+      build_tag:
+        default: ""
+        type: string
 
 jobs:
   test-client-python:
@@ -58,16 +58,31 @@ jobs:
           paths:
             - ./dist/*.tar.gz
             - ./dist/*.whl
-  build-java-client:
+
+  build-client-java:
     working_directory: ~/openlineage/client/java
     docker:
       - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
-      - run: |
-          ./gradlew --no-daemon --stacktrace build
+      - restore_cache:
+          keys:
+            - v1-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-client-java-{{ .Branch }}
+      - run: ./gradlew --no-daemon --stacktrace build
+      - run: ./gradlew --no-daemon jacocoTestReport
+      - run: bash <(curl -s https://codecov.io/bash)
+      - store_test_results:
+          path: client/java/build/test-results/test
+      - store_artifacts:
+          path: build/reports/tests/test
+          destination: test-report
+      - save_cache:
+          key: v1-client-java-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/.gradle
 
-  release-java-client:
+  release-client-java:
     working_directory: ~/openlineage/client/java
     docker:
       - image: cimg/openjdk:11.0
@@ -81,7 +96,7 @@ jobs:
           # Publish *.jar
           ./gradlew publish
 
-  publish-snapshot-java-client:
+  publish-snapshot-client-java:
     working_directory: ~/openlineage/client/java
     docker:
       - image: cimg/openjdk:11.0
@@ -162,12 +177,9 @@ jobs:
 
   build-integration-common:
     working_directory: ~/openlineage/integration/common
-    parameters:
-      build_tag:
-        default: ""
-        type: string
     docker:
       - image: circleci/python:3.6
+    <<: *param_build_tag
     steps:
       - *checkout_project_root
       - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
@@ -179,12 +191,9 @@ jobs:
 
   build-integration-dbt:
     working_directory: ~/openlineage/integration/dbt
-    parameters:
-      build_tag:
-        default: ""
-        type: string
     docker:
       - image: circleci/python:3.6
+    <<: *param_build_tag
     steps:
       - *checkout_project_root
       - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
@@ -206,8 +215,6 @@ jobs:
           keys:
             - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
             - v1-integration-spark-{{ .Branch }}
-      - attach_workspace:
-          at: .
       - run: ./gradlew --no-daemon --stacktrace integrationTest
       - run:
           when: on_fail
@@ -239,12 +246,9 @@ jobs:
 
   build-integration-airflow:
     working_directory: ~/openlineage/integration/airflow
-    parameters:
-      build_tag:
-        default: ""
-        type: string
     docker:
       - image: circleci/python:3.6
+    <<: *param_build_tag
     steps:
       - *checkout_project_root
       - *install_python_client
@@ -291,71 +295,72 @@ jobs:
 workflows:
   openlineage:
     jobs:
-      - gradle/test:
-          app_src_directory: client/java
-      - test-client-python
-      - test-integration-common
+      - build-client-java
+      - publish-snapshot-client-java:
+          <<: *only_main
+          context: release
+          requires:
+            - build-client-java
       - build-integration-spark
-      - build-java-client
       - integration-test-spark:
           requires:
             - build-integration-spark
-      - test-integration-airflow
-      - integration-test-airflow:
-          requires:
-            - test-integration-airflow
-
-      #publish snapshots
-      - publish-snapshot-java-client:
-          <<: *only-on-main-without-release-tag
-          context: release
-          requires:
-            - build-java-client
       - publish-snapshot-integration-spark:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           context: release
           requires:
             - integration-test-spark
-
+      - test-client-python
       - build-client-python:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
+          requires:
+            - test-client-python
+      - test-integration-common
       - build-integration-common:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
+          requires:
+            - test-integration-common
+      - test-integration-airflow
+      - integration-test-airflow:
+          <<: *only_main
+          requires:
+            - test-integration-airflow
       - build-integration-airflow:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
+          requires:
+            - integration-test-airflow
       - build-integration-dbt:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
       - publish-snapshot-python:
-          <<: *only-on-main-without-release-tag
+          <<: *only_main
           context: release
           requires:
             - build-client-python
             - build-integration-common
             - build-integration-airflow
             - build-integration-dbt
-
   release:
     jobs:
-      - build-client-python:
-          <<: *only-on-release
-      - build-integration-common:
-          <<: *only-on-release
-      - build-integration-airflow:
-          <<: *only-on-release
-      - build-integration-dbt:
-          <<: *only-on-release
-      - release-java-client:
-          <<: *only-on-release
+      - release-client-java:
+          <<: *only_on_release
           context: release
       - release-integration-spark:
-          <<: *only-on-release
+          <<: *only_on_release
           context: release
+      - build-client-python:
+          <<: *only_on_release
+      - build-integration-common:
+          <<: *only_on_release
+      - build-integration-airflow:
+          <<: *only_on_release
+      - build-integration-dbt:
+          <<: *only_on_release
       - release-python:
-          <<: *only-on-release
+          <<: *only_on_release
           context: release
           requires:
             - build-client-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         type: string
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -182,7 +182,7 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -196,7 +196,7 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -253,7 +253,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  integration-test-spark:
+  integration-test-integration-spark:
     working_directory: ~/openlineage/integration/spark
     machine: true
     environment:
@@ -262,7 +262,7 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  integration-test-airflow:
+  integration-test-integration-airflow:
     working_directory: ~/openlineage/integration/
     machine: true
     steps:
@@ -304,14 +304,14 @@ workflows:
           requires:
             - build-client-java
       - build-integration-spark
-      - integration-test-spark:
+      - integration-test-integration-spark:
           requires:
             - build-integration-spark
       - publish-snapshot-integration-spark:
           <<: *only_on_main
           context: release
           requires:
-            - integration-test-spark
+            - integration-test-integration-spark
       - unit-test-client-python
       - build-client-python:
           <<: *only_on_main
@@ -325,7 +325,7 @@ workflows:
           requires:
             - unit-test-integration-common
       - unit-test-integration-airflow
-      - integration-test-airflow:
+      - integration-test-integration-airflow:
           <<: *only_on_main
           requires:
             - unit-test-integration-airflow
@@ -333,7 +333,7 @@ workflows:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}
           requires:
-            - integration-test-airflow
+            - integration-test-integration-airflow
       - build-integration-dbt:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -15,6 +15,7 @@
 import org.apache.tools.ant.filters.*
 
 plugins {
+    id 'jacoco'
     id 'java'
     id 'java-library'
     id 'maven-publish'
@@ -149,5 +150,21 @@ jar {
                 'Implementation-Title': project.name,
                 'Implementation-Version': project.version
         )
+    }
+}
+
+def reportsDir = "${buildDir}/reports";
+def coverageDir = "${reportsDir}/coverage";
+
+jacoco {
+    toolVersion = '0.8.5'
+    reportsDir = file(coverageDir)
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+        html.destination = file(coverageDir)
     }
 }


### PR DESCRIPTION
This PR cleans up the `.circleci/config.yml` with the following changes:

* Standardize CI job names
* Add caching and test report to CI job `build-client-java`
* Remove the filter `only-on-main-without-release-tag` (it's not needed and we can filter only on `main`)
* Slight reorder of CI jobs to keep related jobs close and group them by context
* Removed `circleci/gradle@2.2.0`, it's not needed and already handled by `build-client-java`
* Add missing dependencies between CI jobs
* Prefix unit test CI jobs with `unit-`