### PR TITLE
[INTEGRATION][Spark] split CreateTableLikeCommandVisitor implementation

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -182,7 +182,7 @@ sourceSets {
 
     spark3Test {
         java {
-            srcDirs = ["src/test/spark3/java"]
+            srcDirs = ["src/test/common/java", "src/test/spark3/java"]
             compileClasspath = configurations.spark3Test + sourceSets.main.output
             annotationProcessorPath = configurations.lombok
             destinationDirectory.set(file("$buildDir/classes/java/test/"))

--- a/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2VisitorFactoryImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.QueryPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.wrapper.OutputDatasetVisitor;
+import io.openlineage.spark2.agent.lifecycle.plan.CreateTableLikeCommandVisitor;
 import io.openlineage.spark2.agent.lifecycle.plan.DatasetSourceVisitor;
 import java.util.List;
 import org.apache.spark.sql.SQLContext;
@@ -17,6 +18,7 @@ class Spark2VisitorFactoryImpl extends BaseVisitorFactory {
     return ImmutableList.<QueryPlanVisitor<LogicalPlan, OpenLineage.OutputDataset>>builder()
         .addAll(super.getOutputVisitors(sqlContext, jobNamespace))
         .add(new OutputDatasetVisitor(new DatasetSourceVisitor()))
+        .add(new OutputDatasetVisitor(new CreateTableLikeCommandVisitor(sqlContext.sparkSession())))
         .build();
   }
 

--- a/integration/spark/src/main/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/src/main/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -1,0 +1,50 @@
+package io.openlineage.spark2.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.plan.QueryPlanVisitor;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateTableLikeCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableLikeCommand} and extracts the
+ * output {@link OpenLineage.Dataset} being written.
+ */
+@Slf4j
+public class CreateTableLikeCommandVisitor
+    extends QueryPlanVisitor<CreateTableLikeCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public CreateTableLikeCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @SneakyThrows
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CreateTableLikeCommand command = (CreateTableLikeCommand) x;
+    SessionCatalog catalog = sparkSession.sessionState().catalog();
+
+    CatalogTable source = catalog.getTempViewOrPermanentTableMetadata(command.sourceTable());
+    URI location;
+    if (command.location().isEmpty()) {
+      location = catalog.defaultTablePath(command.targetTable());
+    } else {
+      location = new URI(command.location().get());
+    }
+
+    DatasetIdentifier di = PathUtils.fromURI(location, "file");
+    return Collections.singletonList(PlanUtils.getDataset(di, source.schema()));
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -1,0 +1,49 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.plan.QueryPlanVisitor;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateTableLikeCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableLikeCommand} and extracts the
+ * output {@link OpenLineage.Dataset} being written.
+ */
+@Slf4j
+public class CreateTableLikeCommandVisitor
+    extends QueryPlanVisitor<CreateTableLikeCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public CreateTableLikeCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @SneakyThrows
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CreateTableLikeCommand command = (CreateTableLikeCommand) x;
+    SessionCatalog catalog = sparkSession.sessionState().catalog();
+
+    CatalogTable source = catalog.getTempViewOrPermanentTableMetadata(command.sourceTable());
+    URI defaultLocation = catalog.defaultTablePath(command.targetTable());
+
+    URI location =
+        ScalaConversionUtils.<URI>asJavaOptional(command.fileFormat().locationUri())
+            .orElse(defaultLocation);
+    DatasetIdentifier di = PathUtils.fromURI(location, "file");
+    return Collections.singletonList(PlanUtils.getDataset(di, source.schema()));
+  }
+}

--- a/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -1,0 +1,58 @@
+package io.openlineage.spark2.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.execution.command.CreateTableLikeCommand;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class CreateTableLikeCommandVisitorTest {
+  @Test
+  void testCreateTableLikeCommand() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    String database = session.catalog().currentDatabase();
+
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    session.catalog().createTable("table", "csv", schema, Map$.MODULE$.empty());
+
+    CreateTableLikeCommandVisitor visitor = new CreateTableLikeCommandVisitor(session);
+
+    CreateTableLikeCommand command =
+        new CreateTableLikeCommand(
+            TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+            TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+            Option.apply("/path/to/data"),
+            false);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/path/to/data")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -1,0 +1,62 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier$;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
+import org.apache.spark.sql.execution.command.CreateTableLikeCommand;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.Option$;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class CreateTableLikeCommandVisitorTest {
+  @Test
+  void testCreateTableLikeCommand() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    String database = session.catalog().currentDatabase();
+
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    session.catalog().createTable("table", "csv", schema, Map$.MODULE$.empty());
+
+    CreateTableLikeCommandVisitor visitor = new CreateTableLikeCommandVisitor(session);
+
+    CreateTableLikeCommand command =
+        new CreateTableLikeCommand(
+            TableIdentifier$.MODULE$.apply("newtable", Option.apply(database)),
+            TableIdentifier$.MODULE$.apply("table", Option.apply(database)),
+            CatalogStorageFormat.empty(),
+            Option$.MODULE$.empty(),
+            Map$.MODULE$.empty(),
+            false);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/newtable")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}


### PR DESCRIPTION
Due to incompatible `CreateTableLikeCommand` API change between Spark 2.4 and Spark 3.1, the `CreateTableLikeCommandVisitor` has to have different implementations.

This PR creates implementation for both Spark versions, as well as tests for them.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)