### PR TITLE
[INTEGRATION][airflow] add possibility to register custom extractors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ cython_debug/
 *.classpath
 *.project
 *.settings/
+
+gcloud-service-key.json

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -63,15 +63,45 @@ MARQUEZ_NAMESPACE=my_special_ns
 
 ### Extractors : Sending the correct data from your DAGs
 
-If you do nothing, OpenLineage backend will receive the `Job` and the `Run` from your DAGs, but sources and datasets will not be sent.
+If you do nothing, OpenLineage backend will receive the `Job` and the `Run` from your DAGs, but,
+unless you use few operators for which this integration provides extractor, input and output metadata will not be send.
 
-`openlineage-airflow` allows you to do more than that by building "Extractors".  Extractors are in the process of changing right now, but they basically take a task and extract:
+`openlineage-airflow` allows you to do more than that by building "Extractors". Extractor is object
+suited to extract metadata from particular operator (or operators). 
 
 1. Name : The name of the task
-2. Location : Location of the code for the task
-3. Inputs : List of input datasets
-4. Outputs : List of output datasets
-5. Context : The Airflow context for the task
+2. Inputs : List of input datasets
+3. Outputs : List of output datasets
+4. Context : The Airflow context for the task
+
+#### Bundled Extractors
+
+`openlineage-airflow` provides extractors for
+
+* `PostgresOperator`
+* `BigQueryOperator`
+* `SnowflakeOperator`
+* `GreatExpectationsOperator`
+
+#### Custom Extractors
+
+If your DAGs contain additional operators from which you want to extract lineage data, fear not - you can always
+provide custom extractors. They should derive from `BaseExtractor`. 
+
+There are two ways to register them for use in `openlineage-airflow`. 
+
+First one, is to provide environment variable in pattern of 
+```
+OPENLINEAGE_EXTRACTOR_<operator>=full.path.to.ExtractorClass
+```
+
+For example: 
+```
+OPENLINEAGE_EXTRACTOR_PostgresOperator=openlineage.airflow.extractors.postgres_extractor.PostgresExtractor
+```
+
+Second one - working in Airflow 1.10.x only - is to register all additional operator-extractor pairings by 
+providing `lineage_custom_extractors` argument in `openlineage.airflow.DAG`.
 
 #### Great Expectations
 

--- a/integration/airflow/openlineage/airflow/dag.py
+++ b/integration/airflow/openlineage/airflow/dag.py
@@ -71,6 +71,10 @@ class DAG(airflow.models.DAG):
             macros = kwargs["user_defined_macros"]
         macros["lineage_run_id"] = lineage_run_id
         kwargs["user_defined_macros"] = macros
+        if kwargs.__contains__("lineage_custom_extractors"):
+            for operator, extractor in kwargs['lineage_custom_extractors'].items():
+                extractor_mapper.add_extractor(operator, extractor)
+            del kwargs['lineage_custom_extractors']
         super().__init__(*args, **kwargs)
 
     def add_task(self, task):

--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict, Type, Union, Optional
+from typing import List, Dict, Union, Optional
 
 from openlineage.client.run import Dataset
 from pkg_resources import parse_version
 
-from airflow.models import BaseOperator
 from airflow.version import version as AIRFLOW_VERSION
 
 from openlineage.client.facet import BaseFacet
@@ -55,10 +54,8 @@ class StepMetadata:
 
 
 class BaseExtractor(ABC, LoggingMixin):
-    operator_class: Type[BaseOperator] = None
-    operator: operator_class = None
-
     def __init__(self, operator):
+        super().__init__()
         self.operator = operator
         self.patch()
 
@@ -67,13 +64,19 @@ class BaseExtractor(ABC, LoggingMixin):
         pass
 
     @classmethod
-    def get_operator_class(cls):
-        return cls.operator_class
+    def get_operator_classnames(cls) -> List[str]:
+        """
+        Implement this method returning list of operators that extractor works for.
+        Particularly, in Airflow 2 some operators are deprecated and simply subclass the new
+        implementation, for example BigQueryOperator:
+        https://github.com/apache/airflow/blob/main/airflow/contrib/operators/bigquery_operator.py
+        The BigQueryExtractor needs to work with both of them.
+        :return:
+        """
+        raise NotImplementedError()
 
     def validate(self):
-        # TODO: maybe we should also enforce the module
-        assert (self.operator_class is not None and
-                self.operator.__class__ == self.operator_class)
+        assert (self.operator.__class__.__name__ in self.get_operator_classnames())
 
     @abstractmethod
     def extract(self) -> Union[Optional[StepMetadata], List[StepMetadata]]:

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -13,7 +13,7 @@
 import json
 import logging
 import traceback
-from typing import Optional
+from typing import Optional, List
 
 import attr
 
@@ -42,23 +42,13 @@ class SqlContext:
     parser_error: Optional[str] = attr.ib(default=None)
 
 
