### PR TITLE
[INTEGRATION][airflow] add tests that check for order of received events

### DIFF
--- a/integration/airflow/tests/integration/airflow/dags/event_order.py
+++ b/integration/airflow/tests/integration/airflow/dags/event_order.py
@@ -1,0 +1,67 @@
+import datetime
+import os
+import uuid
+
+from airflow.operators.bash_operator import BashOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.utils.dates import days_ago
+from openlineage.client import set_producer, OpenLineageClient
+from openlineage.client.run import RunEvent, Run, Job, RunState
+
+
+_PRODUCER="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
+
+set_producer(_PRODUCER)
+
+from airflow.version import version as AIRFLOW_VERSION
+from pkg_resources import parse_version
+if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
+    from openlineage.airflow import DAG
+else:
+    from airflow import DAG
+
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+
+dag = DAG(
+    'event_order',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Test dag.'
+)
+
+
+def emit_event():
+    client = OpenLineageClient.from_environment()
+    client.emit(RunEvent(
+        RunState.COMPLETE,
+        datetime.datetime.now().isoformat(),
+        Run(runId=str(uuid.uuid4())),
+        Job(namespace=os.getenv('OPENLINEAGE_NAMESPACE'), name='emit_event.wait-for-me'),
+        _PRODUCER,
+        [],
+        []
+    ))
+
+
+t1 = BashOperator(
+    task_id='just_wait',
+    bash_command="sleep 5",
+    dag=dag
+)
+
+t2 = PythonOperator(
+    task_id='emit_event',
+    python_callable=emit_event,
+    dag=dag
+)
+
+t1 >> t2

--- a/integration/airflow/tests/integration/requests/order/1.json
+++ b/integration/airflow/tests/integration/requests/order/1.json
@@ -1,0 +1,6 @@
+{
+  "eventType": "START",
+  "job": {
+    "name": "event_order.just_wait"
+  }
+}

--- a/integration/airflow/tests/integration/requests/order/2.json
+++ b/integration/airflow/tests/integration/requests/order/2.json
@@ -1,0 +1,6 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "name": "event_order.just_wait"
+  }
+}

--- a/integration/airflow/tests/integration/requests/order/3.json
+++ b/integration/airflow/tests/integration/requests/order/3.json
@@ -1,0 +1,6 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "name": "wait-for-me"
+  }
+}

--- a/integration/airflow/tests/integration/server/app.py
+++ b/integration/airflow/tests/integration/server/app.py
@@ -34,7 +34,7 @@ def get_conn():
     if db is None:
         db = g._database = sqlite3.connect(DATABASE)
         db.execute('''
-            CREATE TABLE IF NOT EXISTS requests (body text)
+            CREATE TABLE IF NOT EXISTS requests (body text, job_name text, created_at text)
         ''')
     return db
 
@@ -50,20 +50,31 @@ def close_connection(exception):
 def lineage():
     conn = get_conn()
     if request.method == 'POST':
+        job_name = request.json['job']['name']
         conn.execute("""
-            INSERT INTO requests values (:body)
+            INSERT INTO requests values (:body, :job_name, CURRENT_TIMESTAMP)
         """, {
-            "body": json.dumps(request.json)
+            "body": json.dumps(request.json),
+            "job_name": job_name
         })
+        logger.info(f"job_name: {job_name}")
         logger.info(json.dumps(request.json, sort_keys=True))
         conn.commit()
         return '', 200
     elif request.method == 'GET':
-        received_requests = conn.execute("""
-            SELECT * FROM requests
-        """).fetchall()
+        job_name = request.args.get("job_name")
+        if job_name:
+            received_requests = conn.execute("""
+                SELECT body FROM requests WHERE job_name LIKE :job_name ORDER BY created_at
+            """, {
+                "job_name": f'{job_name}%'
+            }).fetchall()
+        else:
+            received_requests = conn.execute("""
+                SELECT body FROM requests
+            """).fetchall()
         received_requests = [json.loads(req[0]) for req in received_requests]
 
-        logger.info(f"GOT {len(received_requests)} requests")
+        logger.info(f"GOT {len(received_requests)} requests for job {job_name}")
 
         return jsonify(received_requests), 200

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 import json
 import logging
+import os
 import sys
 
 import psycopg2
@@ -60,15 +61,16 @@ def wait_for_dag(dag_id):
         raise Exception('Retry!')
 
 
