### PR TITLE
AlterTableCommands visitors

### DIFF
--- a/integration/spark/integrations/container/pysparkAlterTableAddColumnsEnd.json
+++ b/integration/spark/integrations/container/pysparkAlterTableAddColumnsEnd.json
@@ -1,0 +1,33 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testAlterTable",
+    "name" : "open_lineage_integration_alter_table.execute_alter_table_add_columns_command"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/alter_test/alter_table_test",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "string"
+        }, {
+          "name" : "b",
+          "type" : "string"
+        }, {
+          "name" : "c",
+          "type" : "string"
+        }, {
+          "name" : "d",
+          "type" : "string"
+        } ]
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkAlterTableRenameEnd.json
+++ b/integration/spark/integrations/container/pysparkAlterTableRenameEnd.json
@@ -1,0 +1,37 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testAlterTable",
+    "name" : "open_lineage_integration_alter_table.execute_alter_table_rename_command"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/alter_test/alter_table_test_new",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "string"
+        }, {
+          "name" : "b",
+          "type" : "string"
+        }, {
+          "name" : "c",
+          "type" : "string"
+        }, {
+          "name" : "d",
+          "type" : "string"
+        } ]
+      },
+      "previousTableName" : {
+        "previousTableURI" : "/tmp/alter_test/alter_table_test",
+        "currentTableURI" : "/tmp/alter_test/alter_table_test_new"
+      }
+    }
+  } ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/PreviousTableNameFacet.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/PreviousTableNameFacet.java
@@ -1,0 +1,30 @@
+package io.openlineage.spark.agent.facets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import lombok.Getter;
+
+/**
+ * Facet used to indicate previous table name, when table was renamed as a result of a spark job
+ * execution
+ */
+@Getter
+public class PreviousTableNameFacet extends OpenLineage.DefaultDatasetFacet {
+
+  @JsonProperty("previousTableURI")
+  private String previousTableUri;
+
+  @JsonProperty("currentTableURI")
+  private String currentTableUri;
+
+  /**
+   * @param previousTableUri previous table name
+   * @param currentTableUri current table name
+   */
+  public PreviousTableNameFacet(String previousTableUri, String currentTableUri) {
+    super(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+    this.previousTableUri = previousTableUri;
+    this.currentTableUri = currentTableUri;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -1,6 +1,8 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.plan.AlterTableAddColumnsCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.AlterTableRenameCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.AppendDataVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
@@ -90,6 +92,11 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(
         new OutputDatasetVisitor(new CreateTableLikeCommandVisitor(sqlContext.sparkSession())));
     list.add(new OutputDatasetVisitor(new LoadDataCommandVisitor(sqlContext.sparkSession())));
+    list.add(
+        new OutputDatasetVisitor(new AlterTableRenameCommandVisitor(sqlContext.sparkSession())));
+    list.add(
+        new OutputDatasetVisitor(
+            new AlterTableAddColumnsCommandVisitor(sqlContext.sparkSession())));
     return list;
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
@@ -1,0 +1,45 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand;
+import org.apache.spark.sql.types.StructField;
+import scala.collection.JavaConversions;
+
+public class AlterTableAddColumnsCommandVisitor
+    extends QueryPlanVisitor<AlterTableAddColumnsCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public AlterTableAddColumnsCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @Override
+  @SneakyThrows
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CatalogTable catalogTable =
+        sparkSession
+            .sessionState()
+            .catalog()
+            .getTableMetadata(((AlterTableAddColumnsCommand) x).table());
+
+    List<StructField> tableColumns = Arrays.asList(catalogTable.schema().fields());
+    List<StructField> addedColumns =
+        JavaConversions.seqAsJavaList(((AlterTableAddColumnsCommand) x).colsToAdd());
+
+    if (tableColumns.containsAll(addedColumns)) {
+      return Collections.singletonList(PlanUtils.getDataset(catalogTable));
+    } else {
+      // apply triggered before applying the change - do not send an event
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -1,0 +1,68 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.PlanUtils.datasourceFacet;
+import static io.openlineage.spark.agent.util.PlanUtils.namespaceUri;
+import static io.openlineage.spark.agent.util.PlanUtils.schemaFacet;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.PreviousTableNameFacet;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.AlterTableRenameCommand;
+
+@Slf4j
+public class AlterTableRenameCommandVisitor
+    extends QueryPlanVisitor<AlterTableRenameCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public AlterTableRenameCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @SneakyThrows
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    SessionCatalog sessionCatalog = sparkSession.sessionState().catalog();
+    CatalogTable table;
+    try {
+      table = sessionCatalog.getTableMetadata(((AlterTableRenameCommand) x).newName());
+    } catch (NoSuchTableException e) {
+      log.info("NoSuchTableException caught");
+      // apply method called before altering table - do not send an event
+      return Collections.emptyList();
+    }
+
+    URI currentPath = PlanUtils.getPath(table.location(), table.qualifiedName(), "").toUri();
+
+    AlterTableRenameCommand alterTableRenameCommand = (AlterTableRenameCommand) x;
+    String previousPath =
+        currentPath
+            .getPath()
+            .replace(
+                alterTableRenameCommand.newName().table(),
+                alterTableRenameCommand.oldName().table());
+
+    String namespace = namespaceUri(currentPath);
+    return Collections.singletonList(
+        PlanUtils.getDataset(
+            currentPath.getPath(),
+            namespace,
+            new OpenLineage.DatasetFacetsBuilder()
+                .schema(schemaFacet(table.schema()))
+                .dataSource(datasourceFacet(namespace))
+                .put(
+                    "previousTableName",
+                    new PreviousTableNameFacet(previousPath, currentPath.getPath()))
+                .build()));
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
@@ -1,0 +1,108 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.JavaConversions;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class AlterTableAddColumnsCommandVisitorTest {
+
+  SparkSession session;
+  AlterTableAddColumnsCommandVisitor visitor;
+  String database;
+
+  @AfterEach
+  public void afterEach() {
+    dropTables();
+  }
+
+  private void dropTables() {
+    session
+        .sessionState()
+        .catalog()
+        .dropTable(new TableIdentifier("table1", Option.apply(database)), true, true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+
+    dropTables();
+
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    session.catalog().createTable("table1", "csv", schema, Map$.MODULE$.empty());
+    database = session.catalog().currentDatabase();
+    visitor = new AlterTableAddColumnsCommandVisitor(session);
+  }
+
+  @Test
+  public void testAlterTableAddColumns() {
+    AlterTableAddColumnsCommand command =
+        new AlterTableAddColumnsCommand(
+            new TableIdentifier("table1", Option.apply(database)),
+            JavaConversions.asScalaIterator(
+                    Arrays.asList(
+                            new StructField(
+                                "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>())),
+                            new StructField(
+                                "col3", StringType$.MODULE$, false, new Metadata(new HashMap<>())))
+                        .iterator())
+                .toSeq());
+
+    command.run(session);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertEquals(3, datasets.get(0).getFacets().getSchema().getFields().size());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/table1")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+
+  @Test
+  public void testAlterUpdateColumnsBeforeCommandRun() {
+    AlterTableAddColumnsCommand command =
+        new AlterTableAddColumnsCommand(
+            new TableIdentifier("table1", Option.apply(database)),
+            JavaConversions.asScalaIterator(
+                    Arrays.asList(
+                            new StructField(
+                                "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>())))
+                        .iterator())
+                .toSeq());
+
+    // command is not run
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets).isEmpty();
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
@@ -1,0 +1,105 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.facets.PreviousTableNameFacet;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.AlterTableRenameCommand;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class AlterTableRenameCommandVisitorTest {
+
+  SparkSession session;
+  AlterTableRenameCommandVisitor visitor;
+  String database;
+
+  @AfterEach
+  public void afterEach() {
+    dropTables();
+  }
+
+  private void dropTables() {
+    session
+        .sessionState()
+        .catalog()
+        .dropTable(new TableIdentifier("old_table", Option.apply(database)), true, true);
+    session
+        .sessionState()
+        .catalog()
+        .dropTable(new TableIdentifier("new_table", Option.apply(database)), true, true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+
+    database = session.catalog().currentDatabase();
+    dropTables();
+
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("a", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    session.catalog().createTable("old_table", "csv", schema, Map$.MODULE$.empty());
+    visitor = new AlterTableRenameCommandVisitor(session);
+  }
+
+  @Test
+  void testAlterRenameCommandCommand() {
+    AlterTableRenameCommand command =
+        new AlterTableRenameCommand(
+            new TableIdentifier("old_table", Option.apply(database)),
+            new TableIdentifier("new_table", Option.apply(database)),
+            false);
+    command.run(session);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/new_table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+
+    PreviousTableNameFacet previousTableNameFacet =
+        ((PreviousTableNameFacet)
+            datasets.get(0).getFacets().getAdditionalProperties().get("previousTableName"));
+
+    assertThat(previousTableNameFacet.getPreviousTableUri()).isEqualTo("/tmp/warehouse/old_table");
+    assertThat(previousTableNameFacet.getCurrentTableUri()).isEqualTo("/tmp/warehouse/new_table");
+  }
+
+  @Test
+  void testAlterRenameCommandCommandVisitorBeforeCommandRun() {
+    AlterTableRenameCommand command =
+        new AlterTableRenameCommand(
+            new TableIdentifier("old_table", Option.apply(database)),
+            new TableIdentifier("new_table", Option.apply(database)),
+            false);
+
+    // command is not run
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets).isEmpty();
+  }
+}

--- a/integration/spark/src/test/resources/spark_scripts/spark_alter_table.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_alter_table.py
@@ -1,0 +1,18 @@
+import os
+
+os.makedirs("/tmp/ctas_load", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Alter Table") \
+    .config("spark.sql.warehouse.dir", "file:/tmp/alter_test/") \
+    .enableHiveSupport() \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE alter_table_test (a string, b string)")
+spark.sql("ALTER TABLE alter_table_test ADD COLUMNS (c string, d string)")
+spark.sql("ALTER TABLE alter_table_test RENAME TO alter_table_test_new")


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Implement Spark Visitors for `alter table` commands

Closes: #369

### Solution

Implement `AlterTableAddColumnsCommandVisitor` and `AlterTableRenameCommandVisitor`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [X] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)