### PR TITLE
Use pipeline.number for pypi build tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,13 +331,13 @@ workflows:
       - unit-test-client-python
       - build-client-python:
           <<: *only_on_main
-          build_tag: .dev${CIRCLE_BUILD_NUM}
+          build_tag: ".dev<< pipeline.number >>"
           requires:
             - unit-test-client-python
       - unit-test-integration-common
       - build-integration-common:
           <<: *only_on_main
-          build_tag: .dev${CIRCLE_BUILD_NUM}
+          build_tag: ".dev<< pipeline.number >>"
           requires:
             - unit-test-integration-common
       - unit-test-integration-airflow
@@ -352,12 +352,12 @@ workflows:
               ignore: /pull\/[0-9]+/
       - build-integration-airflow:
           <<: *only_on_main
-          build_tag: .dev${CIRCLE_BUILD_NUM}
+          build_tag: ".dev<< pipeline.number >>"
           requires:
             - integration-test-integration-airflow
       - build-integration-dbt:
           <<: *only_on_main
-          build_tag: .dev${CIRCLE_BUILD_NUM}
+          build_tag: ".dev<< pipeline.number >>"
       - publish-snapshot-python:
           <<: *only_on_main
           context: release


### PR DESCRIPTION
This PR fixes the pypi build tag for our `py` modules by using the CI pipeline number (which is the same throughout the CI build). Currently, we use the build number which changes per CI job in the workflow. For example, the CI job `build-integration-common` has a build [`7046`](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/1088/workflows/744bb0ae-c7d6-4a1f-af90-71f0e9279bc8/jobs/7046) number, and the CI job `build-integration-airflow` has a build number [`7051`](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/1088/workflows/744bb0ae-c7d6-4a1f-af90-71f0e9279bc8/jobs/7051), even though they are part of the same CI pipeline (= [`1088`](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/1088/workflows/744bb0ae-c7d6-4a1f-af90-71f0e9279bc8)).

This causes issues when installing the dev version of `openlineage-airflow` from pypi:

<img width="1481" alt="Screen Shot 2021-10-06 at 8 42 05 AM" src="https://user-images.githubusercontent.com/1553185/136237385-5bfdf464-0c48-430e-b931-09263ff9564d.png">


