### PR TITLE
dbt tests: use jinja templating, compare events not via equal strings

### DIFF
--- a/integration/airflow/tests/integration/docker/up-2.sh
+++ b/integration/airflow/tests/integration/docker/up-2.sh
@@ -53,6 +53,9 @@ psycopg2-binary==2.8.6
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2
+jinja2==3.0.2
+python-dateutil==2.8.2
+${OPENLINEAGE_AIRFLOW_WHL}
 EOL
 
 docker-compose -f docker-compose-2.yml down

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -53,6 +53,9 @@ psycopg2-binary==2.8.6
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2
+jinja2==3.0.2
+python-dateutil==2.8.2
+${OPENLINEAGE_AIRFLOW_WHL}
 EOL
 
 docker-compose down

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -416,7 +416,7 @@ class DbtArtifactProcessor:
         except Exception as e:
             if self.skip_errors:
                 return None
-            raise ValueError(e)
+            raise ValueError() from e
 
     def _to_openlineage_events(self, run: DbtRun) -> Optional[DbtRunResult]:
         if run.status == 'skipped':

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -1,0 +1,91 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import typing
+import logging
+from dateutil.parser import parse
+from jinja2 import Environment
+
+
+log = logging.getLogger(__name__)
+
+
+def any(result: typing.Any):
+    return result
+
+
+def is_datetime(result: typing.Any):
+    try:
+        x = parse(result)  # noqa
+        return "true"
+    except:  # noqa
+        pass
+    return "false"
+
+
+def setup_jinja() -> Environment:
+    env = Environment()
+    env.globals['any'] = any
+    env.globals['is_datetime'] = is_datetime
+    return env
+
+
+env = setup_jinja()
+
+
+def match(expected, result) -> bool:
+    """
+    Check if result is "equal" to expected value.
+    """
+    if isinstance(expected, dict):
+        # Take a look only at keys present at expected dictionary
+        for k, v in expected.items():
+            if k not in result:
+                log.error(f"Key {k} not in event {result}\nExpected {expected}")
+                return False
+            if not match(v, result[k]):
+                log.error(f"For key {k}, value {v} not equals {result[k]}"
+                          f"\nExpected {expected}, request {result}")
+                return False
+    elif isinstance(expected, list):
+        if len(expected) != len(result):
+            return False
+
+        # Try to resolve case where we have wrongly sorted lists by looking at name attr
+        # If name is not present then assume that lists are sorted
+        for i, x in enumerate(expected):
+            if 'name' in x:
+                matched = False
+                for y in result:
+                    if 'name' in y and x['name'] == y['name']:
+                        if not match(x, y):
+                            return False
+                        matched = True
+                        break
+                if not matched:
+                    return False
+            else:
+                if not match(x, result[i]):
+                    return False
+    elif isinstance(expected, str):
+        if expected.lstrip().startswith('{{'):
+            # Evaluate jinja: in some cases, we want to check only if key exists, or if
+            # value has the right type
+            rendered = env.from_string(expected).render(result=result)
+            if rendered == 'true' or rendered == result:
+                return True
+            log.error(f"Rendered value {rendered} does not equal 'true' or {result}")
+            return False
+        elif expected != result:
+            return False
+    elif expected != result:
+        return False
+    return True

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -48,7 +48,9 @@ extras_require = {
         "pytest-cov",
         "mock",
         "flake8",
-        "pandas"
+        "pandas",
+        "jinja2",
+        "python-dateutil"
     ],
 }
 extras_require["dev"] = set(sum(extras_require.values(), []))

