### PR TITLE
[INTEGRATION][airflow] fail integration tests if dag fails

### DIFF
--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -52,7 +52,9 @@ def wait_for_dag(dag_id):
     cur.close()
 
     log.info(f"DAG '{dag_id}' state set to '{state}'.")
-    if state != "success":
+    if state == 'failed':
+        sys.exit(1)
+    elif state != "success":
         raise Exception('Retry!')
 
 


### PR DESCRIPTION
Stop spinning the wheel and retrying for 5 hours.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>