### PR TITLE
Renamed OpenLineageContext to EventEmitter to better reflect its role

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/EventEmitter.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class OpenLineageContext {
+public class EventEmitter {
   @Getter private OpenLineageClient client;
   @Getter private URI lineageURI;
   @Getter private String jobNamespace;
@@ -26,7 +26,7 @@ public class OpenLineageContext {
 
   private final ObjectMapper mapper = OpenLineageClient.createMapper();
 
-  public OpenLineageContext(ArgumentParser argument) throws URISyntaxException {
+  public EventEmitter(ArgumentParser argument) throws URISyntaxException {
     this.client = OpenLineageClient.create(argument.getApiKey(), ForkJoinPool.commonPool());
     // Extract url parameters other than api_key to append to lineageURI
     String queryParams = null;

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -265,7 +265,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     if (sparkEnv != null) {
       try {
         ArgumentParser args = parseConf(sparkEnv.conf());
-        contextFactory = new ContextFactory(new OpenLineageContext(args));
+        contextFactory = new ContextFactory(new EventEmitter(args));
       } catch (URISyntaxException e) {
         log.error("Unable to parse open lineage endpoint. Lineage events will not be collected", e);
       }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/SparkAgent.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/SparkAgent.java
@@ -15,9 +15,7 @@ public class SparkAgent {
   public static void premain(String agentArgs, Instrumentation inst) {
     try {
       premain(
-          agentArgs,
-          inst,
-          new ContextFactory(new OpenLineageContext(ArgumentParser.parse(agentArgs))));
+          agentArgs, inst, new ContextFactory(new EventEmitter(ArgumentParser.parse(agentArgs))));
     } catch (URISyntaxException e) {
       log.error("Could not find openlineage client url", e);
     }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -1,7 +1,7 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.OpenLineageContext;
+import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
@@ -19,7 +19,7 @@ import scala.PartialFunction;
 
 @AllArgsConstructor
 public class ContextFactory {
-  public final OpenLineageContext sparkContext;
+  public final EventEmitter sparkContext;
 
   public void close() {
     sparkContext.close();

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -3,7 +3,7 @@ package io.openlineage.spark.agent.lifecycle;
 import static scala.collection.JavaConversions.asJavaCollection;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.OpenLineageContext;
+import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.client.DatasetParser;
 import io.openlineage.spark.agent.client.DatasetParser.DatasetParseResult;
@@ -60,14 +60,14 @@ import scala.runtime.AbstractFunction0;
 
 @Slf4j
 public class RddExecutionContext implements ExecutionContext {
-  private final OpenLineageContext sparkContext;
+  private final EventEmitter sparkContext;
   private final Optional<SparkContext> sparkContextOption;
   private final UUID runId = UUID.randomUUID();
   private List<URI> inputs;
   private List<URI> outputs;
   private String jobSuffix;
 
-  public RddExecutionContext(int jobId, OpenLineageContext sparkContext) {
+  public RddExecutionContext(int jobId, EventEmitter sparkContext) {
     this.sparkContext = sparkContext;
     sparkContextOption =
         Optional.ofNullable(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -4,8 +4,8 @@ import static io.openlineage.spark.agent.util.PlanUtils.merge;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.JobMetricsHolder;
-import io.openlineage.spark.agent.OpenLineageContext;
 import io.openlineage.spark.agent.client.OpenLineageClient;
 import io.openlineage.spark.agent.facets.ErrorFacet;
 import io.openlineage.spark.agent.facets.LogicalPlanFacet;
@@ -53,7 +53,7 @@ public class SparkSQLExecutionContext implements ExecutionContext {
   private final UnknownEntryFacetListener unknownEntryFacetListener =
       new UnknownEntryFacetListener();
 
-  private OpenLineageContext sparkContext;
+  private EventEmitter sparkContext;
   private final List<QueryPlanVisitor<LogicalPlan, OpenLineage.OutputDataset>>
       outputDatasetSupplier;
   private final List<QueryPlanVisitor<LogicalPlan, OpenLineage.InputDataset>> inputDatasetSupplier;
@@ -67,7 +67,7 @@ public class SparkSQLExecutionContext implements ExecutionContext {
 
   public SparkSQLExecutionContext(
       long executionId,
-      OpenLineageContext sparkContext,
+      EventEmitter sparkContext,
       QueryExecution queryExecution,
       List<QueryPlanVisitor<LogicalPlan, OpenLineage.OutputDataset>> outputDatasetSupplier,
       List<QueryPlanVisitor<LogicalPlan, OpenLineage.InputDataset>> inputDatasetSupplier) {

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/EventEmitterTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/EventEmitterTest.java
@@ -6,12 +6,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 
-public class OpenLineageContextTest {
+public class EventEmitterTest {
 
   @Test
   public void testLineageUri() throws URISyntaxException {
-    OpenLineageContext ctx =
-        new OpenLineageContext(
+    EventEmitter ctx =
+        new EventEmitter(
             ArgumentParser.parse(
                 "https://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/"
                     + "ea445b5c-22eb-457a-8007-01c7c52b6e54?api_key=abc"));
@@ -20,8 +20,8 @@ public class OpenLineageContextTest {
 
   @Test
   public void testLineageUriWithExtraParams() throws URISyntaxException {
-    OpenLineageContext ctx =
-        new OpenLineageContext(
+    EventEmitter ctx =
+        new EventEmitter(
             ArgumentParser.parse(
                 "https://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/"
                     + "ea445b5c-22eb-457a-8007-01c7c52b6e54?api_key=abc&code=123&foo=bar"));

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -38,7 +38,7 @@ import scala.collection.Seq$;
 public class OpenLineageSparkListenerTest {
   @Test
   public void testSqlEventWithJobEventEmitsOnce(SparkSession sparkSession) {
-    OpenLineageContext context = mock(OpenLineageContext.class);
+    EventEmitter context = mock(EventEmitter.class);
     QueryExecution qe = mock(QueryExecution.class);
     LogicalPlan query = mock(LogicalPlan.class);
     SparkPlan plan = mock(SparkPlan.class);

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
@@ -29,8 +29,7 @@ import org.mockito.Mockito;
  */
 public class SparkAgentTestExtension
     implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, ParameterResolver {
-  public static final OpenLineageContext OPEN_LINEAGE_SPARK_CONTEXT =
-      mock(OpenLineageContext.class);
+  public static final EventEmitter OPEN_LINEAGE_SPARK_CONTEXT = mock(EventEmitter.class);
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -1,7 +1,7 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.OpenLineageContext;
+import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
@@ -31,7 +31,7 @@ import scala.PartialFunction;
 public class StaticExecutionContextFactory extends ContextFactory {
   public static final Semaphore semaphore = new Semaphore(1);
 
-  public StaticExecutionContextFactory(OpenLineageContext sparkContext) {
+  public StaticExecutionContextFactory(EventEmitter sparkContext) {
     super(sparkContext);
   }
 
@@ -129,7 +129,7 @@ public class StaticExecutionContextFactory extends ContextFactory {
   }
 
   private static List<PartialFunction<LogicalPlan, List<OpenLineage.Dataset>>>
-      commonDatasetVisitors(SQLContext sqlContext, OpenLineageContext sparkContext) {
+      commonDatasetVisitors(SQLContext sqlContext, EventEmitter sparkContext) {
     List<PartialFunction<LogicalPlan, List<OpenLineage.Dataset>>> list = new ArrayList<>();
     list.add(new LogicalRelationVisitor(sqlContext.sparkContext(), sparkContext.getJobNamespace()));
     list.add(new LogicalRDDVisitor());


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem
As briefly discussed in https://github.com/OpenLineage/OpenLineage/pull/437 , we should rename the `OpenLineageContext`, as it doesn't really reflect what that class does and there's another class that would be better suited to that name. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)