--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -1,43 +1,34 @@
 [{
 	"eventType": "START",
-	"eventTime": "2021-07-07T12:44:46.069306Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.dbt_test.test_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.source_table",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.source_table"
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.test_model",
-		"facets": {},
-		"outputFacets": {}
+		"name": "random-gcp-project.dbt_test1.test_model"
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -46,26 +37,19 @@
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1"
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "random-gcp-project.dbt_test1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": "INT64",
@@ -79,14 +63,10 @@
 		"name": "random-gcp-project.dbt_test1.test_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": "INT64",
@@ -96,8 +76,6 @@
 		},
 		"outputFacets": {
 			"outputStatistics": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
 				"rowCount": 1,
 				"size": 16
 			}

--- a/integration/common/tests/dbt/env_vars/result.json
+++ b/integration/common/tests/dbt/env_vars/result.json
@@ -1,43 +1,34 @@
 [{
 	"eventType": "START",
-	"eventTime": "2021-07-07T12:44:46.069306Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "redshift://foo_host:1111",
-		"name": "foo_db_name.foo_schema.dbt_test.test_model",
-		"facets": {}
+		"name": "foo_db_name.foo_schema.dbt_test.test_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "redshift://foo_host:1111",
-		"name": "foo_db_name.foo_schema.source_table",
-		"facets": {}
+		"name": "foo_db_name.foo_schema.source_table"
 	}],
 	"outputs": [{
 		"namespace": "redshift://foo_host:1111",
-		"name": "foo_db_name.foo_schema.test_model",
-		"facets": {},
-		"outputFacets": {}
+		"name": "foo_db_name.foo_schema.test_model"
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -46,8 +37,6 @@
 		"name": "foo_db_name.foo_schema.dbt_test.test_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1"
 			}
 		}
@@ -58,14 +47,10 @@
 		"name": "foo_db_name.foo_schema.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "redshift://foo_host:1111",
 				"uri": "redshift://foo_host:1111"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": []
 			}
 		}
@@ -75,14 +60,10 @@
 		"name": "foo_db_name.foo_schema.test_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "redshift://foo_host:1111",
 				"uri": "redshift://foo_host:1111"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": null,

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -1,32 +1,27 @@
 [{
 	"eventType": "START",
-	"eventTime": "2021-07-28T13:10:51.245287+00:00",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.source_table",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.source_table"
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.test_second_parallel_dbt_model",
-		"facets": {},
-		"outputFacets": {}
+		"name": "random-gcp-project.dbt_test1.test_second_parallel_dbt_model"
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-28T12:09:46.095543Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+		"runId": "{{ any(result) }}",
 		"facets": {}
 	},
 	"job": {
@@ -44,9 +39,9 @@
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-28T12:09:48.001746Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
+		"runId": "{{ any(result) }}",
 		"facets": {}
 	},
 	"job": {
@@ -68,20 +63,16 @@
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-28T12:09:47.994760Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -90,8 +81,6 @@
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data"
 			}
 		}
@@ -117,25 +106,20 @@
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-28T12:09:48.778721Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -144,8 +128,6 @@
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`test_first_dbt_model`\nwhere id = 1"
 			}
 		}
@@ -156,14 +138,10 @@
 		"name": "random-gcp-project.dbt_test1.test_first_dbt_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": null,
@@ -177,14 +155,10 @@
 		"name": "random-gcp-project.dbt_test1.test_second_dbt_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": null,
@@ -196,20 +170,16 @@
 	}]
 }, {
 	"eventType": "FAIL",
-	"eventTime": "2021-07-28T13:10:51.245287+00:00",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -218,8 +188,6 @@
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1\nbork bork fail"
 			}
 		}
@@ -230,14 +198,10 @@
 		"name": "random-gcp-project.dbt_test1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": []
 			}
 		}

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -1,139 +1,110 @@
 [{
 	"eventType": "START",
-	"eventTime": "2021-07-05T11:43:14.756283Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.jaffle_shop.stg_orders",
-		"facets": {}
+		"name": "DEMO_DB.public.jaffle_shop.stg_orders"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_orders",
-		"facets": {},
-		"outputFacets": {}
+		"name": "DEMO_DB.public.stg_orders"
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-05T11:43:16.271247Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.jaffle_shop.stg_payments",
-		"facets": {}
+		"name": "DEMO_DB.public.jaffle_shop.stg_payments"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_payments",
-		"facets": {},
-		"outputFacets": {}
+		"name": "DEMO_DB.public.stg_payments"
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-05T11:43:17.338870Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.jaffle_shop.stg_customers",
-		"facets": {}
+		"name": "DEMO_DB.public.jaffle_shop.stg_customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_customers",
-		"facets": {},
-		"outputFacets": {}
+		"name": "DEMO_DB.public.stg_customers"
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-05T11:43:18.498280Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.jaffle_shop.orders",
-		"facets": {}
+		"name": "DEMO_DB.public.jaffle_shop.orders"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_orders",
-		"facets": {}
+		"name": "DEMO_DB.public.stg_orders"
 	}, {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_payments",
-		"facets": {}
+		"name": "DEMO_DB.public.stg_payments"
 	}],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.orders",
