### PR TITLE
changed url.getFile instead of url.toURI to fix build on windows

### DIFF
--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -50,7 +50,7 @@ public class Generator {
       URL url = new URL(baseURL);
 
       if (url.getProtocol().equals("file")) {
-        File file = new File(url.toURI());
+        File file = new File(url.getFile());
         if (file.isDirectory()) {
           addURLs(urls, file);
         } else {

--- a/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -180,7 +180,7 @@ public class SparkSQLExecutionContext implements ExecutionContext {
             .job(buildJob(queryExecution))
             .build();
 
-    log.debug("Posting event for start {}: {}", jobEnd, event);
+    log.debug("Posting event for end {}: {}", jobEnd, event);
     sparkContext.emit(event);
   }
 


### PR DESCRIPTION
On windows  (cygwin anyway), I was getting build error

```
gradle build
..
> Task :generateCode FAILED
io.openlineage.client.Generator.main [file:C:\OpenLineage\client\java/../../spec/OpenLineage.json, file:C:\OpenLineage\client\java/../../spec/]
Exception in thread "main" java.lang.IllegalArgumentException: URI is not hierarchical
        at java.io.File.<init>(File.java:420)
        at io.openlineage.client.Generator.main(Generator.java:55)

FAILURE: Build failed with an exception.

```
with the small change, I get
```
BUILD SUCCESSFUL in 7s
6 actionable tasks: 6 executed
```
