### PR TITLE
[INTEGRATION][great expectations] pin version to the one supported by airflow operator

### DIFF
--- a/integration/airflow/tests/integration/docker/up-2.sh
+++ b/integration/airflow/tests/integration/docker/up-2.sh
@@ -42,6 +42,7 @@ OPENLINEAGE_AIRFLOW_WHL_ALL=$(docker run openlineage-airflow-base:latest sh -c "
 # Add revision to requirements.txt
 cat > requirements.txt <<EOL
 airflow-provider-great-expectations==0.0.8
+great-expectations==0.13.42
 dbt-bigquery==0.20.1
 ${OPENLINEAGE_AIRFLOW_WHL}
 EOL
@@ -49,7 +50,7 @@ EOL
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
 requests==2.24.0
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.2
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -40,6 +40,7 @@ OPENLINEAGE_AIRFLOW_WHL_ALL=$(docker run openlineage-airflow-base:latest sh -c "
 # Add revision to requirements.txt
 cat > requirements.txt <<EOL
 airflow-provider-great-expectations==0.0.8
+great-expectations==0.13.42
 dbt-bigquery==0.20.1
 ${OPENLINEAGE_AIRFLOW_WHL}
 EOL
@@ -49,7 +50,7 @@ EOL
 cat > integration-requirements.txt <<EOL
 requests==2.24.0
 setuptools==34.0.0
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.2
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2


### PR DESCRIPTION
This fixes integration test breakage on main branch.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)