### PR TITLE
[INTEGRATION][airflow] great expectations integration test does not depends on version

### DIFF
--- a/integration/airflow/tests/integration/requests/great_expectations.json
+++ b/integration/airflow/tests/integration/requests/great_expectations.json
@@ -147,7 +147,6 @@
                         "notes": {}
                     },
                     "expectation_suite_name": "expectations",
-                    "great_expectations_version": "0.13.32",
                     "run_id": {
                         "run_name": "ge_sqlite_run"
                     }
@@ -303,7 +302,6 @@
                         "notes": {}
                     },
                     "expectation_suite_name": "expectations",
-                    "great_expectations_version": "0.13.32",
                     "run_id": {
                         "run_name": "ge_pandas_run"
                     }
@@ -459,7 +457,6 @@
                         "notes": {}
                     },
                     "expectation_suite_name": "expectations",
-                    "great_expectations_version": "0.13.32",
                     "run_id": {
                         "run_name": "ge_bad_sqlite_run"
                     }


### PR DESCRIPTION
Remove unnecessary check for great expectations version in airflow integration test.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>