### PR TITLE
Fix docker-compose file to specifically reference Spark 3.1.2

### DIFF
--- a/integration/spark/docker-compose.yml
+++ b/integration/spark/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   notebook:
-    image: jupyter/pyspark-notebook
+    image: jupyter/pyspark-notebook:spark-3.1.2
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
### Problem
The latest Jupyter spark image uses Spark 3.2.0. Unfortunately, there's some compatibility issue with that version, so we need to pin the docker-compose file to reference a compatible version of Spark. This updates that file to point to `3.1.2`, which is the latest in the 3.1.x line.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)