### PR TITLE
Fix build for kafka integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,10 @@ jobs:
       spark-version:
         type: string
     working_directory: ~/openlineage/integration/spark
-    docker:
-      - image: circleci/openjdk:8-jdk
+    machine: true
+    environment:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     steps:
       - *checkout_project_root
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,11 +377,11 @@ workflows:
       - build-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.1', '3.1' ]
+              spark-version: [ '2.4.1', '3.1.2' ]
       - integration-test-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.1', '3.1' ]
+              spark-version: [ '2.4.1', '3.1.2' ]
           requires:
             - build-integration-spark
       - publish-snapshot-integration-spark:

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -78,6 +78,10 @@ ext {
     testcontainersVersion = '1.15.3'
     isReleaseVersion = !version.endsWith('SNAPSHOT')
     isSpark3 = project.getProperty('spark.version').startsWith('3')
+    scalaVersion = isSpark3 ? '2.12' : '2.11'
+    kafkaPackage = { scalaVersion, sparkVersion->
+        return "org.apache.spark:spark-sql-kafka-0-10_${scalaVersion}:${sparkVersion}"
+    }
 }
 
 dependencies {
@@ -134,6 +138,7 @@ dependencies {
     spark3Test "org.apache.spark:spark-sql_2.12:${spark3Version}"
     spark3Test "org.apache.spark:spark-hive_2.12:${spark3Version}"
     spark3Test "org.apache.spark:spark-catalyst_2.12:${spark3Version}"
+    spark3Test kafkaPackage('2.12', spark3Version)
 
     spark2Test "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     spark2Test "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
@@ -142,7 +147,7 @@ dependencies {
     spark2Test "org.apache.spark:spark-core_2.11:${sparkVersion}"
     spark2Test "org.apache.spark:spark-sql_2.11:${sparkVersion}"
     spark2Test "org.apache.spark:spark-hive_2.11:${sparkVersion}"
-    spark2Test "org.apache.spark:spark-sql-kafka-0-10_2.11:${sparkVersion}"
+    spark2Test kafkaPackage('2.11', sparkVersion)
 
     spark3 "org.projectlombok:lombok:${lombokVersion}"
     spark3 'io.openlineage:openlineage-java:0.0.1-SNAPSHOT'
@@ -152,7 +157,7 @@ dependencies {
     spark3 "org.apache.spark:spark-core_2.12:${spark3Version}"
     spark3 "org.apache.spark:spark-sql_2.12:${spark3Version}"
     spark3 "org.apache.spark:spark-hive_2.12:${spark3Version}"
-    spark3 "org.apache.spark:spark-sql-kafka-0-10_2.12:3.1.0"
+    spark3 kafkaPackage('2.12', spark3Version)
 
     lombok  "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
@@ -205,9 +210,11 @@ def commonTestConfiguration = {
             'junit.platform.output.capture.stdout': 'true',
             'junit.platform.output.capture.stderr': 'true',
             'spark.version'                       : project.getProperty('spark.version'),
-            'openlineage.spark.jar': "${archivesBaseName}-${project.version}.jar"
+            'openlineage.spark.jar': "${archivesBaseName}-${project.version}.jar",
+            'kafka.package.version': kafkaPackage(scalaVersion, project.getProperty('spark.version'))
     ]
     classpath =  project.sourceSets.test.runtimeClasspath + (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
+    println project.sourceSets.test.runtimeClasspath + (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
 }
 
 test {

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -15,6 +15,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 import groovy.io.FileType
 
+import java.nio.file.Files
+
 buildscript {
     repositories {
         maven {
@@ -199,6 +201,15 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+tasks.register('copyDependencies', Copy) {
+    // delete the dependencies directory so we don't accidentally mix Spark 2 and Spark 3 dependencies
+    delete layout.buildDirectory.dir("dependencies")
+    def config = isSpark3 ? configurations.spark3Test : configurations.spark2Test
+    from config.getFiles()
+    include "*.jar"
+    into layout.buildDirectory.dir("dependencies")
+}
+
 def commonTestConfiguration = {
     forkEvery 1
     maxParallelForks 3
@@ -214,7 +225,6 @@ def commonTestConfiguration = {
             'kafka.package.version': kafkaPackage(scalaVersion, project.getProperty('spark.version'))
     ]
     classpath =  project.sourceSets.test.runtimeClasspath + (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
-    println project.sourceSets.test.runtimeClasspath + (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
 }
 
 test {
@@ -223,6 +233,7 @@ test {
         excludeTags 'integration-test'
     }
     if (!isSpark3) exclude 'io/openlineage/spark3/**'
+    dependsOn copyDependencies
 }
 
 task integrationTest(type: Test) {
@@ -230,7 +241,7 @@ task integrationTest(type: Test) {
     useJUnitPlatform {
         includeTags "integration-test"
     }
-    dependsOn shadowJar
+    dependsOn copyDependencies, shadowJar
 }
 
 spotless {

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/client/HttpError.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/client/HttpError.java
@@ -3,6 +3,8 @@ package io.openlineage.spark.agent.client;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -11,8 +13,9 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
+@RequiredArgsConstructor
 public class HttpError {
   protected Integer code;
-  protected String message;
+  @NonNull protected String message;
   protected String details;
 }

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -60,6 +60,7 @@ public class SparkContainerIntegrationTest {
 
   @AfterEach
   public void cleanupSpark() {
+    mockServerClient.reset();
     try {
       pyspark.stop();
     } catch (Exception e2) {

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -98,6 +98,7 @@ public class SparkContainerIntegrationTest {
         .withFileSystemBind("src/test/resources/test_data", "/test_data")
         .withFileSystemBind("src/test/resources/spark_scripts", "/opt/spark_scripts")
         .withFileSystemBind("build/libs", "/opt/libs")
+        .withFileSystemBind("build/dependencies", "/opt/dependencies")
         .withLogConsumer(SparkContainerIntegrationTest::consumeOutput)
         .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
         .dependsOn(openLineageClientMockContainer)
@@ -129,7 +130,12 @@ public class SparkContainerIntegrationTest {
                   "--conf",
                   "spark.sql.warehouse.dir=/tmp/warehouse",
                   "--jars",
-                  "/opt/libs/" + System.getProperty("openlineage.spark.jar")
+                  "/opt/libs/"
+                      + System.getProperty("openlineage.spark.jar")
+                      + ",/opt/dependencies/spark-sql-kafka-*.jar"
+                      + ",/opt/dependencies/kafka-*.jar"
+                      + ",/opt/dependencies/spark-token-provider-*.jar"
+                      + ",/opt/dependencies/commons-pool2-*.jar"
                 },
                 command)
             .flatMap(Stream::of)
@@ -265,10 +271,7 @@ public class SparkContainerIntegrationTest {
         Arrays.asList(new NewTopic("topicA", 1, (short) 0), new NewTopic("topicB", 1, (short) 0)));
     pyspark =
         makePysparkContainerWithDefaultConf(
-            "testPysparkKafkaReadAssignTest",
-            "--packages",
-            System.getProperty("kafka.package.version"),
-            "/opt/spark_scripts/spark_kafk_assign_read.py");
+            "testPysparkKafkaReadAssignTest", "/opt/spark_scripts/spark_kafk_assign_read.py");
 
     pyspark.setWaitStrategy(Wait.forLogMessage(".*ShutdownHookManager: Shutdown hook called.*", 1));
     pyspark.start();

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -105,7 +105,7 @@ public class SparkContainerIntegrationTest {
   }
 
   private static GenericContainer<?> makeKafkaContainer() {
-    return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"))
+    return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.0"))
         .withNetworkAliases("kafka")
         .withNetwork(network);
   }
@@ -219,10 +219,7 @@ public class SparkContainerIntegrationTest {
         makePysparkContainerWithDefaultConf(
             "testPysparkKafkaReadWriteTest",
             "--packages",
-            "org.apache.spark:spark-sql-kafka-0-10_"
-                + (System.getProperty("spark.version").startsWith("3")
-                    ? "2.12:3.1.0"
-                    : "2.11:2.4.7"),
+            System.getProperty("kafka.package.version"),
             "/opt/spark_scripts/spark_kafka.py");
 
     pyspark.setWaitStrategy(Wait.forLogMessage(".*ShutdownHookManager: Shutdown hook called.*", 1));
@@ -269,10 +266,7 @@ public class SparkContainerIntegrationTest {
         makePysparkContainerWithDefaultConf(
             "testPysparkKafkaReadAssignTest",
             "--packages",
-            "org.apache.spark:spark-sql-kafka-0-10_"
-                + (System.getProperty("spark.version").startsWith("3")
-                    ? "2.12:3.1.0"
-                    : "2.11:2.4.7"),
+            System.getProperty("kafka.package.version"),
             "/opt/spark_scripts/spark_kafk_assign_read.py");
 
     pyspark.setWaitStrategy(Wait.forLogMessage(".*ShutdownHookManager: Shutdown hook called.*", 1));

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -408,7 +408,6 @@ public class SparkReadWriteIntegTest {
     p.setProperty("bootstrap.servers", kafkaContainer.getBootstrapServers());
     p.setProperty("key.serializer", StringSerializer.class.getName());
     p.setProperty("value.serializer", StringSerializer.class.getName());
-    p.setProperty("max.block.ms", "1000");
     KafkaProducer<String, String> producer = new KafkaProducer<>(p);
     CompletableFuture.allOf(
             sendMessage(producer, new ProducerRecord<>("oneTopic", 0, "theKey", "theValue")),
@@ -423,7 +422,6 @@ public class SparkReadWriteIntegTest {
             .read()
             .format("kafka")
             .option("kafka.bootstrap.servers", kafkaContainer.getBootstrapServers())
-            .option("kafka.default.api.timeout.ms", "1000")
             .option("assign", "{\"oneTopic\": [0], \"twoTopic\": [0]}")
             .load();
     kafkaDf.collect();

--- a/integration/spark/src/test/resources/spark_scripts/spark_scripts.iml
+++ b/integration/spark/src/test/resources/spark_scripts/spark_scripts.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (Spark)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
### Problem
Splitting off from https://github.com/OpenLineage/OpenLineage/pull/387 , I had to make several changes to the build in order to get the Kafka integration tests working. In particular, 

- The docker image being used for the unit tests were running in a docker image, which prohibited testcontainers from starting new docker images
- The mockserver didn't get reset between test runs, so sometimes requests from prior tests showed up in a subsequent test's assertions
- The integration tests docker images can't access the internet in CircleCI, so downloading the spark-kafka package failed so I changed the build to copy local dependency jars into the docker image so they can be added to the classpath explicitly.
- The spark.version used in the CI configuration omitted the patch version, so dependency jars weren't being included in the classpath in the spark docker images

Once this PR is approved, I'll merge it with the Kafka one and we can merge the whole thing into main.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modifcation(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)