### PR TITLE
[INTEGRATION] [dbt]: emit expectations assertions facet from dbt test run

### DIFF
--- a/integration/common/tests/dbt/test/dbt_project.yml
+++ b/integration/common/tests/dbt/test/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/test/profiles.yml
+++ b/integration/common/tests/dbt/test/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: speedy-vim-308516
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -1,0 +1,271 @@
+[
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "START",
+        "inputs": [
+            {
+                "facets": {},
+                "name": "speedy-vim-308516.dbt_test1.test_third_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_third_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "START",
+        "inputs": [
+            {
+                "facets": {},
+                "name": "speedy-vim-308516.dbt_test1.test_second_parallel_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "START",
+        "inputs": [
+            {
+                "facets": {},
+                "name": "speedy-vim-308516.dbt_test1.test_second_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_second_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "START",
+        "inputs": [
+            {
+                "facets": {},
+                "name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_first_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "#/definitions/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "not_null",
+                                "success": true
+                            },
+                            {
+                                "column": "second_id",
+                                "assertion": "not_null",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "unique",
+                                "success": true
+                            },
+                            {
+                                "column": "second_id",
+                                "assertion": "unique",
+                                "success": true
+                            }
+                        ]
+                    }
+                },
+                "name": "speedy-vim-308516.dbt_test1.test_third_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_third_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "#/definitions/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "not_null",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "unique",
+                                "success": true
+                            }
+                        ]
+                    }
+                },
+                "name": "speedy-vim-308516.dbt_test1.test_second_parallel_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "#/definitions/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "not_null",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "unique",
+                                "success": false
+                            }
+                        ]
+                    }
+                },
+                "name": "speedy-vim-308516.dbt_test1.test_second_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_second_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "#/definitions/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "expect_column_quantile_values_to_be_between",
+                                "success": false
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "expect_column_median_to_be_between",
+                                "success": false
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "expect_column_values_to_not_be_null",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "not_null",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "unique",
+                                "success": false
+                            }
+                        ]
+                    }
+                },
+                "name": "speedy-vim-308516.dbt_test1.test_first_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "speedy-vim-308516.dbt_test1.model.dbt_bigquery_test.test_first_dbt_model",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {},
+            "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"
+        }
+    }
+]