-		"facets": {},
-		"outputFacets": {}
+		"name": "DEMO_DB.public.orders"
 	}]
 }, {
 	"eventType": "START",
-	"eventTime": "2021-07-05T11:43:22.037678Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "ae0a988e-72ad-4caf-8223-fe9dcb923a3f",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.jaffle_shop.customers",
-		"facets": {}
+		"name": "DEMO_DB.public.jaffle_shop.customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_customers",
-		"facets": {}
+		"name": "DEMO_DB.public.stg_customers"
 	}, {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_orders",
-		"facets": {}
+		"name": "DEMO_DB.public.stg_orders"
 	}, {
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.stg_payments",
-		"facets": {}
+		"name": "DEMO_DB.public.stg_payments"
 	}],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
-		"name": "DEMO_DB.public.customers",
-		"facets": {},
-		"outputFacets": {}
+		"name": "DEMO_DB.public.customers"
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-05T11:43:16.146647Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -148,21 +119,16 @@
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
 					"type": null,
@@ -173,25 +139,22 @@
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",
 	"eventTime": "2021-07-05T11:43:17.218104Z",
 	"run": {
-		"runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -206,21 +169,16 @@
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
 					"type": null,
@@ -238,7 +196,6 @@
 	"eventType": "COMPLETE",
 	"eventTime": "2021-07-05T11:43:18.375002Z",
 	"run": {
-		"runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
 		"facets": {
 			"parent": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -249,7 +206,7 @@
 			"dbt_version": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -264,45 +221,35 @@
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "customer_id",
 					"type": null,
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",
 	"eventTime": "2021-07-05T11:43:21.900891Z",
 	"run": {
-		"runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "0.21.0"
 			}
 		}
@@ -312,8 +259,6 @@
 		"name": "DEMO_DB.public.jaffle_shop.orders",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "\n\nwith orders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final"
 			}
 		}
@@ -324,14 +269,10 @@
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
 					"type": null,
@@ -348,14 +289,10 @@
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
 					"type": null,
@@ -373,14 +310,10 @@
 		"name": "DEMO_DB.public.orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
 					"type": null,
@@ -424,19 +357,15 @@
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-05T11:43:24.406553Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "ae0a988e-72ad-4caf-8223-fe9dcb923a3f",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "0.21.0"
 			}
 		}
@@ -446,26 +375,19 @@
 		"name": "DEMO_DB.public.jaffle_shop.customers",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "with customers as (\n\n    select * from DEMO_DB.public.stg_customers\n\n),\n\norders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final"
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "snowflake://ASDF1234.eu-central-1",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "customer_id",
 					"type": null,
@@ -478,14 +400,10 @@
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "order_id",
 					"type": null,
@@ -502,14 +420,10 @@
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "snowflake://ASDF1234.eu-central-1",
 				"uri": "snowflake://ASDF1234.eu-central-1"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "payment_id",
 					"type": null,
@@ -565,7 +479,6 @@
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }]

--- a/integration/common/tests/dbt/profiles/result.json
+++ b/integration/common/tests/dbt/profiles/result.json
@@ -2,42 +2,32 @@
 	"eventType": "START",
 	"eventTime": "2021-07-07T12:44:46.069306Z",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_prod1.dbt_test.test_model",
-		"facets": {}
+		"name": "random-gcp-project.dbt_prod1.dbt_test.test_model"
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_prod1.source_table",
-		"facets": {}
+		"name": "random-gcp-project.dbt_prod1.source_table"
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_prod1.test_model",
-		"facets": {},
-		"outputFacets": {}
+		"name": "random-gcp-project.dbt_prod1.test_model"
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
                 "dbt_version": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-                    "version": "0.21.0"
+                    "version": "{{ any(result) }}"
                 }
 		}
 	},
@@ -46,27 +36,17 @@
 		"name": "random-gcp-project.dbt_prod1.dbt_test.test_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_prod1`.`source_table`\nwhere id = 1"
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "random-gcp-project.dbt_prod1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
-			},
-			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
-				"fields": []
 			}
 		}
 	}],
@@ -75,21 +55,16 @@
 		"name": "random-gcp-project.dbt_prod1.test_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": null,
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }]

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -1,43 +1,33 @@
 [{
 	"eventType": "START",
-	"eventTime": "2021-07-07T12:44:46.069306Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-		"facets": {}
+		"runId": "{{ any(result) }}"
 	},
 	"job": {
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.dbt_test.test_model"
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.source_table",
-		"facets": {}
+		"name": "random-gcp-project.dbt_test1.source_table"
 	}],
 	"outputs": [{
 		"namespace": "bigquery",
-		"name": "random-gcp-project.dbt_test1.test_model",
-		"facets": {},
-		"outputFacets": {}
+		"name": "random-gcp-project.dbt_test1.test_model"
 	}]
 }, {
 	"eventType": "COMPLETE",
-	"eventTime": "2021-07-07T12:44:46.972743Z",
+	"eventTime": "{{ is_datetime(result) }}",
 	"run": {
-		"runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+				"run": {"runId": "{{ any(result) }}"}
 			},
 			"dbt_version": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "0.21.0"
+				"version": "{{ any(result) }}"
 			}
 		}
 	},
