### PR TITLE
[INTEGRATION] [dbt] parse dbt command line arguments that override defaults

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -181,16 +181,20 @@ class DbtArtifactProcessor:
                         get_from_nullable_chain(catalog, ['sources', node])
                     ))
 
+            output_node = nodes[run['unique_id']]
+
             runs.append(DbtRun(
                 started_at,
                 completed_at,
                 run['status'],
                 inputs,
                 ModelNode(
-                    nodes[run['unique_id']],
+                    output_node,
                     get_from_nullable_chain(catalog, ['nodes', run['unique_id']])
                 ),
-                self.removeprefix(run['unique_id'], 'model.'),
+                f"{output_node['database']}."
+                f"{output_node['schema']}."
+                f"{self.removeprefix(run['unique_id'], 'model.')}",
                 self.dataset_namespace
             ))
         return runs

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -49,15 +49,24 @@ class DbtRunResult:
 
 
 class DbtArtifactProcessor:
-    def __init__(self, producer: str, project: str = 'dbt_project.yml', skip_errors: bool = False):
+    def __init__(
+        self,
+        producer: str,
+        project_dir: Optional[str] = None,
+        profile_name: Optional[str] = None,
+        target: Optional[str] = None,
+        skip_errors: bool = False
+    ):
         self.producer = producer
-        self.dir = os.path.abspath(os.path.dirname(project))
-        self.project = self.load_yaml(project)
+        self.dir = os.path.abspath(project_dir)
+        self.profile_name = profile_name
+        self.target = target
+        self.project = self.load_yaml(os.path.join(project_dir, 'dbt_project.yml'))
         self.job_namespace = self.extract_job_namespace()
         self.dataset_namespace = ""
         self.skip_errors = skip_errors
 
-    def parse(self, target: Optional[str] = None) -> DbtEvents:
+    def parse(self) -> DbtEvents:
         """
             Parse dbt manifest and run_result and produce OpenLineage events.
         """
@@ -73,14 +82,17 @@ class DbtArtifactProcessor:
 
         profile_dir = run_result['args']['profiles_dir']
 
+        if not self.profile_name:
+            self.profile_name = self.project['profile']
+
         profile = self.load_yaml(
             os.path.join(profile_dir, 'profiles.yml')
-        )[self.project['profile']]
+        )[self.profile_name]
 
-        if target:
-            profile = profile['outputs'][target]
-        else:
-            profile = profile['outputs'][profile['target']]
+        if not self.target:
+            self.target = profile['target']
+
+        profile = profile['outputs'][self.target]
 
         self.extract_namespace(profile)
 

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -50,3 +50,17 @@ def get_from_multiple_chains(source: Dict[str, Any], chains: List[List[str]]) ->
         if result:
             return result
     return None