--- a/integration/common/tests/dbt/test/target/manifest.json
+++ b/integration/common/tests/dbt/test/target/manifest.json
@@ -1,0 +1,1641 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
+        "dbt_version": "0.20.0",
+        "generated_at": "2021-08-23T15:06:17.932164Z",
+        "invocation_id": "9adc7020-c784-4179-a4e3-e3c4ffb3b09c",
+        "env": {},
+        "project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+        "user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+        "send_anonymous_usage_stats": true,
+        "adapter_type": "bigquery"
+    },
+    "nodes": {
+        "model.dbt_bigquery_test.test_third_dbt_model": {
+            "raw_sql": "{{ config(materialized='table') }}\n\nselect first.id as id, second.id as second_id \nfrom {{ ref('test_second_dbt_model') }} as first\njoin {{ ref('test_second_parallel_dbt_model') }} as second\non first.id = second.id",
+            "resource_type": "model",
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_second_dbt_model",
+                    "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "table",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1",
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "test_third_dbt_model"
+            ],
+            "unique_id": "model.dbt_bigquery_test.test_third_dbt_model",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "example/test_third_dbt_model.sql",
+            "original_file_path": "models/example/test_third_dbt_model.sql",
+            "name": "test_third_dbt_model",
+            "alias": "test_third_dbt_model",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "e3a6a46f7588f42712f49e9c41feeca702a23b1566a654ae95122bae69c15654"
+            },
+            "tags": [],
+            "refs": [
+                [
+                    "test_second_dbt_model"
+                ],
+                [
+                    "test_second_parallel_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "A starter dbt model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "The primary key of first parallel model",
+                    "meta": {},
+                    "data_type": null,
+                    "quote": null,
+                    "tags": []
+                },
+                "second_id": {
+                    "name": "second_id",
+                    "description": "The primary key of second parallel model",
+                    "meta": {},
+                    "data_type": null,
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": "dbt_bigquery_test://models/example/schema.yml",
+            "compiled_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {
+                "materialized": "table"
+            },
+            "created_at": 1629731179
+        },
+        "model.dbt_bigquery_test.test_second_parallel_dbt_model": {
+            "raw_sql": "select *\nfrom {{ source('dbt_test1', 'source_table') }}\nwhere id = 1\nbork bork fail",
+            "resource_type": "model",
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "source.dbt_bigquery_test.dbt_test1.source_table"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "view",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1",
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "test_second_parallel_dbt_model"
+            ],
+            "unique_id": "model.dbt_bigquery_test.test_second_parallel_dbt_model",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "example/test_second_parallel_dbt_model.sql",
+            "original_file_path": "models/example/test_second_parallel_dbt_model.sql",
+            "name": "test_second_parallel_dbt_model",
+            "alias": "test_second_parallel_dbt_model",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "93bb3d22d248345423d0aa934ab4b3cc89fce04c14bc44469eb6989edec9e11e"
+            },
+            "tags": [],
+            "refs": [],
+            "sources": [
+                [
+                    "dbt_test1",
+                    "source_table"
+                ]
+            ],
+            "description": "A starter dbt model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "The primary key for this table",
+                    "meta": {},
+                    "data_type": null,
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": "dbt_bigquery_test://models/example/schema.yml",
+            "compiled_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179
+        },
+        "model.dbt_bigquery_test.test_second_dbt_model": {
+            "raw_sql": "select *\nfrom {{ ref('test_first_dbt_model') }}\nwhere id = 1",
+            "resource_type": "model",
+            "depends_on": {
+                "macros": [],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "view",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1",
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "test_second_dbt_model"
+            ],
+            "unique_id": "model.dbt_bigquery_test.test_second_dbt_model",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "example/test_second_dbt_model.sql",
+            "original_file_path": "models/example/test_second_dbt_model.sql",
+            "name": "test_second_dbt_model",
+            "alias": "test_second_dbt_model",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "7f0490b21e22d862b7af0547c60ac186464da8a89df7961821d972d83f246374"
+            },
+            "tags": [],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "A starter dbt model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "The primary key for this table",
+                    "meta": {},
+                    "data_type": null,
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": "dbt_bigquery_test://models/example/schema.yml",
+            "compiled_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179
+        },
+        "model.dbt_bigquery_test.test_first_dbt_model": {
+            "raw_sql": "{{ config(materialized='table') }}\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect id\nfrom source_data",
+            "resource_type": "model",
+            "depends_on": {
+                "macros": [],
+                "nodes": []
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "table",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": null,
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1",
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "test_first_dbt_model"
+            ],
+            "unique_id": "model.dbt_bigquery_test.test_first_dbt_model",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "example/test_first_dbt_model.sql",
+            "original_file_path": "models/example/test_first_dbt_model.sql",
+            "name": "test_first_dbt_model",
+            "alias": "test_first_dbt_model",
+            "checksum": {
+                "name": "sha256",
+                "checksum": "381a67a1368d6ba7c8edb0a0403bc1f2106ad136aee93e7fd4ce21a97bec84d4"
+            },
+            "tags": [],
+            "refs": [],
+            "sources": [],
+            "description": "A starter dbt model",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "description": "The primary key for this table",
+                    "meta": {},
+                    "data_type": null,
+                    "quote": null,
+                    "tags": []
+                }
+            },
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": "dbt_bigquery_test://models/example/schema.yml",
+            "compiled_path": null,
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {
+                "materialized": "table"
+            },
+            "created_at": 1629731179
+        },
+        "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1": {
+            "raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_first_dbt_model') }} where {{config.get('where')}}) test_first_dbt_model{% else %}{{ ref('test_first_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "unique_test_first_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/unique_test_first_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "unique_test_first_dbt_model_id",
+            "alias": "unique_test_first_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_first_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_first_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect\n    id,\n    count(*) as n_records\n\nfrom `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`unique_test_first_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_first_dbt_model') }} where {{config.get('where')}}) test_first_dbt_model{% else %}{{ ref('test_first_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "not_null_test_first_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/not_null_test_first_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "not_null_test_first_dbt_model_id",
+            "alias": "not_null_test_first_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_first_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_first_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\nwhere id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`not_null_test_first_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e": {
+            "raw_sql": "{{ dbt_expectations.test_expect_column_values_to_not_be_null(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb\") }}",
+            "test_metadata": {
+                "name": "expect_column_values_to_not_be_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_first_dbt_model') }} where {{config.get('where')}}) test_first_dbt_model{% else %}{{ ref('test_first_dbt_model') }}{% endif %}"
+                },
+                "namespace": "dbt_expectations"
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_expectations.test_expect_column_values_to_not_be_null",
+                    "macro.dbt_expectations.expression_is_true",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": "dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id",
+            "alias": "dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb.sql",
+            "deferred": false,
+            "unrendered_config": {
+                "alias": "dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb"
+            },
+            "created_at": 1629731179,
+            "compiled_sql": "\n\n\n\n\n    with grouped_expression as (\n    select\n        \n        \n    \n  id is not null as expression\n\n\n    from `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\n    \n\n),\nvalidation_errors as (\n\n    select\n        *\n    from\n        grouped_expression\n    where\n        not(expression = true)\n\n)\n\nselect *\nfrom validation_errors\n\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df": {
+            "raw_sql": "{{ dbt_expectations.test_expect_column_median_to_be_between(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba\") }}",
+            "test_metadata": {
+                "name": "expect_column_median_to_be_between",
+                "kwargs": {
+                    "min_value": 7,
+                    "max_value": 21,
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_first_dbt_model') }} where {{config.get('where')}}) test_first_dbt_model{% else %}{{ ref('test_first_dbt_model') }}{% endif %}"
+                },
+                "namespace": "dbt_expectations"
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_expectations.test_expect_column_median_to_be_between",
+                    "macro.dbt_expectations.median",
+                    "macro.dbt_expectations.expression_between",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": "dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7"
+            ],
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7",
+            "alias": "dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba.sql",
+            "deferred": false,
+            "unrendered_config": {
+                "alias": "dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba"
+            },
+            "created_at": 1629731179,
+            "compiled_sql": "\n\n\n\n\n\n    with grouped_expression as (\n    select\n        \n        \n    \n  \n( 1=1 and percentile_cont(id, 0.5)\n    over() >= 7 and percentile_cont(id, 0.5)\n    over() <= 21\n)\n as expression\n\n\n    from `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\n    \n\n),\nvalidation_errors as (\n\n    select\n        *\n    from\n        grouped_expression\n    where\n        not(expression = true)\n\n)\n\nselect *\nfrom validation_errors\n\n\n\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`dbt_expectations_expect_column_42ed9d072f1ef4fbba645e65ad4585ba`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f": {
+            "raw_sql": "{{ dbt_expectations.test_expect_column_quantile_values_to_be_between(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66\") }}",
+            "test_metadata": {
+                "name": "expect_column_quantile_values_to_be_between",
+                "kwargs": {
+                    "quantile": 0.95,
+                    "min_value": 0,
+                    "max_value": 2,
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_first_dbt_model') }} where {{config.get('where')}}) test_first_dbt_model{% else %}{{ ref('test_first_dbt_model') }}{% endif %}"
+                },
+                "namespace": "dbt_expectations"
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt_expectations.test_expect_column_quantile_values_to_be_between",
+                    "macro.dbt_expectations.percentile_cont",
+                    "macro.dbt_expectations.expression_between",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_first_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66",
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95"
+            ],
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95",
+            "alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_first_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+            "deferred": false,
+            "unrendered_config": {
+                "alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66"
+            },
+            "created_at": 1629731179,
+            "compiled_sql": "\n\n\n\n\n\n    with grouped_expression as (\n    select\n        \n        \n    \n  \n( 1=1 and percentile_cont(id, 0.95)\n    over() >= 0 and percentile_cont(id, 0.95)\n    over() <= 2\n)\n as expression\n\n\n    from `speedy-vim-308516`.`dbt_test1`.`test_first_dbt_model`\n    \n\n),\nvalidation_errors as (\n\n    select\n        *\n    from\n        grouped_expression\n    where\n        not(expression = true)\n\n)\n\nselect *\nfrom validation_errors\n\n\n\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1": {
+            "raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_second_dbt_model') }} where {{config.get('where')}}) test_second_dbt_model{% else %}{{ ref('test_second_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_second_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "unique_test_second_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/unique_test_second_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "unique_test_second_dbt_model_id",
+            "alias": "unique_test_second_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_second_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_second_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_second_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect\n    id,\n    count(*) as n_records\n\nfrom `speedy-vim-308516`.`dbt_test1`.`test_second_dbt_model`\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`unique_test_second_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_second_dbt_model') }} where {{config.get('where')}}) test_second_dbt_model{% else %}{{ ref('test_second_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_second_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "not_null_test_second_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/not_null_test_second_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "not_null_test_second_dbt_model_id",
+            "alias": "not_null_test_second_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_second_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_second_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_second_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_second_dbt_model`\nwhere id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`not_null_test_second_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f": {
+            "raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_second_parallel_dbt_model') }} where {{config.get('where')}}) test_second_parallel_dbt_model{% else %}{{ ref('test_second_parallel_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "unique_test_second_parallel_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/unique_test_second_parallel_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "unique_test_second_parallel_dbt_model_id",
+            "alias": "unique_test_second_parallel_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_second_parallel_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_second_parallel_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_second_parallel_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect\n    id,\n    count(*) as n_records\n\nfrom `speedy-vim-308516`.`dbt_test1`.`test_second_parallel_dbt_model`\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`unique_test_second_parallel_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_second_parallel_dbt_model') }} where {{config.get('where')}}) test_second_parallel_dbt_model{% else %}{{ ref('test_second_parallel_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "not_null_test_second_parallel_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/not_null_test_second_parallel_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "not_null_test_second_parallel_dbt_model_id",
+            "alias": "not_null_test_second_parallel_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_second_parallel_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_second_parallel_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_second_parallel_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_second_parallel_dbt_model`\nwhere id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`not_null_test_second_parallel_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6": {
+            "raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_third_dbt_model') }} where {{config.get('where')}}) test_third_dbt_model{% else %}{{ ref('test_third_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_third_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "unique_test_third_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/unique_test_third_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "unique_test_third_dbt_model_id",
+            "alias": "unique_test_third_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_third_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_third_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_third_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect\n    id,\n    count(*) as n_records\n\nfrom `speedy-vim-308516`.`dbt_test1`.`test_third_dbt_model`\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`unique_test_third_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_third_dbt_model') }} where {{config.get('where')}}) test_third_dbt_model{% else %}{{ ref('test_third_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_third_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "not_null_test_third_dbt_model_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/not_null_test_third_dbt_model_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "not_null_test_third_dbt_model_id",
+            "alias": "not_null_test_third_dbt_model_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_third_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_third_dbt_model_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_third_dbt_model_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_third_dbt_model`\nwhere id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`not_null_test_third_dbt_model_id`",
+            "column_name": "id"
+        },
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89": {
+            "raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "unique",
+                "kwargs": {
+                    "column_name": "second_id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_third_dbt_model') }} where {{config.get('where')}}) test_third_dbt_model{% else %}{{ ref('test_third_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_unique",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_third_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "unique_test_third_dbt_model_second_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/unique_test_third_dbt_model_second_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "unique_test_third_dbt_model_second_id",
+            "alias": "unique_test_third_dbt_model_second_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_third_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_third_dbt_model_second_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_third_dbt_model_second_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect\n    second_id,\n    count(*) as n_records\n\nfrom `speedy-vim-308516`.`dbt_test1`.`test_third_dbt_model`\nwhere second_id is not null\ngroup by second_id\nhaving count(*) > 1\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`unique_test_third_dbt_model_second_id`",
+            "column_name": "second_id"
+        },
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "second_id",
+                    "model": "{% if config.get('where') %}(select * from {{ ref('test_third_dbt_model') }} where {{config.get('where')}}) test_third_dbt_model{% else %}{{ ref('test_third_dbt_model') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "model.dbt_bigquery_test.test_third_dbt_model"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "not_null_test_third_dbt_model_second_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/not_null_test_third_dbt_model_second_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "not_null_test_third_dbt_model_second_id",
+            "alias": "not_null_test_third_dbt_model_second_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [
+                [
+                    "test_third_dbt_model"
+                ]
+            ],
+            "sources": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_third_dbt_model_second_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/not_null_test_third_dbt_model_second_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `speedy-vim-308516`.`dbt_test1`.`test_third_dbt_model`\nwhere second_id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`speedy-vim-308516`.`dbt_test1_dbt_test__audit`.`not_null_test_third_dbt_model_second_id`",
+            "column_name": "second_id"
+        }
+    },
+    "sources": {
+        "source.dbt_bigquery_test.dbt_test1.source_table": {
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "dbt_test1",
+                "source_table"
+            ],
+            "database": "speedy-vim-308516",
+            "schema": "dbt_test1",
+            "unique_id": "source.dbt_bigquery_test.dbt_test1.source_table",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "models/example/schema.yml",
+            "original_file_path": "models/example/schema.yml",
+            "name": "source_table",
+            "source_name": "dbt_test1",
+            "source_description": "",
+            "loader": "",
+            "identifier": "source_table",
+            "resource_type": "source",
+            "quoting": {
+                "database": null,
+                "schema": null,
+                "identifier": null,
+                "column": null
+            },
+            "loaded_at_field": null,
+            "freshness": {
+                "warn_after": null,
+                "error_after": null,
+                "filter": null
+            },
+            "external": null,
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "source_meta": {},
+            "tags": [],
+            "config": {
+                "enabled": true
+            },
+            "patch_path": null,
+            "unrendered_config": {},
+            "relation_name": "`speedy-vim-308516`.`dbt_test1`.`source_table`",
+            "created_at": 1629731179
+        }
+    },
+    "macros": {},
+    "docs": {
+        "dbt.__overview__": {
+            "unique_id": "dbt.__overview__",
+            "package_name": "dbt",
+            "root_path": "/home/dbt/tools/pyenv/versions/3.7.3/lib/python3.7/site-packages/dbt/include/global_project",
+            "path": "overview.md",
+            "original_file_path": "docs/overview.md",
+            "name": "__overview__",
+            "block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+        }
+    },
+    "exposures": {},
+    "selectors": {},
+    "disabled": [],
+    "parent_map": {
+        "model.dbt_bigquery_test.test_third_dbt_model": [
+            "model.dbt_bigquery_test.test_second_dbt_model",
+            "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+        ],
+        "model.dbt_bigquery_test.test_second_parallel_dbt_model": [
+            "source.dbt_bigquery_test.dbt_test1.source_table"
+        ],
+        "model.dbt_bigquery_test.test_second_dbt_model": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "model.dbt_bigquery_test.test_first_dbt_model": [],
+        "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f": [
+            "model.dbt_bigquery_test.test_first_dbt_model"
+        ],
+        "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1": [
+            "model.dbt_bigquery_test.test_second_dbt_model"
+        ],
+        "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a": [
+            "model.dbt_bigquery_test.test_second_dbt_model"
+        ],
+        "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f": [
+            "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+        ],
+        "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b": [
+            "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+        ],
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6": [
+            "model.dbt_bigquery_test.test_third_dbt_model"
+        ],
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb": [
+            "model.dbt_bigquery_test.test_third_dbt_model"
+        ],
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89": [
+            "model.dbt_bigquery_test.test_third_dbt_model"
+        ],
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604": [
+            "model.dbt_bigquery_test.test_third_dbt_model"
+        ],
+        "source.dbt_bigquery_test.dbt_test1.source_table": []
+    },
+    "child_map": {
+        "model.dbt_bigquery_test.test_third_dbt_model": [
+            "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb",
+            "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604",
+            "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6",
+            "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89"
+        ],
+        "model.dbt_bigquery_test.test_second_parallel_dbt_model": [
+            "model.dbt_bigquery_test.test_third_dbt_model",
+            "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b",
+            "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f"
+        ],
+        "model.dbt_bigquery_test.test_second_dbt_model": [
+            "model.dbt_bigquery_test.test_third_dbt_model",
+            "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a",
+            "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1"
+        ],
+        "model.dbt_bigquery_test.test_first_dbt_model": [
+            "model.dbt_bigquery_test.test_second_dbt_model",
+            "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df",
+            "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f",
+            "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e",
+            "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a",
+            "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1"
+        ],
+        "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1": [],
+        "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a": [],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e": [],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df": [],
+        "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f": [],
+        "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1": [],
+        "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a": [],
+        "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f": [],
+        "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b": [],
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6": [],
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb": [],
+        "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89": [],
+        "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604": [],
+        "source.dbt_bigquery_test.dbt_test1.source_table": [
+            "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+        ]
+    }
+}

--- a/integration/common/tests/dbt/test/target/run_results.json
+++ b/integration/common/tests/dbt/test/target/run_results.json
@@ -1,0 +1,298 @@
+{
+    "metadata": {
+        "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
+        "dbt_version": "0.20.0",
+        "generated_at": "2021-08-23T15:06:44.629950Z",
+        "invocation_id": "9adc7020-c784-4179-a4e3-e3c4ffb3b09c",
+        "env": {}
+    },
+    "results": [
+        {
+            "status": "fail",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:20.164505Z",
+                    "completed_at": "2021-08-23T15:06:20.189774Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:20.190308Z",
+                    "completed_at": "2021-08-23T15:06:23.909633Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.7533376216888428,
+            "adapter_response": {},
+            "message": "Got 6 results, configured to fail if != 0",
+            "failures": 6,
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.7d02be244f"
+        },
+        {
+            "status": "fail",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:20.156724Z",
+                    "completed_at": "2021-08-23T15:06:20.166865Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:20.167003Z",
+                    "completed_at": "2021-08-23T15:06:24.005845Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.8504960536956787,
+            "adapter_response": {},
+            "message": "Got 6 results, configured to fail if != 0",
+            "failures": 6,
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__7.98cdd3d9df"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:23.912133Z",
+                    "completed_at": "2021-08-23T15:06:23.923956Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:23.924229Z",
+                    "completed_at": "2021-08-23T15:06:27.348364Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.437467098236084,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:24.008644Z",
+                    "completed_at": "2021-08-23T15:06:24.031682Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:24.034392Z",
+                    "completed_at": "2021-08-23T15:06:27.418481Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.411060333251953,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.not_null_test_first_dbt_model_id.a8c5d0180a"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:27.350502Z",
+                    "completed_at": "2021-08-23T15:06:27.360546Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:27.360805Z",
+                    "completed_at": "2021-08-23T15:06:30.639540Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.290224313735962,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.not_null_test_second_dbt_model_id.6458075b2a"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:27.421589Z",
+                    "completed_at": "2021-08-23T15:06:27.431605Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:27.431959Z",
+                    "completed_at": "2021-08-23T15:06:30.953596Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.533139705657959,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.not_null_test_second_parallel_dbt_model_id.92c37ea38b"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:30.641498Z",
+                    "completed_at": "2021-08-23T15:06:30.651306Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:30.651542Z",
+                    "completed_at": "2021-08-23T15:06:34.041843Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.4014694690704346,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:30.955735Z",
+                    "completed_at": "2021-08-23T15:06:30.965672Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:30.965962Z",
+                    "completed_at": "2021-08-23T15:06:34.153919Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.1995866298675537,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604"
+        },
+        {
+            "status": "fail",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:34.044673Z",
+                    "completed_at": "2021-08-23T15:06:34.063220Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:34.063485Z",
+                    "completed_at": "2021-08-23T15:06:37.522108Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.478731870651245,
+            "adapter_response": {},
+            "message": "Got 1 result, configured to fail if != 0",
+            "failures": 1,
+            "unique_id": "test.dbt_bigquery_test.unique_test_first_dbt_model_id.1f3ee5c4a1"
+        },
+        {
+            "status": "fail",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:34.167301Z",
+                    "completed_at": "2021-08-23T15:06:34.178614Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:34.179017Z",
+                    "completed_at": "2021-08-23T15:06:37.525838Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.3604183197021484,
+            "adapter_response": {},
+            "message": "Got 1 result, configured to fail if != 0",
+            "failures": 1,
+            "unique_id": "test.dbt_bigquery_test.unique_test_second_dbt_model_id.ba8cd8dfe1"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:37.527381Z",
+                    "completed_at": "2021-08-23T15:06:37.540834Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:37.549807Z",
+                    "completed_at": "2021-08-23T15:06:41.235964Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.7105484008789062,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.unique_test_second_parallel_dbt_model_id.d59ed1725f"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:37.540649Z",
+                    "completed_at": "2021-08-23T15:06:37.552869Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:37.553393Z",
+                    "completed_at": "2021-08-23T15:06:41.912560Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 4.373392820358276,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.unique_test_third_dbt_model_id.66d6711da6"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:41.238521Z",
+                    "completed_at": "2021-08-23T15:06:41.249977Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:41.250212Z",
+                    "completed_at": "2021-08-23T15:06:44.586958Z"
+                }
+            ],
+            "thread_id": "Thread-2",
+            "execution_time": 3.3493618965148926,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89"
+        }
+    ],
+    "elapsed_time": 25.34427523612976,
+    "args": {
+        "log_format": "default",
+        "write_json": true,
+        "use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/test",
+        "use_cache": true,
+        "data": false,
+        "schema": false,
+        "store_failures": true,
+        "version_check": true,
+        "which": "test",
+        "rpc_method": "test"
+    }
+}

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -129,3 +129,28 @@ def test_dbt_parse_failed_event(mock_datetime, mock_uuid):
     ]
     with open('tests/dbt/fail/result.json', 'r') as f:
         assert events == json.load(f)
