### PR TITLE
[INTEGRATION][dbt] allow to parse unspecified, future version of artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.3.1...HEAD)
 
 * dbt: column descriptions are properly filled from metadata.json [@mobuchowski](https://github.com/mobuchowski)
+* dbt: allow parsing artifacts with version higher than officially supported  [@mobuchowski](https://github.com/mobuchowski)
 
 ## [0.3.1](https://github.com/OpenLineage/OpenLineage/releases/tag/0.3.1) - 2021-10-21
 
@@ -12,7 +13,7 @@
 ## [0.3.0](https://github.com/OpenLineage/OpenLineage/releases/tag/0.3.0) - 2021-10-21
 
 ### Added
-* Spark3 support [@OleksandrDvornik](https://github.com/OleksandrDvornik)/[@collado-mike](https://github.com/collado-mike)
+* Spark3 support [@OleksandrDvornik](https://github.com/OleksandrDvornik) / [@collado-mike](https://github.com/collado-mike)
 * LineageBackend for Airflow 2 [@mobuchowski](https://github.com/mobuchowski)
 * Adding custom spark version facet to spark integration [@OleksandrDvornik](https://github.com/OleksandrDvornik)
 * Adding dbt version facet [@mobuchowski](https://github.com/mobuchowski)

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -10,6 +10,7 @@ import collections
 from typing import List, Tuple, Dict, Optional, TypeVar
 
 import attr
+import logging
 
 from openlineage.client.facet import DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField, \
     SqlJobFacet, OutputStatisticsOutputDatasetFacet, ParentRunFacet, BaseFacet, \
@@ -96,6 +97,8 @@ class DbtVersionRunFacet(BaseFacet):
 
 T = TypeVar('T')
 
+logging.getLogger('null').addHandler(logging.NullHandler())
+
 
 class DbtArtifactProcessor:
     def __init__(
@@ -104,7 +107,8 @@ class DbtArtifactProcessor:
         project_dir: str,
         profile_name: Optional[str] = None,
         target: Optional[str] = None,
-        skip_errors: bool = False
+        skip_errors: bool = False,
+        logger: logging.Logger = logging.getLogger("null")
     ):
         self.producer = producer
         self.dir = os.path.abspath(project_dir)
@@ -112,6 +116,7 @@ class DbtArtifactProcessor:
         self.profile_name = profile_name
         self.target = target
         self.jinja_environment = None
+        self.logger = logger
 
         self.job_namespace = ""
         self.dataset_namespace = ""
@@ -137,11 +142,14 @@ class DbtArtifactProcessor:
         """
             Parse dbt manifest and run_result and produce OpenLineage events.
         """
-        manifest = self.load_manifest(self.manifest_path)
-        run_result = self.load_run_results(self.run_result_path)
+        manifest = self.load_metadata(self.manifest_path, [2, 3], self.logger)
+        run_result = self.load_metadata(self.run_result_path, [2, 3], self.logger)
         self.run_metadata = run_result['metadata']
 
-        catalog = self.load_catalog(self.catalog_path)
+        try:
+            catalog = self.load_metadata(self.catalog_path, [1], self.logger)
+        except FileNotFoundError:
+            catalog = None
 
         profile_dir = run_result['args']['profiles_dir']
 
@@ -176,39 +184,38 @@ class DbtArtifactProcessor:
             f"{run_result['args']['which']} - should be run or test"
         )
 
-    @staticmethod
-    def load_metadata(path: str, desired_schema_versions: List[str]) -> Dict:
+    @classmethod
+    def load_metadata(
+        cls,
+        path: str,
+        desired_schema_versions: List[int],
+        logger: logging.Logger
+    ) -> Dict:
         with open(path, 'r') as f:
             metadata = json.load(f)
-            schema_version = get_from_nullable_chain(metadata, ['metadata', 'dbt_schema_version'])
+            str_schema_version = get_from_nullable_chain(
+                metadata,
+                ['metadata', 'dbt_schema_version']
+            )
+            schema_version = cls.get_version_number(str_schema_version)
             if schema_version not in desired_schema_versions:
-                # Maybe we should accept it and throw exception only if it substantially differs
-                raise ValueError(f"Wrong version of dbt metadata: {schema_version}, "
-                                 f"should be in {desired_schema_versions}")
+                if schema_version > max(desired_schema_versions):
+                    logger.warning(
+                        f"Artifact schema version: {str_schema_version} is above dbt-ol "
+                        f"supported version {max(desired_schema_versions)}. "
+                        f"This might cause errors."
+                    )
+                else:
+                    raise ValueError(f"Wrong version of dbt metadata: {schema_version}, "
+                                     f"should be in {desired_schema_versions}")
             return metadata
 
-    @classmethod
-    def load_manifest(cls, path: str) -> Dict:
-        return cls.load_metadata(path, [
-            "https://schemas.getdbt.com/dbt/manifest/v2.json",
-            "https://schemas.getdbt.com/dbt/manifest/v3.json",
-        ])
-
-    @classmethod
-    def load_run_results(cls, path: str) -> Dict:
-        return cls.load_metadata(path, [
-            "https://schemas.getdbt.com/dbt/run-results/v2.json",
-            "https://schemas.getdbt.com/dbt/run-results/v3.json"
-        ])
-
-    @classmethod
-    def load_catalog(cls, path: str) -> Optional[Dict]:
-        try:
-            return cls.load_metadata(path, [
-                "https://schemas.getdbt.com/dbt/catalog/v1.json"
-            ])
-        except FileNotFoundError:
-            return None
+    @staticmethod
+    def get_version_number(version: str) -> int:
+        # "https://schemas.getdbt.com/dbt/manifest/v2.json" -> "v2.json"
+        file = version.split('/')[-1]
+        # "v2.json" -> 2
+        return int(file.split('.')[0][1:])
 
     @staticmethod
     def env_var(var: str, default: Optional[str] = None) -> str:

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -191,3 +191,22 @@ def test_jinja_list(jinja_env):
     assert ["key", "test_variable"] == DbtArtifactProcessor.render_values_jinja(
         jinja_env, test_list
     )
+
+
+def test_logging_handler_warns():
+    path = 'tests/dbt/test/target/manifest.json'
+    logger = mock.Mock()
+    DbtArtifactProcessor.load_metadata(path, [1], logger)
+
+    logger.warning.assert_called_once_with(
+        "Artifact schema version: https://schemas.getdbt.com/dbt/manifest/v2.json is above "
+        "dbt-ol supported version 1. This might cause errors."
+    )
+
+
+def test_logging_handler_does_not_warn():
+    path = 'tests/dbt/test/target/manifest.json'
+    logger = mock.Mock()
+    DbtArtifactProcessor.load_metadata(path, [2], logger)
+
+    logger.warning.assert_not_called()

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import logging
 import subprocess
 import sys
 import time
@@ -79,9 +80,14 @@ def dbt_run_event_end(
     )
 
 
+logger = logging.getLogger("dbtol")
+logger.setLevel("INFO")
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
 def main():
-    print(f"Running OpenLineage dbt wrapper version {__version__}")
-    print(f"This wrapper will send OpenLineage events at the end of dbt execution.")
+    logger.info(f"Running OpenLineage dbt wrapper version {__version__}")
+    logger.info(f"This wrapper will send OpenLineage events at the end of dbt execution.")
 
     args = sys.argv[2:]
     target = parse_single_arg(args, ['-t', '--target'])
@@ -90,7 +96,7 @@ def main():
 
     client = setup_client()
     if client is None:
-        print("OPENLINEAGE_URL is not set: stopping execution")
+        logger.info("OPENLINEAGE_URL is not set: stopping execution")
         sys.exit(1)
 
     # We can get this if we have been orchestrated by an external system like airflow
@@ -112,6 +118,7 @@ def main():
         target=target,
         project_dir=project_dir,
         profile_name=profile_name,
+        logger=logger
     )
 
     # Always emit "wrapping event" around dbt run. This indicates start of dbt execution, since
@@ -145,12 +152,12 @@ def main():
     # or does not exist, do not emit dbt events.
     try:
         if os.stat(processor.run_result_path).st_mtime < pre_run_time:
-            print(f"OpenLineage events not emittled: run_result file "
-                  f"({processor.run_result_path}) was not modified by dbt")
+            logger.info(f"OpenLineage events not emittled: run_result file "
+                        f"({processor.run_result_path}) was not modified by dbt")
             return
     except FileNotFoundError:
-        print(f"OpenLineage events not emittled:"
-              f"did not find run_result file ({processor.run_result_path})")
+        logger.info(f"OpenLineage events not emittled:"
+                    f"did not find run_result file ({processor.run_result_path})")
         return
 
     events = processor.parse().events()
@@ -164,7 +171,7 @@ def main():
         job_name=dbt_run_metadata.job_name,
         parent_run_metadata=parent_run_metadata
     ))
-    print(f"Emitted {len(events) + 2} openlineage events")
+    logger.info(f"Emitted {len(events) + 2} openlineage events")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, if `DbtMetadataArtifact` encounters artifact with schema version not exactly matching one that is supported by `dbt-ol`, it throws exception. This PR changes this behavior, when the metadata version is higher than currently supported (and tested with). If we encounter artifact with higher version, we warn the user and continue processing.  

Also, change raw `print()` calls to logger calls - this allows more granular control over output, and allows to test it easily.

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/389

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)