### PR TITLE
dbt: support manifest and run-results v3

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+
 import yaml
 import os
 import uuid
@@ -71,7 +72,7 @@ class DbtArtifactProcessor:
         project_dir: str,
         profile_name: Optional[str] = None,
         target: Optional[str] = None,
-        skip_errors: bool = False,
+        skip_errors: bool = False
     ):
         self.producer = producer
         self.dir = os.path.abspath(project_dir)
@@ -138,28 +139,36 @@ class DbtArtifactProcessor:
         )
 
     @staticmethod
-    def load_metadata(path: str, desired_schema_version: str) -> Dict:
+    def load_metadata(path: str, desired_schema_versions: List[str]) -> Dict:
         with open(path, 'r') as f:
             metadata = json.load(f)
             schema_version = get_from_nullable_chain(metadata, ['metadata', 'dbt_schema_version'])
-            if schema_version != desired_schema_version:
+            if schema_version not in desired_schema_versions:
                 # Maybe we should accept it and throw exception only if it substantially differs
                 raise ValueError(f"Wrong version of dbt metadata: {schema_version}, "
-                                 f"should be {desired_schema_version}")
+                                 f"should be in {desired_schema_versions}")
             return metadata
 
     @classmethod
     def load_manifest(cls, path: str) -> Dict:
-        return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/manifest/v2.json")
+        return cls.load_metadata(path, [
+            "https://schemas.getdbt.com/dbt/manifest/v2.json",
+            "https://schemas.getdbt.com/dbt/manifest/v3.json",
+        ])
 
     @classmethod
     def load_run_results(cls, path: str) -> Dict:
-        return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/run-results/v2.json")
+        return cls.load_metadata(path, [
+            "https://schemas.getdbt.com/dbt/run-results/v2.json",
+            "https://schemas.getdbt.com/dbt/run-results/v3.json"
+        ])
 
     @classmethod
     def load_catalog(cls, path: str) -> Optional[Dict]:
         try:
-            return cls.load_metadata(path, "https://schemas.getdbt.com/dbt/catalog/v1.json")
+            return cls.load_metadata(path, [
+                "https://schemas.getdbt.com/dbt/catalog/v1.json"
+            ])
         except FileNotFoundError:
             return None
 


### PR DESCRIPTION
There are no major differences between v2 and v3 metadata, at least those impacting information that we're collecting. 
This PR makes `dbt-ol` treat v3 metadata the same way we treated v2. 

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>