### PR TITLE
Fixes for getting GreatExpectations action working in Airflow

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -90,12 +90,8 @@ class OpenLineageAdapter:
             job=self._build_job(
                 job_name, job_description, code_location, sql
             ),
-            inputs=[
-                dataset.to_openlineage_dataset() for dataset in step.inputs
-            ] if step else None,
-            outputs=[
-                dataset.to_openlineage_dataset() for dataset in step.outputs
-            ] if step else None,
+            inputs=step.inputs if step else None,
+            outputs=step.outputs if step else None,
             producer=_PRODUCER
         )
         self.get_or_create_openlineage_client().emit(event)
@@ -128,12 +124,8 @@ class OpenLineageAdapter:
             job=self._build_job(
                 job_name, sql=sql
             ),
-            inputs=[
-                dataset.to_openlineage_dataset() for dataset in step.inputs
-            ],
-            outputs=[
-                dataset.to_openlineage_dataset() for dataset in step.outputs
-            ],
+            inputs=step.inputs,
+            outputs=step.outputs,
             producer=_PRODUCER
         )
         self.get_or_create_openlineage_client().emit(event)
@@ -161,12 +153,8 @@ class OpenLineageAdapter:
             job=self._build_job(
                 job_name
             ),
-            inputs=[
-                dataset.to_openlineage_dataset() for dataset in step.inputs
-            ],
-            outputs=[
-                dataset.to_openlineage_dataset() for dataset in step.outputs
-            ],
+            inputs=step.inputs,
+            outputs=step.outputs,
             producer=_PRODUCER
         )
         self.get_or_create_openlineage_client().emit(event)

--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import List, Dict, Type, Union, Optional
+
+from openlineage.client.run import Dataset
 from pkg_resources import parse_version
 
 from airflow.models import BaseOperator
 from airflow.version import version as AIRFLOW_VERSION
 
 from openlineage.client.facet import BaseFacet
-from openlineage.common.dataset import Dataset
 
 if parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"):
     # Corrects path of import for Airflow versions below 1.10.11

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -94,8 +94,8 @@ class BigQueryExtractor(BaseExtractor):
 
         return StepMetadata(
             name=get_job_name(task=self.operator),
-            inputs=inputs,
-            outputs=[output] if output else [],
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[output.to_openlineage_dataset()] if output else [],
             run_facets=run_facets,
             context={
                 "sql": context.sql

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -92,8 +92,8 @@ class PostgresExtractor(BaseExtractor):
 
         return StepMetadata(
             name=f"{self.operator.dag_id}.{self.operator.task_id}",
-            inputs=inputs,
-            outputs=outputs,
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in outputs],
             context={
                 'sql': self.operator.sql
             }

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "flake8",
         "SQLAlchemy",       # must be set to 1.3.* for airflow tests compatibility
         "Flask-SQLAlchemy",  # must be set to 2.4.* for airflow tests compatibility
-        "pandas-gbq",       # must be set to 0.14.* for airflow tests compatibility
+        "pandas-gbq==0.14.1",       # must be set to 0.14.* for airflow tests compatibility
         "snowflake-connector-python",
         "apache-airflow==1.10.12",
         "apache-airflow[gcp_api]==1.10.12",

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -97,26 +97,26 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         assert step_meta.inputs[0].name == \
             'bigquery-public-data.usa_names.usa_1910_2013'
 
-        assert step_meta.inputs[0].fields is not None
-        assert step_meta.inputs[0].source.name == 'bigquery'
-        assert step_meta.inputs[0].source.connection_url == 'bigquery'
-        assert len(step_meta.inputs[0].fields) == 5
+        assert step_meta.inputs[0].facets['schema'].fields is not None
+        assert step_meta.inputs[0].facets['dataSource'].name == 'bigquery'
+        assert step_meta.inputs[0].facets['dataSource'].uri == 'bigquery'
+        assert len(step_meta.inputs[0].facets['schema'].fields) == 5
         assert step_meta.outputs is not None
         assert len(step_meta.outputs) == 1
-        assert step_meta.outputs[0].fields is not None
-        assert len(step_meta.outputs[0].fields) == 2
+        assert step_meta.outputs[0].facets['schema'].fields is not None
+        assert len(step_meta.outputs[0].facets['schema'].fields) == 2
         assert step_meta.outputs[0].name == \
             'bq-airflow-openlineage.new_dataset.output_table'
 
         assert BigQueryStatisticsDatasetFacet(
             rowCount=20,
             size=321
-        ) == step_meta.outputs[0].custom_facets['stats']
+        ) == step_meta.outputs[0].facets['stats']
 
         assert OutputStatisticsOutputDatasetFacet(
             rowCount=20,
             size=321
-        ) == step_meta.outputs[0].output_facets['outputStatistics']
+        ) == step_meta.outputs[0].outputFacets['outputStatistics']
 
         assert len(step_meta.run_facets) == 1
         assert BigQueryJobRunFacet(

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -125,7 +125,7 @@ def test_extract(get_connection, mock_get_table_schemas):
                 connection_url=CONN_URI_WITHOUT_USERPASS
             ),
             fields=[]