+
+
+def parse_single_arg(args, keys: List[str]) -> Optional[str]:
+    """
+    In provided argument list, find first key that has value and return that value.
+    Values can be passed either as one argument {key}={value}, or two: {key} {value}
+    """
+    for key in keys:
+        for i, arg in enumerate(args):
+            if arg == key and len(args) > i:
+                return args[i+1]
+            if arg.startswith(f"{key}="):
+                return arg.split("=", 1)[1]
+    return None

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -7,7 +7,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_second_parallel_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -31,7 +31,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_first_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -51,7 +51,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_second_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -75,7 +75,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_first_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -117,7 +117,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_second_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -179,7 +179,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_bigquery_test.test_second_parallel_dbt_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -7,7 +7,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_orders",
+		"name": "DEMO_DB.public.jaffle_shop.stg_orders",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -27,7 +27,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_payments",
+		"name": "DEMO_DB.public.jaffle_shop.stg_payments",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -47,7 +47,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_customers",
+		"name": "DEMO_DB.public.jaffle_shop.stg_customers",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -67,7 +67,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.orders",
+		"name": "DEMO_DB.public.jaffle_shop.orders",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -95,7 +95,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.customers",
+		"name": "DEMO_DB.public.jaffle_shop.customers",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -127,7 +127,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_orders",
+		"name": "DEMO_DB.public.jaffle_shop.stg_orders",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -173,7 +173,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_payments",
+		"name": "DEMO_DB.public.jaffle_shop.stg_payments",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -219,7 +219,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.stg_customers",
+		"name": "DEMO_DB.public.jaffle_shop.stg_customers",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -261,7 +261,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.orders",
+		"name": "DEMO_DB.public.jaffle_shop.orders",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -383,7 +383,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "jaffle_shop.customers",
+		"name": "DEMO_DB.public.jaffle_shop.customers",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/profiles/dbt_project.yml
+++ b/integration/common/tests/dbt/profiles/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/profiles/profiles.yml
+++ b/integration/common/tests/dbt/profiles/profiles.yml
@@ -1,0 +1,23 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: speedy-vim-308516
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive
+        prod:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: speedy-vim-308516
+            dataset: dbt_prod1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/profiles/result.json
+++ b/integration/common/tests/dbt/profiles/result.json
@@ -7,18 +7,18 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "speedy-vim-308516.dbt_test1.dbt_test.test_model",
+		"name": "speedy-vim-308516.dbt_prod1.dbt_test.test_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"name": "speedy-vim-308516.dbt_prod1.source_table",
 		"facets": {}
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"name": "speedy-vim-308516.dbt_prod1.test_model",
 		"facets": {},
 		"outputFacets": {}
 	}]
@@ -31,19 +31,19 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "speedy-vim-308516.dbt_test1.dbt_test.test_model",
+		"name": "speedy-vim-308516.dbt_prod1.dbt_test.test_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
-				"query": "select *\nfrom `speedy-vim-308516`.`dbt_test1`.`source_table`\nwhere id = 1"
+				"query": "select *\nfrom `speedy-vim-308516`.`dbt_prod1`.`source_table`\nwhere id = 1"
 			}
 		}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "speedy-vim-308516.dbt_test1.source_table",
+		"name": "speedy-vim-308516.dbt_prod1.source_table",
 		"facets": {
 			"dataSource": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -54,17 +54,13 @@
 			"schema": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
-				"fields": [{
-					"name": "id",
-					"type": "INT64",
-					"description": null
-				}]
+				"fields": []
 			}
 		}
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "speedy-vim-308516.dbt_test1.test_model",
+		"name": "speedy-vim-308516.dbt_prod1.test_model",
 		"facets": {
 			"dataSource": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -77,18 +73,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
-					"type": "INT64",
+					"type": null,
 					"description": null
 				}]
 			}
 		},
-		"outputFacets": {
-			"outputStatistics": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
-				"rowCount": 1,
-				"size": 16
-			}
-		}
+		"outputFacets": {}
 	}]
 }]

