### PR TITLE
[INTEGRATION][spark] implement PathUtils helper class

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
@@ -1,0 +1,9 @@
+package io.openlineage.spark.agent.util;
+
+import lombok.Value;
+
+@Value
+public class DatasetIdentifier {
+  String name;
+  String namespace;
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -1,0 +1,88 @@
+package io.openlineage.spark.agent.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+
+@Slf4j
+public class PathUtils {
+
+  private static final String DEFAULT_SCHEME = "file";
+
+  public static DatasetIdentifier fromPath(Path path) {
+    return PathUtils.fromPath(path, DEFAULT_SCHEME);
+  }
+
+  public static DatasetIdentifier fromPath(Path path, String defaultScheme) {
+    if (path.isAbsoluteAndSchemeAuthorityNull()) {
+      return new DatasetIdentifier(path.toString(), defaultScheme);
+    }
+    URI uri = path.toUri();
+    String namespace =
+        Optional.ofNullable(uri.getAuthority())
+            .map(a -> String.format("%s://%s", uri.getScheme(), a))
+            .orElseGet(
+                () -> {
+                  if (uri.getScheme() != null) {
+                    return uri.getScheme();
+                  } else {
+                    return defaultScheme;
+                  }
+                });
+    String name = fixName(uri.getPath());
+    return new DatasetIdentifier(name, namespace);
+  }
+
+  public static DatasetIdentifier fromURI(URI location, String defaultScheme) {
+    return fromPath(new Path(location), defaultScheme);
+  }
+
+  public static DatasetIdentifier fromCatalogTable(CatalogTable catalogTable, String authority) {
+    try {
+      URI location = catalogTable.location();
+      return PathUtils.fromURI(location, "file");
+    } catch (Exception e) { // Java does not recognize scala exception
+      if (e instanceof AnalysisException) {
+        try {
+          String qualifiedName = catalogTable.qualifiedName();
+          if (!qualifiedName.startsWith("/")) {
+            qualifiedName = String.format("/%s", qualifiedName);
+          }
+          return PathUtils.fromPath(
+              new Path(new URI("hive", authority, qualifiedName, null, null)));
+        } catch (URISyntaxException uriSyntaxException) {
+          throw new IllegalArgumentException(uriSyntaxException);
+        }
+      }
+      throw e;
+    }
+  }
+
+  public static DatasetIdentifier fromCatalogTable(CatalogTable catalogTable) {
+    String authority =
+        ScalaConversionUtils.asJavaOptional(catalogTable.storage().locationUri())
+            .map(URI::toString)
+            .orElse(
+                SparkSession.active()
+                    .sessionState()
+                    .catalog()
+                    .defaultTablePath(catalogTable.identifier())
+                    .toString());
+    return PathUtils.fromCatalogTable(catalogTable, authority);
+  }
+
+  private static String fixName(String name) {
+    if (name.chars().filter(x -> x == '/').count() > 1) {
+      return name;
+    }
+    if (name.startsWith("/")) {
+      return name.substring(1);
+    }
+    return name;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
@@ -1,6 +1,7 @@
 package io.openlineage.spark.agent.util;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -53,6 +54,17 @@ public class ScalaConversionUtils {
    */
   public static <T> List<T> fromSeq(Seq<T> seq) {
     return JavaConverters.bufferAsJavaListConverter(seq.<T>toBuffer()).asJava();
+  }
+
+  /**
+   * Convert a {@link scala.collection.immutable.Map} to a Java {@link java.util.Map}.
+   *
+   * @param map
+   * @param <K, V>
+   * @return
+   */
+  public static <K, V> Map<K, V> fromMap(scala.collection.immutable.Map<K, V> map) {
+    return JavaConverters.mapAsJavaMapConverter(map).asJava();
   }
 
   /**

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/SparkConfUtils.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/SparkConfUtils.java
@@ -4,6 +4,9 @@ import java.util.Optional;
 import org.apache.spark.SparkConf;
 
 public class SparkConfUtils {
+  private static final String metastoreUriKey = "spark.sql.hive.metastore.uris";
+  private static final String metastoreHadoopUriKey = "spark.hadoop.hive.metastore.uris";
+
   public static String findSparkConfigKey(SparkConf conf, String name, String defaultValue) {
     return findSparkConfigKey(conf, name).orElse(defaultValue);
   }
@@ -12,5 +15,11 @@ public class SparkConfUtils {
     return ScalaConversionUtils.asJavaOptional(
         conf.getOption(name)
             .getOrElse(ScalaConversionUtils.toScalaFn(() -> conf.getOption("spark." + name))));
+  }
+
+  public static Optional<String> getMetastoreKey(SparkConf conf) {
+    return Optional.ofNullable(
+        SparkConfUtils.findSparkConfigKey(conf, metastoreUriKey)
+            .orElse(SparkConfUtils.findSparkConfigKey(conf, metastoreHadoopUriKey).orElse(null)));
   }
 }

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -1,0 +1,108 @@
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+@Slf4j
+public class PathUtilsTest {
+
+  @Test
+  void testPathSeparation() {
+    Path path = new Path("scheme:/asdf/fdsa");
+    assertThat(path.toUri().getScheme()).isEqualTo("scheme");
+    assertThat(path.toUri().getAuthority()).isEqualTo(null);
+    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
+
+    path = new Path("scheme://asdf/fdsa");
+    assertThat(path.toUri().getScheme()).isEqualTo("scheme");
+    assertThat(path.toUri().getAuthority()).isEqualTo("asdf");
+    assertThat(path.toUri().getPath()).isEqualTo("/fdsa");
+
+    path = new Path("scheme:///asdf/fdsa");
+    assertThat(path.toUri().getScheme()).isEqualTo("scheme");
+    assertThat(path.toUri().getAuthority()).isEqualTo(null);
+    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
+
+    path = new Path("scheme:////asdf/fdsa");
+    assertThat(path.toUri().getScheme()).isEqualTo("scheme");
+    assertThat(path.toUri().getAuthority()).isEqualTo(null);
+    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
+  }
+
+  @Test
+  void testFromPathWithoutSchema() {
+    DatasetIdentifier di = PathUtils.fromPath(new Path("/home/test"));
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("file");
+
+    di = PathUtils.fromPath(new Path("/home/test"), "hive");
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("hive");
+
+    di = PathUtils.fromPath(new Path("home/test"));
+    assertThat(di.getName()).isEqualTo("home/test");
+    assertThat(di.getNamespace()).isEqualTo("file");
+  }
+
+  @Test
+  void testFromPathWithSchema() {
+    DatasetIdentifier di = PathUtils.fromPath(new Path("file:/home/test"));
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("file");
+
+    di = PathUtils.fromPath(new Path("hdfs://namenode:8020/home/test"));
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("hdfs://namenode:8020");
+  }
+
+  @Test
+  void testFromURI() throws URISyntaxException {
+    DatasetIdentifier di = PathUtils.fromURI(new URI("file:///home/test"), null);
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("file");
+
+    di = PathUtils.fromURI(new URI(null, null, "/home/test", null), "file");
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("file");
+
+    di =
+        PathUtils.fromURI(
+            new URI("hdfs", null, "localhost", 8020, "/home/test", null, null), "file");
+    assertThat(di.getName()).isEqualTo("/home/test");
+    assertThat(di.getNamespace()).isEqualTo("hdfs://localhost:8020");
+
+    di = PathUtils.fromURI(new URI("s3://data-bucket/path"), "file");
+    assertThat(di.getName()).isEqualTo("path");
+    assertThat(di.getNamespace()).isEqualTo("s3://data-bucket");
+  }
+
+  @Test
+  void testFromCatalogTable() {
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.identifier()).thenReturn(TableIdentifier$.MODULE$.apply("table"));
+    when(catalogTable.qualifiedName()).thenReturn("table");
+    given(catalogTable.location())
+        .willAnswer(
+            invocation -> {
+              throw new AnalysisException(
+                  "", Option.empty(), Option.empty(), Option.empty(), Option.empty());
+            });
+
+    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, "10.1.0.1:9083");
+    assertThat(catalogTable.qualifiedName()).isEqualTo("table");
+    assertThat(di.getName()).isEqualTo("table");
+    assertThat(di.getNamespace()).isEqualTo("hive://10.1.0.1:9083");
+  }
+}


### PR DESCRIPTION
Currently, `QueryPlanVisitor` is responsible for maintaining 
1) extracting relevant data from `LogicalPlan` implementations 
2) creating meaningful dataset naming from extracted data
3) constructing `OpenLineage.Dataset` instance. 

There is `PlanUtils` class that conflates 2) and 3).
This PR adds testable `PathUtils` class  helping with 2) in ordinary cases. 
Next PR in this series will move existing implementations to using `PathUtils` and decouples `PlanUtils` from doing 3).

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)