### PR TITLE
Fix release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,10 @@ jobs:
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
           export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
+
+          # publish jar to maven local so it can be found by dependents
+          ./gradlew publishToMavenLocal
+
           # Publish *.jar
           ./gradlew publish
       - save_cache:

--- a/new-version.sh
+++ b/new-version.sh
@@ -125,15 +125,11 @@ if [[ "${RELEASE_VERSION}" == *-rc.? ]]; then
   PYTHON_RELEASE_VERSION="${RELEASE_VERSION%-*}${RELEASE_CANDIDATE//.}"
 fi
 
-# (1) Bump python module versions for release candidates
-# This is only necessary when we are publishing a release candidate
-# This is necessary to get bump2version to bump from x.y.z to x.y.z-rc1
-if [ -n "$RELEASE_CANDIDATE" ]; then
-  PYTHON_MODULES=(client/python/ integration/common/ integration/airflow/ integration/dbt/)
-  for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
-    (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${PYTHON_RELEASE_VERSION}" --allow-dirty)
-  done
-fi
+# (1) Bump python module versions
+PYTHON_MODULES=(client/python/ integration/common/ integration/airflow/ integration/dbt/)
+for PYTHON_MODULE in "${PYTHON_MODULES[@]}"; do
+  (cd "${PYTHON_MODULE}" && bump2version manual --new-version "${PYTHON_RELEASE_VERSION}" --allow-dirty)
+done
 
 # (2) Bump java module versions
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./client/java/gradle.properties


### PR DESCRIPTION
### Problem

The release steps fail for the spark integration, as the java client isn't published to the local maven repository by default. This adds that step. 

Also, the python modules can't be published currently, since we assumed 0.2.3. was going to be the next release.
Closes: #353

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)