### PR TITLE
Fix BigQueryNodeVisitor to use tableName() method

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
     compileOnly 'com.google.cloud.spark:spark-bigquery_2.11:0.21.1'
 
-    testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.19.1'
+    testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.21.1'
     testImplementation "net.bytebuddy:byte-buddy-agent:${bytebuddyVersion}"
     testImplementation "net.bytebuddy:byte-buddy-dep:${bytebuddyVersion}"
     testImplementation "org.apache.spark:spark-core_2.11:${sparkVersion}"

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -58,7 +58,6 @@ archivesBaseName='openlineage-spark'
 ext {
     assertjVersion = '3.20.2'
     junit5Version = '5.7.2'
-    bytebuddyVersion = '1.10.21'
     sparkVersion = '2.4.7'
     jacksonVersion = '2.12.2'
     postgresqlVersion = '42.2.19'
@@ -85,8 +84,6 @@ dependencies {
     compileOnly 'com.google.cloud.spark:spark-bigquery_2.11:0.21.1'
 
     testImplementation 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.21.1'
-    testImplementation "net.bytebuddy:byte-buddy-agent:${bytebuddyVersion}"
-    testImplementation "net.bytebuddy:byte-buddy-dep:${bytebuddyVersion}"
     testImplementation "org.apache.spark:spark-core_2.11:${sparkVersion}"
     testImplementation "org.apache.spark:spark-sql_2.11:${sparkVersion}"
     testImplementation platform('org.junit:junit-bom:5.7.1')

--- a/integration/spark/integrations/sparkrdd/1.json
+++ b/integration/spark/integrations/sparkrdd/1.json
@@ -19,7 +19,7 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "word_count.shuffled_map_partitions_hadoop"
+    "name" : "test_rdd.shuffled_map_partitions_hadoop"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",

--- a/integration/spark/integrations/sparkrdd/2.json
+++ b/integration/spark/integrations/sparkrdd/2.json
@@ -19,7 +19,7 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "word_count.shuffled_map_partitions_hadoop"
+    "name" : "test_rdd.shuffled_map_partitions_hadoop"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",

--- a/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeVisitor.java
+++ b/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeVisitor.java
@@ -4,7 +4,6 @@ import com.google.cloud.spark.bigquery.BigQueryRelation;
 import com.google.cloud.spark.bigquery.BigQueryRelationProvider;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PlanUtils;
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +23,7 @@ import org.apache.spark.sql.sources.CreatableRelationProvider;
  * bigquery tables is always <code>bigquery</code> and the name is the FQN.
  */
 public class BigQueryNodeVisitor extends QueryPlanVisitor<LogicalPlan> {
+  private static final String BIGQUERY_NAMESPACE = "bigquery";
   private final SQLContext sqlContext;
 
   public BigQueryNodeVisitor(SQLContext sqlContext) {
@@ -75,15 +75,12 @@ public class BigQueryNodeVisitor extends QueryPlanVisitor<LogicalPlan> {
         .map(
             s -> {
               BigQueryRelation relation = s.get();
-              String name =
-                  String.format(
-                      "%s.%s.%s",
-                      relation.tableId().getProject(),
-                      relation.tableId().getDataset(),
-                      relation.tableId().getTable());
+              String name = relation.tableName();
               return Collections.singletonList(
                   PlanUtils.getDataset(
-                      URI.create(String.format("bigquery://%s", name)), x.schema()));
+                      name,
+                      BIGQUERY_NAMESPACE,
+                      PlanUtils.datasetFacet(relation.schema(), BIGQUERY_NAMESPACE)));
             })
         .orElse(null);
   }

--- a/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -28,15 +28,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.SparkSession$;
 import org.assertj.core.api.Condition;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,27 +47,14 @@ public class LibraryTest {
   private final TypeReference<Map<String, Object>> mapTypeReference =
       new TypeReference<Map<String, Object>>() {};
 
-  @AfterEach
-  public void tearDown() throws Exception {
-    SparkSession$.MODULE$.cleanupAnyExistingSession();
-  }
-
   @RepeatedTest(30)
-  public void testSparkSql() throws IOException, TimeoutException {
+  public void testSparkSql(SparkSession spark) throws IOException, TimeoutException {
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getJobNamespace())
         .thenReturn("ns_name");
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getParentJobName())
         .thenReturn("job_name");
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getParentRunId())
         .thenReturn(Optional.of(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54")));
-
-    final SparkSession spark =
-        SparkSession.builder()
-            .master("local[*]")
-            .appName("Word Count")
-            .config("spark.driver.host", "127.0.0.1")
-            .config("spark.driver.bindAddress", "127.0.0.1")
-            .getOrCreate();
 
     URL url = Resources.getResource("test_data/data.txt");
     final Dataset<String> data = spark.read().textFile(url.getPath());
@@ -139,7 +123,7 @@ public class LibraryTest {
   }
 
   @Test
-  public void testRdd() throws IOException {
+  public void testRdd(SparkSession spark) throws IOException {
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getJobNamespace())
         .thenReturn("ns_name");
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getParentJobName())
@@ -148,8 +132,7 @@ public class LibraryTest {
         .thenReturn(Optional.of(UUID.fromString("8d99e33e-2a1c-4254-9600-18f23435fc3b")));
 
     URL url = Resources.getResource("test_data/data.txt");
-    SparkConf conf = new SparkConf().setAppName("Word Count").setMaster("local[*]");
-    JavaSparkContext sc = new JavaSparkContext(conf);
+    JavaSparkContext sc = new JavaSparkContext(spark.sparkContext());
     JavaRDD<String> textFile = sc.textFile(url.getPath());
 
     textFile
@@ -189,9 +172,8 @@ public class LibraryTest {
   }
 
   @Test
-  public void testRDDName() {
-    SparkConf conf = new SparkConf().setAppName("Word Count").setMaster("local[*]");
-    JavaSparkContext sc = new JavaSparkContext(conf);
+  public void testRDDName(SparkSession spark) {
+    JavaSparkContext sc = new JavaSparkContext(spark.sparkContext());
     JavaRDD<Integer> numbers =
         sc.parallelize(IntStream.range(1, 100).mapToObj(Integer::new).collect(Collectors.toList()));
     numbers.setName("numbers");

--- a/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
+++ b/integration/spark/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
@@ -1,33 +1,23 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.spark.Partition;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.SparkSession$;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
-import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
-import org.apache.spark.sql.execution.streaming.ConsoleRelation;
-import org.apache.spark.sql.types.FloatType$;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -35,7 +25,6 @@ import org.postgresql.Driver;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.Seq$;
-import scala.collection.immutable.HashMap;
 import scala.collection.immutable.Map$;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -95,39 +84,5 @@ class LogicalRelationVisitorTest {
     assertEquals(sparkTableName, ds.getName());
     assertEquals(URI.create(connectionUri), ds.getFacets().getDataSource().getUri());
     assertEquals(connectionUri, ds.getFacets().getDataSource().getName());
-  }
-
-  @Test
-  void testApplyUnknownRelation() {
-    SparkSession session = SparkSession.builder().master("local").getOrCreate();
-    LogicalRelationVisitor visitor =
-        new LogicalRelationVisitor(session.sparkContext(), "testnamespace");
-    org.apache.spark.sql.Dataset<Row> dataFrame =
-        session.createDataFrame(
-            Arrays.asList(new GenericRow(new Object[] {1, "hello", 5.4})),
-            new StructType(
-                new StructField[] {
-                  new StructField(
-                      "num", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
-                  new StructField(
-                      "word", StringType$.MODULE$, false, new Metadata(new HashMap<>())),
-                  new StructField("fl", FloatType$.MODULE$, false, new Metadata(new HashMap<>()))
-                }));
-    ConsoleRelation consoleRelation = new ConsoleRelation(session.sqlContext(), dataFrame);
-    LogicalRelation logicalRelation =
-        new LogicalRelation(
-            consoleRelation, consoleRelation.schema().toAttributes(), Option.empty(), false);
-    assertTrue(visitor.isDefinedAt(logicalRelation));
-    List<OpenLineage.Dataset> datasets = visitor.apply(logicalRelation);
-    Assertions.assertThat(datasets)
-        .isNotEmpty()
-        .hasSize(1)
-        .first()
-        .hasFieldOrPropertyWithValue("name", "ConsoleRelation_struct<num:int,word:string,fl:float>")
-        .extracting("facets")
-        .extracting("documentation")
-        .extracting("description")
-        .asString()
-        .startsWith("Relation[num#6,word#7,fl#8] ConsoleRelation(");
   }
 }

--- a/integration/spark/src/test/resources/test_data/.gitignore
+++ b/integration/spark/src/test/resources/test_data/.gitignore
@@ -1,0 +1,3 @@
+rdd_to_csv_output
+rdd_to_table
+test_output


### PR DESCRIPTION
The `LogicalRelationVisitor` was matching `BigQueryRelation`s, causing nodes to be reported as `DirectBigQueryRelation_struct<...>`. The `UnknownEntryFacet` captures information on unvisited nodes, including unknown `LogicalRelation`s, so this code is a) redundant and b) forces the node visiting to happen in a specific order to be correct. Rather than impose an order, which won't scale to extensions that might be authored outside of this library, I removed that code.

I also noticed that the existing Spark integration tests still rely on the bytebuddy/javaagent approach rather than using the Spark ListenerBus. I modified the extension to use the listener approach and updated affected tests accordingly.