### PR TITLE
[TEST] extend spark semaphore timeout

### DIFF
--- a/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -42,7 +42,7 @@ public class StaticExecutionContextFactory extends ContextFactory {
    * @throws InterruptedException
    */
   public static void waitForExecutionEnd() throws InterruptedException, TimeoutException {
-    boolean acquired = semaphore.tryAcquire(1, TimeUnit.SECONDS);
+    boolean acquired = semaphore.tryAcquire(5, TimeUnit.SECONDS);
     if (!acquired) {
       throw new TimeoutException(
           "Unable to acquire permit within expected timeout- "


### PR DESCRIPTION
Try to fix flaky test https://github.com/OpenLineage/OpenLineage/issues/233 by extending the timeout.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>