### PR TITLE
[INTEGRATION][AIRFLOW] fix issue with using Airflow integration when extra dependencies are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.4.0...HEAD)
 
+### Fixed
+* airflow: fix import failures when dependencies for bigquery, dbt, great_expectations extractors are missing [@lukaszlaszko](https://github.com/lukaszlaszko)
+
 ## [0.4.0](https://github.com/OpenLineage/OpenLineage/releases/tag/0.4.0) - 2021-12-13
 
 ### Added

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -16,7 +16,7 @@ _extractors = list(
                 'openlineage.airflow.extractors.bigquery_extractorBigQueryExtractor'
             ),
             try_import_from_string(
-                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'
+                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'  # noqa: E501
             ),
             try_import_from_string(
                 'openlineage.airflow.extractors.snowflake_extractor.SnowflakeExtractor'
@@ -30,7 +30,7 @@ _patchers = list(
         lambda t: t is not None,
         [
             try_import_from_string(
-                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'
+                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'  # noqa: E501
             )
         ],
     )
@@ -43,6 +43,7 @@ class Extractors:
     dependency. Patchers are a category of extractor that needs to hook up to operator's
     internals during DAG creation.
     """
+
     def __init__(self):
         # Do not expose extractors relying on external dependencies that are not installed
         self.extractors = {}

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -6,18 +6,34 @@ from openlineage.airflow.extractors.base import BaseExtractor
 from openlineage.airflow.utils import import_from_string, try_import_from_string
 
 _extractors = list(
-    filter(None, [
-        try_import_from_string('openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'),
-        try_import_from_string('openlineage.airflow.extractors.bigquery_extractorBigQueryExtractor'),
-        try_import_from_string('openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'),
-        try_import_from_string('openlineage.airflow.extractors.snowflake_extractor.SnowflakeExtractor')
-    ])
+    filter(
+        None,
+        [
+            try_import_from_string(
+                'openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.bigquery_extractorBigQueryExtractor'
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.snowflake_extractor.SnowflakeExtractor'
+            ),
+        ],
+    )
 )
 
 _patchers = list(
-    filter(None, [
-        try_import_from_string('openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor')
-    ])
+    filter(
+        None,
+        [
+            try_import_from_string(
+                'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'
+            )
+        ],
+    )
 )
 
 

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -3,22 +3,22 @@ import os
 from typing import Type, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor
-from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
-from openlineage.airflow.extractors.great_expectations_extractor import GreatExpectationsExtractor
-from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
-from openlineage.airflow.extractors.snowflake_extractor import SnowflakeExtractor
-from openlineage.airflow.utils import import_from_string
+from openlineage.airflow.utils import import_from_string, try_import_from_string
 
-_extractors = [
-    PostgresExtractor,
-    BigQueryExtractor,
-    GreatExpectationsExtractor,
-    SnowflakeExtractor
-]
+_extractors = list(
+    filter(None, [
+        try_import_from_string('openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'),
+        try_import_from_string('openlineage.airflow.extractors.bigquery_extractorBigQueryExtractor'),
+        try_import_from_string('openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'),
+        try_import_from_string('openlineage.airflow.extractors.snowflake_extractor.SnowflakeExtractor')
+    ])
+)
 
-_patchers = [
-    GreatExpectationsExtractor
-]
+_patchers = list(
+    filter(None, [
+        try_import_from_string('openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor')
+    ])
+)
 
 
 class Extractors:

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -7,7 +7,7 @@ from openlineage.airflow.utils import import_from_string, try_import_from_string
 
 _extractors = list(
     filter(
-        None,
+        lambda t: t is not None,
         [
             try_import_from_string(
                 'openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'
@@ -27,7 +27,7 @@ _extractors = list(
 
 _patchers = list(
     filter(
-        None,
+        lambda t: t is not None,
         [
             try_import_from_string(
                 'openlineage.airflow.extractors.great_expectations_extractor.GreatExpectationsExtractor'

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 from uuid import uuid4
 from urllib.parse import urlparse, urlunparse
+from warnings import warn
 
 from airflow.version import version as AIRFLOW_VERSION
 
@@ -225,6 +226,14 @@ def import_from_string(path: str):
         return getattr(module, target)
     except Exception as e:
         raise ImportError(f"Failed to import {path}") from e
+
+
+def try_import_from_string(path: str):
+    try:
+        return import_from_string(path)
+    except ImportError as e:
+        warn(e.msg)
+        return None
 
 
 def choose_based_on_version(airflow_1_version, airflow_2_version):


### PR DESCRIPTION
### Problem

Currently, Airflow integration can't be used unless all extra dependencies for registered extractors are installed. This is particularly impractical in situation when neither Google BigQuery nor Great Expectations are used by Airflow deployment. 

Closes: #438

### Solution

As a solution import errors are suppressed when extractors are registered into [openlineage.airflow.extractors._extractors](https://github.com/lukaszlaszko/OpenLineage/blob/airflow/allow-use-without-extras/integration/airflow/openlineage/airflow/extractors/extractors.py#L8) and [openlineage.airflow.extractors._patchers](https://github.com/lukaszlaszko/OpenLineage/blob/airflow/allow-use-without-extras/integration/airflow/openlineage/airflow/extractors/extractors.py#L17). This will prevent startup import failure and eliminate extractors with missing dependencies.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)