### PR TITLE
[INTEGRATION] [dbt] strip model from job name, provide job namespace by env variable

### DIFF
--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -6,8 +6,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_test.test_model",
+		"namespace": "test-namespace",
+		"name": "dbt_test.test_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -30,8 +30,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_test.test_model",
+		"namespace": "test-namespace",
+		"name": "dbt_test.test_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -6,8 +6,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_second_parallel_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -30,8 +30,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_first_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_first_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -50,8 +50,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_second_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_second_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -74,8 +74,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_first_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_first_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -116,8 +116,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_second_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_second_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -178,8 +178,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_bigquery_test.test_second_parallel_dbt_model",
+		"namespace": "test-namespace",
+		"name": "dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -6,8 +6,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_orders",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_orders",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -26,8 +26,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_payments",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_payments",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -46,8 +46,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_customers",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_customers",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -66,8 +66,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.orders",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.orders",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -94,8 +94,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.customers",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.customers",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -126,8 +126,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_orders",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_orders",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -172,8 +172,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_payments",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_payments",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -218,8 +218,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.stg_customers",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.stg_customers",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -260,8 +260,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.orders",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.orders",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -382,8 +382,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "model.jaffle_shop.customers",
+		"namespace": "test-namespace",
+		"name": "jaffle_shop.customers",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -6,8 +6,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_test.test_model",
+		"namespace": "test-namespace",
+		"name": "dbt_test.test_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -30,8 +30,8 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
-		"name": "model.dbt_test.test_model",
+		"namespace": "test-namespace",
+		"name": "dbt_test.test_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import attr
 import pytest
+import os
 
 from openlineage.common.provider.dbt import DbtArtifactProcessor
 from openlineage.client import set_producer
@@ -12,6 +13,7 @@ from openlineage.client import set_producer
 @pytest.fixture(scope='session', autouse=True)
 def setup_producer():
     set_producer('https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt')
+    os.environ['OPENLINEAGE_NAMESPACE'] = 'test-namespace'
 
 
 def serialize(inst, field, value):

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -37,6 +37,7 @@ OpenLineage client depends on environment variables:
 
 * `OPENLINEAGE_URL` - point to service which will consume OpenLineage events
 * `OPENLINEAGE_API_KEY` - set if consumer of OpenLineage events requires `Bearer` authentication key
+* `OPENLINEAGE_NAMESPACE` - set if you are using something other than the `default` namespace for job namespace.
 
 
 ## Usage

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -23,7 +23,7 @@ def main():
         return
 
     client = OpenLineageClient.from_environment()
-    processor = DbtArtifactProcessor(PRODUCER)
+    processor = DbtArtifactProcessor(producer=PRODUCER)
     events = processor.parse().events()
 
     for event in events:


### PR DESCRIPTION
This PR strips `model.` from job names, since it's unnecessary - they are all prefixed by this.
Also, this PR provides possibility to override default job namespace by providing `OPENLINEAGE_NAMESPACE` env variable.

https://github.com/OpenLineage/OpenLineage/issues/193
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>