### PR TITLE
Add support for running airflow integration tests on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,12 +361,14 @@ workflows:
             - unit-test-integration-common
             - unit-test-client-python
       - integration-test-integration-airflow:
-          <<: *only_on_main
           context: integration-tests
           requires:
             - unit-test-integration-airflow
             - unit-test-integration-common
             - unit-test-client-python
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
       - integration-test-integration-airflow-on-forks:
           <<: *only_on_forks
           context: integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ only_on_main: &only_on_main
     branches:
       only: main
 
+only_on_forks: &only_on_forks
+  filters:
+    branches:
+      # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      only: /pull\/[0-9]+/n
+
 # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
 only_on_release: &only_on_release
   filters:
@@ -32,6 +38,18 @@ param_build_tag: &param_build_tag
       build_tag:
         default: ""
         type: string
+
+run-integration-test-integration-airflow: &run-integration-test-integration-airflow
+  working_directory: ~/openlineage/integration/
+  machine: true
+  steps:
+    - *checkout_project_root
+    - gcp-cli/install
+    - gcp-cli/initialize
+    - run: ../.circleci/get-docker-compose.sh
+    - run: cp -r ../client/python python
+    - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
+    - run: ./airflow/tests/integration/docker/up.sh
 
 jobs:
   unit-test-client-python:
@@ -277,16 +295,10 @@ jobs:
             - ./dist/*.tar.gz
 
   integration-test-integration-airflow:
-    working_directory: ~/openlineage/integration/
-    machine: true
-    steps:
-      - *checkout_project_root
-      - gcp-cli/install
-      - gcp-cli/initialize
-      - run: ../.circleci/get-docker-compose.sh
-      - run: cp -r ../client/python python
-      - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
-      - run: ./airflow/tests/integration/docker/up.sh
+    <<: *run-integration-test-integration-airflow
+
+  integration-test-integration-airflow-on-forks:
+    <<: *run-integration-test-integration-airflow
 
   publish-snapshot-python:
     working_directory: ~/openlineage
@@ -341,12 +353,25 @@ workflows:
           requires:
             - unit-test-integration-common
       - unit-test-integration-airflow
+      - hold-test-integration-airflow-on-forks:
+          <<: *only_on_forks
+          type: approval
+          requires:
+            - unit-test-integration-airflow
+            - unit-test-integration-common
+            - unit-test-client-python
       - integration-test-integration-airflow:
+          <<: *only_on_main
           context: integration-tests
           requires:
             - unit-test-integration-airflow
             - unit-test-integration-common
             - unit-test-client-python
+      - integration-test-integration-airflow-on-forks:
+          <<: *only_on_forks
+          context: integration-tests
+          requires:
+            - hold-test-integration-airflow-on-forks
       - build-integration-airflow:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ only_on_forks: &only_on_forks
   filters:
     branches:
       # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      only: /pull\/[0-9]+/n
+      only: /pull\/[0-9]+/
 
 # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
 only_on_release: &only_on_release


### PR DESCRIPTION
This PR adds an approval step to set the CI context containing secrets required when running Airflow integration tests. On a fork, the following CI jobs will run:

```bash
# Required maintainer approval
hold-test-integration-airflow-on-forks
# Sets the integration-tests context required for running Airflow integration tests
integration-test-integration-airflow-on-forks
```

Since the CI jobs `integration-test-integration-airflow` and `integration-test-integration-airflow-on-forks` use the same testing logic, the mapping `run-integration-test-integration-airflow` has also been added.

### References

* [Triggering trusted CI jobs on untrusted forks](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/)
* [Approving jobs that use restricted contexts](https://circleci.com/docs/2.0/contexts/#approving-jobs-that-use-restricted-contexts)