### PR TITLE
[python] [client] strip host value. Closes #347

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 * facet: adding custom spark version facet to spark integration [@OleksandrDvornik](https://github.com/OleksandrDvornik)
 
+### Fixed
+
+* strip openlineage url in python client [@OleksandrDvornik](https://github.com/OleksandrDvornik)
+
 ## [0.2.3](https://github.com/OpenLineage/OpenLineage/releases/tag/0.2.3) - 2021-10-07
 
 ### Fixed

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -12,11 +12,12 @@
 
 import os
 import logging
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 import attr
 from requests import Session
 from requests.adapters import HTTPAdapter
+from urllib3.util.url import parse_url
 
 from openlineage.client import constants
 from openlineage.client.run import RunEvent
@@ -41,9 +42,13 @@ class OpenLineageClient:
             options: OpenLineageClientOptions = OpenLineageClientOptions(),
             session: Session = None
     ):
-        parsed = urlparse(url)
-        if not (parsed.scheme and parsed.netloc):
-            raise ValueError(f"Need valid url for OpenLineageClient, passed {url}")
+        url = url.strip()
+        try:
+            parsed = parse_url(url)
+            if not (parsed.scheme and parsed.netloc):
+                raise ValueError(f"Need valid url for OpenLineageClient, passed {url}")
+        except Exception as e:
+            raise ValueError(f"Need valid url for OpenLineageClient, passed {url}. Exception: {e}")
         self.url = url
         self.options = options
         self.session = session if session else Session()

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -41,14 +41,22 @@ def test_client_fails_to_create_with_wrong_url():
     with pytest.raises(ValueError):
         OpenLineageClient(url="196.168.0.1", session=session)
 
+
 def test_client_passes_to_create_with_valid_url():
     session = MagicMock()
-    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == "http://196.168.0.1"
-    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == "http://196.168.0.1"
-    assert OpenLineageClient(url="http://example.com  ", session=session).url == "http://example.com"
-    assert OpenLineageClient(url=" http://example.com", session=session).url == "http://example.com"
-    assert OpenLineageClient(url="  http://marquez:5000  ", session=session).url == "http://marquez:5000"
-    assert OpenLineageClient(url="  https://marquez  ", session=session).url == "https://marquez"
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == \
+           "http://196.168.0.1"
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == \
+           "http://196.168.0.1"
+    assert OpenLineageClient(url="http://example.com  ", session=session).url == \
+           "http://example.com"
+    assert OpenLineageClient(url=" http://example.com", session=session).url == \
+           "http://example.com"
+    assert OpenLineageClient(url="  http://marquez:5000  ", session=session).url == \
+           "http://marquez:5000"
+    assert OpenLineageClient(url="  https://marquez  ", session=session).url == \
+           "https://marquez"
+
 
 def test_client_sends_proper_json_with_minimal_event():
     session = MagicMock()

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -41,6 +41,14 @@ def test_client_fails_to_create_with_wrong_url():
     with pytest.raises(ValueError):
         OpenLineageClient(url="196.168.0.1", session=session)
 
+def test_client_passes_to_create_with_valid_url():
+    session = MagicMock()
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == "http://196.168.0.1"
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == "http://196.168.0.1"
+    assert OpenLineageClient(url="http://example.com  ", session=session).url == "http://example.com"
+    assert OpenLineageClient(url=" http://example.com", session=session).url == "http://example.com"
+    assert OpenLineageClient(url="  http://marquez:5000  ", session=session).url == "http://marquez:5000"
+    assert OpenLineageClient(url="  https://marquez  ", session=session).url == "https://marquez"
 
 def test_client_sends_proper_json_with_minimal_event():
     session = MagicMock()


### PR DESCRIPTION
Signed-off-by: olek <oleksandr.dvornik@gmail.com>

### Problem
We don't trim openlineage url

Closes: #347

### Solution
Trim spaces

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)