### PR TITLE
Remove instance references to extractors from DAG and avoid copying log property for serializability

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -42,6 +42,7 @@ class OpenLineageAdapter:
             marquez_url = os.getenv('MARQUEZ_URL')
             marquez_api_key = os.getenv('MARQUEZ_API_KEY')
             if marquez_url:
+                log.info(f"Sending lineage events to {marquez_url}")
                 self._client = OpenLineageClient(marquez_url, OpenLineageClientOptions(
                     api_key=marquez_api_key
                 ))

--- a/integration/airflow/tests/integration/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/airflow/config/log_config.py
@@ -73,10 +73,9 @@ LOGGING_CONFIG = {
             'stream': 'sys.stdout'
         },
         'task': {
-            'class': 'airflow.utils.log.file_task_handler.FileTaskHandler',
-            'formatter': 'airflow',
-            'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
-            'filename_template': FILENAME_TEMPLATE,
+            'class': 'airflow.utils.log.logging_mixin.RedirectStdHandler',
+            'formatter': 'airflow_coloured',
+            'stream': 'sys.stdout'
         },
         'processor': {
             'class': 'airflow.utils.log.file_processor_handler.FileProcessorHandler',
@@ -86,6 +85,11 @@ LOGGING_CONFIG = {
         }
     },
     'loggers': {
+        'openlineage.airflow': {
+            'handler': ['console'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
         'airflow.processor': {
             'handlers': ['processor'],
             'level': LOG_LEVEL,

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -16,6 +16,7 @@ import uuid
 from uuid import UUID
 
 import mock
+import openlineage.airflow.dag
 import pytest
 from airflow.models import (TaskInstance, DagRun)
 from airflow.operators.dummy_operator import DummyOperator
@@ -37,7 +38,6 @@ from openlineage.airflow import __version__ as OPENLINEAGE_AIRFLOW_VERSION
 from openlineage.airflow.extractors import (
     BaseExtractor, StepMetadata
 )
-from openlineage.airflow.extractors.extractors import Extractors
 from openlineage.airflow.facets import AirflowRunArgsRunFacet, \
     AirflowVersionRunFacet
 from openlineage.airflow.utils import get_location, get_job_name, new_lineage_run_id
@@ -380,16 +380,15 @@ def test_openlineage_dag_with_extractor(
     # --- test setup
 
     # Add the dummy extractor to the list for the task above
-    extractor_mapper = Extractors()
-    extractor_mapper.extractors[TestFixtureDummyOperator] = TestFixtureDummyExtractor
+    openlineage.airflow.dag.extractor_mapper.extractors[TestFixtureDummyOperator] = \
+        TestFixtureDummyExtractor
 
     dag_id = 'test_openlineage_dag_with_extractor'
     dag = DAG(
         dag_id,
         schedule_interval='@daily',
         default_args=DAG_DEFAULT_ARGS,
-        description=DAG_DESCRIPTION,
-        extractor_mapper=extractor_mapper
+        description=DAG_DESCRIPTION
     )
 
     dag_run_id = 'test_openlineage_dag_with_extractor_run_id'
@@ -504,16 +503,16 @@ def test_openlineage_dag_with_extract_on_complete(
     # --- test setup
 
     # Add the dummy extractor to the list for the task above
-    extractor_mapper = Extractors()
-    extractor_mapper.extractors[TestFixtureDummyOperator] = TestFixtureDummyExtractorOnComplete
+    openlineage.airflow.dag.extractors.clear()
+    openlineage.airflow.dag.extractor_mapper.extractors[TestFixtureDummyOperator] = \
+        TestFixtureDummyExtractorOnComplete
 
     dag_id = 'test_openlineage_dag_with_extractor_on_complete'
     dag = DAG(
         dag_id,
         schedule_interval='@daily',
         default_args=DAG_DEFAULT_ARGS,
-        description=DAG_DESCRIPTION,
-        extractor_mapper=extractor_mapper
+        description=DAG_DESCRIPTION
     )
 
     dag_run_id = 'test_openlineage_dag_with_extractor_run_id'
@@ -667,8 +666,8 @@ def test_openlineage_dag_with_extractor_returning_two_steps(
     # --- test setup
 
     # Add the dummy extractor to the list for the task above
-    extractor_mapper = Extractors()
-    extractor_mapper.extractors[TestFixtureDummyOperator] = \
+    openlineage.airflow.dag.extractors.clear()
+    openlineage.airflow.dag.extractor_mapper.extractors[TestFixtureDummyOperator] = \
         TestFixtureDummyExtractorWithMultipleSteps
 
     dag_id = 'test_openlineage_dag_with_extractor_returning_two_steps'
@@ -676,8 +675,7 @@ def test_openlineage_dag_with_extractor_returning_two_steps(
         dag_id,
         schedule_interval='@daily',
         default_args=DAG_DEFAULT_ARGS,
-        description=DAG_DESCRIPTION,
-        extractor_mapper=extractor_mapper
+        description=DAG_DESCRIPTION
     )
 
     dag_run_id = 'test_openlineage_dag_with_extractor_returning_two_steps_run_id'
@@ -776,6 +774,8 @@ def test_openlineage_dag_adds_custom_facets(
         new_lineage_run_id,
         clear_db_airflow_dags,
 ):
+    openlineage.airflow.dag.extractors.clear()
+    openlineage.airflow.dag.extractor_mapper.extractors.pop(TestFixtureDummyOperator, None)
 
     dag = DAG(
         DAG_ID,
@@ -907,16 +907,16 @@ def test_openlineage_dag_with_hooking_operator(
     # --- test setup
 
     # Add the dummy extractor to the list for the task above
-    extractor_mapper = Extractors()
-    extractor_mapper.extractors[TestFixtureHookingDummyOperator] = TestFixtureHookingDummyExtractor
+    openlineage.airflow.dag.extractors.clear()
+    openlineage.airflow.dag.extractor_mapper.extractors[TestFixtureHookingDummyOperator] = \
+        TestFixtureHookingDummyExtractor
 
     dag_id = 'test_openlineage_dag_with_extractor_returning_two_steps'
     dag = DAG(
         dag_id,
         schedule_interval='@daily',
         default_args=DAG_DEFAULT_ARGS,
-        description=DAG_DESCRIPTION,
-        extractor_mapper=extractor_mapper
+        description=DAG_DESCRIPTION
     )
 
     dag_run_id = 'test_openlineage_dag_with_extractor_returning_two_steps_run_id'


### PR DESCRIPTION
This addresses the issue outlined in https://github.com/OpenLineage/OpenLineage/issues/218 . I moved the Extractors map from an instance variable to a static one outside the DAG instance- this seemed reasonable, as the extractors themselves aren't stateful and don't need to be reinstantiated for each instance of the DAG. Removing them from the DAG's properties means we don't have to worry about an Extractor holding a property that can't be serialized with the DAG.

The other issue I identified with the `_log` property of the `LoggingMixin`. The logger itself isn't serializable. The parent class already inherits the `LoggingMixin`, so there's no need for us to also mixin that property. The parent class doesn't have a problem being serialized because the logger is instantiated lazily and the parent DAG doesn't make a call to the logger until after the DAG has been serialized when clearing a task in the UI. However, the OpenLineage DAG executes a log statement immediately in the constructor. I overrode the `__deepcopy__` method to skip the `_log` property when serializing.

Between these two changes, I was able to restore the Clear functionality in the Airflow UI

As a separate change, I included some logging statements for debugging purposes. This included writing OpenLineage log lines to stdout in the integration tests at DEBUG level.