### PR TITLE
create & drop table with tests

### DIFF
--- a/integration/spark/integrations/container/pysparkCreateTableCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkCreateTableCompleteEvent.json
@@ -1,0 +1,32 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testCreateTable",
+    "name": "open_lineage_integration_create_table.execute_create_table_command"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/create_test/create_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "string"
+            },
+            {
+              "name": "b",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/integrations/container/pysparkCreateTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkCreateTableStartEvent.json
@@ -1,0 +1,32 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testCreateTable",
+    "name": "open_lineage_integration_create_table.execute_create_table_command"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/create_test/create_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "string"
+            },
+            {
+              "name": "b",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/integrations/container/pysparkDropTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkDropTableStartEvent.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testDropTable",
+    "name": "open_lineage_integration_drop_table.execute_drop_table_command"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/drop_test/drop_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "tableStateChange": {
+          "stateChange": "drop"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/TableStateChangeFacet.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/TableStateChangeFacet.java
@@ -1,0 +1,32 @@
+package io.openlineage.spark.agent.facets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import lombok.Getter;
+
+/** Facet used to notify state change performed on table like "CREATE", "DROP" or "TRUNCATE". */
+@Getter
+public class TableStateChangeFacet extends OpenLineage.DefaultDatasetFacet {
+
+  public enum StateChange {
+    CREATE,
+    DROP,
+    TRUNCATE;
+
+    @JsonValue
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
+  @JsonProperty("stateChange")
+  private StateChange stateChange;
+
+  public TableStateChangeFacet(StateChange stateChange) {
+    super(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+    this.stateChange = stateChange;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -9,6 +9,8 @@ import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateHiveTableAsSelectCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.CreateTableCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.DropTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDirVisitor;
@@ -89,6 +91,8 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(
         new OutputDatasetVisitor(
             new AlterTableAddColumnsCommandVisitor(sqlContext.sparkSession())));
+    list.add(new OutputDatasetVisitor(new CreateTableCommandVisitor()));
+    list.add(new OutputDatasetVisitor(new DropTableCommandVisitor(sqlContext.sparkSession())));
     return list;
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
@@ -1,0 +1,27 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.CreateTableCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableCommand} and extracts the output
+ * {@link OpenLineage.Dataset} being written.
+ */
+public class CreateTableCommandVisitor
+    extends QueryPlanVisitor<CreateTableCommand, OpenLineage.Dataset> {
+
+  @Override
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    CreateTableCommand command = (CreateTableCommand) x;
+    CatalogTable catalogTable = command.table();
+
+    return Collections.singletonList(
+        PlanUtils.getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
@@ -1,0 +1,58 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.PlanUtils.datasourceFacet;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.DropTableCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link DropTableCommand} and extracts the output
+ * {@link OpenLineage.Dataset} being written.
+ */
+public class DropTableCommandVisitor
+    extends QueryPlanVisitor<DropTableCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public DropTableCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @Override
+  @SneakyThrows
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    DropTableCommand command = (DropTableCommand) x;
+
+    if (sparkSession.sessionState().catalog().tableExists(command.tableName())) {
+      // prepare an event, table will be deleted soon
+      CatalogTable table =
+          sparkSession.sessionState().catalog().getTableMetadata(command.tableName());
+      DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
+
+      return Collections.singletonList(
+          PlanUtils.getDataset(
+              datasetIdentifier,
+              new OpenLineage.DatasetFacetsBuilder()
+                  .schema(null)
+                  .dataSource(datasourceFacet(datasetIdentifier.getNamespace()))
+                  .put(
+                      "tableStateChange",
+                      new TableStateChangeFacet(TableStateChangeFacet.StateChange.DROP))
+                  .build()));
+
+    } else {
+      // already deleted, do nothing
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -1,0 +1,67 @@
+package io.openlineage.spark.agent.lifecycle;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import scala.Option;
+import scala.collection.Seq$;
+import scala.collection.immutable.HashMap;
+
+public class CatalogTableTestUtils {
+
+  @SneakyThrows
+  public static CatalogTable getCatalogTable(TableIdentifier tableIdentifier) {
+    Method applyMethod =
+        Arrays.stream(CatalogTable.class.getDeclaredMethods())
+            .filter(m -> m.getName().equals("apply"))
+            .findFirst()
+            .get();
+    List<Object> params = new ArrayList<>();
+    params.add(tableIdentifier);
+    params.add(CatalogTableType.MANAGED());
+    params.add(
+        CatalogStorageFormat.apply(
+            Option.apply(new URI("/some-location")),
+            Option.empty(),
+            Option.empty(),
+            Option.empty(),
+            false,
+            null));
+    params.add(
+        new StructType(
+            new StructField[] {
+              new StructField("name", StringType$.MODULE$, false, Metadata.empty())
+            }));
+    params.add(Option.empty());
+    params.add(Seq$.MODULE$.<String>newBuilder().$plus$eq("name").result());
+    params.add(Option.empty());
+    params.add("");
+    params.add(Instant.now().getEpochSecond());
+    params.add(Instant.now().getEpochSecond());
+    params.add("v1");
+    params.add(new HashMap<>());
+    params.add(Option.empty());
+    params.add(Option.empty());
+    params.add(Option.empty());
+    params.add(Seq$.MODULE$.<String>empty());
+    params.add(false);
+    params.add(false);
+    params.add(new HashMap<>());
+    if (applyMethod.getParameterCount() > 19) {
+      params.add(Option.empty());
+    }
+    return (CatalogTable) applyMethod.invoke(null, params.toArray());
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -63,6 +63,7 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,6 +75,7 @@ import scala.Tuple2;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
+@Tag("integration-test")
 public class SparkReadWriteIntegTest {
 
   private final KafkaContainer kafkaContainer =

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
@@ -1,0 +1,42 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
+import java.util.List;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.CreateTableCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class CreateTableCommandVisitorTest {
+
+  CreateTableCommandVisitor visitor;
+  String database = "default";
+  CreateTableCommand command;
+  TableIdentifier table = new TableIdentifier("create_table", Option.apply(database));
+
+  @BeforeEach
+  public void setup() {
+    command = new CreateTableCommand(CatalogTableTestUtils.getCatalogTable(table), true);
+    visitor = new CreateTableCommandVisitor();
+  }
+
+  @Test
+  void testCreateTableCommand() {
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    assertEquals(1, datasets.get(0).getFacets().getSchema().getFields().size());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/some-location")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
@@ -1,0 +1,88 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.DropTableCommand;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class DropTableCommandVisitorTest {
+
+  SparkSession session;
+  DropTableCommandVisitor visitor;
+  DropTableCommand command;
+  String database;
+  TableIdentifier table = new TableIdentifier("drop_table");
+
+  @BeforeEach
+  public void setup() {
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+
+    database = session.catalog().currentDatabase();
+    command = new DropTableCommand(table, true, false, true);
+    visitor = new DropTableCommandVisitor(session);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    session.sessionState().catalog().dropTable(table, true, true);
+  }
+
+  @Test
+  public void testDropTableCommandWhenTableDoesNotExist() {
+    // make sure table does not exist
+    session.sessionState().catalog().dropTable(table, true, true);
+    command.run(session);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets).isEmpty();
+  }
+
+  @Test
+  public void testDropCommand() {
+    // create some other table first
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("field1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+    session.catalog().createTable("drop_table", "csv", schema, Map$.MODULE$.empty());
+
+    // apply the visitor before running the command
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+
+    assertEquals(null, datasets.get(0).getFacets().getSchema());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/drop_table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+
+    TableStateChangeFacet tableStateChangeFacet =
+        ((TableStateChangeFacet)
+            datasets.get(0).getFacets().getAdditionalProperties().get("tableStateChange"));
+
+    assertThat(
+        tableStateChangeFacet.getStateChange().equals(TableStateChangeFacet.StateChange.DROP));
+  }
+}

--- a/integration/spark/src/test/resources/spark_scripts/spark_create_table.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_create_table.py
@@ -1,0 +1,16 @@
+import os
+
+os.makedirs("/tmp/create_test", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Create Table") \
+    .config("spark.sql.warehouse.dir", "file:/tmp/create_test/") \
+    .enableHiveSupport() \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE create_table_test (a string, b string)")

--- a/integration/spark/src/test/resources/spark_scripts/spark_drop_table.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_drop_table.py
@@ -1,0 +1,18 @@
+import os
+
+os.makedirs("/tmp/ctas_load", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Drop Table") \
+    .config("spark.sql.warehouse.dir", "file:/tmp/drop_test/") \
+    .enableHiveSupport() \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE drop_table_test (a string, b string)")
+
+spark.sql("DROP TABLE drop_table_test")

--- a/integration/spark/src/test/resources/test_data/serde/hadoopfsrelation-node.json
+++ b/integration/spark/src/test/resources/test_data/serde/hadoopfsrelation-node.json
@@ -13,7 +13,7 @@
           "name": "MANAGED"
         },
         "storage": {
-          "locationUri": null,
+          "locationUri": "/some-location",
           "inputFormat": null,
           "outputFormat": null,
           "serde": null,

--- a/integration/spark/src/test/resources/test_data/serde/insertintofs-node.json
+++ b/integration/spark/src/test/resources/test_data/serde/insertintofs-node.json
@@ -49,7 +49,7 @@
             "name": "MANAGED"
           },
           "storage": {
-            "locationUri": null,
+            "locationUri": "/some-location",
             "inputFormat": null,
             "outputFormat": null,
             "serde": null,


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Increase Spark visitor coverage

Closes: #370

### Solution

Implements `DropTableCommandVisitor` and `CreateTableCommandVisitor`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)