### PR TITLE
[INTEGRATION][dbt] fail execution if OPENLINEAGE_URL is unset

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -3,16 +3,29 @@ import subprocess
 import sys
 import time
 import os
+from typing import Optional
 
 from tqdm import tqdm
 from openlineage.common.provider.dbt import DbtArtifactProcessor
-from openlineage.client.client import OpenLineageClient
+from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
 
 __version__ = "0.2.3"
 
 from openlineage.common.utils import parse_single_arg
 
 PRODUCER = f'https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integration/dbt'
+
+
+def setup_client() -> Optional[OpenLineageClient]:
+    url = os.getenv("OPENLINEAGE_URL")
+    if not url:
+        return None
+    return OpenLineageClient(
+        url=url,
+        options=OpenLineageClientOptions(
+            api_key=os.getenv("OPENLINEAGE_API_KEY", None)
+        )
+    )
 
 
 def main():
@@ -24,7 +37,11 @@ def main():
     project_dir = parse_single_arg(args, ['--project-dir'], default='./')
     profile_name = parse_single_arg(args, ['--profile'])
 
-    client = OpenLineageClient.from_environment()
+    client = setup_client()
+    if client is None:
+        print("OPENLINEAGE_URL is not set: stopping execution")
+        sys.exit(1)
+
     processor = DbtArtifactProcessor(
         producer=PRODUCER,
         target=target,


### PR DESCRIPTION
Currently, `dbt-ol` will run even if `OPENLINEAGE_URL` is unset. This causes nomal dbt execution, after which user sees that events weren't emitted.

We should assume that variables/config should be set and valid - and fail the run if they aren't. After all, if someone wouldn't need lineage events, they wouldn't use our wrapper.

When https://github.com/OpenLineage/OpenLineage/issues/287 is done, we should use emitting dbt parent run as way to check if URL is valid and reachable.

This will require change with introduction of client `Backend` or `Transport` - we should check if any transport is configured correctly, instead of just simple http one.   

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>