### PR TITLE
[INTEGRATION][dbt] skip non-test nodes while processing assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * dbt: column descriptions are properly filled from metadata.json [@mobuchowski](https://github.com/mobuchowski)
 * dbt: allow parsing artifacts with version higher than officially supported  [@mobuchowski](https://github.com/mobuchowski)
 * dbt: dbt build command is supported  [@mobuchowski](https://github.com/mobuchowski)
-
+* dbt: fix crash when build command is used with seeds in dbt 1.0.0rc3 [@mobuchowski](https://github.com/mobuchowski)
 
 ## [0.3.1](https://github.com/OpenLineage/OpenLineage/releases/tag/0.3.1) - 2021-10-21
 

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -167,8 +167,8 @@ class DbtArtifactProcessor:
         """
             Parse dbt manifest and run_result and produce OpenLineage events.
         """
-        manifest = self.load_metadata(self.manifest_path, [2, 3], self.logger)
-        run_result = self.load_metadata(self.run_result_path, [2, 3], self.logger)
+        manifest = self.load_metadata(self.manifest_path, [2, 3, 4], self.logger)
+        run_result = self.load_metadata(self.run_result_path, [2, 3, 4], self.logger)
         self.run_metadata = run_result['metadata']
         self.command = run_result['args']['which']
 
@@ -418,9 +418,9 @@ class DbtArtifactProcessor:
     ) -> Dict[str, List[Assertion]]:
         assertions = collections.defaultdict(list)
         for run in context.run_results['results']:
-            test_node = nodes[run['unique_id']]
             if not run['unique_id'].startswith('test.'):
                 continue
+            test_node = nodes[run['unique_id']]
 
             model_node = None
             for node in context.manifest['parent_map'][run['unique_id']]:

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -6,7 +6,7 @@ from unittest import mock
 import attr
 import pytest
 
-from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata
+from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata, DbtRunContext
 from openlineage.client import set_producer
 from openlineage.common.test import match
 
@@ -211,3 +211,15 @@ def test_logging_handler_does_not_warn():
     DbtArtifactProcessor.load_metadata(path, [2], logger)
 
     logger.warning.assert_not_called()
+
+
+def test_seed_snapshot_nodes_do_not_throw():
+    processor = DbtArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/test',
+    )
+
+    # Should just skip processing
+    processor.parse_assertions(
+        DbtRunContext({}, {"results": [{"unique_id": "seed.jaffle_shop.raw_orders"}]}), {}
+    )


### PR DESCRIPTION
This avoids the problem of referring to non-existing `seed` node that can appear when using build command. 
Also, bump the officially compatible manifest and run_results file version to 4.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: #421 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)