### PR TITLE
Add redshift naming spec

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -30,8 +30,8 @@ Identifier:
 
 #### Redshift:
 Datasource hierarchy:
- * Host
- * Port
+ * Host: examplecluster.\<XXXXXXXXXXXX>.us-west-2.redshift.amazonaws.com
+ * Port: 5439
  
 Naming hierarchy:
  * Database

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -27,6 +27,23 @@ Identifier:
    * Authority = {host}:{port}
  * Unique name: {database}.{schema}.{table}
    * URI =  postgres://{host}:{port}/{database}.{schema}.{table}
+
+#### Redshift:
+Datasource hierarchy:
+ * Host
+ * Port
+
+Naming hierarchy:
+ * Database
+ * Schema
+ * Table
+
+Identifier:
+ * Namespace: redshift://{host}:{port} of the cluster instance.
+   * Scheme = redshift
+   * Authority = {host}:{port}
+ * Unique name: {database}.{schema}.{table}
+   * URI =  redshift://{host}:{port}/{database}.{schema}.{table}
   
 #### Snowflake
 See: [Object Identifiers — Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/identifiers.html)

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -32,7 +32,7 @@ Identifier:
 Datasource hierarchy:
  * Host
  * Port
-
+ 
 Naming hierarchy:
  * Database
  * Schema


### PR DESCRIPTION
This PR adds Redshift naming specs.

Given that Redshift is based on Postgres, the proposed naming specs are almost identical to Postgres naming specs.