### PR TITLE
update class name for lineage backend

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -65,7 +65,7 @@ When enabled, the library will:
 Set your LineageBackend in your [airflow.cfg](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html) or via environmental variable `AIRFLOW__LINEAGE__BACKEND`
 to 
 ```
-openlineage.airflow.backend.OpenLineageBackend
+openlineage.lineage_backend.OpenLineageBackend
 ```
 
 In contrast to integration via subclassing `DAG`, `LineageBackend` based approach collects all metadata 


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@datakin.com>

### Problem

The Airflow 2 integration via the `AIRFLOW__LINEAGE__BACKEND` does not work using the value currently recommended in the README.

### Solution

This updates the README to match the value in `integration/airflow/tests/integration/docker-compose-2.yml` for the OpenLineageBackend environment variable. I was able to get the integration to work with the value I found there.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)