### PR TITLE
airflow: modify LineageBackend approach to be used in 1.10 when available

### DIFF
--- a/integration/airflow/Dockerfile.tests
+++ b/integration/airflow/Dockerfile.tests
@@ -8,7 +8,7 @@ COPY dbt /tmp/openlineage-integration-dbt
 RUN cd /tmp/openlineage-client-python && pip wheel --no-deps --wheel-dir=/tmp/openlineage-client-python/wheel .
 RUN cd /tmp/openlineage-integration-common && pip wheel --no-deps --wheel-dir=/tmp/openlineage-integration-common/wheel .
 RUN cd /tmp/openlineage-integration-dbt && pip wheel --no-deps --wheel-dir=/tmp/openlineage-integration-dbt/wheel .
-COPY airflow/openlineage/airflow /app/openlineage/airflow
+COPY airflow/openlineage /app/openlineage
 WORKDIR /app
 RUN ls -halt /tmp/openlineage-client-python/wheel
 RUN pip wheel --no-deps --wheel-dir=/app/wheel -e /tmp/openlineage-client-python .[tests]

--- a/integration/airflow/tests/integration/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/airflow/config/log_config.py
@@ -103,6 +103,11 @@ LOGGING_CONFIG = {
             'level': LOG_LEVEL,
             'propagate': False,
         },
+        'airflow.lineage': {
+            'handlers': ['console', 'task'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
         'flask_appbuilder': {
             'handler': ['console'],
             'level': FAB_LOG_LEVEL,

--- a/integration/airflow/tests/integration/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -28,6 +28,7 @@ dag = DAG(
     description='Determines the popular day of week orders are placed.'
 )
 
+
 t1 = PostgresOperator(
     task_id='postgres_if_not_exists',
     postgres_conn_id='food_delivery_db',

--- a/integration/airflow/tests/integration/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/docker-compose-2.yml
@@ -19,7 +19,8 @@ x-airflow-common: &airflow-common
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
     AIRFLOW__CORE__LOAD_EXAMPLES: "False"
-    AIRFLOW__LINEAGE__BACKEND: openlineage.airflow.backend.OpenLineageBackend
+    AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 60.0
+    AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     AIRFLOW_CONN_FOOD_DELIVERY_DB: postgres://food_delivery:food_delivery@postgres:5432/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=speedy-vim-308516&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "False"

--- a/integration/airflow/tests/integration/docker-compose.yml
+++ b/integration/airflow/tests/integration/docker-compose.yml
@@ -25,11 +25,13 @@ services:
       - AIRFLOW_DATABASE_PASSWORD=airflow
       - AIRFLOW_EXECUTOR=CeleryExecutor
       - AIRFLOW_LOAD_EXAMPLES=no
+      - AIRFLOW__LINEAGE__BACKEND=openlineage.lineage_backend.OpenLineageBackend
       - AIRFLOW_CONN_FOOD_DELIVERY_DB=postgres://food_delivery:food_delivery@postgres:5432/food_delivery
       - AIRFLOW_CONN_BQ_CONN=google-cloud-platform://?extra__google_cloud_platform__project=speedy-vim-308516&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
       - AIRFLOW__CORE__LOGGING_CONFIG_CLASS=log_config.LOGGING_CONFIG
       - AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=false
       - GOOGLE_APPLICATION_CREDENTIALS=/opt/config/gcloud/gcloud-service-key.json
+      - OPENLINEAGE_URL=http://backend:5000
       - OPENLINEAGE_NAMESPACE=food_delivery
     volumes:
       - ./airflow/logs:/opt/airflow/logs
@@ -56,6 +58,7 @@ services:
       - AIRFLOW_DATABASE_PASSWORD=airflow
       - AIRFLOW_EXECUTOR=CeleryExecutor
       - AIRFLOW_LOAD_EXAMPLES=no
+      - AIRFLOW__LINEAGE__BACKEND=openlineage.lineage_backend.OpenLineageBackend
       - AIRFLOW_CONN_FOOD_DELIVERY_DB=postgres://food_delivery:food_delivery@postgres:5432/food_delivery
       - AIRFLOW_CONN_BQ_CONN=google-cloud-platform://?extra__google_cloud_platform__project=speedy-vim-308516&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
       - AIRFLOW__CORE__LOGGING_CONFIG_CLASS=log_config.LOGGING_CONFIG
@@ -63,6 +66,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/opt/config/gcloud/gcloud-service-key.json
       - OPENLINEAGE_URL=http://backend:5000
       - OPENLINEAGE_NAMESPACE=food_delivery
+
     volumes:
       - ./airflow/logs:/opt/airflow/logs
       - ./airflow/dags:/opt/bitnami/airflow/dags
@@ -85,6 +89,7 @@ services:
       - AIRFLOW_DATABASE_USERNAME=airflow
       - AIRFLOW_DATABASE_PASSWORD=airflow
       - AIRFLOW_EXECUTOR=CeleryExecutor
+      - AIRFLOW__LINEAGE__BACKEND=openlineage.lineage_backend.OpenLineageBackend
       - AIRFLOW_CONN_FOOD_DELIVERY_DB=postgres://food_delivery:food_delivery@postgres:5432/food_delivery
       - AIRFLOW_CONN_BQ_CONN=google-cloud-platform://?extra__google_cloud_platform__project=speedy-vim-308516&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
       - AIRFLOW__CORE__LOGGING_CONFIG_CLASS=log_config.LOGGING_CONFIG

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -55,4 +55,5 @@ retrying==1.3.3
 pytest==6.2.2
 EOL
 
+docker-compose down
 docker-compose up -V --build --force-recreate --exit-code-from integration


### PR DESCRIPTION
In Airflow 1, if `OpenLineageBackend` is detected in Airflow configuration, then `openlineage.DAG` stops emitting `COMPLETE` events and leave that to `OpenLineageBackend`. Similarly, when `1.10` is detected, `OpenLineageBackend` stops emitting `START` events.

Due to Airflow 1 import conflicts, `OpenLineageBackend` can't be located in `openlineage.airflow` namespace. If you have idea about better place for this than `openlineage.lineage_backend.OpenLineageBackend` please let me know.

Closes https://github.com/OpenLineage/OpenLineage/issues/313 

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>