### PR TITLE
dbt: add dbt version facet

### DIFF
--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -41,14 +41,14 @@ extras_require = {
         "snowflake-connector-python"
     ],
     "airflow-1": [
-        "apache-airflow==1.10.12",
-        "apache-airflow[gcp_api]==1.10.12",
-        "apache-airflow[google]==1.10.12",
-        "apache-airflow[postgres]==1.10.12",
+        "apache-airflow==1.10.15",
+        "apache-airflow[gcp_api]==1.10.15",
+        "apache-airflow[google]==1.10.15",
+        "apache-airflow[postgres]==1.10.15",
         "airflow-provider-great-expectations==0.0.8",
     ],
     "airflow-2": [
-        "apache-airflow==2.1.2",
+        "apache-airflow==2.1.3",
         "apache-airflow-providers-postgres==2.0.0",
         "apache-airflow-providers-snowflake==2.1.0",
         "apache-airflow-providers-google==5.0.0",

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -12,6 +12,7 @@
 import json
 import logging
 import sys
+
 import psycopg2
 import time
 import requests

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -12,9 +12,10 @@ from typing import List, Tuple, Dict, Optional, TypeVar
 import attr
 
 from openlineage.client.facet import DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField, \
-    SqlJobFacet, OutputStatisticsOutputDatasetFacet, ParentRunFacet
+    SqlJobFacet, OutputStatisticsOutputDatasetFacet, ParentRunFacet, BaseFacet, \
+    Assertion, DataQualityAssertionsDatasetFacet
 from openlineage.client.run import RunEvent, RunState, Run, Job, Dataset, OutputDataset
-from openlineage.client.facet import Assertion, DataQualityAssertionsDatasetFacet
+from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.utils import get_from_nullable_chain, get_from_multiple_chains
 
 
@@ -84,6 +85,15 @@ class ParentRunMetadata:
         )
 
 
+@attr.s
+class DbtVersionRunFacet(BaseFacet):
+    version: str = attr.ib()
+
+    @staticmethod
+    def _get_schema() -> str:
+        return GITHUB_LOCATION + "dbt-version-run-facet.json"
+
+
 T = TypeVar('T')
 
 
@@ -107,6 +117,7 @@ class DbtArtifactProcessor:
         self.dataset_namespace = ""
         self.skip_errors = skip_errors
         self.project = self.load_yaml_with_jinja(os.path.join(project_dir, 'dbt_project.yml'))