+
+
+@mock.patch('uuid.uuid4')
+@mock.patch('datetime.datetime')
+def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid):
+    mock_datetime.now.return_value.isoformat.return_value = '2021-08-25T11:00:25.277467+00:00'
+    mock_uuid.side_effect = [
+        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
+        '1a69c0a7-04bb-408b-980e-cbbfb1831ef7',
+        'f99310b4-339a-4381-ad3e-c1b95c24ff11',
+        'c11f2efd-4415-45fc-8081-10d2aaa594d2',
+    ]
+
+    processor = DbtArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/test'
+    )
+    dbt_events = processor.parse()
+    events = [
+        attr.asdict(event, value_serializer=serialize)
+        for event
+        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+    ]
+    with open('tests/dbt/test/result.json', 'r') as f:
+        assert events == json.load(f)

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -36,7 +36,7 @@ def main():
     )
     process.wait()
 
-    if len(sys.argv) < 2 or sys.argv[1] != 'run':
+    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test']:
         return
 
     # If run_result has modification time before dbt command
@@ -56,6 +56,7 @@ def main():
     for event in events:
         client.emit(event)
     print(f"Emitted {len(events)} openlineage events")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Capture results of `dbt test` invocation as `ExpectationsAssertionsDatasetFacet`.

From each tested model, generates pair of start/complete events. On complete event, tested model is treated as input `Dataset` without any output datasets. Results of all test runs for one model are attached as one facet.


Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>