### PR TITLE
contributing: mention how to trigger CI runs on forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing  to OpenLineage
+# Contributing to OpenLineage
 
 This project welcomes contributors from any organization or background, provided they are
 willing to follow the simple processes outlined below, as well as adhere to the 
@@ -80,3 +80,9 @@ Look tickets labeled ['good first issue'][goodfirstissues] and ['help wanted'][h
 [contributionvideos]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [goodfirstissues]: https://github.com/OpenLineage/OpenLineage/labels/good%20first%20issue
 [helpwantedissues]: https://github.com/OpenLineage/OpenLineage/labels/help%20wanted
+
+## Triggering CI runs from forks (committers)
+
+CI runs on forks are disabled due to possibility to access external services via CI run. 
+Once contributor decides PR is ready to be checked, they can use [this script](https://github.com/jklukas/git-push-fork-to-upstream-branch)
+to trigger CI run on separate branch with same commit ID. This will update CI status of a PR.


### PR DESCRIPTION
CI runs on forks are disabled. Mention in the CONTRIBUTING doc how to run CI on forks.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)