+        self.run_metadata = None
 
         self.manifest_path = os.path.join(self.dir, self.project['target-path'], 'manifest.json')
         self.run_result_path = os.path.join(
@@ -128,6 +139,8 @@ class DbtArtifactProcessor:
         """
         manifest = self.load_manifest(self.manifest_path)
         run_result = self.load_run_results(self.run_result_path)
+        self.run_metadata = run_result['metadata']
+
         catalog = self.load_catalog(self.catalog_path)
 
         profile_dir = run_result['args']['profiles_dir']
@@ -380,7 +393,8 @@ class DbtArtifactProcessor:
                 run=Run(
                     runId=run_id,
                     facets={
-                        "parent": self._dbt_run_metadata.to_openlineage()
+                        "parent": self._dbt_run_metadata.to_openlineage(),
+                        "dbt_version": self.dbt_version_facet()
                     }
                 ),
                 job=Job(
@@ -432,7 +446,8 @@ class DbtArtifactProcessor:
                     run=Run(
                         runId=run.run_id,
                         facets={
-                            "parent": self._dbt_run_metadata.to_openlineage()
+                            "parent": self._dbt_run_metadata.to_openlineage(),
+                            "dbt_version": self.dbt_version_facet()
                         }
                     ),
                     job=Job(
@@ -456,11 +471,8 @@ class DbtArtifactProcessor:
                     run=Run(
                         runId=run.run_id,
                         facets={
-                            "parent": ParentRunFacet.create(
-                                runId=self.dbt_run_metadata.run_id,
-                                namespace=self.dbt_run_metadata.job_namespace,
-                                name=self.dbt_run_metadata.job_name
-                            )
+                            "parent": self._dbt_run_metadata.to_openlineage(),
+                            "dbt_version": self.dbt_version_facet()
                         }
                     ),
                     job=Job(
@@ -600,6 +612,11 @@ class DbtArtifactProcessor:
                 f"Only 'snowflake', 'bigquery', and 'redshift' adapters are supported right now. "
                 f"Passed {profile['type']}"
             )
+
+    def dbt_version_facet(self):
+        return DbtVersionRunFacet(
+            version=self.run_metadata['dbt_version']
+        )
 
     @staticmethod
     def get_timings(timings: List[Dict]) -> Tuple[str, str]:

--- a/integration/common/openlineage/common/schema/dbt-version-run-facet.json
+++ b/integration/common/openlineage/common/schema/dbt-version-run-facet.json
@@ -1,0 +1,22 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "DbtVersionRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/1-0-2/OpenLineage.json#/definitions/BaseFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "string",
+              "example": "0.20.1"
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -33,6 +33,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/catalog/target/manifest.json
+++ b/integration/common/tests/dbt/catalog/target/manifest.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:44.367050Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {},

--- a/integration/common/tests/dbt/catalog/target/run_results.json
+++ b/integration/common/tests/dbt/catalog/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:51.891863Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {}

--- a/integration/common/tests/dbt/env_vars/result.json
+++ b/integration/common/tests/dbt/env_vars/result.json
@@ -33,6 +33,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/env_vars/target/manifest.json
+++ b/integration/common/tests/dbt/env_vars/target/manifest.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:44.367050Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {},

--- a/integration/common/tests/dbt/env_vars/target/run_results.json
+++ b/integration/common/tests/dbt/env_vars/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:51.891863Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {}

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -77,6 +77,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -126,6 +131,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -195,6 +205,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/fail/target/run_results.json
+++ b/integration/common/tests/dbt/fail/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-28T12:09:48.781634Z",
 		"invocation_id": "8c814240-637d-4a36-937e-43787f5c79e0",
 		"env": {}

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -129,6 +129,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -182,6 +187,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -235,6 +245,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -284,6 +299,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},
@@ -413,6 +433,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/large/target/manifest.json
+++ b/integration/common/tests/dbt/large/target/manifest.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-05T11:43:09.384637Z",
 		"invocation_id": "ebb384bf-f2f3-4303-bb1b-98b1daa6d2d4",
 		"env": {},

--- a/integration/common/tests/dbt/large/target/run_results.json
+++ b/integration/common/tests/dbt/large/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-05T11:43:26.134009Z",
 		"invocation_id": "ebb384bf-f2f3-4303-bb1b-98b1daa6d2d4",
 		"env": {}

--- a/integration/common/tests/dbt/profiles/result.json
+++ b/integration/common/tests/dbt/profiles/result.json
@@ -33,7 +33,12 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
-			}
+			},
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
+                }
 		}
 	},
 	"job": {

--- a/integration/common/tests/dbt/profiles/target/manifest.json
+++ b/integration/common/tests/dbt/profiles/target/manifest.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:44.367050Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {},

--- a/integration/common/tests/dbt/profiles/target/run_results.json
+++ b/integration/common/tests/dbt/profiles/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:51.891863Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {}

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -33,6 +33,11 @@
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/small/target/manifest.json
+++ b/integration/common/tests/dbt/small/target/manifest.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:44.367050Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {},

--- a/integration/common/tests/dbt/small/target/run_results.json
+++ b/integration/common/tests/dbt/small/target/run_results.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-		"dbt_version": "0.20.0rc2",
+		"dbt_version": "0.21.0",
 		"generated_at": "2021-07-07T12:44:51.891863Z",
 		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
 		"env": {}

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -138,6 +138,11 @@
                     "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                },
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
                 }
             },
             "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99"
@@ -184,6 +189,11 @@
                     "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                },
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
                 }
             },
             "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7"
@@ -230,6 +240,11 @@
                     "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                },
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
                 }
             },
             "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11"
@@ -291,6 +306,11 @@
                     "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                },
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
                 }
             },
             "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"

--- a/integration/common/tests/dbt/test/target/run_results.json
+++ b/integration/common/tests/dbt/test/target/run_results.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
-        "dbt_version": "0.20.0",
+        "dbt_version": "0.21.0",
         "generated_at": "2021-08-23T15:06:44.629950Z",
         "invocation_id": "9adc7020-c784-4179-a4e3-e3c4ffb3b09c",
         "env": {}


### PR DESCRIPTION
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

### Problem

Add `DbtVersionRunFacet` to capture `dbt` version that `dbt-ol` is working with.

Also, had to modify many tests. Created an issue to clean that up. https://github.com/OpenLineage/OpenLineage/issues/342

Closes: https://github.com/OpenLineage/OpenLineage/issues/341

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)