--- a/integration/common/tests/dbt/profiles/target/manifest.json
+++ b/integration/common/tests/dbt/profiles/target/manifest.json
@@ -1,0 +1,147 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:44.367050Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {},
+		"project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.dbt_test.test_model": {
+			"raw_sql": "select *\nfrom {{ source('dbt_prod1', 'source_table') }}\nwhere id = 1",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["source.dbt_test.dbt_prod1.source_table"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "speedy-vim-308516",
+			"schema": "dbt_prod1",
+			"fqn": ["dbt_test", "example", "test_model"],
+			"unique_id": "model.dbt_test.test_model",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "example/test_second_parallel_dbt_model.sql",
+			"original_file_path": "models/example/test_model.sql",
+			"name": "test_model",
+			"alias": "test_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "318f640067e471c6a2e8d370039786939aaf4197c4be4ee64677e59f1f1a9a34"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [
+				["dbt_prod1", "source_table"]
+			],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "dbt_test://models/example/schema.yml",
+			"compiled_path": "target/compiled/dbt_test/models/example/test_model.sql",
+			"build_path": "target/run/dbt_test/models/example/test_model.sql",
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625661884,
+			"compiled_sql": "select *\nfrom `speedy-vim-308516`.`dbt_prod1`.`source_table`\nwhere id = 1",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`speedy-vim-308516`.`dbt_prod1`.`test_model`"
+		}
+	},
+  	"sources": {
+		"source.dbt_test.dbt_prod1.source_table": {
+			"fqn": ["dbt_test", "example", "dbt_prod1", "source_table"],
+			"database": "speedy-vim-308516",
+			"schema": "dbt_prod1",
+			"unique_id": "source.dbt_test.dbt_prod1.source_table",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "models/example/schema.yml",
+			"original_file_path": "models/example/schema.yml",
+			"name": "source_table",
+			"source_name": "dbt_prod1",
+			"source_description": "",
+			"loader": "",
+			"identifier": "source_table",
+			"resource_type": "source",
+			"quoting": {
+				"database": null,
+				"schema": null,
+				"identifier": null,
+				"column": null
+			},
+			"loaded_at_field": null,
+			"freshness": {
+				"warn_after": null,
+				"error_after": null,
+				"filter": null
+			},
+			"external": null,
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"source_meta": {},
+			"tags": [],
+			"config": {
+				"enabled": true
+			},
+			"patch_path": null,
+			"unrendered_config": {},
+			"relation_name": "`speedy-vim-308516`.`dbt_prod1`.`source_table`",
+			"created_at": 1625661884
+		}
+	},
+	"macros": {},
+	"docs": {
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.dbt_test.test_model": ["source.dbt_test.dbt_prod1.source_table"]
+	},
+	"child_map": {
+		"model.dbt_test.test_model": []
+	}
+}

