### PR TITLE
DON'T MERGE! Spark integration test for version 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
       - run: ./gradlew --no-daemon --stacktrace integrationTest -Pspark.version=<<parameters.spark_version>>
       - run:
           when: on_fail
-          command: cat integration/spark/build/test-results/integrationTests<<parameters.spark_version>>/TEST-*.xml
+          command: cat integration/spark/build/test-results/integrationTest/TEST-*.xml
       - run: ./gradlew --no-daemon jacocoTestReport
       - store_test_results:
           path: integration/spark/build/test-results/integrationTests<<parameters.spark_version>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,33 @@ param_build_tag: &param_build_tag
         default: ""
         type: string
 
+commands:
+  integration-test-integration-spark-command:
+    parameters:
+      spark_version:
+        type: string
+        default: "2.4.1"
+    steps:
+      - *checkout_project_root
+      - restore_cache:
+          keys:
+            - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+            - v1-integration-spark-{{ .Branch }}
+      - run: ./gradlew --no-daemon --stacktrace integrationTest -Pspark.version=<<parameters.spark_version>>
+      - run:
+          when: on_fail
+          command: cat integration/spark/build/test-results/integrationTests/TEST-*.xml
+      - run: ./gradlew --no-daemon jacocoTestReport
+      - store_test_results:
+          path: integration/spark/build/test-results/integrationTests
+      - store_artifacts:
+          path: integration/spark/build/reports/tests/integrationTests
+          destination: test-report
+      - save_cache:
+          key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/.gradle
+
 jobs:
   unit-test-client-python:
     working_directory: ~/openlineage/client/python
@@ -212,25 +239,17 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: "true"
       JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     steps:
-      - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
-            - v1-integration-spark-{{ .Branch }}
-      - run: ./gradlew --no-daemon --stacktrace integrationTest
-      - run:
-          when: on_fail
-          command: cat integration/spark/build/test-results/integrationTests/TEST-*.xml
-      - run: ./gradlew --no-daemon jacocoTestReport
-      - store_test_results:
-          path: integration/spark/build/test-results/integrationTests
-      - store_artifacts:
-          path: integration/spark/build/reports/tests/integrationTests
-          destination: test-report
-      - save_cache:
-          key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - ~/.gradle
+      - integration-test-integration-spark-command
+
+  integration-test-integration-spark-v-3:
+    working_directory: ~/openlineage/integration/spark
+    machine: true
+    environment:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    steps:
+      - integration-test-integration-spark-command:
+          spark_version: '3.1'
 
   unit-test-integration-airflow:
     working_directory: ~/openlineage/integration/airflow
@@ -307,6 +326,9 @@ workflows:
       - integration-test-integration-spark:
           requires:
             - build-integration-spark
+      - integration-test-integration-spark-v-3:
+          requires:
+            - integration-test-integration-spark
       - publish-snapshot-integration-spark:
           <<: *only_on_main
           context: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,12 @@ commands:
       - run: ./gradlew --no-daemon --stacktrace integrationTest -Pspark.version=<<parameters.spark_version>>
       - run:
           when: on_fail
-          command: cat integration/spark/build/test-results/integrationTests/TEST-*.xml
+          command: cat integration/spark/build/test-results/integrationTests<<parameters.spark_version>>/TEST-*.xml
       - run: ./gradlew --no-daemon jacocoTestReport
       - store_test_results:
-          path: integration/spark/build/test-results/integrationTests
+          path: integration/spark/build/test-results/integrationTests<<parameters.spark_version>>
       - store_artifacts:
-          path: integration/spark/build/reports/tests/integrationTests
+          path: integration/spark/build/reports/tests/integrationTests<<parameters.spark_version>>
           destination: test-report
       - save_cache:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
@@ -328,7 +328,7 @@ workflows:
             - build-integration-spark
       - integration-test-integration-spark-v-3:
           requires:
-            - integration-test-integration-spark
+            - build-integration-spark
       - publish-snapshot-integration-spark:
           <<: *only_on_main
           context: release


### PR DESCRIPTION
DO NOT MERGE!
PR for [issue](https://github.com/OpenLineage/OpenLineage/issues/128)
We can run integration tests (mark with 'integration-test' tag) just specifying a spark version passing to gradle task.
It will reduce code duplication like [here](https://github.com/OpenLineage/OpenLineage/pull/215) 
Open question are SparkReadWriteIntegTest and LibraryTest tests are it IT test or unit test.

I was trying to use scala 2.12 at runtime for test, but it's cause different exceptions.
For example in SparkReadWriteIntegTest we have specified  StringType$.MODULE$ (compile 2.11) as type, and when we create a dataset (2.12 runtime) it can't match structType to provided rows and falling with wrapped NullPointerException
`org.apache.spark.sql.execution.analysis.DetectAmbiguousSelfJoin$.org$apache$spark$sql$execution$analysis$DetectAmbiguousSelfJoin$$isColumnReference(DetectAmbiguousSelfJoin.scala:47)`

LibraryTest failing with 
` java.lang.NoClassDefFoundError: Could not initialize class org.apache.spark.rdd.RDDOperationScope$`
LogicalRelationVisitorTest failing with
`java.lang.NoSuchMethodError: org.apache.spark.sql.execution.datasources.LogicalRelation.simpleString()Ljava/lang/String;
`

Second try was to compile tests only with scala 2.12, but it cause issues at compile time.

Approach with dependencies was like bellow:

```
if (project.getProperty('spark.version').startsWith('3')) {
        testRuntimeOnly "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
        testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.21.1'
        testRuntimeOnly "org.apache.spark:spark-core_2.12:${spark3Version}"
        testRuntimeOnly "org.apache.spark:spark-sql_2.12:${spark3Version}"
    } else {
        implementation "com.fasterxml.jackson.module:jackson-module-scala_2.11:${jacksonVersion}"
        testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.21.1'
        testRuntimeOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
        testRuntimeOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
    }
```


