### PR TITLE
[1 of 2] Fix python sdist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         type: string
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -182,7 +182,7 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -196,7 +196,7 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -253,7 +253,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
-      - run: python setup.py egg_info -b << parameters.build_tag >> sdist bdist_wheel
+      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
This PR wraps the param `<< parameters.build_tag >>` in quotes (`""`) to fix the resulting python version. Without the quotes, `sdist` gets appended to the version:

```
'0.1.0rc4sdist' is an invalid value for Version. Error: Start and end with a letter or numeral containing only ASCII numeric and '.', '_' and '-'.
```

see failing CI job, https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/507/workflows/0433a888-2650-48b5-8e68-2ea26d41b99e/jobs/2716