### PR TITLE
[PROPOSAL] add expectations assertions facet

### DIFF
--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -317,6 +317,8 @@ public class JavaPoetGenerator {
           return ClassName.get(Long.class);
         } else if (primitiveType.getName().equals("number")) {
           return ClassName.get(Double.class);
+        } else if (primitiveType.getName().equals("boolean")) {
+          return ClassName.get(Boolean.class);
         } else if (primitiveType.getName().equals("string")) {
           if (primitiveType.getFormat() != null) {
             String format = primitiveType.getFormat();

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -167,3 +167,22 @@ class DataQualityMetricsInputDatasetFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return SCHEMA_URI + "#/definitions/DataQualityMetricsInputDatasetFacet"
+
+
+@attr.s
+class Assertion:
+    assertion: str = attr.ib()
+    success: bool = attr.ib()
+    column: Optional[str] = attr.ib(default=None)
+
+
+@attr.s
+class DataQualityAssertionsDatasetFacet(BaseFacet):
+    """
+    This facet represents of asserted expectations on dataset or it's column
+    """
+    assertions: List[Assertion] = attr.ib()
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "#/definitions/DataQualityAssertionsDatasetFacet"  # noqa

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/1-0-0/OpenLineage.json",
+  "$id": "https://openlineage.io/spec/1-0-1/OpenLineage.json",
   "definitions": {
     "RunEvent": {
       "type": "object",
@@ -142,6 +142,9 @@
               "properties": {
                 "dataQualityMetrics" : {
                   "$ref": "#/definitions/DataQualityMetricsInputDatasetFacet"
+                },
+                "dataQualityAssertions": {
+                  "$ref": "#/definitions/DataQualityAssertionsDatasetFacet"
                 }
               },
               "additionalProperties": {
@@ -442,6 +445,41 @@
           ]
         }
       ]
+    },
+    "DataQualityAssertionsDatasetFacet": {
+      "description": "list of tests performed on dataset or dataset columns, and their results",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "required": ["assertions"],
+          "properties": {
+            "assertions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "assertion": {
+                    "type": "string",
+                    "description": "Type of expectation test that dataset is subjected to",
+                    "example":  "not_null"
+                  },
+                  "success": {"type":  "boolean"},
+                  "column": {
+                    "type":  "string",
+                    "description": "Column that expectation is testing. It should match the name provided in SchemaDatasetFacet. If column field is empty, then expectation refers to whole dataset.",
+                    "example":  "id"
+                  }
+                },
+                "required": ["assertion", "success"]
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
     },
     "DataQualityMetricsInputDatasetFacet": {
       "allOf": [

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -127,6 +127,8 @@ Example of valid name is `BigQueryStatisticsJobFacet` and it's key `bigQuery_sta
 
 - **dataQualityMetrics**: Captures dataset level and column level data quality metrics when scanning a dataset whith a DataQuality library (row count, byte size, null count, distinct count, average, min, max, quantiles).
 
+- **dataQualityAssertions**: Captures the result of running data tests on dataset or its columns.
+
 #### Output Dataset Facets
 - **outputStatistics**: Captures the size of the output written to a dataset (row count and byte size).
 


### PR DESCRIPTION
This PR standarizes expectation assertion facet, as described in https://github.com/OpenLineage/OpenLineage/issues/221.

This allows using standarized facet for both Great Expectations and dbt-expectations. 

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>