### PR TITLE
[INTEGRATION][AIRFLOW] Use task instance start date for event time of the start event instead of dag execution date.

### DIFF
--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -51,7 +51,7 @@ class Backend:
                 run_id=run_id,
                 job_name=job_name,
                 job_description=dag.description,
-                event_time=DagUtils.get_start_time(dagrun.execution_date),
+                event_time=DagUtils.get_start_time(task_instance.start_date),
                 parent_run_id=dagrun.run_id,
                 code_location=self._get_location(operator),
                 nominal_start_time=DagUtils.get_start_time(dagrun.execution_date),

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -96,6 +96,16 @@ def check_matches_ordered(expected_events, actual_events) -> bool:
     return True
 
 
+def check_event_time_ordered(actual_events) -> bool:
+    event_times = [event['eventTime'] for event in actual_events]
+
+    # Check event times are not all same and properly ordered
+    if len(set(event_times)) != len(event_times) or \
+            event_times != sorted(event_times):
+        return False
+    return True
+
+
 def get_events(job_name: str = None):
     time.sleep(5)
     params = {}
@@ -166,6 +176,10 @@ def test_integration_ordered(dag_id, request_dir: str):
 
     if not check_matches_ordered(expected_events, actual_events):
         log.info(f"failed to compare events!")
+        sys.exit(1)
+
+    if not check_event_time_ordered(actual_events):
+        log.info(f"failed on event timestamp order!")
         sys.exit(1)
 
 


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu@datakin.com>

### Problem
From the airflow 2.x integration, the `eventTime` of the start event uses `dagrun.execution_date` which is scheduled time of the dag but not the actual task start time.

Closes: #455 

### Solution
This PR changes to use `task_instance.start_date` instead of `dagrun.execution_date`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)