### PR TITLE
[INTEGRATION][Airflow] fix Airflow dependency issue by using official dependency constraints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,8 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
-      - run: pip install -e .[dev,airflow-1]
+      - run: pip install --upgrade pip==20.2.4
+      - run: pip install -e .[dev,airflow-1] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15/constraints-3.6.txt"
       - run: flake8 --exclude integration
       - run: airflow initdb
       - run: pytest --cov=openlineage --ignore tests/integration tests/
@@ -281,7 +282,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
-      - run: pip install -e .[dev,airflow-2]
+      - run: pip install -e .[dev,airflow-2] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-2.1.3/constraints-3.6.txt"
       - run: flake8 --exclude integration
       - run: airflow db init
       - run: pytest --cov=openlineage --ignore tests/integration --ignore tests/test_openlineage_dag.py tests/

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -41,10 +41,7 @@ extras_require = {
         "snowflake-connector-python"
     ],
     "airflow-1": [
-        "apache-airflow==1.10.15",
-        "apache-airflow[gcp_api]==1.10.15",
-        "apache-airflow[google]==1.10.15",
-        "apache-airflow[postgres]==1.10.15",
+        "apache-airflow[gcp_api,google,postgres]==1.10.15",
         "airflow-provider-great-expectations==0.0.8",
     ],
     "airflow-2": [


### PR DESCRIPTION
Incompatible release of `wtfforms` broke build. 
To mitigate issues like that, use official Airflow constraints for dependencies. 
Those are tested configurations by Airflow that are more of less guaranteed to be compatible with each other.

Direct cause of errors: https://github.com/apache/airflow/pull/19466

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)