-def try_load_operator():
-    try:
-        from airflow.contrib.operators.bigquery_operator import BigQueryOperator
-        return BigQueryOperator
-    except Exception:
-        log.warn('Did not find bigquery_operator library or failed to import it')
-        return None
-
-
-Operator = try_load_operator()
-
-
 class BigQueryExtractor(BaseExtractor):
-    operator_class = Operator
-
     def __init__(self, operator: BaseOperator):
         super().__init__(operator)
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['BigQueryOperator']
 
     def extract(self) -> Optional[StepMetadata]:
         return None

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Optional
+from typing import Optional, List
 
 from openlineage.airflow.extractors.base import BaseExtractor, StepMetadata
 
@@ -33,11 +33,13 @@ class GreatExpectationsExtractorImpl(BaseExtractor):
     Great Expectations extractor extracts validation data from CheckpointResult object and
     parses it via ExpectationsParsers. Results are used to prepare data quality facet.
     """
-    operator_class = GreatExpectationsOperator
-
     def __init__(self, operator):
         super().__init__(operator)
         self.result = None
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return [GreatExpectationsOperator.__name__] if GreatExpectationsOperator else []
 
     def extract(self) -> Optional[StepMetadata]:
         return None
@@ -52,3 +54,7 @@ else:
     class GreatExpectationsExtractor:
         def __init__(self):
             raise RuntimeError('Great Expectations provider not found')
+
+        @classmethod
+        def get_operator_classnames(cls) -> List[str]:
+            return []

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -10,11 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from contextlib import closing
-from typing import Optional
+from typing import Optional, List
 from urllib.parse import urlparse
 
 from airflow.hooks.postgres_hook import PostgresHook
-from airflow.operators.postgres_operator import PostgresOperator
 
 from openlineage.airflow.utils import get_normalized_postgres_connection_uri, get_connection
 from openlineage.airflow.extractors.base import (
@@ -39,12 +38,15 @@ _UDT_NAME = 4
 
 
 class PostgresExtractor(BaseExtractor):
-    operator_class = PostgresOperator
     default_schema = 'public'
 
     def __init__(self, operator):
         super().__init__(operator)
         self.conn = None
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['PostgresOperator']
 
     def extract(self) -> StepMetadata:
         # (1) Parse sql statement to obtain input / output tables.

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 from openlineage.airflow.utils import get_connection_uri, get_connection  # noqa
@@ -6,25 +7,15 @@ from openlineage.airflow.utils import get_connection_uri, get_connection  # noqa
 log = logging.getLogger(__file__)
 
 
-# Snowflake is optional dependency.
-def try_load_operator():
-    try:
-        from airflow.contrib.operators.snowflake_operator import SnowflakeOperator
-        return SnowflakeOperator
-    except Exception:
-        log.warn('Did not find snowflake_operator library or failed to import it')
-        return None
-
-
-Operator = try_load_operator()
-
-
 class SnowflakeExtractor(PostgresExtractor):
-    operator_class = Operator
     source_type = 'SNOWFLAKE'
 
     def __init__(self, operator):
         super().__init__(operator)
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['SnowflakeOperator']
 
     def _information_schema_query(self, table_names: str) -> str:
         return f"""

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -1,9 +1,12 @@
+import os
+
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from airflow.contrib.operators.snowflake_operator import SnowflakeOperator
 from airflow.operators.postgres_operator import PostgresOperator
 from great_expectations_provider.operators.great_expectations import GreatExpectationsOperator
 
 from openlineage.airflow.extractors import Extractors
+from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
 
 def test_all_extractors():
@@ -18,3 +21,18 @@ def test_all_extractors():
 
     for extractor in extractors:
         assert Extractors().get_extractor_class(extractor)
+
+
+def test_env_extractors():
+    os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
+        'openlineage.airflow.extractors.extractors.PostgresExtractor'
+
+    assert len(Extractors().extractors) == 5
+    del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']
+
+
+def test_adding_extractors():
+    extractors = Extractors()
+    assert len(extractors.extractors) == 4
+    extractors.add_extractor("test", PostgresExtractor)
+    assert len(extractors.extractors) == 5

--- a/integration/airflow/tests/integration/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/airflow/config/log_config.py
@@ -43,11 +43,11 @@ COLORED_LOG = conf.getboolean('core', 'COLORED_CONSOLE_LOG')
 
 COLORED_FORMATTER_CLASS = conf.get('core', 'COLORED_FORMATTER_CLASS')
 
-# BASE_LOG_FOLDER = '/opt/airflow/logs'
-BASE_LOG_FOLDER = conf.get('core', 'BASE_LOG_FOLDER')
-
-# PROCESSOR_LOG_FOLDER = '/opt/airflow/logs'
-PROCESSOR_LOG_FOLDER = conf.get('scheduler', 'CHILD_PROCESS_LOG_DIRECTORY')
+BASE_LOG_FOLDER = '/opt/airflow/logs'
+# BASE_LOG_FOLDER = conf.get('core', 'BASE_LOG_FOLDER')
+#
+PROCESSOR_LOG_FOLDER = '/opt/airflow/logs'
+# PROCESSOR_LOG_FOLDER = conf.get('scheduler', 'CHILD_PROCESS_LOG_DIRECTORY')
 
 DAG_PROCESSOR_MANAGER_LOG_LOCATION = \
     conf.get('core', 'DAG_PROCESSOR_MANAGER_LOG_LOCATION')

