### PR TITLE
Refactor java builds to eliminate duplication in java publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
   build-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: circleci/openjdk:8-jdk
     steps:
       - *checkout_project_root
       - restore_cache:
@@ -89,7 +89,7 @@ jobs:
   release-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: circleci/openjdk:8-jdk
     steps:
       - *checkout_project_root
       - run: |
@@ -111,7 +111,7 @@ jobs:
   publish-snapshot-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: circleci/openjdk:8-jdk
     steps:
       - *checkout_project_root
       - run: |
@@ -133,9 +133,6 @@ jobs:
             - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-release-client-java-{{ .Branch }}
       - run: |
-          cd ../../client/java
-          ./gradlew  --no-daemon publishToMavenLocal
-          cd -
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
           export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           keys:
             - v1-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-client-java-{{ .Branch }}
-      - run: ./gradlew --no-daemon --stacktrace build
+      - run: ./gradlew --no-daemon --stacktrace build publishToMavenLocal
       - run: ./gradlew --no-daemon jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - run: ./gradlew javadoc
@@ -90,13 +90,20 @@ jobs:
     working_directory: ~/openlineage/client/java
     docker:
       - image: cimg/openjdk:8.0
+    parameters:
+      username:
+        type: string
+        default: $ARTIFACTORY_USERNAME
+      password:
+        type: string
+        default: $ARTIFACTORY_PASSWORD
     steps:
       - *checkout_project_root
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)
-          export RELEASE_USERNAME=$(echo $SONATYPE_USER)
+          export RELEASE_PASSWORD=$(echo << parameters.password >>)
+          export RELEASE_USERNAME=$(echo << parameters.username >>)
 
           # publish jar to maven local so it can be found by dependents
           ./gradlew publishToMavenLocal
@@ -107,52 +114,6 @@ jobs:
           key: v1-release-client-java-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.m2
-
-  publish-snapshot-client-java:
-    working_directory: ~/openlineage/client/java
-    docker:
-      - image: cimg/openjdk:8.0
-    steps:
-      - *checkout_project_root
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
-          # Publish *.jar
-          ./gradlew --no-daemon publish
-
-  release-integration-spark:
-    working_directory: ~/openlineage/integration/spark
-    docker:
-      - image: cimg/openjdk:8.0
-    steps:
-      - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
-            - v1-release-client-java-{{ .Branch }}
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)
-          export RELEASE_USERNAME=$(echo $SONATYPE_USER)
-          # Publish *.jar
-          ./gradlew --no-daemon publish
-
-  publish-snapshot-integration-spark:
-    working_directory: ~/openlineage/integration/spark
-    docker:
-      - image: cimg/openjdk:8.0
-    steps:
-      - *checkout_project_root
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
-          # Publish *.jar
-          ./gradlew --no-daemon publish
 
   build-integration-spark:
     parameters:
@@ -165,11 +126,11 @@ jobs:
       - *checkout_project_root
       - restore_cache:
           keys:
+            - v1-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
             - v1-integration-spark-{{ .Branch }}
       - attach_workspace:
           at: .
-      - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
       - run: ./gradlew --no-daemon --stacktrace build -Pspark.version=<< parameters.spark-version >>
       - run:
           when: on_fail
@@ -185,6 +146,31 @@ jobs:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.gradle
+
+  release-integration-spark:
+    working_directory: ~/openlineage/integration/spark
+    parameters:
+      username:
+        type: string
+        default: $ARTIFACTORY_USERNAME
+      password:
+        type: string
+        default: $ARTIFACTORY_PASSWORD
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - *checkout_project_root
+      - restore_cache:
+          keys:
+            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-{{ .Branch }}
+      - run: |
+          # Get, then decode the GPG private key used to sign *.jar
+          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
+          export RELEASE_PASSWORD=$(echo << parameters.password >>)
+          export RELEASE_USERNAME=$(echo << parameters.username >>)
+          # Publish *.jar
+          ./gradlew publish
 
   unit-test-integration-common:
     working_directory: ~/openlineage/integration/common
