### PR TITLE
truncate table visitor

### DIFF
--- a/integration/spark/integrations/container/pysparkTruncateTableCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkTruncateTableCompleteEvent.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testTruncateTable",
+    "name": "open_lineage_integration_truncate_table.execute_truncate_table_command"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/truncate_test/truncate_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "tableStateChange": {
+          "stateChange": "truncate"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/integrations/container/pysparkTruncateTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkTruncateTableStartEvent.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testTruncateTable",
+    "name": "open_lineage_integration_truncate_table.execute_truncate_table_command"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/truncate_test/truncate_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "tableStateChange": {
+          "stateChange": "truncate"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -24,6 +24,7 @@ import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.QueryPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.TruncateTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.wrapper.InputDatasetVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.wrapper.OutputDatasetVisitor;
 import java.util.ArrayList;
@@ -93,6 +94,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
             new AlterTableAddColumnsCommandVisitor(sqlContext.sparkSession())));
     list.add(new OutputDatasetVisitor(new CreateTableCommandVisitor()));
     list.add(new OutputDatasetVisitor(new DropTableCommandVisitor(sqlContext.sparkSession())));
+    list.add(new OutputDatasetVisitor(new TruncateTableCommandVisitor(sqlContext.sparkSession())));
     return list;
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -1,0 +1,57 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.PlanUtils.datasourceFacet;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
+import java.util.Collections;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.TruncateTableCommand;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link TruncateTableCommand} and extracts the output
+ * {@link OpenLineage.Dataset} being written.
+ */
+public class TruncateTableCommandVisitor
+    extends QueryPlanVisitor<TruncateTableCommand, OpenLineage.Dataset> {
+
+  private final SparkSession sparkSession;
+
+  public TruncateTableCommandVisitor(SparkSession sparkSession) {
+    this.sparkSession = sparkSession;
+  }
+
+  @Override
+  @SneakyThrows
+  public List<OpenLineage.Dataset> apply(LogicalPlan x) {
+    TruncateTableCommand command = (TruncateTableCommand) x;
+
+    if (sparkSession.sessionState().catalog().tableExists(command.tableName())) {
+      CatalogTable table =
+          sparkSession.sessionState().catalog().getTableMetadata(command.tableName());
+      DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
+
+      return Collections.singletonList(
+          PlanUtils.getDataset(
+              datasetIdentifier,
+              new OpenLineage.DatasetFacetsBuilder()
+                  .schema(null)
+                  .dataSource(datasourceFacet(datasetIdentifier.getNamespace()))
+                  .put(
+                      "tableStateChange",
+                      new TableStateChangeFacet(TableStateChangeFacet.StateChange.TRUNCATE))
+                  .build()));
+
+    } else {
+      // table does not exist, cannot prepare an event
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
@@ -1,0 +1,96 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import java.util.List;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.TruncateTableCommand;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class TruncateTableCommandVisitorTest {
+
+  SparkSession session;
+  TruncateTableCommandVisitor visitor;
+  TruncateTableCommand command;
+  String database;
+  TableIdentifier table = new TableIdentifier("truncate_table");
+
+  @BeforeEach
+  public void setup() {
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+
+    database = session.catalog().currentDatabase();
+    command = new TruncateTableCommand(table, Option.empty());
+    visitor = new TruncateTableCommandVisitor(session);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    session.sessionState().catalog().dropTable(table, true, true);
+  }
+
+  @Test
+  public void testTruncateTableCommandWhenTableDoesNotExist() {
+    // make sure table does not exist
+    session.sessionState().catalog().dropTable(table, true, true);
+    try {
+      command.run(session);
+      // exception should be thrown before
+      Assert.fail();
+    } catch (Exception e) {
+      // do nothing, Scala NoSuchTableException thrown
+    }
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+    assertThat(datasets).isEmpty();
+  }
+
+  @Test
+  public void testTruncateCommand() {
+    // create some table
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("field1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+    session.catalog().createTable("truncate_table", "csv", schema, Map$.MODULE$.empty());
+
+    // apply the visitor before running the command
+    List<OpenLineage.Dataset> datasets = visitor.apply(command);
+
+    assertEquals(null, datasets.get(0).getFacets().getSchema());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/truncate_table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+
+    TableStateChangeFacet tableStateChangeFacet =
+        ((TableStateChangeFacet)
+            datasets.get(0).getFacets().getAdditionalProperties().get("tableStateChange"));
+
+    assertThat(
+        tableStateChangeFacet.getStateChange().equals(TableStateChangeFacet.StateChange.TRUNCATE));
+  }
+}

--- a/integration/spark/src/test/resources/spark_scripts/spark_truncate_table.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_truncate_table.py
@@ -1,0 +1,21 @@
+import os
+import time
+
+os.makedirs("/tmp/ctas_load", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Truncate Table") \
+    .config("spark.sql.warehouse.dir", "file:/tmp/truncate_test/") \
+    .enableHiveSupport() \
+    .getOrCreate()
+
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE truncate_table_test (a string, b string)")
+
+spark.sql("TRUNCATE TABLE truncate_table_test")
+
+time.sleep(3)


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Implement Spark visiitor for `TruncateTableCommand`.

Closes: #370

### Solution

Implement Spark visiitor for `TruncateTableCommand`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)