### PR TITLE
merge fromHiveTable & fromCatalogTable methods

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -127,6 +127,7 @@ dependencies {
     testCompile "org.assertj:assertj-core:${assertjVersion}"
     testCompile "org.junit.jupiter:junit-jupiter:${junit5Version}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    testCompile "org.mockito:mockito-inline:${mockitoVersion}"
     testCompile "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testCompile "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -75,16 +75,12 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(new OutputDatasetVisitor(new AppendDataVisitor(allCommonVisitors)));
     list.add(new OutputDatasetVisitor(new InsertIntoDirVisitor()));
     if (InsertIntoHiveTableVisitor.hasHiveClasses()) {
-      list.add(new OutputDatasetVisitor(new InsertIntoHiveTableVisitor(sqlContext.sparkSession())));
+      list.add(new OutputDatasetVisitor(new InsertIntoHiveTableVisitor()));
       list.add(new OutputDatasetVisitor(new InsertIntoHiveDirVisitor()));
-      list.add(
-          new OutputDatasetVisitor(
-              new CreateHiveTableAsSelectCommandVisitor(sqlContext.sparkSession())));
+      list.add(new OutputDatasetVisitor(new CreateHiveTableAsSelectCommandVisitor()));
     }
     if (OptimizedCreateHiveTableAsSelectCommandVisitor.hasClasses()) {
-      list.add(
-          new OutputDatasetVisitor(
-              new OptimizedCreateHiveTableAsSelectCommandVisitor(sqlContext.sparkSession())));
+      list.add(new OutputDatasetVisitor(new OptimizedCreateHiveTableAsSelectCommandVisitor()));
     }
     list.add(new OutputDatasetVisitor(new CreateDataSourceTableCommandVisitor()));
     list.add(new OutputDatasetVisitor(new LoadDataCommandVisitor(sqlContext.sparkSession())));

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
@@ -7,7 +7,6 @@ import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Collections;
 import java.util.List;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -22,17 +21,11 @@ import org.apache.spark.sql.types.StructType;
 public class CreateHiveTableAsSelectCommandVisitor
     extends QueryPlanVisitor<CreateHiveTableAsSelectCommand, OpenLineage.Dataset> {
 
-  private final SparkSession sparkSession;
-
-  public CreateHiveTableAsSelectCommandVisitor(SparkSession sparkSession) {
-    this.sparkSession = sparkSession;
-  }
-
   @Override
   public List<OpenLineage.Dataset> apply(LogicalPlan x) {
     CreateHiveTableAsSelectCommand command = (CreateHiveTableAsSelectCommand) x;
     CatalogTable table = command.tableDesc();
-    DatasetIdentifier di = PathUtils.fromHiveTable(sparkSession, table);
+    DatasetIdentifier di = PathUtils.fromCatalogTable(table);
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
     return Collections.singletonList(PlanUtils.getDataset(di, schema));
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
@@ -5,7 +5,6 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import java.util.Collections;
 import java.util.List;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable;
@@ -16,12 +15,6 @@ import org.apache.spark.sql.hive.execution.InsertIntoHiveTable;
  */
 public class InsertIntoHiveTableVisitor
     extends QueryPlanVisitor<InsertIntoHiveTable, OpenLineage.Dataset> {
-
-  private final SparkSession sparkSession;
-
-  public InsertIntoHiveTableVisitor(SparkSession sparkSession) {
-    this.sparkSession = sparkSession;
-  }
 
   public static boolean hasHiveClasses() {
     try {
@@ -41,6 +34,6 @@ public class InsertIntoHiveTableVisitor
     CatalogTable table = cmd.table();
 
     return Collections.singletonList(
-        PlanUtils.getDataset(PathUtils.fromHiveTable(sparkSession, table), table.schema()));
+        PlanUtils.getDataset(PathUtils.fromCatalogTable(table), table.schema()));
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -7,7 +7,6 @@ import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Collections;
 import java.util.List;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -35,12 +34,6 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
     return false;
   }
 
-  private final SparkSession sparkSession;
-
-  public OptimizedCreateHiveTableAsSelectCommandVisitor(SparkSession sparkSession) {
-    this.sparkSession = sparkSession;
-  }
-
   @Override
   public boolean isDefinedAt(LogicalPlan plan) {
     return (plan instanceof OptimizedCreateHiveTableAsSelectCommand);
@@ -50,7 +43,7 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
   public List<OpenLineage.Dataset> apply(LogicalPlan x) {
     OptimizedCreateHiveTableAsSelectCommand command = (OptimizedCreateHiveTableAsSelectCommand) x;
     CatalogTable table = command.tableDesc();
-    DatasetIdentifier datasetIdentifier = PathUtils.fromHiveTable(sparkSession, table);
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
 
     return Collections.singletonList(PlanUtils.getDataset(datasetIdentifier, schema));

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -79,12 +79,14 @@ public class IcebergHandler implements CatalogHandler {
   private DatasetIdentifier getHiveIdentifier(
       SparkSession session, @Nullable String confUri, String table) {
     table = String.format("/%s", table);
+    URI uri;
     if (confUri == null) {
-      URI uri =
+      uri =
           SparkConfUtils.getMetastoreUri(session.sparkContext().conf())
               .orElseThrow(() -> new UnsupportedCatalogException("hive"));
-      return PathUtils.fromHiveTable(table, uri);
+    } else {
+      uri = new URI(confUri);
     }
-    return PathUtils.fromHiveTable(table, new URI(confUri));
+    return PathUtils.fromPath(new Path(PathUtils.enrichHiveMetastoreURIWithTableName(uri, table)));
   }
 }

--- a/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -41,8 +41,7 @@ class CreateHiveTableAsSelectCommandVisitorTest {
   @Test
   void testCreateHiveTableAsSelectCommand() {
     SparkSession session = SparkSession.builder().master("local").getOrCreate();
-    CreateHiveTableAsSelectCommandVisitor visitor =
-        new CreateHiveTableAsSelectCommandVisitor(session);
+    CreateHiveTableAsSelectCommandVisitor visitor = new CreateHiveTableAsSelectCommandVisitor();
 
     CreateHiveTableAsSelectCommand command =
         new CreateHiveTableAsSelectCommand(

--- a/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/src/test/spark2/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -42,7 +42,7 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
   void testOptimizedCreateHiveTableAsSelectCommand() {
     SparkSession session = SparkSession.builder().master("local").getOrCreate();
     OptimizedCreateHiveTableAsSelectCommandVisitor visitor =
-        new OptimizedCreateHiveTableAsSelectCommandVisitor(session);
+        new OptimizedCreateHiveTableAsSelectCommandVisitor();
 
     OptimizedCreateHiveTableAsSelectCommand command =
         new OptimizedCreateHiveTableAsSelectCommand(


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Problem: PathUtils contains methods fromCatalogTable and fromHiveTable which should be merged into one method so that this does not have to be distinguished on each visitors side.

Closes: #431

### Solution

Refactor `PathUtils` class

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)