@@ -405,12 +391,16 @@ workflows:
   openlineage:
     jobs:
       - build-client-java
-      - publish-snapshot-client-java:
+      - release-client-java:
           <<: *only_on_main
           context: release
+          password: $ARTIFACTORY_PASSWORD
+          username: $ARTIFACTORY_USERNAME
           requires:
             - build-client-java
       - build-integration-spark:
+          requires:
+            - build-client-java
           matrix:
             parameters:
               spark-version: [ '2.4.1', '3.1.2' ]
@@ -420,9 +410,11 @@ workflows:
               spark-version: [ '2.4.1', '3.1.2' ]
           requires:
             - build-integration-spark
-      - publish-snapshot-integration-spark:
+      - release-integration-spark:
           <<: *only_on_main
           context: release
+          password: $ARTIFACTORY_PASSWORD
+          username: $ARTIFACTORY_USERNAME
           requires:
             - integration-test-integration-spark
       - unit-test-client-python
@@ -481,9 +473,13 @@ workflows:
     jobs:
       - release-client-java:
           <<: *only_on_release
+          password: $SONATYPE_PASSWORD
+          username: $SONATYPE_USER
           context: release
       - release-integration-spark:
           <<: *only_on_release
+          password: $SONATYPE_PASSWORD
+          username: $SONATYPE_USER
           context: release
           requires:
             - release-client-java

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
   build-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - restore_cache:
@@ -89,7 +89,7 @@ jobs:
   release-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - run: |
@@ -111,7 +111,7 @@ jobs:
   publish-snapshot-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - run: |
@@ -125,7 +125,7 @@ jobs:
   release-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - restore_cache:
@@ -143,7 +143,7 @@ jobs:
   publish-snapshot-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - run: |
@@ -159,10 +159,8 @@ jobs:
       spark-version:
         type: string
     working_directory: ~/openlineage/integration/spark
-    machine: true
-    environment:
-      TESTCONTAINERS_RYUK_DISABLED: "true"
-      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    docker:
+      - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
       - restore_cache:

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -28,12 +28,14 @@ import java.util.stream.IntStream;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import scala.Tuple2;
 
+@Tag("integration-test")
 @ExtendWith(SparkAgentTestExtension.class)
 public class LibraryTest {
 

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -82,6 +82,7 @@ import org.testcontainers.utility.DockerImageName;
 import scala.Tuple2;
 import scala.collection.immutable.HashMap;
 
+@Tag("integration-test")
 @ExtendWith(SparkAgentTestExtension.class)
 @Tag("integration-test")
 public class SparkReadWriteIntegTest {


### PR DESCRIPTION
### Problem
The client and spark integration publish jobs never run until we are ready to do a release, meaning that bugs in the scripts aren't caught until we need to do a release. The logic also gets out of sync between them.

### Solution
Builds on https://github.com/OpenLineage/OpenLineage/pull/356

This consolidates the publishing tasks for both the java client and the spark integration so that the same task is run for publishing snapshots and full releases. This also reuses the client jar built in the earliest task across the testing and the publishing tasks. 

To speed up the Spark unit test build, I changed the `LibraryTest` and `SparkReadWriteIntegTest` to run during the `integrationTest` phase. The tests don't substantially increase the time of the `integrationTest` task, as the setup time dominates the time of that task, but removing them from the unit tests do significantly reduce the time of that task. Since the integration tests are dependent on the unit tests, this does reduce the overall build time.

See https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/1299/workflows/9149eef1-2dde-45d9-9c1a-94d489495163 where the unit tests ran with the original setup

and  see https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/1300/workflows/f02fd3c1-bdf6-45be-b6a9-8cb4181e2d9b where the unit tests ran with the reduced time.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)