### PR TITLE
[INTEGRATION][dbt] Support dbt build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * dbt: column descriptions are properly filled from metadata.json [@mobuchowski](https://github.com/mobuchowski)
 * dbt: allow parsing artifacts with version higher than officially supported  [@mobuchowski](https://github.com/mobuchowski)
+* dbt: dbt build command is supported  [@mobuchowski](https://github.com/mobuchowski)
+
 
 ## [0.3.1](https://github.com/OpenLineage/OpenLineage/releases/tag/0.3.1) - 2021-10-21
 

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -48,21 +48,11 @@ class DbtRun:
     started_at: str = attr.ib()
     completed_at: str = attr.ib()
     status: str = attr.ib()
-    inputs: List[ModelNode] = attr.ib()
-    output: Optional[ModelNode] = attr.ib()
+    inputs: List[Dataset] = attr.ib()
+    output: Optional[Dataset] = attr.ib()
     job_name: str = attr.ib()
     namespace: str = attr.ib()
     run_id: str = attr.ib(factory=lambda: str(uuid.uuid4()))
-
-
-@attr.s
-class DbtEvents:
-    starts: List[RunEvent] = attr.ib()
-    completes: List[RunEvent] = attr.ib()
-    fails: List[RunEvent] = attr.ib()
-
-    def events(self):
-        return self.starts + self.completes + self.fails
 
 
 @attr.s
@@ -70,6 +60,40 @@ class DbtRunResult:
     start: RunEvent = attr.ib()
     complete: Optional[RunEvent] = attr.ib(default=None)
     fail: Optional[RunEvent] = attr.ib(default=None)
+
+
+@attr.s
+class DbtEvents:
+    starts: List[RunEvent] = attr.ib(factory=list)
+    completes: List[RunEvent] = attr.ib(factory=list)
+    fails: List[RunEvent] = attr.ib(factory=list)
+
+    def events(self):
+        return self.starts + self.completes + self.fails
+
+    def add(self, item: Optional[DbtRunResult]):
+        if not item:
+            return
+        self.starts.append(item.start)
+        if item.complete:
+            self.completes.append(item.complete)
+        if item.fail:
+            self.fails.append(item.fail)
+
+    def __iadd__(self, other):
+        if isinstance(other, DbtEvents):
+            self.starts += other.starts
+            self.completes += other.completes
+            self.fails += other.fails
+            return self
+        raise NotImplementedError()
+
+
+@attr.s
+class DbtRunContext:
+    manifest: Dict = attr.ib()
+    run_results: Dict = attr.ib()
+    catalog: Optional[Dict] = attr.ib(default=None)
 
 
 @attr.s
@@ -123,6 +147,7 @@ class DbtArtifactProcessor:
         self.skip_errors = skip_errors
         self.project = self.load_yaml_with_jinja(os.path.join(project_dir, 'dbt_project.yml'))
         self.run_metadata = None
+        self.command = None
 
         self.manifest_path = os.path.join(self.dir, self.project['target-path'], 'manifest.json')
         self.run_result_path = os.path.join(
@@ -145,6 +170,7 @@ class DbtArtifactProcessor:
         manifest = self.load_metadata(self.manifest_path, [2, 3], self.logger)
         run_result = self.load_metadata(self.run_result_path, [2, 3], self.logger)
         self.run_metadata = run_result['metadata']
+        self.command = run_result['args']['which']
 
         try:
             catalog = self.load_metadata(self.catalog_path, [1], self.logger)
@@ -175,14 +201,20 @@ class DbtArtifactProcessor:
             if name.startswith('model.') or name.startswith('test.'):
                 nodes[name] = node
 
-        if run_result['args']['which'] == 'run':
-            return self.parse_run(manifest, run_result, catalog, nodes)
-        elif run_result['args']['which'] == 'test':
-            return self.parse_test(manifest, run_result, catalog, nodes)
-        raise ValueError(
-            f"Not recognized run command "
-            f"{run_result['args']['which']} - should be run or test"
-        )
+        context = DbtRunContext(manifest, run_result, catalog)
+
+        if self.command not in ['run', 'build', 'test']:
+            raise ValueError(
+                f"Not recognized run command "
+                f"{self.command} - should be run, test or build"
+            )
+
+        events = DbtEvents()
+        if self.command in ['run', 'build']:
+            events += self.parse_execution(context, nodes)
+        if self.command in ['test', 'build']:
+            events += self.parse_test(context, nodes)
+        return events
 
     @classmethod
     def load_metadata(
@@ -273,64 +305,68 @@ class DbtArtifactProcessor:
         else:
             return value
 
-    def parse_run(
+    def parse_execution(
         self,
-        manifest: Dict,
-        run_results: Dict,
-        catalog: Optional[Dict],
+        context: DbtRunContext,
         nodes: Dict
     ) -> DbtEvents:
-        runs = []
-        for run in run_results['results']:
+        events = DbtEvents()
+        for run in context.run_results['results']:
+            name = run['unique_id']
+            if not name.startswith('model.') and not name.startswith('source.'):
+                continue
+            if run['status'] == 'skipped':
+                continue
+
+            output_node = nodes[name]
             started_at, completed_at = self.get_timings(run['timing'])
+            namespace, name, _ = self.extract_dataset_data(
+                ModelNode(output_node), None, has_facets=False
+            )
 
             inputs = []
-            for node in manifest['parent_map'][run['unique_id']]:
+            for node in context.manifest['parent_map'][run['unique_id']]:
                 if node.startswith('model.'):
                     inputs.append(ModelNode(
                         nodes[node],
-                        get_from_nullable_chain(catalog, ['nodes', node])
+                        get_from_nullable_chain(context.catalog, ['nodes', node])
                     ))
                 elif node.startswith('source.'):
                     inputs.append(ModelNode(
-                        manifest['sources'][node],
-                        get_from_nullable_chain(catalog, ['sources', node])
+                        context.manifest['sources'][node],
+                        get_from_nullable_chain(context.catalog, ['sources', node])
                     ))
 
-            output_node = nodes[run['unique_id']]
-
-            runs.append(DbtRun(
+            run_id = str(uuid.uuid4())
+            job_name = f"{output_node['database']}.{output_node['schema']}" \
+                f".{self.removeprefix(run['unique_id'], 'model.')}" \
+                + (".build.run" if self.command == 'build' else "")
+            events.add(self.to_openlineage_events(
+                run['status'],
                 started_at,
                 completed_at,
-                run['status'],
-                inputs,
-                ModelNode(
-                    output_node,
-                    get_from_nullable_chain(catalog, ['nodes', run['unique_id']])
+                self.get_run(run_id),
+                Job(
+                    namespace=self.job_namespace,
+                    name=job_name,
+                    facets={
+                        'sql': SqlJobFacet(output_node['compiled_sql'])
+                    }
                 ),
-                f"{output_node['database']}."
-                f"{output_node['schema']}."
-                f"{self.removeprefix(run['unique_id'], 'model.')}",
-                self.dataset_namespace
+                [self.node_to_dataset(node, has_facets=True) for node in inputs],
+                self.node_to_output_dataset(
+                    ModelNode(
+                        output_node,
+                        get_from_nullable_chain(context.catalog, ['nodes', run['unique_id']])
+                    ),
+                    has_facets=True
+                )
             ))
-
-        start_events, complete_events, fail_events = [], [], []
-        for run in runs:
-            results = self.to_openlineage_events(run)
-            if not results:
-                continue
-            start_events.append(results.start)
-            if results.complete:
-                complete_events.append(results.complete)
-            elif results.fail:
-                fail_events.append(results.fail)
-        return DbtEvents(start_events, complete_events, fail_events)
+        return events
 
     def parse_test(
         self,
-        manifest: Dict,
-        run_results: Dict,
-        catalog: Optional[Dict],
+        context: DbtRunContext,
         nodes: Dict
     ) -> DbtEvents:
 
@@ -338,13 +374,56 @@ class DbtArtifactProcessor:
         started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         completed_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
+        assertions = self.parse_assertions(context, nodes)
+
+        events = DbtEvents()
+        for name, node in context.manifest['nodes'].items():
+            if not name.startswith('model.') and not name.startswith('source.'):
+                continue
+            if len(assertions[name]) == 0:
+                continue
+
+            assertion_facet = DataQualityAssertionsDatasetFacet(
+                assertions=assertions[name]
+            )
+
+            namespace, name, _ = self.extract_dataset_data(
+                ModelNode(node),
+                assertion_facet,
+                has_facets=False
+            )
+
+            job_name = f"{node['database']}.{node['schema']}." \
+                f"{self.removeprefix(node['unique_id'], 'model.')}" \
+                + (".build.test" if self.command == 'build' else "")
+
+            run_id = str(uuid.uuid4())
+            events.add(self.to_openlineage_events(
+                "success",
+                started_at,
+                completed_at,
+                self.get_run(run_id),
+                Job(self.job_namespace, job_name),
+                [Dataset(namespace, name, facets={
+                    "dataQualityAssertions": assertion_facet
+                })],
+                None
+            ))
+        return events
+
+    def parse_assertions(
+        self,
+        context: DbtRunContext,
+        nodes: Dict
+    ) -> Dict[str, List[Assertion]]:
         assertions = collections.defaultdict(list)
-
-        for run in run_results['results']:
-
+        for run in context.run_results['results']:
             test_node = nodes[run['unique_id']]
+            if not run['unique_id'].startswith('test.'):
+                continue
+
             model_node = None
-            for node in manifest['parent_map'][run['unique_id']]:
+            for node in context.manifest['parent_map'][run['unique_id']]:
                 if node.startswith('model.') or node.startswith('source.'):
                     model_node = node
 
@@ -361,151 +440,81 @@ class DbtArtifactProcessor:
                 raise ValueError(
                     f"Model node connected to test {nodes[run['unique_id']]} not found"
                 )
+        return assertions
 
-        starts, completes = [], []
-        for name, node in manifest['nodes'].items():
-            if not name.startswith('model.') and not name.startswith('source.'):
-                continue
-            if len(assertions[name]) == 0:
-                continue
-
-            assertion_facet = DataQualityAssertionsDatasetFacet(
-                assertions=assertions[name]
-            )
-
-            namespace, name, _ = self.extract_dataset_data(ModelNode(node), has_facets=False)
-
-            job_name = f"{node['database']}." \
-                f"{node['schema']}." \
-                f"{self.removeprefix(node['unique_id'], 'test.')}"
-
-            run_id = str(uuid.uuid4())
-            starts.append(RunEvent(
-                eventType=RunState.START,
-                eventTime=started_at,
-                run=Run(
-                    runId=run_id
-                ),
-                job=Job(
-                    namespace=self.job_namespace,
-                    name=job_name
-                ),
-                producer=self.producer,
-                inputs=[Dataset(namespace, name)],
-                outputs=[]
-            ))
-            completes.append(RunEvent(
-                eventType=RunState.COMPLETE,
-                eventTime=completed_at,
-                run=Run(
-                    runId=run_id,
-                    facets={
-                        "parent": self._dbt_run_metadata.to_openlineage(),
-                        "dbt_version": self.dbt_version_facet()
-                    }
-                ),
-                job=Job(
-                    namespace=self.job_namespace,
-                    name=job_name
-                ),
-                producer=self.producer,
-                inputs=[Dataset(namespace, name, facets={
-                    "dataQualityAssertions": assertion_facet
-                })],
-                outputs=[]
-            ))
-
-        return DbtEvents(starts, completes, [])
-
-    def to_openlineage_events(self, run: DbtRun) -> Optional[DbtRunResult]:
+    def to_openlineage_events(self, *args, **kwargs) -> Optional[DbtRunResult]:
         try:
-            return self._to_openlineage_events(run)
+            return self._to_openlineage_events(*args, **kwargs)
         except Exception as e:
             if self.skip_errors:
                 return None
             raise ValueError() from e
 
-    def _to_openlineage_events(self, run: DbtRun) -> Optional[DbtRunResult]:
-        if run.status == 'skipped':
-            return None
-
+    def _to_openlineage_events(
+        self,
+        status: str,
+        started_at: str,
+        completed_at: str,
+        run: Run,
+        job: Job,
+        inputs: List[Dataset],
+        output: Optional[Dataset]
+    ) -> Optional[DbtRunResult]:
         start = RunEvent(
             eventType=RunState.START,
-            eventTime=run.started_at,
-            run=Run(
-                runId=run.run_id
-            ),
-            job=Job(
-                namespace=self.job_namespace,
-                name=run.job_name
-            ),
+            eventTime=started_at,
+            run=run,
+            job=job,
             producer=self.producer,
-            inputs=[self.node_to_dataset(node) for node in run.inputs],
-            outputs=[self.node_to_output_dataset(run.output)] if run.output else []
+            inputs=inputs,
+            outputs=[output] if output else []
         )
-
-        if run.status == 'success':
+        if status == 'success':
             return DbtRunResult(
                 start,
                 complete=RunEvent(
                     eventType=RunState.COMPLETE,
-                    eventTime=run.completed_at,
-                    run=Run(
-                        runId=run.run_id,
-                        facets={
-                            "parent": self._dbt_run_metadata.to_openlineage(),
-                            "dbt_version": self.dbt_version_facet()
-                        }
-                    ),
-                    job=Job(
-                        namespace=self.job_namespace,
-                        name=run.job_name,
-                        facets={
-                            'sql': SqlJobFacet(run.output.metadata_node['compiled_sql'])
-                        }
-                    ),
+                    eventTime=completed_at,
+                    run=run,
+                    job=job,
                     producer=self.producer,
-                    inputs=[self.node_to_dataset(node, has_facets=True) for node in run.inputs],
-                    outputs=[self.node_to_output_dataset(run.output, has_facets=True)]
+                    inputs=inputs,
+                    outputs=[output] if output else []
                 )
             )
-        elif run.status == 'error':
+        elif status == 'error':
             return DbtRunResult(
                 start,
                 fail=RunEvent(
                     eventType=RunState.FAIL,
-                    eventTime=run.completed_at,
-                    run=Run(
-                        runId=run.run_id,
-                        facets={
-                            "parent": self._dbt_run_metadata.to_openlineage(),
-                            "dbt_version": self.dbt_version_facet()
-                        }
-                    ),
-                    job=Job(
-                        namespace=self.job_namespace,
-                        name=run.job_name,
-                        facets={
-                            'sql': SqlJobFacet(run.output.metadata_node['compiled_sql'])
-                        }
-                    ),
+                    eventTime=completed_at,
+                    run=run,
+                    job=job,
                     producer=self.producer,
-                    inputs=[self.node_to_dataset(node, has_facets=True) for node in run.inputs],
+                    inputs=inputs,
                     outputs=[]
                 )
             )
         else:
             # Should not happen?
-            raise ValueError(f"Run status was {run.status}, "
-                             f"should be in ['success', 'skipped', 'skipped']")
+            raise ValueError(f"Run status was {status}, "
+                             f"should be in ['success', 'skipped', 'error']")
 
-    def node_to_dataset(self, node: ModelNode, has_facets: bool = False) -> Dataset:
-        return Dataset(
-            *self.extract_dataset_data(node, has_facets)
-        )
+    def node_to_dataset(
+        self,
+        node: ModelNode,
+        assertions: Optional[DataQualityAssertionsDatasetFacet] = None,
+        has_facets: bool = False
+    ) -> Dataset:
+        name, namespace, facets = self.extract_dataset_data(node, assertions, has_facets)
+        return Dataset(name, namespace, facets)
 
-    def node_to_output_dataset(self, node: ModelNode, has_facets: bool = False) -> OutputDataset:
-        name, namespace, facets = self.extract_dataset_data(node, has_facets)
+    def node_to_output_dataset(
+        self,
+        node: ModelNode,
+        has_facets: bool = False
+    ) -> OutputDataset:
+        name, namespace, facets = self.extract_dataset_data(node, None, has_facets)
         output_facets = {}
         if has_facets and node.catalog_node:
             bytes = get_from_multiple_chains(
@@ -539,7 +548,10 @@ class DbtArtifactProcessor:
         )
 
     def extract_dataset_data(
-            self, node: ModelNode, has_facets: bool = False
+        self,
+        node: ModelNode,
+        assertions: Optional[DataQualityAssertionsDatasetFacet],
+        has_facets: bool = False
     ) -> Tuple[str, str, Dict]:
         if has_facets:
             facets = {
@@ -551,6 +563,8 @@ class DbtArtifactProcessor:
                     fields=self.extract_metadata_fields(node.metadata_node['columns'].values())
                 )
             }
+            if assertions:
+                facets['dataQualityAssertions'] = assertions
             if node.catalog_node:
                 facets['schema'] = SchemaDatasetFacet(
                     fields=self.extract_catalog_fields(
@@ -624,6 +638,15 @@ class DbtArtifactProcessor:
                 f"Only 'snowflake', 'bigquery', and 'redshift' adapters are supported right now. "
                 f"Passed {profile['type']}"
             )
+
+    def get_run(self, run_id: str) -> Run:
+        return Run(
+            runId=run_id,
+            facets={
+                "parent": self._dbt_run_metadata.to_openlineage(),
+                "dbt_version": self.dbt_version_facet()
+            }
+        )
 
     def dbt_version_facet(self):
         return DbtVersionRunFacet(

--- a/integration/common/tests/dbt/build/dbt_project.yml
+++ b/integration/common/tests/dbt/build/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the {% raw %} `{{ config(...) }}` {% endraw %} macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/build/profiles.yml
+++ b/integration/common/tests/dbt/build/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: random-gcp-project
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/build/result.json
+++ b/integration/common/tests/dbt/build/result.json
@@ -1,0 +1,102 @@
+[
+    {
+	    "eventTime": "{{ is_datetime(result) }}",
+        "eventType": "START",
+        "job": {
+            "namespace": "bigquery",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.run"
+        },
+        "run": {
+		    "runId": "{{ any(result) }}"
+        }
+    },
+    {
+        "eventTime": "{{ is_datetime(result) }}",
+        "eventType": "START",
+        "job": {
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.test",
+            "namespace": "bigquery"
+        },
+        "run": {
+            "runId": "{{ any(result) }}"
+        }
+    },
+    {
+	    "eventTime": "{{ is_datetime(result) }}",
+        "eventType": "COMPLETE",
+        "outputs": [
+            {
+                "facets": {},
+                "name": "random-gcp-project.dbt_test1.test_first_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.run",
+            "namespace": "bigquery"
+        },
+        "inputs": [],
+        "run": {
+            "facets": {
+                "parent": {
+                    "job": {"name": "dbt-job-name", "namespace": "dbt"},
+                    "run": {"runId": "{{ any(result) }}"}
+                },
+                "dbt_version": {
+                    "version": "0.21.0"
+                }
+            },
+            "runId": "{{ any(result) }}"
+        }
+    },
+    {
+	    "eventTime": "{{ is_datetime(result) }}",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "facets": {
+                    "dataQualityAssertions": {
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "expect_column_median_to_be_between",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "expect_column_quantile_values_to_be_between",
+                                "success": true
+                            },
+                            {
+                                "column": "id",
+                                "assertion": "unique",
+                                "success": true
+                            }
+                        ]
+                    }
+                },
+                "name": "random-gcp-project.dbt_test1.test_first_dbt_model",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.test",
+            "namespace": "bigquery"
+        },
+        "outputs": [],
+        "run": {
+            "facets": {
+                "parent": {
+                    "job": {"name": "dbt-job-name", "namespace": "dbt"},
+                    "run": {"runId": "{{ any(result) }}"}
+                },
+                "dbt_version": {
+                    "version": "0.21.0"
+                }
+            },
+            "runId": "{{ any(result) }}"
+        }
+    }
+]

--- a/integration/common/tests/dbt/build/target/manifest.json
+++ b/integration/common/tests/dbt/build/target/manifest.json
@@ -1,0 +1,372 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v3.json",
+		"dbt_version": "0.21.0",
+		"generated_at": "2021-11-09T14:19:58.793963Z",
+		"invocation_id": "b1d24c06-5f63-40e4-a0a2-b0a8d46fb18f",
+		"env": {},
+		"project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.dbt_bigquery_test.test_first_dbt_model": {
+			"raw_sql": "{{ config(materialized='table') }}\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect id\nfrom source_data",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.persist_docs"],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "table",
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"on_schema_change": "ignore",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"fqn": ["dbt_bigquery_test", "example", "test_first_dbt_model"],
+			"unique_id": "model.dbt_bigquery_test.test_first_dbt_model",
+			"package_name": "dbt_bigquery_test",
+			"root_path": "/home/code/code/dbt-test",
+			"path": "example/test_first_dbt_model.sql",
+			"original_file_path": "models/example/test_first_dbt_model.sql",
+			"name": "test_first_dbt_model",
+			"alias": "test_first_dbt_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "381a67a1368d6ba7c8edb0a0403bc1f2106ad136aee93e7fd4ce21a97bec84d4"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "dbt_bigquery_test://models/example/schema.yml",
+			"compiled_path": "target/compiled/dbt_bigquery_test/models/example/test_first_dbt_model.sql",
+			"build_path": "target/run/dbt_bigquery_test/models/example/test_first_dbt_model.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1636467600,
+			"compiled_sql": "\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect id\nfrom source_data",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`test_first_dbt_model`"
+		},
+		"test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "id",
+					"model": "{{ get_where_subquery(ref('test_first_dbt_model')) }}"
+				},
+				"namespace": null
+			},
+			"compiled": true,
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique", "macro.dbt.get_where_subquery", "macro.dbt.should_store_failures", "macro.dbt.statement"],
+				"nodes": ["model.dbt_bigquery_test.test_first_dbt_model"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1_dbt_test__audit",
+			"fqn": ["dbt_bigquery_test", "schema_test", "unique_test_first_dbt_model_id"],
+			"unique_id": "test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c",
+			"package_name": "dbt_bigquery_test",
+			"root_path": "/home/code/code/dbt-test",
+			"path": "schema_test/unique_test_first_dbt_model_id.sql",
+			"original_file_path": "models/example/schema.yml",
+			"name": "unique_test_first_dbt_model_id",
+			"alias": "unique_test_first_dbt_model_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["test_first_dbt_model"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_first_dbt_model_id.sql",
+			"build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/unique_test_first_dbt_model_id.sql",
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1636467600,
+			"compiled_sql": "\n    \n    \n\nselect\n    id as unique_field,\n    count(*) as n_records\n\nfrom `random-gcp-project`.`dbt_test1`.`test_first_dbt_model`\nwhere id is not null\ngroup by id\nhaving count(*) > 1\n\n\n",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": null,
+			"column_name": "id"
+		},
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d": {
+			"raw_sql": "{{ dbt_expectations.test_expect_column_median_to_be_between(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d\") }}",
+			"test_metadata": {
+				"name": "expect_column_median_to_be_between",
+				"kwargs": {
+					"min_value": 1,
+					"max_value": 21,
+					"column_name": "id",
+					"model": "{{ get_where_subquery(ref('test_first_dbt_model')) }}"
+				},
+				"namespace": "dbt_expectations"
+			},
+			"compiled": true,
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt_expectations.test_expect_column_median_to_be_between", "macro.dbt_expectations.median", "macro.dbt_expectations.expression_between", "macro.dbt.get_where_subquery", "macro.dbt.should_store_failures", "macro.dbt.statement"],
+				"nodes": ["model.dbt_bigquery_test.test_first_dbt_model"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": "dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1_dbt_test__audit",
+			"fqn": ["dbt_bigquery_test", "schema_test", "dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1"],
+			"unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d",
+			"package_name": "dbt_bigquery_test",
+			"root_path": "/home/code/code/dbt-test",
+			"path": "schema_test/dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d.sql",
+			"original_file_path": "models/example/schema.yml",
+			"name": "dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1",
+			"alias": "dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["test_first_dbt_model"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d.sql",
+			"build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "dbt_expectations_expect_column_5786256edcb425b1d59b09c5db4cc38d"
+			},
+			"created_at": 1636467600,
+			"compiled_sql": "\n\n\n\n\n\n    with grouped_expression as (\n    select\n        \n        \n    \n  \n( 1=1 and percentile_cont(id, 0.5)\n    over() >= 1 and percentile_cont(id, 0.5)\n    over() <= 21\n)\n as expression\n\n\n    from `random-gcp-project`.`dbt_test1`.`test_first_dbt_model`\n    \n\n),\nvalidation_errors as (\n\n    select\n        *\n    from\n        grouped_expression\n    where\n        not(expression = true)\n\n)\n\nselect *\nfrom validation_errors\n\n\n\n\n\n",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": null,
+			"column_name": "id"
+		},
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43": {
+			"raw_sql": "{{ dbt_expectations.test_expect_column_quantile_values_to_be_between(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66\") }}",
+			"test_metadata": {
+				"name": "expect_column_quantile_values_to_be_between",
+				"kwargs": {
+					"quantile": 0.95,
+					"min_value": 0,
+					"max_value": 2,
+					"column_name": "id",
+					"model": "{{ get_where_subquery(ref('test_first_dbt_model')) }}"
+				},
+				"namespace": "dbt_expectations"
+			},
+			"compiled": true,
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt_expectations.test_expect_column_quantile_values_to_be_between", "macro.dbt_expectations.percentile_cont", "macro.dbt_expectations.expression_between", "macro.dbt.get_where_subquery", "macro.dbt.should_store_failures", "macro.dbt.statement"],
+				"nodes": ["model.dbt_bigquery_test.test_first_dbt_model"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1_dbt_test__audit",
+			"fqn": ["dbt_bigquery_test", "schema_test", "dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95"],
+			"unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43",
+			"package_name": "dbt_bigquery_test",
+			"root_path": "/home/code/code/dbt-test",
+			"path": "schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+			"original_file_path": "models/example/schema.yml",
+			"name": "dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95",
+			"alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["test_first_dbt_model"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+			"build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "dbt_expectations_expect_column_d022aaa18f7eaf98a4880853937cfe66"
+			},
+			"created_at": 1636467600,
+			"compiled_sql": "\n\n\n\n\n\n    with grouped_expression as (\n    select\n        \n        \n    \n  \n( 1=1 and percentile_cont(id, 0.95)\n    over() >= 0 and percentile_cont(id, 0.95)\n    over() <= 2\n)\n as expression\n\n\n    from `random-gcp-project`.`dbt_test1`.`test_first_dbt_model`\n    \n\n),\nvalidation_errors as (\n\n    select\n        *\n    from\n        grouped_expression\n    where\n        not(expression = true)\n\n)\n\nselect *\nfrom validation_errors\n\n\n\n\n\n",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": null,
+			"column_name": "id"
+		}
+	},
+	"sources": {
+		"source.dbt_bigquery_test.dbt_test1.source_table": {
+			"fqn": ["dbt_bigquery_test", "example", "dbt_test1", "source_table"],
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"unique_id": "source.dbt_bigquery_test.dbt_test1.source_table",
+			"package_name": "dbt_bigquery_test",
+			"root_path": "/home/code/code/dbt-test",
+			"path": "models/example/schema.yml",
+			"original_file_path": "models/example/schema.yml",
+			"name": "source_table",
+			"source_name": "dbt_test1",
+			"source_description": "",
+			"loader": "",
+			"identifier": "source_table",
+			"resource_type": "source",
+			"quoting": {
+				"database": null,
+				"schema": null,
+				"identifier": null,
+				"column": null
+			},
+			"loaded_at_field": null,
+			"freshness": {
+				"warn_after": null,
+				"error_after": null,
+				"filter": null
+			},
+			"external": null,
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"source_meta": {},
+			"tags": [],
+			"config": {
+				"enabled": true
+			},
+			"patch_path": null,
+			"unrendered_config": {},
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`source_table`",
+			"created_at": 1636467600
+		}
+	},
+	"macros": {},
+	"docs": {
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.dbt_bigquery_test.test_first_dbt_model": [],
+		"test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c": ["model.dbt_bigquery_test.test_first_dbt_model"],
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d": ["model.dbt_bigquery_test.test_first_dbt_model"],
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43": ["model.dbt_bigquery_test.test_first_dbt_model"],
+		"source.dbt_bigquery_test.dbt_test1.source_table": []
+	},
+	"child_map": {
+		"model.dbt_bigquery_test.test_first_dbt_model": ["test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d", "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43", "test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c"],
+		"test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c": [],
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d": [],
+		"test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43": [],
+		"source.dbt_bigquery_test.dbt_test1.source_table": []
+	}
+}

--- a/integration/common/tests/dbt/build/target/run_results.json
+++ b/integration/common/tests/dbt/build/target/run_results.json
@@ -1,0 +1,97 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v3.json",
+		"dbt_version": "0.21.0",
+		"generated_at": "2021-11-09T14:20:08.032240Z",
+		"invocation_id": "b1d24c06-5f63-40e4-a0a2-b0a8d46fb18f",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-11-09T14:20:01.025669Z",
+			"completed_at": "2021-11-09T14:20:01.028618Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-11-09T14:20:01.028876Z",
+			"completed_at": "2021-11-09T14:20:04.470460Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 3.445859909057617,
+		"adapter_response": {
+			"_message": "CREATE TABLE (2.0 rows, 0.0 Bytes processed)",
+			"code": "CREATE TABLE",
+			"rows_affected": 2,
+			"bytes_processed": 0
+		},
+		"message": "CREATE TABLE (2.0 rows, 0.0 Bytes processed)",
+		"failures": null,
+		"unique_id": "model.dbt_bigquery_test.test_first_dbt_model"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-11-09T14:20:04.476502Z",
+			"completed_at": "2021-11-09T14:20:04.508504Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-11-09T14:20:04.519118Z",
+			"completed_at": "2021-11-09T14:20:06.436524Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 1.962324619293213,
+		"adapter_response": {},
+		"message": null,
+		"failures": 0,
+		"unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_median_to_be_between_test_first_dbt_model_id__21__1.dd83ff215d"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-11-09T14:20:04.476877Z",
+			"completed_at": "2021-11-09T14:20:04.508141Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-11-09T14:20:04.508889Z",
+			"completed_at": "2021-11-09T14:20:06.666529Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.191458225250244,
+		"adapter_response": {},
+		"message": null,
+		"failures": 0,
+		"unique_id": "test.dbt_bigquery_test.dbt_expectations_expect_column_quantile_values_to_be_between_test_first_dbt_model_id__2__0__0_95.af5e727e43"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-11-09T14:20:06.440501Z",
+			"completed_at": "2021-11-09T14:20:06.454287Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-11-09T14:20:06.454691Z",
+			"completed_at": "2021-11-09T14:20:08.024819Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 1.586305856704712,
+		"adapter_response": {},
+		"message": null,
+		"failures": 0,
+		"unique_id": "test.dbt_bigquery_test.unique_test_first_dbt_model_id.f2b0bdd46c"
+	}],
+	"elapsed_time": 7.9490602016448975,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/test",
+		"use_cache": true,
+		"store_failures": false,
+		"greedy": false,
+		"resource_types": [],
+		"version_check": true,
+		"which": "build",
+		"rpc_method": "build"
+	}
+}

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -9,7 +9,7 @@
             }
         ],
         "job": {
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_third_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_third_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -28,7 +28,7 @@
             }
         ],
         "job": {
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -47,7 +47,7 @@
             }
         ],
         "job": {
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -66,7 +66,7 @@
             }
         ],
         "job": {
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_first_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -114,7 +114,7 @@
         ],
         "job": {
             "facets": {},
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_third_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_third_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -158,7 +158,7 @@
             }
         ],
         "job": {
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_parallel_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -205,7 +205,7 @@
         ],
         "job": {
             "facets": {},
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_second_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],
@@ -271,7 +271,7 @@
         ],
         "job": {
             "facets": {},
-            "name": "random-gcp-project.dbt_test1.model.dbt_bigquery_test.test_first_dbt_model",
+            "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
             "namespace": "bigquery"
         },
         "outputs": [],

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -40,7 +40,8 @@ def serialize(inst, field, value):
         "tests/dbt/large",
         "tests/dbt/profiles",
         "tests/dbt/catalog",
-        "tests/dbt/fail"
+        "tests/dbt/fail",
+        "tests/dbt/build"
     ]
 )
 def test_dbt_parse_and_compare_event(path, parent_run_metadata):

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -145,7 +145,7 @@ def main():
     )
     process.wait()
 
-    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test']:
+    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test', 'build']:
         return
 
     # If run_result has modification time before dbt command


### PR DESCRIPTION
Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>

Dbt 0.21.0 introduced new command, `[dbt build](https://docs.getdbt.com/reference/commands/build)`. From our perspective, this command combines `dbt run` and `dbt test`, so should events generated by `dbt-ol build`. 

Main difference in behavior between running those commands separately and with `dbt-ol build` is that `dbt-ol test` incantation generated events with `DataQualityAssertionsDatasetFacet` attached to input datasets. With `dbt-ol build` the command does attach those facets to output datasets - so the end event looks like `dbt-ol run` event, but with assertions facet attached.

Some refactoring was required to add the command efficiently: `dbt-ol build` and `dbt-ol run` share the same parse command. The parsing data quality assertions was separated, and all the commands share event generation method. 

Closes: https://github.com/OpenLineage/OpenLineage/issues/376

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)