### PR TITLE
spark# Resolve #315 ignoring 'constraints' and 'isEmpty' fields

### DIFF
--- a/integration/spark/integrations/container/pysparkHiveCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveCompleteEvent.json
@@ -73,24 +73,6 @@
                                 "attrs": []
                             },
                             "canonicalizedPlan": false,
-                            "constraints": [
-                                {
-                                    "deterministic": true,
-                                    "origin": {
-                                        "line": null,
-                                        "startPosition": null
-                                    },
-                                    "resolved": true
-                                },
-                                {
-                                    "deterministic": true,
-                                    "origin": {
-                                        "line": null,
-                                        "startPosition": null
-                                    },
-                                    "resolved": true
-                                }
-                            ],
                             "data": [
                                 {
                                     "values": [

--- a/integration/spark/integrations/container/pysparkHiveOverwriteDirCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveOverwriteDirCompleteEvent.json
@@ -97,21 +97,6 @@
 							"attrs": []
 						},
 						"resolved": true,
-						"constraints": [{
-							"origin": {
-								"line": null,
-								"startPosition": null
-							},
-							"deterministic": true,
-							"resolved": true
-						}, {
-							"origin": {
-								"line": null,
-								"startPosition": null
-							},
-							"deterministic": true,
-							"resolved": true
-						}],
 						"statsCache": null,
 						"traceEnabled": false,
 						"canonicalizedPlan": false

--- a/integration/spark/integrations/container/pysparkHiveOverwriteDirStartEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveOverwriteDirStartEvent.json
@@ -97,21 +97,6 @@
 							"attrs": []
 						},
 						"resolved": true,
-						"constraints": [{
-							"origin": {
-								"line": null,
-								"startPosition": null
-							},
-							"deterministic": true,
-							"resolved": true
-						}, {
-							"origin": {
-								"line": null,
-								"startPosition": null
-							},
-							"deterministic": true,
-							"resolved": true
-						}],
 						"statsCache": null,
 						"traceEnabled": false,
 						"canonicalizedPlan": false

--- a/integration/spark/integrations/container/pysparkHiveStartEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveStartEvent.json
@@ -129,24 +129,6 @@
                                 "attrs": []
                             },
                             "canonicalizedPlan": false,
-                            "constraints": [
-                                {
-                                    "deterministic": true,
-                                    "origin": {
-                                        "line": null,
-                                        "startPosition": null
-                                    },
-                                    "resolved": true
-                                },
-                                {
-                                    "deterministic": true,
-                                    "origin": {
-                                        "line": null,
-                                        "startPosition": null
-                                    },
-                                    "resolved": true
-                                }
-                            ],
                             "data": [
                                 {
                                     "values": [

--- a/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -88,6 +88,7 @@ class LogicalPlanSerializer {
     public Boolean isEmpty() {
       return false;
     }
+
     @JsonIgnore
     public Partition[] getPartitions() {
       return null;

--- a/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -57,7 +57,7 @@ class LogicalPlanSerializer {
     try {
       return mapper.writeValueAsString(x);
     } catch (Throwable e) {
-      return "Unable to serialize {}: " + e.getMessage();
+      return "Unable to serialize: " + e.getMessage();
     }
   }
 
@@ -72,7 +72,7 @@ class LogicalPlanSerializer {
    * and 'containsChild' fields ignored cause we don't need them for the root node in {@link
    * LogicalPlan} and leaf nodes don't have child nodes in {@link LogicalPlan}
    */
-  @JsonIgnoreProperties({"child", "containsChild", "canonicalized"})
+  @JsonIgnoreProperties({"child", "containsChild", "canonicalized", "constraints"})
   abstract class ChildMixIn {}
 
   public static class PythonRDDMixin {
@@ -84,6 +84,10 @@ class LogicalPlanSerializer {
   public static class RDDMixin {
     @JsonIgnore private Partition[] partitions;
 
+    @JsonIgnore
+    public Boolean isEmpty() {
+      return false;
+    }
     @JsonIgnore
     public Partition[] getPartitions() {
       return null;


### PR DESCRIPTION
Resolves #315 
Ignoring few additional fields in  `LogicalPlanSerializer` which causes SparkContext shutdown