### PR TITLE
spark: Support Azure Cosmos DB Spark Connector in Open Lineage

### DIFF
--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -30,6 +30,10 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
 
   public <D extends Dataset> List<PartialFunction<LogicalPlan, List<D>>> getCommonVisitors(
       OpenLineageContext context, DatasetFactory<D> factory) {
-    return super.getBaseCommonVisitors(context, factory);
+        DatasetFactory<OutputDataset> outputFactory = DatasetFactory.output(context.getOpenLineage());
+    return ImmutableList.<PartialFunction<LogicalPlan, List<D>>>builder()
+        .addAll(super.getBaseCommonVisitors(context, factory))
+        .add(new DataSourceV2RelationVisitor(context, outputFactory))
+        .build();
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -30,7 +30,7 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
 
   public <D extends Dataset> List<PartialFunction<LogicalPlan, List<D>>> getCommonVisitors(
       OpenLineageContext context, DatasetFactory<D> factory) {
-        DatasetFactory<OutputDataset> outputFactory = DatasetFactory.output(context.getOpenLineage());
+    DatasetFactory<OutputDataset> outputFactory = DatasetFactory.output(context.getOpenLineage());
     return ImmutableList.<PartialFunction<LogicalPlan, List<D>>>builder()
         .addAll(super.getBaseCommonVisitors(context, factory))
         .add(new DataSourceV2RelationVisitor(context, outputFactory))

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
@@ -42,6 +42,7 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
     super(context);
     this.factory = factory;
   }
+
   private boolean isV2ScanRelation(LogicalPlan logicalPlan) {
     return logicalPlan instanceof DataSourceV2ScanRelation;
   }
@@ -57,7 +58,7 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
     return plan instanceof DataSourceV2Relation
         && !findDatasetProvider(plan).equals(Provider.UNKNOWN);
   }
-  
+
   private String providerPropertyOrTableMetadata(Table table) {
     if (table.properties().containsKey("provider")
         && table.properties().getOrDefault("provider", null) != null) {
@@ -110,7 +111,6 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
   }
 
   private D findDatasetForAzureCosmos(DataSourceV2Relation relation) {
-    String namespace = "azurecosmos";
     String relationName = relation.table().name().replace("com.azure.cosmos.spark.items.", "");
     int expectedParts = 3;
     String[] tableParts = relationName.split("\\.", expectedParts);
@@ -126,16 +126,16 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
       tableName = String.format("/colls/%s", tableParts[2]);
     }
     return factory.getDataset(
-      tableName,
+        tableName,
         namespace,
-      new OpenLineage.DatasetFacetsBuilder()
-          .schema(PlanUtils.schemaFacet(context.getOpenLineage(), relation.schema()))
-          .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), namespace))
-          .put(
-              "table_provider",
-              new TableProviderFacet(
-                Provider.AZURECOSMOS.name().toLowerCase(), "json")) // Cosmos is always json
-          .build());
+        new OpenLineage.DatasetFacetsBuilder()
+            .schema(PlanUtils.schemaFacet(context.getOpenLineage(), relation.schema()))
+            .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), namespace))
+            .put(
+                "table_provider",
+                new TableProviderFacet(
+                    Provider.AZURECOSMOS.name().toLowerCase(), "json")) // Cosmos is always json
+            .build());
   }
 
   private D findDatasetForDelta(DataSourceV2Relation relation) {

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
@@ -115,13 +115,15 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
     int expectedParts = 3;
     String[] tableParts = relationName.split("\\.", expectedParts);
     String tableName;
+    String namespace;
     if (tableParts.length != expectedParts) {
       tableName = relationName;
+      namespace = relationName;
     } else {
-      tableName =
+      namespace =
           String.format(
-              "https://%s.documents.azure.com/dbs/%s/colls/%s",
-              tableParts[0], tableParts[1], tableParts[2]);
+              "azurecosmos://%s.documents.azure.com/dbs/%s", tableParts[0], tableParts[1]);
+      tableName = String.format("/colls/%s", tableParts[2]);
     }
     return factory.getDataset(
       tableName,
@@ -167,7 +169,7 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
     } else {
       plan = logicalPlan;
     }
