### PR TITLE
[INTEGRATION][dbt] do not emit events if run_result file was not updated

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -66,19 +66,19 @@ class DbtArtifactProcessor:
         self.dataset_namespace = ""
         self.skip_errors = skip_errors
 
+        self.manifest_path = os.path.join(self.dir, self.project['target-path'], 'manifest.json')
+        self.run_result_path = os.path.join(
+            self.dir, self.project['target-path'], 'run_results.json'
+        )
+        self.catalog_path = os.path.join(self.dir, self.project['target-path'], 'catalog.json')
+
     def parse(self) -> DbtEvents:
         """
             Parse dbt manifest and run_result and produce OpenLineage events.
         """
-        manifest = self.load_manifest(
-            os.path.join(self.dir, self.project['target-path'], 'manifest.json')
-        )
-        run_result = self.load_run_results(
-            os.path.join(self.dir, self.project['target-path'], 'run_results.json')
-        )
-        catalog = self.load_catalog(
-            os.path.join(self.dir, self.project['target-path'], 'catalog.json')
-        )
+        manifest = self.load_manifest(self.manifest_path)
+        run_result = self.load_run_results(self.run_result_path)
+        catalog = self.load_catalog(self.catalog_path)
 
         profile_dir = run_result['args']['profiles_dir']
 

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import subprocess
 import sys
+import time
+import os
 
 from openlineage.common.provider.dbt import DbtArtifactProcessor
 from openlineage.client.client import OpenLineageClient
@@ -13,17 +15,6 @@ PRODUCER = f'https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integ
 
 
 def main():
-    process = subprocess.Popen(
-        ["dbt"] + sys.argv[1:],
-        stdout=sys.stdout,
-        stderr=sys.stderr
-    )
-
-    process.wait()
-
-    if len(sys.argv) < 2 or sys.argv[1] != 'run':
-        return
-
     args = sys.argv[2:]
     target = parse_single_arg(args, ['-t', '--target'])
     project_dir = parse_single_arg(args, ['--project-dir'], default='./')
@@ -36,6 +27,30 @@ def main():
         project_dir=project_dir,
         profile_name=profile_name
     )
+
+    pre_run_time = time.time()
+    process = subprocess.Popen(
+        ["dbt"] + sys.argv[1:],
+        stdout=sys.stdout,
+        stderr=sys.stderr
+    )
+    process.wait()
+
+    if len(sys.argv) < 2 or sys.argv[1] != 'run':
+        return
+
+    # If run_result has modification time before dbt command
+    # or does not exist, do not emit dbt events.
+    try:
+        if os.stat(processor.run_result_path).st_mtime < pre_run_time:
+            print(f"OpenLineage events not emittled: run_result file "
+                  f"({processor.run_result_path}) was not modified by dbt")
+            return
+    except FileNotFoundError:
+        print(f"OpenLineage events not emittled:"
+              f"did not find run_result file ({processor.run_result_path})")
+        return
+
     events = processor.parse().events()
 
     for event in events:


### PR DESCRIPTION
Dbt runs (and tests) that execute sql on selected target save run completion metadata to `run_result.json` file. 
If file was not updated by dbt after recent run - file modification time was in the past before run - do not emit OL events.

This does not impact or emit fail events - it represents situation where job did not start to run. It could be compared to situation where Airflow DAG fails to parse when it's not valid python. 

Fixes https://github.com/OpenLineage/OpenLineage/issues/229

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>