@@ -46,27 +36,17 @@
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
 		"facets": {
 			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1"
 			}
 		}
 	},
-	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
 		"namespace": "bigquery",
 		"name": "random-gcp-project.dbt_test1.source_table",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
-			},
-			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
-				"fields": []
 			}
 		}
 	}],
@@ -75,21 +55,16 @@
 		"name": "random-gcp-project.dbt_test1.test_model",
 		"facets": {
 			"dataSource": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
 				"name": "bigquery",
 				"uri": "bigquery"
 			},
 			"schema": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
 				"fields": [{
 					"name": "id",
 					"type": null,
 					"description": null
 				}]
 			}
-		},
-		"outputFacets": {}
+		}
 	}]
 }]

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -4,21 +4,18 @@
         "eventType": "START",
         "inputs": [
             {
-                "facets": {},
                 "name": "random-gcp-project.dbt_test1.test_third_dbt_model",
                 "namespace": "bigquery"
             }
         ],
         "job": {
-            "facets": {},
             "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_third_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         "run": {
-            "facets": {},
-            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99"
+            "runId": "{{ any(result) }}"
         }
     },
     {
@@ -26,21 +23,18 @@
         "eventType": "START",
         "inputs": [
             {
-                "facets": {},
                 "name": "random-gcp-project.dbt_test1.test_second_parallel_dbt_model",
                 "namespace": "bigquery"
             }
         ],
         "job": {
-            "facets": {},
             "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         "run": {
-            "facets": {},
-            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7"
+            "runId": "{{ any(result) }}"
         }
     },
     {
@@ -48,21 +42,18 @@
         "eventType": "START",
         "inputs": [
             {
-                "facets": {},
                 "name": "random-gcp-project.dbt_test1.test_second_dbt_model",
                 "namespace": "bigquery"
             }
         ],
         "job": {
-            "facets": {},
             "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         "run": {
-            "facets": {},
-            "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11"
+            "runId": "{{ any(result) }}"
         }
     },
     {
@@ -70,20 +61,17 @@
         "eventType": "START",
         "inputs": [
             {
-                "facets": {},
                 "name": "random-gcp-project.dbt_test1.test_first_dbt_model",
                 "namespace": "bigquery"
             }
         ],
         "job": {
-            "facets": {},
             "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_first_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         "run": {
-            "facets": {},
             "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"
         }
     },
@@ -134,18 +122,14 @@
         "run": {
             "facets": {
                 "parent": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
                 },
                 "dbt_version": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-                    "version": "0.21.0"
+                    "version": "{{ any(result) }}"
                 }
             },
-            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99"
+            "runId": "{{ any(result) }}"
         }
     },
     {
@@ -155,8 +139,6 @@
             {
                 "facets": {
                     "dataQualityAssertions": {
-                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                        "_schemaURL": "#/definitions/DataQualityAssertionsDatasetFacet",
                         "assertions": [
                             {
                                 "column": "id",
@@ -176,7 +158,6 @@
             }
         ],
         "job": {
-            "facets": {},
             "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
             "namespace": "bigquery"
         },
@@ -185,18 +166,14 @@
         "run": {
             "facets": {
                 "parent": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
-                    "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                    "run": {"runId": "{{ any(result) }}"}
                 },
                 "dbt_version": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-                    "version": "0.21.0"
+                    "version": "{{ any(result) }}"
                 }
             },
-            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7"
+            "runId": "{{ any(result) }}"
         }
     },
     {

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -8,6 +8,7 @@ import pytest
 
 from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata
 from openlineage.client import set_producer
+from openlineage.common.test import match
 
 import os
 
@@ -32,15 +33,20 @@ def serialize(inst, field, value):
     return value
 
 
-@mock.patch('uuid.uuid4')
-def test_dbt_parse_small_event(mock_uuid, parent_run_metadata):
-    mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/dbt/small",
+        "tests/dbt/large",
+        "tests/dbt/profiles",
+        "tests/dbt/catalog",
+        "tests/dbt/fail"
     ]
-
+)
+def test_dbt_parse_and_compare_event(path, parent_run_metadata):
     processor = DbtArtifactProcessor(
         producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/small'
+        project_dir=path
     )
     processor.dbt_run_metadata = parent_run_metadata
     dbt_events = processor.parse()
