### PR TITLE
Cache `.m2/` for java client release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,6 @@ jobs:
       - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
-            - v1-release-client-java-{{ .Branch }}
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
@@ -127,6 +123,10 @@ jobs:
       - image: circleci/openjdk:8-jdk
     steps:
       - *checkout_project_root
+      - restore_cache:
+          keys:
+            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-{{ .Branch }}
       - run: |
           cd ../../client/java
           ./gradlew  --no-daemon publishToMavenLocal


### PR DESCRIPTION
### Problem

The CI job `release-integration-spark` fails on release as it depends on the `openlineage-java` artifact to be published to maven before it can be triggered.

Closes: https://github.com/OpenLineage/OpenLineage/issues/350

### Solution

Add CI job `release-client-java` as a dependency for `release-integration-spark`,  ensuring  the `openlineage-java` artifact is published to local maven. When running the `gradle publish` task, it also runs the `publishPubNamePublicationToRepoNameRepository` tasks. We can then save / load the cached `~/.m2` with the artifact.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)