### PR TITLE
[INTEGRATION][spark] add visitor for CreateDataSourceTableAsSelectCommand

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     testCompile "org.junit.jupiter:junit-jupiter:${junit5Version}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
     testCompile "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
-    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testCompile "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
     testCompileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
     testCompileOnly 'com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.21.1'
@@ -156,7 +156,7 @@ dependencies {
 
 sourceSets {
     main.java.srcDirs = ["src/main/common/java", "src/main/spark2/java"]
-    test.java.srcDirs = ["src/test/common/java"]
+    test.java.srcDirs = ["src/test/common/java", "src/test/spark2/java"]
 
     spark3{
         java {

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -29,6 +29,7 @@ import org.apache.spark.SparkEnv;
 import org.apache.spark.SparkEnv$;
 import org.apache.spark.rdd.PairRDDFunctions;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
@@ -114,8 +115,10 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   @Override
   public void onOtherEvent(SparkListenerEvent event) {
     if (event instanceof SparkListenerSQLExecutionStart) {
+      log.warn(event + "\n---------------------------------------------------------------------\n");
       sparkSQLExecStart((SparkListenerSQLExecutionStart) event);
     } else if (event instanceof SparkListenerSQLExecutionEnd) {
+      log.warn(event + "\n---------------------------------------------------------------------\n");
       sparkSQLExecEnd((SparkListenerSQLExecutionEnd) event);
     }
   }
@@ -137,6 +140,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   /** called by the SparkListener when a job starts */
   @Override
   public void onJobStart(SparkListenerJobStart jobStart) {
+    log.warn(jobStart + "\n---------------------------------------------------------------------\n");
     ScalaConversionUtils.asJavaOptional(
             SparkSession.getActiveSession()
                 .map(ScalaConversionUtils.toScalaFn(sess -> sess.sparkContext()))
@@ -163,6 +167,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   /** called by the SparkListener when a job ends */
   @Override
   public void onJobEnd(SparkListenerJobEnd jobEnd) {
+    log.warn(jobEnd + "\n---------------------------------------------------------------------\n");
     ExecutionContext context = rddExecutionRegistry.remove(jobEnd.jobId());
     context.end(jobEnd);
   }
@@ -239,6 +244,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
    */
   @Override
   public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
+    log.warn("onAppStart");
     if (contextFactory != null) {
       return;
     }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
@@ -1,0 +1,25 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateDataSourceTableAsSelectCommand} and
+ * extracts the output {@link OpenLineage.Dataset} being written.
+ */
+public class CreateDataSourceTableAsSelectCommandVisitor
+    extends QueryPlanVisitor<CreateDataSourceTableAsSelectCommand, OpenLineage.Dataset> {
+
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CreateDataSourceTableAsSelectCommand command = (CreateDataSourceTableAsSelectCommand) x;
+    CatalogTable catalogTable = command.table();
+    return Collections.singletonList(
+        PlanUtils.getDataset(catalogTable));
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
@@ -1,0 +1,24 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateDataSourceTableCommand} and
+ * extracts the output {@link OpenLineage.Dataset} being written.
+ */
+public class CreateDataSourceTableCommandVisitor
+    extends QueryPlanVisitor<CreateDataSourceTableCommand, OpenLineage.Dataset> {
+
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CreateDataSourceTableCommand command = (CreateDataSourceTableCommand) x;
+    CatalogTable catalogTable = command.table();
+    return Collections.singletonList(PlanUtils.getDataset(catalogTable,""));
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
@@ -1,0 +1,67 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.SneakyThrows;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link LoadDataCommandVisitor} and
+ * extracts the output {@link OpenLineage.Dataset} being written.
+ */
+public class LoadDataCommandVisitor
+  extends QueryPlanVisitor<LoadDataCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+  
+  public LoadDataCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+  
+  @SneakyThrows
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    LoadDataCommand command = (LoadDataCommand) x;
+    CatalogTable table = sparkSession.sessionState().catalog().getTableMetadata(command.table());
+    return Collections.singletonList(PlanUtils.getDataset(table));
+  }
+
+//  @SneakyThrows
+//  private Path getHivePath(LoadDataCommand command) {
+//    // This logic is copied and translated from Scala from the LoadDataCommand itself
+//    if (command.isLocal()) {
+//      FileContext localFS = FileContext.getLocalFSFileContext();
+//      return LoadDataCommand.makeQualified(FsConstants.LOCAL_FS_URI, localFS.getWorkingDirectory(),
+//        new Path(command.path()));
+//    } else {
+//      Path loadPath = new Path(command.path());
+//      // Follow Hive's behavior:
+//      // If no schema or authority is provided with non-local inpath,
+//      // we will use hadoop configuration "fs.defaultFS".
+//      String defaultFSConf = SparkSession.active().sessionState().newHadoopConf().get("fs.defaultFS")
+//      URI defaultFS;
+//      if (defaultFSConf == null) {
+//        defaultFS = new URI("");
+//      } else {
+//        defaultFS = new URI(defaultFSConf);
+//      }
+//      // Follow Hive's behavior:
+//      // If LOCAL is not specified, and the path is relative,
+//      // then the path is interpreted relative to "/user/<username>"
+//      Path uriPath = new Path(String.format("/user/%s/", System.getProperty("user.name")));
+//      // makeQualified() will ignore the query parameter part while creating a path, so the
+//      // entire  string will be considered while making a Path instance,this is mainly done
+//      // by considering the wild card scenario in mind.as per old logic query param  is
+//      // been considered while creating URI instance and if path contains wild card char '?'
+//      // the remaining characters after '?' will be removed while forming URI instance
+//      return LoadDataCommand.makeQualified(defaultFS, uriPath, loadPath);
+//    }
+//  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
@@ -1,0 +1,62 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.execution.command.LoadDataCommand;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
+
+import java.util.List;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class LoadDataCommandVisitorTest {
+  @Test
+  void testLoadDataCommand() {
+    SparkSession session = SparkSession.builder()
+      .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+      .master("local")
+      .getOrCreate();
+    String database = session.catalog().currentDatabase();
+    
+    StructType schema = new StructType(
+      new StructField[] {
+        new StructField(
+          "key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+        new StructField(
+          "value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+      });
+
+    session.catalog().createTable("table", "csv", schema, Map$.MODULE$.empty());
+    
+    LoadDataCommandVisitor visitor = new LoadDataCommandVisitor(session);
+
+    LoadDataCommand command = new LoadDataCommand(
+      TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+      "/path/to/data",
+      true,
+      false,
+      Option.empty()
+    );
+    
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+      .singleElement()
+      .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/table")
+      .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/src/test/spark2/java/io/openlineage/spark3/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/src/test/spark2/java/io/openlineage/spark3/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -1,0 +1,95 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.net.URI;
+import java.util.List;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.Seq$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class CreateDataSourceTableAsSelectCommandVisitorTest {
+
+  @Test
+  void testCTASCommand() {
+    CreateDataSourceTableAsSelectCommandVisitor visitor =
+        new CreateDataSourceTableAsSelectCommandVisitor();
+
+    CreateDataSourceTableAsSelectCommand command =
+        new CreateDataSourceTableAsSelectCommand(
+            table(
+                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                CatalogTableType.EXTERNAL(),
+                CatalogStorageFormat$.MODULE$.apply(
+                    Option.apply(URI.create("s3://bucket/directory")),
+                    null,
+                    null,
+                    null,
+                    false,
+                    Map$.MODULE$.empty()),
+                new StructType(
+                    new StructField[] {
+                      new StructField(
+                          "key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+                      new StructField(
+                          "value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+                    })),
+            null,
+            null,
+            Seq$.MODULE$.<String>empty());
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/directory")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+  }
+
+  // Can't use Scala's default parameters from Java.
+  CatalogTable table(
+      TableIdentifier identifier,
+      CatalogTableType tableType,
+      CatalogStorageFormat storageFormat,
+      StructType schema) {
+    return CatalogTable$.MODULE$.apply(
+        identifier,
+        tableType,
+        storageFormat,
+        schema,
+        null,
+        Seq$.MODULE$.<String>empty(),
+        null,
+        "",
+        System.currentTimeMillis(),
+        -1L,
+        "",
+        Map$.MODULE$.empty(),
+        null,
+        null,
+        null,
+        Seq$.MODULE$.<String>empty(),
+        false,
+        true,
+        Map$.MODULE$.empty());
+  }
+}

--- a/integration/spark/src/test/spark2/java/io/openlineage/spark3/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/src/test/spark2/java/io/openlineage/spark3/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -1,0 +1,94 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.net.URI;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType;
+import org.apache.spark.sql.execution.command.CreateDataSourceTableCommand;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.Seq$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class CreateDataSourceTableCommandVisitorTest {
+
+  @Test
+  void testCreateDataSourceTableCommand() {
+    CreateDataSourceTableCommandVisitor visitor =
+        new CreateDataSourceTableCommandVisitor();
+
+    CreateDataSourceTableCommand command =
+        new CreateDataSourceTableCommand(
+            table(
+                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                CatalogTableType.EXTERNAL(),
+                CatalogStorageFormat$.MODULE$.apply(
+                    Option.apply(URI.create("s3://bucket/directory")),
+                    null,
+                    null,
+                    null,
+                    false,
+                    Map$.MODULE$.empty()),
+                new StructType(
+                    new StructField[] {
+                      new StructField(
+                          "key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+                      new StructField(
+                          "value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+                    })),
+            false);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/directory")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+  }
+
+  // Can't use Scala's default parameters from Java.
+  CatalogTable table(
+      TableIdentifier identifier,
+      CatalogTableType tableType,
+      CatalogStorageFormat storageFormat,
+      StructType schema) {
+    return CatalogTable$.MODULE$.apply(
+        identifier,
+        tableType,
+        storageFormat,
+        schema,
+        null,
+        Seq$.MODULE$.<String>empty(),
+        null,
+        "",
+        System.currentTimeMillis(),
+        -1L,
+        "",
+        Map$.MODULE$.empty(),
+        null,
+        null,
+        null,
+        Seq$.MODULE$.<String>empty(),
+        false,
+        true,
+        Map$.MODULE$.empty());
+  }
+}


### PR DESCRIPTION
Cover `org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand`.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/370

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)