### PR TITLE
Skip airflow integration tests on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,12 +342,14 @@ workflows:
             - unit-test-integration-common
       - unit-test-integration-airflow
       - integration-test-integration-airflow:
-          <<: *only_on_main
           context: integration-tests
           requires:
             - unit-test-integration-airflow
             - unit-test-integration-common
             - unit-test-client-python
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
       - build-integration-airflow:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ only_on_main: &only_on_main
     branches:
       only: main
 
-only_on_forks: &only_on_forks
-  filters:
-    branches:
-      # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-      only: /pull\/[0-9]+/
-
 # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
 only_on_release: &only_on_release
   filters:
@@ -38,18 +32,6 @@ param_build_tag: &param_build_tag
       build_tag:
         default: ""
         type: string
-
-run-integration-test-integration-airflow: &run-integration-test-integration-airflow
-  working_directory: ~/openlineage/integration/
-  machine: true
-  steps:
-    - *checkout_project_root
-    - gcp-cli/install
-    - gcp-cli/initialize
-    - run: ../.circleci/get-docker-compose.sh
-    - run: cp -r ../client/python python
-    - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
-    - run: ./airflow/tests/integration/docker/up.sh
 
 jobs:
   unit-test-client-python:
@@ -295,10 +277,16 @@ jobs:
             - ./dist/*.tar.gz
 
   integration-test-integration-airflow:
-    <<: *run-integration-test-integration-airflow
-
-  integration-test-integration-airflow-on-forks:
-    <<: *run-integration-test-integration-airflow
+    working_directory: ~/openlineage/integration/
+    machine: true
+    steps:
+      - *checkout_project_root
+      - gcp-cli/install
+      - gcp-cli/initialize
+      - run: ../.circleci/get-docker-compose.sh
+      - run: cp -r ../client/python python
+      - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
+      - run: ./airflow/tests/integration/docker/up.sh
 
   publish-snapshot-python:
     working_directory: ~/openlineage
@@ -353,27 +341,13 @@ workflows:
           requires:
             - unit-test-integration-common
       - unit-test-integration-airflow
-      - hold-test-integration-airflow-on-forks:
-          <<: *only_on_forks
-          type: approval
-          requires:
-            - unit-test-integration-airflow
-            - unit-test-integration-common
-            - unit-test-client-python
       - integration-test-integration-airflow:
+          <<: *only_on_main
           context: integration-tests
           requires:
             - unit-test-integration-airflow
             - unit-test-integration-common
             - unit-test-client-python
-          filters:
-            branches:
-              ignore: /pull\/[0-9]+/
-      - integration-test-integration-airflow-on-forks:
-          <<: *only_on_forks
-          context: integration-tests
-          requires:
-            - hold-test-integration-airflow-on-forks
       - build-integration-airflow:
           <<: *only_on_main
           build_tag: .dev${CIRCLE_BUILD_NUM}


### PR DESCRIPTION
This PR is a continuation of #299. Unfortunately, there's no way around sharing secrets in a forked PR without explicitly enabling it (see [OSS forked PRs](https://circleci.com/docs/2.0/oss/#pass-secrets-to-builds-from-forked-pull-requests)):

> If you are comfortable sharing secrets with anyone who forks your project and opens a PR, you can enable the Pass secrets to builds from forked pull requests option. In the Project Settings>Advanced of your project, set the Pass secrets to builds from forked pull requests option to On.

Enabling the ability to pass secrets to forked PRs means someone can run the CI job with SSH enabled, allowing anyone to view sensitive information. This PR restricts the airflow integration CI job to run on the `main` branch and PRs opened by committer (skipped on forked PRs). I think it's a reasonable alternative. We can catch bugs early with extensive unit tests, using mock servers, etc but would have to rely on running the airflow integrations to fully tests the integration.