-    
+
     Provider provider = findDatasetProvider(logicalPlan);
     DataSourceV2Relation x = (DataSourceV2Relation) logicalPlan;
 

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
@@ -106,6 +106,7 @@ public class DataSourceV2RelationVisitorTest {
   @Test
   public void testIsDefinedAtForNonDefinedProvider() {
     Mockito.when(dataSourceV2Relation.table()).thenReturn(table);
+    Mockito.when(table.name()).thenReturn("table");
     Assertions.assertFalse(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
   }
 
@@ -140,5 +141,28 @@ public class DataSourceV2RelationVisitorTest {
 
     Assertions.assertEquals("file:/tmp/delta/spark-warehouse/tbl", dataset.getNamespace());
     Assertions.assertEquals("table", dataset.getName());
+  }
+
+  @Test
+  public void testIsDefinedForAzureCosmos() {
+
+    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
+    Mockito.when(table.properties()).thenReturn(tableProperties);
+    Mockito.when(table.name()).thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
+    Assertions.assertTrue(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
+  }
+
+  @Test
+  public void testApplyAzureCosmosLocal() {
+
+    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
+    Mockito.when(table.properties()).thenReturn(tableProperties);
+    Mockito.when(table.name()).thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
+    Mockito.when(dataSourceV2Relation.schema()).thenReturn(new StructType());
+
+    OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
+
+    Assertions.assertEquals("azurecosmos", dataset.getNamespace());
+    Assertions.assertEquals("https://serviceName.documents.azure.com/dbs/databaseName/colls/collectionName", dataset.getName());
   }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
@@ -164,9 +164,8 @@ public class DataSourceV2RelationVisitorTest {
 
     OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
 
-    Assertions.assertEquals("azurecosmos", dataset.getNamespace());
     Assertions.assertEquals(
-        "https://serviceName.documents.azure.com/dbs/databaseName/colls/collectionName",
-        dataset.getName());
+        "azurecosmos://serviceName.documents.azure.com/dbs/databaseName", dataset.getNamespace());
+    Assertions.assertEquals("/colls/collectionName", dataset.getName());
   }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
@@ -148,7 +148,8 @@ public class DataSourceV2RelationVisitorTest {
 
     Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
     Mockito.when(table.properties()).thenReturn(tableProperties);
-    Mockito.when(table.name()).thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
+    Mockito.when(table.name())
+        .thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
     Assertions.assertTrue(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
   }
 
@@ -157,12 +158,15 @@ public class DataSourceV2RelationVisitorTest {
 
     Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
     Mockito.when(table.properties()).thenReturn(tableProperties);
-    Mockito.when(table.name()).thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
+    Mockito.when(table.name())
+        .thenReturn("com.azure.cosmos.spark.items.serviceName.databaseName.collectionName");
     Mockito.when(dataSourceV2Relation.schema()).thenReturn(new StructType());
 
     OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
 
     Assertions.assertEquals("azurecosmos", dataset.getNamespace());
-    Assertions.assertEquals("https://serviceName.documents.azure.com/dbs/databaseName/colls/collectionName", dataset.getName());
+    Assertions.assertEquals(
+        "https://serviceName.documents.azure.com/dbs/databaseName/colls/collectionName",
+        dataset.getName());
   }
 }


### PR DESCRIPTION
### Problem

We would like to extend OpenLineage's Spark integration to work with the [Azure Cosmos DB Spark Connector for Spark3](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3-1_2-12).

This would enable people using Spark, OpenLineage, and Cosmos DB to observe the input and output to their spark jobs.

Closes: #449

### Solution

The solution requires extending the DataSourceV2RelationVisitor to support the Azure Cosmos DB as a provider.

* Azure Cosmos DB Spark Connector does not use the provider property on the table but can be determined based on name.
  * The Cosmos DB connector defines a Cosmos "table" as `com.azure.cosmos.spark.items.<serviceName>.<databaseName>.<collectionName>`
* The Azure Cosmos DB write operations are all `AppendData`. As such, the `Spark3VisitorFactoryImpl.java` must include `DataSourceV2RelationVisitor` as one of its common visitors.
  * This gets fed into `AppendData` so the underlying relation can be tested against a `DataSourceV2RelationVisitor`.
* When reading Cosmos DB, Spark uses a `DataSourceV2ScanRelation`.
  * This class has a `relation` property which is actually `DataSourceV2Relation`.
  * Since it was that simple, rather than making an entirely new SCAN relation class, I hitched it onto the existing DataSourceV2Relation class.
* I followed the same process as Iceberg which does not check if you are using any Iceberg Jars (like the BigQuery integration).

To support this addition, I added two tests similar to the Delta and Iceberge DataSourceV2Relation tests. I also modified `testIsDefinedAtForNonDefinedProvider` so that a mock table name was provided since the implementation now checks if the table name matches the pattern for Cosmos DB.

**Scope**: This solution has been tested locally on a Spark-Shell with the ` --packages "com.azure.cosmos.spark:azure-cosmos-spark_3-1_2-12:4.5.0"` parameter along with in Azure Databricks on a Spark 3.1.2 cluster.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)