-def check_matches(expected_requests, received_requests):
-    for expected in expected_requests:
+def check_matches(expected_events, actual_events) -> bool:
+    for expected in expected_events:
         is_compared = False
-        for request in received_requests:
-            if expected['eventType'] == request['eventType'] and \
-                    expected['job']['name'] == request['job']['name']:
+        for actual in actual_events:
+            # Try to find matching event by eventType and job name
+            if expected['eventType'] == actual['eventType'] and \
+                    expected['job']['name'] == actual['job']['name']:
                 is_compared = True
-                if not match(expected, request):
-                    log.info(f"failed to compare expected {expected}\nwith request {request}")
+                if not match(expected, actual):
+                    log.info(f"failed to compare expected {expected}\nwith actual {actual}")
                     return False
                 break
         if not is_compared:
@@ -78,13 +80,40 @@ def check_matches(expected_requests, received_requests):
     return True
 
 
-def check_events_emitted(expected_requests):
+def check_matches_ordered(expected_events, actual_events) -> bool:
+    for index, expected in enumerate(expected_events):
+        # Actual events have to be in the same order as expected events
+        actual = actual_events[index]
+        if expected['eventType'] == actual['eventType'] and \
+                expected['job']['name'] == actual['job']['name']:
+            if not match(expected, actual):
+                log.info(f"failed to compare expected {expected}\nwith actual {actual}")
+                return False
+            break
+        log.info(f"Wrong order of events: expected {expected['eventType']} - "
+                 f"{expected['job']['name']}\ngot {actual['eventType']} - {actual['job']['name']}")
+        return False
+    return True
+
+
+def get_events(job_name: str = None):
     time.sleep(5)
+    params = {}
+
+    if job_name:
+        params = {
+            "job_name": job_name
+        }
+
     # Service in ./server captures requests and serves them
-    r = requests.get('http://backend:5000/api/v1/lineage', timeout=5)
+    r = requests.get(
+        'http://backend:5000/api/v1/lineage',
+        params=params,
+        timeout=5
+    )
     r.raise_for_status()
     received_requests = r.json()
-    return check_matches(expected_requests, received_requests)
+    return received_requests
 
 
 def setup_db():
@@ -105,10 +134,37 @@ def test_integration(dag_id, request_path):
     wait_for_dag(dag_id)
     # (2) Read expected events
     with open(request_path, 'r') as f:
-        expected_requests = json.load(f)
+        expected_events = json.load(f)
+
+    # (3) Get actual events
+    actual_events = get_events()
 
     # (3) Verify events emitted
-    if not check_events_emitted(expected_requests):
+    if not check_matches(expected_events, actual_events):
+        log.info(f"failed to compare events!")
+        sys.exit(1)
+
+
+def test_integration_ordered(dag_id, request_dir: str):
+    log.info(f"Checking dag {dag_id}")
+    # (1) Wait for DAG to complete
+    wait_for_dag(dag_id)
+
+    # (2) Find and read events in given directory on order of file names.
+    #     The events have to arrive at the server in the same order.
+    event_files = sorted(
+        os.listdir(request_dir),
+        key=lambda x: int(x.split('.')[0])
+    )
+    expected_events = []
+    for file in event_files:
+        with open(os.path.join(request_dir, file), 'r') as f:
+            expected_events.append(json.load(f))
+
+    # (3) Get actual events with job names starting with dag_id
+    actual_events = get_events(dag_id)
+
+    if not check_matches_ordered(expected_events, actual_events):
         log.info(f"failed to compare events!")
         sys.exit(1)
 
@@ -120,3 +176,4 @@ if __name__ == '__main__':
     test_integration('bigquery_orders_popular_day_of_week', 'requests/bigquery.json')
     test_integration('dbt_dag', 'requests/dbt.json')
     test_integration('custom_extractor', 'requests/custom_extractor.json')
+    test_integration_ordered('event_order', 'requests/order')


### PR DESCRIPTION
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

### Problem

In the past, we could emit `COMPLETE` events from inside Airflow tasks before Airflow integration emitted tests for previous task in DAG. That was solved by https://github.com/OpenLineage/OpenLineage/pull/327 
This PR adds integration test to confirm that it works as intended.

Closes: #337 

### Solution

Test event server now can respond with events starting with particular job name - like `dag_id` - and in order of ingestion.
 `test_integration_ordered` asks for request for given dag, and instead of searching for event matching by event type and job name, it assumes that next event must match. If not, that means that event either did not came, or the order in which events come is wrong. 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)