### PR TITLE
[INTEGRATION][SPARK]Support for SqlDWRelation on Databricks' Azure Synapse/SQL DW Connector

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -24,6 +24,7 @@ import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.SqlDWDatabricksVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.TruncateTableCommandVisitor;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -45,6 +46,9 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     }
     if (KafkaRelationVisitor.hasKafkaClasses()) {
       list.add(new KafkaRelationVisitor(context, factory));
+    }
+    if (SqlDWDatabricksVisitor.hasSqlDWDatabricksClasses()) {
+      list.add(new SqlDWDatabricksVisitor(context, factory));
     }
     return list;
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
@@ -1,0 +1,127 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.api.java.Optional;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.sources.BaseRelation;
+
+/**
+ * {@link LogicalPlan} visitor that matches SqlDWRelation that comes from an Azure Databricks
+ * environment. This function extracts a {@link OpenLineage.Dataset} from the SQL DW/ Synapse table
+ * referenced by the relation. The convention used for a namespace is a URI of <code>
+ * sqlserver://&lt;server&gt;.&lt;.datasetId&gt;.&lt;tableName&gt;</code> . The name for Sql Dw
+ * tables may be table name (e.g. "exampleInputA") or a multi-part name (e.g.
+ * "[dbo].[exampleInputA]"). If the data source is a query (e.g. <code>
+ * ((select \"id\" FROM dbo.exampleInputA WHERE postalCode != '55555') q)</code>) then the name will
+ * be <code>COMPLEX</code>.
+ */
+@Slf4j
+public class SqlDWDatabricksVisitor<D extends OpenLineage.Dataset>
+    extends QueryPlanVisitor<LogicalPlan, D> {
+  private final DatasetFactory<D> factory;
+  private static final Pattern dbJdbcPattern = Pattern.compile("database=([^;]*);?");
+  private static final Pattern serverJdbcPattern = Pattern.compile("jdbc:([^;]*);?");
+  private static final String DATABRICKS_CLASS_NAME = "com.databricks.spark.sqldw.SqlDWRelation";
+
+  public SqlDWDatabricksVisitor(OpenLineageContext context, DatasetFactory<D> factory) {
+    super(context);
+    this.factory = factory;
+  }
+
+  public static boolean hasSqlDWDatabricksClasses() {
+    try {
+      SqlDWDatabricksVisitor.class.getClassLoader().loadClass(DATABRICKS_CLASS_NAME);
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  protected boolean isSqlDwRelationClass(LogicalPlan plan) {
+    return plan instanceof LogicalRelation
+        && ((LogicalRelation) plan).relation().getClass().getName().equals(DATABRICKS_CLASS_NAME);
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan plan) {
+    return isSqlDwRelationClass(plan);
+  }
+
+  private Optional<String> getName(BaseRelation relation) {
+    String tableName;
+    try {
+      tableName = (String) FieldUtils.readField(relation, "tableNameOrSubquery", true);
+    } catch (IllegalAccessException e) {
+      log.warn("Unable to discover SQLDW tableNameOrSubquery property");
+      return Optional.empty();
+    }
+    // The Synapse connector will return a table name wrapped in double quotes
+    // or you could have a query string (e.g. (SELECT * FROM table)q)
+    if (tableName.startsWith("\"") && tableName.endsWith("\"")) {
+      tableName = tableName.replace("\"", "");
+    }
+    // TODO If there is a query, we should ultimately parse the SQL but
+    // returning COMPLEX to be consistent with other implementations.
+    if (tableName.startsWith("(")) {
+      tableName = "COMPLEX";
+    }
+    return Optional.of(tableName);
+  }
+
+  private Optional<String> getNameSpace(BaseRelation relation) {
+
+    String jdbcUrl;
+    try {
+      Object fieldDetails = FieldUtils.readField(relation, "params", true);
+      jdbcUrl = (String) MethodUtils.invokeMethod(fieldDetails, true, "jdbcUrl");
+    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+      log.warn("Unable to discover SQLDW jdbcUrl Parameters");
+      return Optional.empty();
+    }
+
+    Matcher serverMatcher = serverJdbcPattern.matcher(jdbcUrl);
+    boolean serverIsFound = serverMatcher.find();
+    Matcher dbMatcher = dbJdbcPattern.matcher(jdbcUrl);
+    boolean dbIsFound = dbMatcher.find();
+
+    if (!(dbIsFound && serverIsFound)) {
+      log.warn("Unable to discover SQLDW database name or server name from jdbc url");
+      return Optional.empty();
+    }
+
+    String databaseSubString = dbMatcher.group(1);
+    String serverSubString = serverMatcher.group(1);
+    String output = String.format("%s;database=%s;", serverSubString, databaseSubString);
+
+    return Optional.of(output);
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan x) {
+    BaseRelation relation = ((LogicalRelation) x).relation();
+    List<D> output;
+    Optional<String> name = getName(relation);
+    Optional<String> namespace = getNameSpace(relation);
+    if (name.isPresent() && namespace.isPresent()) {
+      output =
+          Collections.singletonList(
+              factory.getDataset(name.get(), namespace.get(), relation.schema()));
+    } else {
+      output = Collections.emptyList();
+    }
+    return output;
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -1,0 +1,197 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.List;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SparkSession$;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.sources.BaseRelation;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Seq$;
+
+class SqlDwRelationParams {
+  private String jdbcUrlField;
+  private String somethingElse;
+
+  private String jdbcUrl() {
+    return jdbcUrlField;
+  }
+
+  private String getSomethingElse() {
+    return somethingElse;
+  }
+
+  public SqlDwRelationParams(String jdbcUrl) {
+    this.jdbcUrlField = jdbcUrl;
+    somethingElse = "ABC";
+  }
+}
+
+class MockSqlDWBaseRelation extends BaseRelation {
+  private final String tableNameOrSubquery;
+  private final Object params;
+
+  @Override
+  public SQLContext sqlContext() {
+    return null;
+  }
+
+  @Override
+  public StructType schema() {
+    return new StructType(
+        new StructField[] {new StructField("name", StringType$.MODULE$, false, null)});
+  }
+
+  public MockSqlDWBaseRelation(String tableNameOrSubquery, String jdbcUrl) {
+    this.tableNameOrSubquery = tableNameOrSubquery;
+    this.params = new SqlDwRelationParams(jdbcUrl);
+  }
+}
+
+class TestSqlDWDatabricksVisitor extends SqlDWDatabricksVisitor {
+  public TestSqlDWDatabricksVisitor(OpenLineageContext context, DatasetFactory factory) {
+    super(context, factory);
+  }
+
+  @Override
+  protected boolean isSqlDwRelationClass(LogicalPlan plan) {
+    return true;
+  }
+}
+
+@ExtendWith(SparkAgentTestExtension.class)
+class SQLDWDatabricksVisitorTest {
+  @AfterEach
+  public void tearDown() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
+  @Test
+  void testSQLDWRelation() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    String inputName = "\"dbo\".\"table1\"";
+    String inputJdbcUrl =
+        "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB";
+    String expectedName = "dbo.table1";
+    String expectedNamespace =
+        "sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB;";
+
+    // Instantiate a MockSQLDWRelation
+    LogicalRelation lr =
+        new LogicalRelation(
+            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+            Seq$.MODULE$
+                .<AttributeReference>newBuilder()
+                .$plus$eq(
+                    new AttributeReference(
+                        "name",
+                        StringType$.MODULE$,
+                        false,
+                        null,
+                        ExprId.apply(1L),
+                        Seq$.MODULE$.<String>empty()))
+                .result(),
+            Option.empty(),
+            false);
+
+    TestSqlDWDatabricksVisitor visitor =
+        new TestSqlDWDatabricksVisitor(
+            SparkAgentTestExtension.newContext(session),
+            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+    List<OpenLineage.Dataset> datasets = visitor.apply(lr);
+
+    assertEquals(1, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals(expectedNamespace, ds.getNamespace());
+    assertEquals(expectedName, ds.getName());
+  }
+
+  @Test
+  void testSQLDWRelationComplexQuery() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    String inputName = "(SELECT * FROM dbo.table1) q";
+    String inputJdbcUrl =
+        "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB";
+    String expectedName = "COMPLEX";
+    String expectedNamespace =
+        "sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB;";
+
+    // Instantiate a MockSQLDWRelation
+    LogicalRelation lr =
+        new LogicalRelation(
+            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+            Seq$.MODULE$
+                .<AttributeReference>newBuilder()
+                .$plus$eq(
+                    new AttributeReference(
+                        "name",
+                        StringType$.MODULE$,
+                        false,
+                        null,
+                        ExprId.apply(1L),
+                        Seq$.MODULE$.<String>empty()))
+                .result(),
+            Option.empty(),
+            false);
+
+    TestSqlDWDatabricksVisitor visitor =
+        new TestSqlDWDatabricksVisitor(
+            SparkAgentTestExtension.newContext(session),
+            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+    List<OpenLineage.Dataset> datasets = visitor.apply(lr);
+
+    assertEquals(1, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals(expectedNamespace, ds.getNamespace());
+    assertEquals(expectedName, ds.getName());
+  }
+
+  @Test
+  void testSQLDWRelationBadJdbcUrl() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    String inputName = "dbo.mytable";
+    String inputJdbcUrl = "sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB";
+
+    // Instantiate a MockSQLDWRelation
+    LogicalRelation lr =
+        new LogicalRelation(
+            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+            Seq$.MODULE$
+                .<AttributeReference>newBuilder()
+                .$plus$eq(
+                    new AttributeReference(
+                        "name",
+                        StringType$.MODULE$,
+                        false,
+                        null,
+                        ExprId.apply(1L),
+                        Seq$.MODULE$.<String>empty()))
+                .result(),
+            Option.empty(),
+            false);
+
+    TestSqlDWDatabricksVisitor visitor =
+        new TestSqlDWDatabricksVisitor(
+            SparkAgentTestExtension.newContext(session),
+            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+    List<OpenLineage.Dataset> datasets = visitor.apply(lr);
+
+    assertEquals(0, datasets.size());
+  }
+}


### PR DESCRIPTION
Defines a SqlDWDatabricksVisitor that extracts a namespace of `sqlserver://<server>;database=<db>;`
and name of `<table name>` or `(<query>) q`.

Signed-off-by: Will Johnson <will@willj.co>

### Problem

[Databricks' Azure Synapse connector](https://docs.microsoft.com/en-us/azure/databricks/data/data-sources/azure/synapse-analytics) supports connecting Azure Databricks environments to Azure Synapse (formerly Sql Data Warehouse). The classes are all proprietary / closed source but can be accessed via reflection. The SqlDWRelation extends a Base Relation which works with a JDBC connection to Azure Synapse. As a result, I am proposing that we add a SqlDWRelationVisitor much in the same way as there is a BigQueryNodeVisitor.

Closes: #452

### Solution

Implement a SqlDWRelationVisitor that extracts the jdbc url and table name using reflection since the class is private.

The namespace will be sqlserver://server;database=databaseName; and the name will be either the table name or query (a user may submit a query or table name and Azure SQL DW / Synapse will execute the query or select all records from the table name and then return the results).

**Scope**: This solution has been tested on Azure Databricks Runtimes 8.3 and 9.1 LTS

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_) **Happy to add additional tests but would appreciate guidance on what we should do for cloud infra**
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)