--- a/integration/airflow/tests/integration/airflow/dags/custom_extractor.py
+++ b/integration/airflow/tests/integration/airflow/dags/custom_extractor.py
@@ -1,0 +1,23 @@
+from typing import Union, Optional, List
+
+from openlineage.client.run import Dataset
+from openlineage.airflow.extractors import StepMetadata
+from openlineage.airflow.extractors.base import BaseExtractor
+
+
+class BashExtractor(BaseExtractor):
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['BashOperator']
+
+    def extract(self) -> Union[Optional[StepMetadata], List[StepMetadata]]:
+        return StepMetadata(
+            "test",
+            inputs=[
+                Dataset(
+                    namespace="test",
+                    name="dataset",
+                    facets={}
+                )
+            ]
+        )

--- a/integration/airflow/tests/integration/airflow/dags/custom_extractor_dag.py
+++ b/integration/airflow/tests/integration/airflow/dags/custom_extractor_dag.py
@@ -1,0 +1,33 @@
+import os
+
+from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
+
+os.environ["OPENLINEAGE_EXTRACTOR_BashOperator"] = 'custom_extractor.BashExtractor'
+from openlineage.airflow import DAG
+from openlineage.client import set_producer
+
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+
+dag = DAG(
+    'custom_extractor',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Test dag.'
+)
+
+t1 = BashOperator(
+    task_id='custom_extractor',
+    bash_command="ls -halt",
+    dag=dag
+)

--- a/integration/airflow/tests/integration/airflow/logs/latest
+++ b/integration/airflow/tests/integration/airflow/logs/latest
@@ -1,1 +1,0 @@
-/opt/airflow/logs/2021-09-03

--- a/integration/airflow/tests/integration/requests/custom_extractor.json
+++ b/integration/airflow/tests/integration/requests/custom_extractor.json
@@ -1,0 +1,48 @@
+ [{
+ 		"eventType": "START",
+ 		"inputs": [{
+ 			"facets": {},
+ 			"name": "dataset",
+ 			"namespace": "test"
+ 		}],
+ 		"job": {
+ 			"facets": {
+ 				"documentation": {
+ 					"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow",
+ 					"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DocumentationJobFacet",
+ 					"description": "Test dag."
+ 				}
+ 			},
+ 			"name": "custom_extractor.custom_extractor",
+ 			"namespace": "food_delivery"
+ 		},
+ 		"outputs": [],
+ 		"run": {
+ 			"facets": {
+ 				"airflow_runArgs": {
+ 					"externalTrigger": false
+ 				},
+ 				"parentRun": {
+ 					"job": {
+ 						"name": "custom_extractor.custom_extractor",
+ 						"namespace": "food_delivery"
+ 					}
+ 				}
+ 			}
+ 		}
+ 	},
+ 	{
+ 		"eventType": "COMPLETE",
+ 		"inputs": [{
+ 			"facets": {},
+ 			"name": "dataset",
+ 			"namespace": "test"
+ 		}],
+ 		"job": {
+ 			"facets": {},
+ 			"name": "custom_extractor.custom_extractor",
+ 			"namespace": "food_delivery"
+ 		},
+ 		"outputs": []
+ 	}
+ ]

--- a/integration/airflow/tests/integration/server/app.py
+++ b/integration/airflow/tests/integration/server/app.py
@@ -65,4 +65,6 @@ def lineage():
 
         logger.info(f"GOT {len(received_requests)} requests")
 
+        logger.info(json.dumps(received_requests, indent=4, sort_keys=True))
+
         return jsonify(received_requests), 200

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -153,3 +153,4 @@ if __name__ == '__main__':
     test_integration('postgres_orders_popular_day_of_week', 'requests/postgres.json')
     test_integration('bigquery_orders_popular_day_of_week', 'requests/bigquery.json')
     test_integration('dbt_dag', 'requests/dbt.json')
+    test_integration('custom_extractor', 'requests/custom_extractor.json')


### PR DESCRIPTION
There are two mechanisms to add custom extractors that this PR adds. First one is done by mapping in code via `custom_extractors` argument in DAG class. This one won't work with Airflow 2 as we won't be subclassing DAG there. 

Second one is via env variables: the operator is given via key. If prefix matches `OPENLINEAGE_EXTRACTOR_`, then, `Extractors` class tries to important extractor for which import path is given via value - similar to how Airflow deals with `LineageBackend`.

Fixes https://github.com/OpenLineage/OpenLineage/issues/242

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>