### PR TITLE
[INTEGRATION][airflow] revert task log handler changes from console to file 

### DIFF
--- a/integration/airflow/tests/integration/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/airflow/config/log_config.py
@@ -73,9 +73,10 @@ LOGGING_CONFIG = {
             'stream': 'sys.stdout'
         },
         'task': {
-            'class': 'airflow.utils.log.logging_mixin.RedirectStdHandler',
-            'formatter': 'airflow_coloured',
-            'stream': 'sys.stdout'
+            'class': 'airflow.utils.log.file_task_handler.FileTaskHandler',
+            'formatter': 'airflow',
+            'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
+            'filename_template': FILENAME_TEMPLATE,
         },
         'processor': {
             'class': 'airflow.utils.log.file_processor_handler.FileProcessorHandler',


### PR DESCRIPTION
https://github.com/OpenLineage/OpenLineage/pull/219 changed task log handler to console. As tasks are running on celery worker process, it causes crash and test runs in the loop: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/605/workflows/9616567d-21c8-4d58-8451-d18de394bf79/jobs/3479

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>