@@ -49,107 +55,8 @@ def test_dbt_parse_small_event(mock_uuid, parent_run_metadata):
         for event
         in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
-    with open('tests/dbt/small/result.json', 'r') as f:
-        assert events == json.load(f)
-
-
-@mock.patch('uuid.uuid4')
-def test_dbt_parse_event_with_profiles(mock_uuid, parent_run_metadata):
-    mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
-    ]
-
-    processor = DbtArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/profiles',
-        target='prod',
-    )
-    processor.dbt_run_metadata = parent_run_metadata
-
-    dbt_events = processor.parse()
-    events = [
-        attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
-    ]
-    with open('tests/dbt/profiles/result.json', 'r') as f:
-        assert events == json.load(f)
-
-
-@mock.patch('uuid.uuid4')
-def test_dbt_parse_catalog_event(mock_uuid, parent_run_metadata):
-    mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
-    ]
-
-    processor = DbtArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/catalog',
-    )
-    processor.dbt_run_metadata = parent_run_metadata
-
-    dbt_events = processor.parse()
-    events = [
-        attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
-    ]
-    with open('tests/dbt/catalog/result.json', 'r') as f:
-        assert events == json.load(f)
-
-
-@mock.patch('uuid.uuid4')
-def test_dbt_parse_large_event(mock_uuid, parent_run_metadata):
-    mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
-        '1a69c0a7-04bb-408b-980e-cbbfb1831ef7',
-        'f99310b4-339a-4381-ad3e-c1b95c24ff11',
-        'c11f2efd-4415-45fc-8081-10d2aaa594d2',
-        'ae0a988e-72ad-4caf-8223-fe9dcb923a3f'
-    ]
-
-    processor = DbtArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/large',
-    )
-    processor.dbt_run_metadata = parent_run_metadata
-
-    dbt_events = processor.parse()
-    events = [
-        attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
-    ]
-    with open('tests/dbt/large/result.json', 'r') as f:
-        assert events == json.load(f)
-
-
-@mock.patch('uuid.uuid4')
-@mock.patch('datetime.datetime')
-def test_dbt_parse_failed_event(mock_datetime, mock_uuid, parent_run_metadata):
-    mock_datetime.now.return_value.isoformat.return_value = '2021-07-28T13:10:51.245287+00:00'
-    mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
-        '1a69c0a7-04bb-408b-980e-cbbfb1831ef7',
-        'f99310b4-339a-4381-ad3e-c1b95c24ff11',
-        'c11f2efd-4415-45fc-8081-10d2aaa594d2',
-        'ae0a988e-72ad-4caf-8223-fe9dcb923a3f'
-    ]
-
-    processor = DbtArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/fail',
-    )
-    processor.dbt_run_metadata = parent_run_metadata
-
-    dbt_events = processor.parse()
-    events = [
-        attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
-    ]
-    with open('tests/dbt/fail/result.json', 'r') as f:
-        assert events == json.load(f)
+    with open(f'{path}/result.json', 'r') as f:
+        assert match(json.load(f), events)
 
 
 @mock.patch('uuid.uuid4')
@@ -176,7 +83,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
     with open('tests/dbt/test/result.json', 'r') as f:
-        assert events == json.load(f)
+        assert match(json.load(f), events)
 
 
 @mock.patch('uuid.uuid4')
@@ -210,7 +117,7 @@ def test_dbt_parse_profile_with_env_vars(mock_uuid, parent_run_metadata):
         in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
     with open('tests/dbt/env_vars/result.json', 'r') as f:
-        assert events == json.load(f)
+        assert match(json.load(f), events)
 
 
 @pytest.fixture()

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -34,6 +34,7 @@ extras_require = {
         "pytest-cov",
         "mock",
         "flake8",
+        "python-dateutil"
     ],
 }
 extras_require["dev"] = set(sum(extras_require.values(), []))


### PR DESCRIPTION
Use match function to compare events. Use jinja methods to express requirements like existence of key, or checking if it's the right type. This has the advantage of comparing only the keys we want - not requiring byte-perfect equality when we don't want it.

Closes https://github.com/OpenLineage/OpenLineage/issues/342

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)