-        )]
+        ).to_openlineage_dataset()]
 
     expected_context = {
         'sql': SQL,
@@ -162,7 +162,7 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
                 connection_url=CONN_URI_WITHOUT_USERPASS
             ),
             fields=[]
-        )]
+        ).to_openlineage_dataset()]
 
     expected_context = {
         'sql': SQL,

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -121,7 +121,7 @@ def test_extract(get_connection, mock_get_table_schemas):
                 connection_url=CONN_URI
             ),
             fields=[]
-        )]
+        ).to_openlineage_dataset()]
 
     expected_context = {
         'sql': SQL,

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -299,10 +299,10 @@ class TestFixtureDummyExtractor(BaseExtractor):
 
     def extract(self) -> StepMetadata:
         inputs = [
-            Dataset.from_table(self.source, "extract_input1")
+            Dataset.from_table(self.source, "extract_input1").to_openlineage_dataset()
         ]
         outputs = [
-            Dataset.from_table(self.source, "extract_output1")
+            Dataset.from_table(self.source, "extract_output1").to_openlineage_dataset()
         ]
         return StepMetadata(
             name=get_job_name(task=self.operator),
@@ -348,10 +348,10 @@ class TestFixtureDummyExtractorOnComplete(BaseExtractor):
                     description='',
                     ordinal_position=2
                 )]
-            ))
+            )).to_openlineage_dataset()
         ]
         outputs = [
-            Dataset.from_table(self.source, "extract_on_complete_output1")
+            Dataset.from_table(self.source, "extract_on_complete_output1").to_openlineage_dataset()
         ]
         return StepMetadata(
             name=get_job_name(task=self.operator),
@@ -622,10 +622,10 @@ class TestFixtureDummyExtractorWithMultipleSteps(BaseExtractor):
 
     def extract(self) -> [StepMetadata]:
         inputs = [
-            Dataset.from_table(self.source, "extract_input1")
+            Dataset.from_table(self.source, "extract_input1").to_openlineage_dataset()
         ]
         outputs = [
-            Dataset.from_table(self.source, "extract_output1")
+            Dataset.from_table(self.source, "extract_output1").to_openlineage_dataset()
         ]
         return [StepMetadata(
             name=get_job_name(task=self.operator),

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -89,12 +89,14 @@ class OpenLineageValidationAction(ValidationAction):
         self.job_description = job_description
         self.code_location = code_location
         self.do_publish = do_publish
-        self.log = logging.getLogger(self.__class__.__module__ + '.' + self.__class__.__name__)
 
     def _run(self, validation_result_suite: ExpectationSuiteValidationResult,
              validation_result_suite_identifier: ValidationResultIdentifier,
              data_asset: GEDataset,
              payload=None):
+        # Initialize logger here so that the action is serializable until it actually runs
+        self.log = logging.getLogger(self.__class__.__module__ + '.' + self.__class__.__name__)
+
         datasets = []
         if isinstance(data_asset, SqlAlchemyDataset):
             datasets = self._fetch_datasets_from_sql_source(data_asset, validation_result_suite)


### PR DESCRIPTION
I was working on trying to automatically add lineage collection to GreatExpectationsOperators if they weren't explicitly configured to include the OpenLineageValidationAction. I wasn't successful in this attempt (the current extractor workflow doesn't hook into the right points to be able to modify the `DataContext` in the way we'd need. 

However, I did include these changes I made to support that effort. Namely

1. Change the `StepMetadata` class to return vanilla OpenLineage `InputDataset`s and `OutputDataset`s rather than the other model we use- this would enable us to extract the Dataset and RunEvent information the validation action returns via XCOM to construct a correct model to report
2. Move the OpenLineageValidationAction's log field initialization to outside of the constructor, as that causes the `Clear` functionality to fail.