--- a/integration/common/tests/dbt/profiles/target/run_results.json
+++ b/integration/common/tests/dbt/profiles/target/run_results.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
+		"dbt_version": "0.20.0rc2",
+		"generated_at": "2021-07-07T12:44:51.891863Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-07T12:44:46.053875Z",
+			"completed_at": "2021-07-07T12:44:46.063996Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-07T12:44:46.069306Z",
+			"completed_at": "2021-07-07T12:44:46.972743Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 0.9195568561553955,
+		"adapter_response": {
+			"_message": "OK",
+			"code": "CREATE VIEW"
+		},
+		"message": "OK",
+		"failures": null,
+		"unique_id": "model.dbt_test.test_model"
+	}],
+	"elapsed_time": 7.067806243896484,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/profiles",
+		"use_cache": true,
+		"version_check": true,
+		"which": "run",
+		"rpc_method": "run"
+	}
+}

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -7,7 +7,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_test.test_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_test.test_model",
 		"facets": {}
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -31,7 +31,7 @@
 	},
 	"job": {
 		"namespace": "test-namespace",
-		"name": "dbt_test.test_model",
+		"name": "speedy-vim-308516.dbt_test1.dbt_test.test_model",
 		"facets": {
 			"sql": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -29,8 +29,8 @@ def test_dbt_parse_small_event(mock_uuid):
     ]
 
     processor = DbtArtifactProcessor(
-        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        'tests/dbt/small/dbt_project.yml'
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/small'
     )
     dbt_events = processor.parse()
     events = [
@@ -49,8 +49,8 @@ def test_dbt_parse_catalog_event(mock_uuid):
     ]
 
     processor = DbtArtifactProcessor(
-        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        'tests/dbt/catalog/dbt_project.yml'
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/catalog'
     )
     dbt_events = processor.parse()
     events = [
@@ -73,8 +73,8 @@ def test_dbt_parse_large_event(mock_uuid):
     ]
 
     processor = DbtArtifactProcessor(
-        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        'tests/dbt/large/dbt_project.yml'
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/large'
     )
     dbt_events = processor.parse()
     events = [
@@ -99,8 +99,8 @@ def test_dbt_parse_failed_event(mock_datetime, mock_uuid):
     ]
 
     processor = DbtArtifactProcessor(
-        'https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        'tests/dbt/fail/dbt_project.yml'
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/fail'
     )
     dbt_events = processor.parse()
     events = [

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -43,6 +43,27 @@ def test_dbt_parse_small_event(mock_uuid):
 
 
 @mock.patch('uuid.uuid4')
+def test_dbt_parse_event_with_profiles(mock_uuid):
+    mock_uuid.side_effect = [
+        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
+    ]
+
+    processor = DbtArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/profiles',
+        target='prod'
+    )
+    dbt_events = processor.parse()
+    events = [
+        attr.asdict(event, value_serializer=serialize)
+        for event
+        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+    ]
+    with open('tests/dbt/profiles/result.json', 'r') as f:
+        assert events == json.load(f)
+
+
+@mock.patch('uuid.uuid4')
 def test_dbt_parse_catalog_event(mock_uuid):
     mock_uuid.side_effect = [
         '6edf42ed-d8d0-454a-b819-d09b9067ff99',

--- a/integration/common/tests/test_utils.py
+++ b/integration/common/tests/test_utils.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from openlineage.common.utils import get_from_nullable_chain
+from openlineage.common.utils import get_from_nullable_chain, parse_single_arg
 
 
 def test_nullable_chain_fails():
@@ -24,3 +24,22 @@ def test_nullable_chain_works():
 
     x = {"first": {"second": {"third": 42, "fourth": {"empty": 56}}}}
     assert get_from_nullable_chain(x, ['first', 'second', 'third']) == 42
+
+
+def test_parse_single_arg_does_not_exist():
+    assert parse_single_arg(['dbt', 'run'], ['-t', '--target']) is None
+    assert parse_single_arg(['python', 'main.py', '--random_arg', 'yes'], ['--what']) is None
+
+
+def test_parse_single_arg_next():
+    assert parse_single_arg(['dbt', 'run', '--target', 'prod'], ['-t', '--target']) == 'prod'
+    assert parse_single_arg(['python', '--random=yes', '--what', 'asdf'], ['--what']) == 'asdf'
+
+
+def test_parse_single_arg_equals():
+    assert parse_single_arg(['dbt', 'run', '--target=prod'], ['-t', '--target']) == 'prod'
+    assert parse_single_arg(['python', '--random=yes', '--what=asdf'], ['--what']) == 'asdf'
+
+
+def test_parse_single_arg_gets_first_key():
+    assert parse_single_arg(['dbt', 'run', '--target=prod', '-t=a'], ['-t', '--target']) == 'a'

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -7,6 +7,8 @@ from openlineage.client.client import OpenLineageClient
 
 __version__ = "0.1.0"
 
+from openlineage.common.utils import parse_single_arg
+
 PRODUCER = f'https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integration/dbt'
 
 
@@ -22,8 +24,18 @@ def main():
     if len(sys.argv) < 2 or sys.argv[1] != 'run':
         return
 
+    args = sys.argv[2:]
+    target = parse_single_arg(args, ['-t', '--target'])
+    project_dir = parse_single_arg(args, ['--project-dir'])
+    profile_name = parse_single_arg(args, ['--profile'])
+
     client = OpenLineageClient.from_environment()
-    processor = DbtArtifactProcessor(producer=PRODUCER)
+    processor = DbtArtifactProcessor(
+        producer=PRODUCER,
+        target=target,
+        project_dir=project_dir,
+        profile_name=profile_name
+    )
     events = processor.parse().events()
 
     for event in events:


### PR DESCRIPTION
dbt run has few command line arguments that change location of artifacts, like `--project-dir` or ones that override defaults, like `--profile`. This PR adds support for few of them that can affect lineage event generation. 

Solves issue 2) in https://github.com/OpenLineage/OpenLineage/issues/193
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>