### PR TITLE
Upgrade airflow version for integration tests

### DIFF
--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -1,26 +1,28 @@
 FROM openlineage-airflow-base:latest AS build
 
-FROM bitnami/airflow-scheduler:1.10.12 AS scheduler
+FROM bitnami/airflow-scheduler:1.10.15 AS scheduler
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
 USER 1001
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
 
-
-FROM bitnami/airflow-worker:1.10.12 AS worker
+FROM bitnami/airflow-worker:1.10.15 AS worker
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
 USER 1001
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
 
-FROM bitnami/airflow:1.10.12 AS airflow
+FROM bitnami/airflow:1.10.15 AS airflow
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
 USER 1001
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
 
 FROM openlineage-airflow-base:latest AS integration
 COPY integration-requirements.txt integration-requirements.txt

--- a/integration/airflow/tests/integration/docker-compose.yml
+++ b/integration/airflow/tests/integration/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       context: .
       target: scheduler
     environment:
+      - AIRFLOW_WEBSERVER_HOST=airflow
       - AIRFLOW_FERNET_KEY=Z2uDm0ZL60fXNkEXG8LW99Ki2zf8wkmIltaTz1iQPDU=
       - AIRFLOW_DATABASE_HOST=postgres
       - AIRFLOW_DATABASE_NAME=airflow
@@ -77,6 +78,7 @@ services:
       context: .
       target: worker
     environment:
+      - AIRFLOW_WEBSERVER_HOST=airflow
       - AIRFLOW_FERNET_KEY=Z2uDm0ZL60fXNkEXG8LW99Ki2zf8wkmIltaTz1iQPDU=
       - AIRFLOW_DATABASE_HOST=postgres
       - AIRFLOW_DATABASE_NAME=airflow

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -48,10 +48,11 @@ EOL
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
 requests==2.24.0
+setuptools==34.0.0
 psycopg2-binary==2.8.6
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2
 EOL
 
-docker-compose up --build --force-recreate --exit-code-from integration
+docker-compose up -V --build --force-recreate --exit-code-from integration


### PR DESCRIPTION
I was trying to get task callbacks working and thought maybe upgrading the bitnami airflow version would help. It didn't, but here's a PR with the upgrade anyway.