### PR TITLE
overwrite v2 visitors

### DIFF
--- a/integration/spark/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
@@ -1,0 +1,30 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.overwrite_by_expression"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.tbl",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      },
+      "tableStateChange": {
+        "stateChange": "overwrite"
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkV2OverwriteByExpressionStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwriteByExpressionStartEvent.json
@@ -1,0 +1,30 @@
+{
+  "eventType" : "START",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.overwrite_by_expression"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.tbl",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      },
+      "tableStateChange": {
+        "stateChange": "overwrite"
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
@@ -1,0 +1,33 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.overwrite_partitions_dynamic"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.tbl",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        }, {
+          "name" : "c",
+          "type" : "long"
+        } ]
+      },
+      "tableStateChange": {
+        "stateChange": "overwrite"
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
@@ -1,0 +1,33 @@
+{
+  "eventType" : "START",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.overwrite_partitions_dynamic"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.tbl",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        }, {
+          "name" : "c",
+          "type" : "long"
+        } ]
+      },
+      "tableStateChange": {
+        "stateChange": "overwrite"
+      }
+    }
+  } ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/TableStateChangeFacet.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/TableStateChangeFacet.java
@@ -4,16 +4,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.client.OpenLineageClient;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /** Facet used to notify state change performed on table like "CREATE", "DROP" or "TRUNCATE". */
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class TableStateChangeFacet extends OpenLineage.DefaultDatasetFacet {
 
   public enum StateChange {
     CREATE,
     DROP,
-    TRUNCATE;
+    TRUNCATE,
+    OVERWRITE;
 
     @JsonValue
     @Override

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
@@ -4,6 +4,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
 import java.net.URI;
+import java.util.Map;
 import org.apache.spark.sql.types.StructType;
 
 /**
@@ -125,6 +126,33 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
   }
 
   /**
+   * Construct a {@link io.openlineage.client.OpenLineage.Dataset} with the given {@link
+   * DatasetIdentifier}, schema and facets map.
+   *
+   * @param ident
+   * @param schema
+   * @param facets
+   * @return
+   */
+  public D getDataset(
+      DatasetIdentifier ident,
+      StructType schema,
+      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+    OpenLineage.DatasetFacetsBuilder builder =
+        openLineage
+            .newDatasetFacetsBuilder()
+            .schema(PlanUtils.schemaFacet(openLineage, schema))
+            .dataSource(PlanUtils.datasourceFacet(openLineage, ident.getNamespace()));
+
+    facets.forEach((key, facet) -> builder.put(key, facet));
+
+    return getDataset(ident.getName(), ident.getNamespace(), builder.build());
+  }
+
+  /**
+   * Construct a {@link io.openlineage.client.OpenLineage.Dataset} with the given {@link
+   * DatasetIdentifier} and {@link OpenLineage.DatasetFacets}.
+   *
    * @param ident
    * @param datasetFacet
    * @return

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -9,6 +9,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateTableAsSelectVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateTableLikeCommandVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeVisitor;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import scala.PartialFunction;
@@ -24,6 +25,7 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
         .add(new CreateTableAsSelectVisitor(context))
         .add(new DataSourceV2RelationVisitor(context, outputFactory))
         .add(new CreateTableAsSelectVisitor(context))
+        .add(new TableContentChangeVisitor(context))
         .add(new CreateTableLikeCommandVisitor(context))
         .build();
   }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableAsSelectVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableAsSelectVisitor.java
@@ -1,13 +1,19 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
+import static io.openlineage.spark.agent.facets.TableStateChangeFacet.StateChange.CREATE;
+
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -27,14 +33,22 @@ public class CreateTableAsSelectVisitor
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     CreateTableAsSelect command = (CreateTableAsSelect) x;
-    List<DatasetIdentifier> datasetIds =
-        PlanUtils3.getDataset(
-            context.getSparkSession().get(),
-            command.catalog(),
-            command.tableName(),
-            ScalaConversionUtils.<String, String>fromMap(command.properties()));
-    return datasetIds.stream()
-        .map(id -> outputDataset().getDataset(id, command.tableSchema()))
-        .collect(Collectors.toList());
+
+    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, String> tableProperties =
+        ScalaConversionUtils.<String, String>fromMap(command.properties());
+    facetMap.put("tableStateChange", new TableStateChangeFacet(CREATE));
+    PlanUtils3.includeProviderFacet(command.catalog(), tableProperties, facetMap);
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(
+            context, command.catalog(), command.tableName(), tableProperties);
+
+    if (di.isPresent()) {
+      return Collections.singletonList(
+          outputDataset().getDataset(di.get(), command.tableSchema(), facetMap));
+    } else {
+      return Collections.emptyList();
+    }
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
@@ -1,0 +1,59 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.facets.TableStateChangeFacet.StateChange.OVERWRITE;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression;
+import org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+public class TableContentChangeVisitor
+    extends QueryPlanVisitor<LogicalPlan, OpenLineage.OutputDataset> {
+
+  public TableContentChangeVisitor(OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan x) {
+    return (x instanceof OverwriteByExpression)
+        || (x instanceof OverwritePartitionsDynamic)
+        || (x instanceof InsertIntoStatement);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    NamedRelation table;
+    TableStateChangeFacet overwriteFacet = new TableStateChangeFacet(OVERWRITE);
+    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+
+    // INSERT OVERWRITE TABLE SQL statement is translated into InsertIntoTable logical operator.
+    if (x instanceof OverwriteByExpression) {
+      table = ((OverwriteByExpression) x).table();
+      facetMap.put("tableStateChange", overwriteFacet);
+    } else if (x instanceof InsertIntoStatement) {
+      table = (NamedRelation) ((InsertIntoStatement) x).table();
+      if (((InsertIntoStatement) x).overwrite()) {
+        facetMap.put("tableStateChange", overwriteFacet);
+      }
+    } else {
+      table = ((OverwritePartitionsDynamic) x).table();
+      facetMap.put("tableStateChange", overwriteFacet);
+    }
+
+    return PlanUtils3.fromDataSourceV2Relation(
+        outputDataset(), context, (DataSourceV2Relation) table, facetMap);
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
@@ -1,7 +1,9 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -16,4 +18,10 @@ public interface CatalogHandler {
       TableCatalog tableCatalog,
       Identifier identifier,
       Map<String, String> properties);
+
+  default Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
+    return Optional.empty();
+  }
+
+  String getName();
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -1,9 +1,11 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -11,7 +13,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 public class CatalogUtils3 {
 
-  private static List<CatalogHandler> parsers = getHandlers();
+  private static List<CatalogHandler> catalogHandlers = getHandlers();
 
   private static List<CatalogHandler> getHandlers() {
     List<CatalogHandler> handlers =
@@ -28,11 +30,38 @@ public class CatalogUtils3 {
       TableCatalog catalog,
       Identifier identifier,
       Map<String, String> properties) {
-    for (CatalogHandler parser : parsers) {
-      if (parser.isClass(catalog)) {
-        return parser.getDatasetIdentifier(session, catalog, identifier, properties);
-      }
-    }
-    throw new UnsupportedCatalogException(catalog.getClass().getCanonicalName());
+    return getDatasetIdentifier(session, catalog, identifier, properties, catalogHandlers);
+  }
+
+  public static DatasetIdentifier getDatasetIdentifier(
+      SparkSession session,
+      TableCatalog catalog,
+      Identifier identifier,
+      Map<String, String> properties,
+      List<CatalogHandler> handlers) {
+
+    return handlers.stream()
+        .filter(handler -> handler.isClass(catalog))
+        .map(handler -> handler.getDatasetIdentifier(session, catalog, identifier, properties))
+        .findAny()
+        .orElseThrow(() -> new UnsupportedCatalogException(catalog.getClass().getCanonicalName()));
+  }
+
+  public static Optional<CatalogHandler> getCatalogHandler(TableCatalog catalog) {
+    return catalogHandlers.stream().filter(handler -> handler.isClass(catalog)).findAny();
+  }
+
+  public static Optional<TableProviderFacet> getTableProviderFacet(
+      TableCatalog catalog, Map<String, String> properties) {
+    Optional<CatalogHandler> catalogHandler = getCatalogHandler(catalog);
+    return catalogHandler.isPresent()
+        ? catalogHandler.get().getTableProviderFacet(properties)
+        : Optional.empty();
+  }
+
+  public static Optional<CatalogHandler> getCatalogHandlerByProvider(String provider) {
+    return catalogHandlers.stream()
+        .filter(handler -> handler.getName().equalsIgnoreCase(provider))
+        .findAny();
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -1,5 +1,6 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import java.util.Arrays;
@@ -62,7 +63,16 @@ public class DeltaHandler implements CatalogHandler {
                                     .reduce((x, y) -> y)
                                     .orElse(null))))
                     .toString()));
-    log.warn(path.toString());
+    log.info(path.toString());
     return PathUtils.fromPath(path, "file");
+  }
+
+  public Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
+    return Optional.of(new TableProviderFacet("delta", "parquet")); // Delta is always parquet
+  }
+
+  @Override
+  public String getName() {
+    return "delta";
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -41,4 +41,9 @@ public class JdbcHandler implements CatalogHandler {
 
     return new DatasetIdentifier(name, JdbcUtils.sanitizeJdbcUrl(options.url()));
   }
+
+  @Override
+  public String getName() {
+    return "jdbc";
+  }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
@@ -28,4 +28,9 @@ public class V2SessionCatalogHandler implements CatalogHandler {
     V2SessionCatalog catalog = (V2SessionCatalog) tableCatalog;
     throw new UnsupportedCatalogException(V2SessionCatalog.class.getCanonicalName());
   }
+
+  @Override
+  public String getName() {
+    return "session";
+  }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -1,15 +1,22 @@
 package io.openlineage.spark3.agent.utils;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 /**
  * Utility functions for traversing a {@link
@@ -18,20 +25,70 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 @Slf4j
 public class PlanUtils3 {
 
-  public static List<DatasetIdentifier> getDataset(
-      SparkSession session,
+  public static Optional<DatasetIdentifier> getDatasetIdentifier(
+      OpenLineageContext context,
       TableCatalog catalog,
       Identifier identifier,
       Map<String, String> properties) {
-    DatasetIdentifier datasetIdentifier;
+
+    SparkSession sparkSession =
+        context
+            .getSparkSession()
+            .orElseThrow(() -> new IllegalArgumentException("SparkSession cannot be empty"));
+
     try {
-      datasetIdentifier =
-          CatalogUtils3.getDatasetIdentifier(session, catalog, identifier, properties);
+      return (Optional.of(
+          CatalogUtils3.getDatasetIdentifier(sparkSession, catalog, identifier, properties)));
     } catch (UnsupportedCatalogException ex) {
       log.error(String.format("Catalog %s is unsupported", ex.getMessage()), ex);
+      return Optional.empty();
+    }
+  }
+
+  public static void includeProviderFacet(
+      TableCatalog catalog,
+      Map<String, String> properties,
+      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+    Optional<TableProviderFacet> providerFacet =
+        CatalogUtils3.getTableProviderFacet(catalog, properties);
+    if (providerFacet.isPresent()) {
+      facets.put("tableProvider", providerFacet.get());
+    }
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> fromDataSourceV2Relation(
+      DatasetFactory<D> datasetFactory, OpenLineageContext context, DataSourceV2Relation relation) {
+    return fromDataSourceV2Relation(datasetFactory, context, relation, new HashMap<>());
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> fromDataSourceV2Relation(
+      DatasetFactory<D> datasetFactory,
+      OpenLineageContext context,
+      DataSourceV2Relation relation,
+      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+
+    if (relation.identifier().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Couldn't find identifier for dataset in plan " + relation);
+    }
+    Identifier identifier = relation.identifier().get();
+
+    if (relation.catalog().isEmpty() || !(relation.catalog().get() instanceof TableCatalog)) {
+      throw new IllegalArgumentException("Couldn't find catalog for dataset in plan " + relation);
+    }
+    TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
+
+    Map<String, String> tableProperties = relation.table().properties();
+
+    includeProviderFacet(tableCatalog, tableProperties, facets);
+    Optional<DatasetIdentifier> datasetIdentifier =
+        PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+
+    if (datasetIdentifier.isPresent()) {
+      return Collections.singletonList(
+          datasetFactory.getDataset(datasetIdentifier.get(), relation.schema(), facets));
+    } else {
       return Collections.emptyList();
     }
-
-    return Collections.singletonList(datasetIdentifier);
   }
 }

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -78,7 +78,7 @@ public class SparkContainerIntegrationTest {
       logger.error("Unable to shut down pyspark container", e2);
     }
     try {
-      kafka.stop();
+      if (kafka != null) kafka.stop();
     } catch (Exception e2) {
       logger.error("Unable to shut down kafka container", e2);
     }
@@ -277,6 +277,8 @@ public class SparkContainerIntegrationTest {
   @CsvSource(
       value = {
         "spark_v2_create.py:pysparkV2CreateTableAsSelectStartEvent.json:pysparkV2CreateTableAsSelectCompleteEvent.json",
+        "spark_v2_overwrite_by_expression.py:pysparkV2OverwriteByExpressionStartEvent.json:pysparkV2OverwriteByExpressionCompleteEvent.json",
+        "spark_v2_overwrite_partitions.py:pysparkV2OverwritePartitionsStartEvent.json:pysparkV2OverwritePartitionsCompleteEvent.json"
       },
       delimiter = ':')
   public void testV2Commands(

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_by_expression.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_by_expression.py
@@ -1,0 +1,30 @@
+import os
+import time
+
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2_overwrite", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration V2 Commands") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog") \
+    .config("spark.sql.catalog.spark_catalog.type", "hive") \
+    .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.local.type", "hadoop") \
+    .config("spark.sql.catalog.local.warehouse", "/tmp/v2_overwrite") \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .config("packages", "org.apache.iceberg:iceberg-spark3-runtime:0.12.1") \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+df = spark.createDataFrame([
+    {'a': 1, 'b': 2},
+    {'a': 3, 'b': 4}
+])
+df.createOrReplaceTempView('temp')
+
+spark.sql("CREATE TABLE local.db.tbl USING iceberg AS SELECT * FROM temp")
+spark.sql("INSERT OVERWRITE local.db.tbl VALUES (5,6),(7,8)")
+
+

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_partitions.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_partitions.py
@@ -1,0 +1,32 @@
+import os
+import time
+
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2_overwrite", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration V2 Commands") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog") \
+    .config("spark.sql.catalog.spark_catalog.type", "hive") \
+    .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.local.type", "hadoop") \
+    .config("spark.sql.catalog.local.warehouse", "/tmp/v2_overwrite") \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .config("packages", "org.apache.iceberg:iceberg-spark3-runtime:0.12.1") \
+    .config("spark.sql.sources.partitionOverwriteMode", "dynamic") \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+df = spark.createDataFrame([
+    {'a': 1, 'b': 2, 'c': 3},
+    {'a': 4, 'b': 5, 'c': 6}
+])
+df.createOrReplaceTempView('temp')
+
+spark.sql("CREATE TABLE local.db.tbl (a long, b  long) PARTITIONED BY (c long)")
+spark.sql("INSERT INTO local.db.tbl PARTITION (c=1) VALUES (2, 3)")
+spark.sql("INSERT OVERWRITE TABLE local.db.tbl PARTITION(c) SELECT * FROM temp")
+
+

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableAsSelectVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableAsSelectVisitorTest.java
@@ -1,128 +1,86 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.openlineage.spark.agent.facets.TableStateChangeFacet.StateChange.CREATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
-import org.apache.commons.lang.reflect.FieldUtils;
-import org.apache.iceberg.spark.SparkCatalog;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation$;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
-import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import scala.collection.Map$;
-import scala.collection.Seq$;
+import org.mockito.MockedStatic;
 import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
 
-@ExtendWith(SparkAgentTestExtension.class)
 class CreateTableAsSelectVisitorTest {
 
-  private CreateTableAsSelect createCTAS(TableCatalog tableCatalog) {
-    return new CreateTableAsSelect(
-        tableCatalog,
-        new Identifier() {
-          @Override
-          public String[] namespace() {
-            return new String[] {"database", "schema"};
-          }
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+          .build();
 
-          @Override
-          public String name() {
-            return "table";
-          }
+  CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+  TableCatalog catalogTable = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Map<String, String> commandProperties = new HashMap<>();
+  Identifier tableName = Identifier.of(new String[] {"db"}, "table");
 
-          @Override
-          public String toString() {
-            return "database.schema.table";
-          }
-        },
-        Seq$.MODULE$.empty(),
-        LocalRelation$.MODULE$.apply(
-            new StructField("key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
-            Seq$.MODULE$.<StructField>empty()),
-        Map$.MODULE$.empty(),
-        Map$.MODULE$.empty(),
-        false);
+  @Test
+  public void testApply() {
+    when(logicalPlan.catalog()).thenReturn(catalogTable);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    when(logicalPlan.properties()).thenReturn(commandProperties);
+
+    DatasetIdentifier di = new DatasetIdentifier("table", "db");
+    CreateTableAsSelectVisitor visitor = new CreateTableAsSelectVisitor(openLineageContext);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalogTable,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(logicalPlan.properties())))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          new TableStateChangeFacet(CREATE),
+          outputDatasets.get(0).getFacets().getAdditionalProperties().get("tableStateChange"));
+    }
   }
 
   @Test
-  void testCreateTableAsSelectJdbcCommand() throws IllegalAccessException {
-    SparkSession session = SparkSession.builder().master("local").getOrCreate();
-    CreateTableAsSelectVisitor visitor =
-        new CreateTableAsSelectVisitor(SparkAgentTestExtension.newContext(session));
+  public void testApplyWhenNoDatasetIdentifierReturned() {
+    CreateTableAsSelectVisitor visitor = new CreateTableAsSelectVisitor(openLineageContext);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalogTable,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(logicalPlan.properties())))
+          .thenReturn(Optional.empty());
 
-    JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
-    JDBCOptions options = mock(JDBCOptions.class);
-    when(options.url()).thenReturn("jdbc:postgresql://postgreshost:5432");
-    FieldUtils.writeField(tableCatalog, "options", options, true);
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
 
-    CreateTableAsSelect command = createCTAS(tableCatalog);
-
-    assertThat(visitor.isDefinedAt(command)).isTrue();
-    List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
-    assertThat(datasets)
-        .singleElement()
-        .hasFieldOrPropertyWithValue("name", "database.schema.table")
-        .hasFieldOrPropertyWithValue("namespace", "postgresql://postgreshost:5432");
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "hdfs://namenode:8020/warehouse,hdfs://namenode:8020,/warehouse/database.schema.table",
-    "/tmp/warehouse,file,/tmp/warehouse/database.schema.table"
-  })
-  void testCreateTableAsSelectIcebergHadoopCommand(
-      String warehouseConf, String namespace, String name) throws IllegalAccessException {
-    SparkSession session = SparkSession.builder().master("local").getOrCreate();
-    session.conf().set("spark.sql.catalog.test.type", "hadoop");
-    session.conf().set("spark.sql.catalog.test.warehouse", warehouseConf);
-
-    CreateTableAsSelectVisitor visitor =
-        new CreateTableAsSelectVisitor(SparkAgentTestExtension.newContext(session));
-    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
-    when(sparkCatalog.name()).thenReturn("test");
-
-    CreateTableAsSelect command = createCTAS(sparkCatalog);
-
-    assertThat(visitor.isDefinedAt(command)).isTrue();
-    List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
-    assertThat(datasets)
-        .singleElement()
-        .hasFieldOrPropertyWithValue("name", name)
-        .hasFieldOrPropertyWithValue("namespace", namespace);
-  }
-
-  @Test
-  void testCreateTableAsSelectIcebergHiveCommand() throws IllegalAccessException {
-    SparkSession session = SparkSession.builder().master("local").getOrCreate();
-    session.conf().set("spark.sql.catalog.test.type", "hive");
-    session.conf().set("spark.sql.catalog.test.uri", "thrift://metastore-host:10001");
-
-    CreateTableAsSelectVisitor visitor =
-        new CreateTableAsSelectVisitor(SparkAgentTestExtension.newContext(session));
-    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
-    when(sparkCatalog.name()).thenReturn("test");
-
-    CreateTableAsSelect command = createCTAS(sparkCatalog);
-
-    assertThat(visitor.isDefinedAt(command)).isTrue();
-    List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
-    assertThat(datasets)
-        .singleElement()
-        .hasFieldOrPropertyWithValue("name", "database.schema.table")
-        .hasFieldOrPropertyWithValue("namespace", "hive://metastore-host:10001");
+      assertEquals(0, outputDatasets.size());
+    }
   }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitorTest.java
@@ -1,144 +1,35 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.OutputDataset;
-import io.openlineage.spark.agent.client.OpenLineageClient;
-import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
-import org.apache.spark.sql.connector.catalog.Table;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
-import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.MockedStatic;
 
 public class DataSourceV2RelationVisitorTest {
 
-  private final OpenLineage openLineage =
-      new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
-  DataSourceV2RelationVisitor<OutputDataset> dataSourceV2RelationVisitor =
-      new DataSourceV2RelationVisitor(
-          OpenLineageContext.builder()
-              .sparkContext(
-                  SparkContext.getOrCreate(new SparkConf().setMaster("local").setAppName("test")))
-              .openLineage(openLineage)
-              .build(),
-          DatasetFactory.output(openLineage));
-  DataSourceV2Relation dataSourceV2Relation = Mockito.mock(DataSourceV2Relation.class);
-  Table table = Mockito.mock(Table.class);
-  Map<String, String> tableProperties = new HashMap<>();
-
-  @AfterEach
-  public void resetMock() {
-    Mockito.reset(dataSourceV2Relation);
-    Mockito.reset(table);
-  }
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  DatasetFactory<OpenLineage.OutputDataset> datasetFactory = mock(DatasetFactory.class);
+  DataSourceV2RelationVisitor visitor =
+      new DataSourceV2RelationVisitor(openLineageContext, datasetFactory);
+  LogicalPlan logicalPlan = mock(DataSourceV2Relation.class);
 
   @Test
-  public void testApplyExceptionIsThrownWhenNonSupportedProvider() {
-    Exception exception =
-        assertThrows(
-            RuntimeException.class, () -> dataSourceV2RelationVisitor.apply(dataSourceV2Relation));
-
-    Assertions.assertTrue(
-        exception.getMessage().startsWith("Couldn't find provider for dataset in plan"));
-  }
-
-  @Test
-  public void testIsDefinedAtFailsWhenProviderUnknown() {
-    tableProperties.put("provider", "unsupported/provider");
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-
-    Assertions.assertFalse(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
-  }
-
-  @Test
-  public void testApplyForIcebergOnGS() {
-    tableProperties.put("provider", "iceberg");
-    tableProperties.put("format", "iceberg/parquet");
-    tableProperties.put("location", "gs://bucket/catalog/db/table");
-
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(dataSourceV2Relation.schema()).thenReturn(new StructType());
-    Mockito.when(table.name()).thenReturn("remote-gcs.db.table");
-
-    OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
-
-    TableProviderFacet tableProviderFacet =
-        (TableProviderFacet) dataset.getFacets().getAdditionalProperties().get("table_provider");
-
-    Assertions.assertEquals("parquet", tableProviderFacet.getFormat());
-    Assertions.assertEquals("iceberg", tableProviderFacet.getProvider());
-    Assertions.assertEquals("gs://bucket/catalog/db/table", dataset.getNamespace());
-    Assertions.assertEquals("remote-gcs.db.table", dataset.getName());
-  }
-
-  @Test
-  public void testApplyForIcebergOnLocal() {
-    tableProperties.put("provider", "iceberg");
-    tableProperties.put("location", "/tmp/catalog/db/table");
-    tableProperties.put("format", "iceberg/parquet");
-
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(dataSourceV2Relation.schema()).thenReturn(new StructType());
-    Mockito.when(table.name()).thenReturn("local.db.table");
-
-    OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
-
-    TableProviderFacet tableProviderFacet =
-        (TableProviderFacet) dataset.getFacets().getAdditionalProperties().get("table_provider");
-
-    Assertions.assertEquals("file:///tmp/catalog/db/table", dataset.getNamespace());
-    Assertions.assertEquals("local.db.table", dataset.getName());
-  }
-
-  @Test
-  public void testIsDefinedAtForNonDefinedProvider() {
-    Mockito.when(dataSourceV2Relation.table()).thenReturn(table);
-    Assertions.assertFalse(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
-  }
-
-  @Test
-  public void testIsDefinedAtForIceberg() {
-    tableProperties.put("provider", "iceberg");
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-    Assertions.assertTrue(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
-  }
-
-  @Test
-  public void testIsDefinedForDelta() {
-    tableProperties.put("provider", "delta");
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-    Assertions.assertTrue(dataSourceV2RelationVisitor.isDefinedAt(dataSourceV2Relation));
-  }
-
-  @Test
-  public void testApplyDeltaLocal() {
-    tableProperties.put("provider", "delta");
-    tableProperties.put("location", "file:/tmp/delta/spark-warehouse/tbl");
-    tableProperties.put("format", "parquet");
-
-    Mockito.when(table.properties()).thenReturn(tableProperties);
-    Mockito.when((dataSourceV2Relation).table()).thenReturn(table);
-    Mockito.when(dataSourceV2Relation.schema()).thenReturn(new StructType());
-    Mockito.when(table.name()).thenReturn("table");
-
-    OpenLineage.Dataset dataset = dataSourceV2RelationVisitor.apply(dataSourceV2Relation).get(0);
-
-    Assertions.assertEquals("file:/tmp/delta/spark-warehouse/tbl", dataset.getNamespace());
-    Assertions.assertEquals("table", dataset.getName());
+  public void testApply() {
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      visitor.apply(logicalPlan);
+      mocked.verify(
+          () ->
+              PlanUtils3.fromDataSourceV2Relation(
+                  datasetFactory, openLineageContext, (DataSourceV2Relation) logicalPlan),
+          times(1));
+    }
   }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
@@ -1,0 +1,107 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.facets.TableStateChangeFacet.StateChange.OVERWRITE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.HashMap;
+import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression;
+import org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class TableContentChangeVisitorTest {
+
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
+  OpenLineage openLineage = mock(OpenLineage.class);
+
+  TableContentChangeVisitor visitor;
+
+  @BeforeEach
+  public void setUp() {
+    when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
+    visitor = new TableContentChangeVisitor(openLineageContext);
+  }
+
+  @Test
+  public void testApplyForOverwriteByExpression() {
+    OverwriteByExpression logicalPlan = mock(OverwriteByExpression.class);
+    when(logicalPlan.table()).thenReturn(dataSourceV2Relation);
+    verify(logicalPlan, OVERWRITE);
+  }
+
+  @Test
+  public void testApplyForOverwritePartitionsDynamic() {
+    OverwritePartitionsDynamic logicalPlan = mock(OverwritePartitionsDynamic.class);
+    when(logicalPlan.table()).thenReturn(dataSourceV2Relation);
+    verify(logicalPlan, OVERWRITE);
+  }
+
+  @Test
+  public void testApplyForInsertIntoStatement() {
+    InsertIntoStatement logicalPlan = mock(InsertIntoStatement.class);
+    when(logicalPlan.table()).thenReturn(dataSourceV2Relation);
+    when(logicalPlan.overwrite()).thenReturn(true);
+    verify(logicalPlan, OVERWRITE);
+  }
+
+  @Test
+  public void testApplyForInsertIntoStatementWithOverwriteDisabled() {
+    InsertIntoStatement logicalPlan = mock(InsertIntoStatement.class);
+    when(logicalPlan.table()).thenReturn(dataSourceV2Relation);
+    when(logicalPlan.overwrite()).thenReturn(false);
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      visitor.apply(logicalPlan);
+      mocked.verify(
+          () ->
+              PlanUtils3.fromDataSourceV2Relation(
+                  any(DatasetFactory.class),
+                  eq(openLineageContext),
+                  eq(dataSourceV2Relation),
+                  eq(new HashMap<>())),
+          times(1));
+    }
+  }
+
+  @Test
+  public void testIsDefined() {
+    assertTrue(visitor.isDefinedAt(mock(OverwriteByExpression.class)));
+    assertTrue(visitor.isDefinedAt(mock(OverwritePartitionsDynamic.class)));
+    assertTrue(visitor.isDefinedAt(mock(InsertIntoStatement.class)));
+    assertFalse(visitor.isDefinedAt(mock(LogicalPlan.class)));
+  }
+
+  private void verify(LogicalPlan logicalPlan, TableStateChangeFacet.StateChange stateChange) {
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      visitor.apply(logicalPlan);
+      mocked.verify(
+          () ->
+              PlanUtils3.fromDataSourceV2Relation(
+                  any(DatasetFactory.class),
+                  eq(openLineageContext),
+                  eq(dataSourceV2Relation),
+                  eq(
+                      Collections.singletonMap(
+                          "tableStateChange", new TableStateChangeFacet(stateChange)))),
+          times(1));
+    }
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3Test.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3Test.java
@@ -1,0 +1,101 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.Test;
+
+public class CatalogUtils3Test {
+
+  @Test
+  public void testGetCatalogHandlerByProviderForIceberg() {
+    assertTrue(
+        CatalogUtils3.getCatalogHandlerByProvider("Iceberg").get() instanceof IcebergHandler);
+  }
+
+  @Test
+  public void testGetCatalogHandlerByProviderForDelta() {
+    assertTrue(CatalogUtils3.getCatalogHandlerByProvider("Delta").get() instanceof DeltaHandler);
+  }
+
+  @Test
+  public void getCatalogHandlerByProviderUnknown() {
+    assertEquals(Optional.empty(), CatalogUtils3.getCatalogHandlerByProvider("Unknown"));
+  }
+
+  @Test
+  public void testGetCatalogHandler() {
+    TableCatalog tableCatalog = mock(org.apache.iceberg.spark.SparkCatalog.class);
+    assertTrue(CatalogUtils3.getCatalogHandler(tableCatalog).get() instanceof IcebergHandler);
+  }
+
+  @Test
+  public void testGetCatalogHandlerEmpty() {
+    assertEquals(Optional.empty(), CatalogUtils3.getCatalogHandler(mock(TableCatalog.class)));
+  }
+
+  @Test
+  public void testGetTableProviderFacet() {
+    TableCatalog tableCatalog = mock(org.apache.iceberg.spark.SparkCatalog.class);
+    Map<String, String> properties = new HashMap<>();
+    assertEquals(
+        "iceberg",
+        CatalogUtils3.getTableProviderFacet(tableCatalog, properties).get().getProvider());
+  }
+
+  @Test
+  public void testGetTableProviderFacetWhenHandlerUnknown() {
+    TableCatalog tableCatalog = mock(TableCatalog.class);
+    Map<String, String> properties = new HashMap<>();
+    assertEquals(Optional.empty(), CatalogUtils3.getTableProviderFacet(tableCatalog, properties));
+  }
+
+  @Test
+  public void testGetDatasetIdentifier() {
+    CatalogHandler catalogHandler = mock(CatalogHandler.class);
+    when(catalogHandler.isClass(any())).thenReturn(true);
+    when(catalogHandler.getDatasetIdentifier(any(), any(), any(), any()))
+        .thenReturn(new DatasetIdentifier("name", "namespace"));
+
+    DatasetIdentifier datasetIdentifier =
+        CatalogUtils3.getDatasetIdentifier(
+            mock(SparkSession.class),
+            mock(TableCatalog.class),
+            mock(Identifier.class),
+            new HashMap<>(),
+            Arrays.asList(catalogHandler));
+
+    assertEquals("name", datasetIdentifier.getName());
+    assertEquals("namespace", datasetIdentifier.getNamespace());
+  }
+
+  @Test
+  public void testGetDatasetIdentifierWhenCatalogUnsupported() {
+    CatalogHandler catalogHandler = mock(CatalogHandler.class);
+    when(catalogHandler.isClass(any())).thenReturn(false);
+
+    UnsupportedCatalogException exception =
+        assertThrows(
+            UnsupportedCatalogException.class,
+            () -> {
+              CatalogUtils3.getDatasetIdentifier(
+                  mock(SparkSession.class),
+                  mock(TableCatalog.class),
+                  mock(Identifier.class),
+                  new HashMap<>(),
+                  Arrays.asList(catalogHandler));
+            });
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -1,0 +1,6 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+public class DeltaHandlerTest {
+
+  // FIXME: write test
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -1,0 +1,86 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.facets.TableProviderFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class IcebergHandlerTest {
+
+  private IcebergHandler icebergHandler = new IcebergHandler();
+
+  @ParameterizedTest
+  @CsvSource({
+    "hdfs://namenode:8020/warehouse,hdfs://namenode:8020,/warehouse/database.schema.table",
+    "/tmp/warehouse,file,/tmp/warehouse/database.schema.table"
+  })
+  public void testGetDatasetIdentifierForHadoop(
+      String warehouseConf, String namespace, String name) {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    session.conf().set("spark.sql.catalog.test.type", "hadoop");
+    session.conf().set("spark.sql.catalog.test.warehouse", warehouseConf);
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(sparkCatalog.name()).thenReturn("test");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            session,
+            sparkCatalog,
+            Identifier.of(new String[] {"database", "schema"}, "table"),
+            new HashMap<>());
+
+    assertEquals(name, datasetIdentifier.getName());
+    assertEquals(namespace, datasetIdentifier.getNamespace());
+  }
+
+  @Test
+  public void testGetDatasetIdentifierForHive() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    session.conf().set("spark.sql.catalog.test.type", "hive");
+    session.conf().set("spark.sql.catalog.test.uri", "thrift://metastore-host:10001");
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(sparkCatalog.name()).thenReturn("test");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            session,
+            sparkCatalog,
+            Identifier.of(new String[] {"database", "schema"}, "table"),
+            new HashMap<>());
+
+    assertEquals("database.schema.table", datasetIdentifier.getName());
+    assertEquals("hive://metastore-host:10001", datasetIdentifier.getNamespace());
+  }
+
+  @Test
+  public void testGetTableProviderFacet() {
+    Optional<TableProviderFacet> tableProviderFacet =
+        icebergHandler.getTableProviderFacet(Collections.singletonMap("format", "iceberg/parquet"));
+    assertEquals("iceberg", tableProviderFacet.get().getProvider());
+    assertEquals("parquet", tableProviderFacet.get().getFormat());
+  }
+
+  @Test
+  public void testGetTableProviderFacetWhenFormatNotProvided() {
+    Optional<TableProviderFacet> tableProviderFacet =
+        icebergHandler.getTableProviderFacet(new HashMap<>());
+    assertEquals("iceberg", tableProviderFacet.get().getProvider());
+    assertEquals("", tableProviderFacet.get().getFormat());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -1,0 +1,39 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import java.util.HashMap;
+import lombok.SneakyThrows;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
+import org.junit.jupiter.api.Test;
+
+public class JdbcHandlerTest {
+
+  @Test
+  @SneakyThrows
+  public void testGetDatasetIdentifier() {
+    JdbcHandler handler = new JdbcHandler();
+
+    JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
+    JDBCOptions options = mock(JDBCOptions.class);
+    when(options.url()).thenReturn("jdbc:postgresql://postgreshost:5432");
+    FieldUtils.writeField(tableCatalog, "options", options, true);
+
+    DatasetIdentifier datasetIdentifier =
+        handler.getDatasetIdentifier(
+            mock(SparkSession.class),
+            tableCatalog,
+            Identifier.of(new String[] {"database", "schema"}, "table"),
+            new HashMap<>());
+
+    assertEquals("database.schema.table", datasetIdentifier.getName());
+    assertEquals("postgresql://postgreshost:5432", datasetIdentifier.getNamespace());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -1,0 +1,176 @@
+package io.openlineage.spark3.agent.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableProviderFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+public class PlanUtils3Test {
+
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  SparkSession sparkSession = mock(SparkSession.class);
+  DatasetFactory<OpenLineage.Dataset> datasetFactory = mock(DatasetFactory.class);
+  DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
+  TableCatalog tableCatalog = mock(TableCatalog.class);
+  Identifier identifier = mock(Identifier.class);
+  StructType schema = mock(StructType.class);
+  Map<String, OpenLineage.DefaultDatasetFacet> facets;
+  Table table = mock(Table.class);
+  Map<String, String> tableProperties;
+
+  @BeforeEach
+  public void setUp() {
+    tableProperties = new HashMap<>();
+    facets = new HashMap<>();
+    when(openLineageContext.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(dataSourceV2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(identifier));
+    when(dataSourceV2Relation.schema()).thenReturn(schema);
+    when(dataSourceV2Relation.table()).thenReturn(table);
+    when(table.properties()).thenReturn(tableProperties);
+  }
+
+  @Test
+  public void testFromDataSourceV2Relation() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      DatasetIdentifier di = mock(DatasetIdentifier.class);
+      OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
+
+      when(CatalogUtils3.getDatasetIdentifier(
+              sparkSession, tableCatalog, identifier, tableProperties))
+          .thenReturn(di);
+      when(datasetFactory.getDataset(di, schema, facets)).thenReturn(dataset);
+
+      assertEquals(
+          Collections.singletonList(dataset),
+          PlanUtils3.fromDataSourceV2Relation(
+              datasetFactory, openLineageContext, dataSourceV2Relation, facets));
+    }
+  }
+
+  @Test
+  public void testFromDataSourceV2RelationWhenDatasetIdentifierEmpty() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      DatasetIdentifier di = mock(DatasetIdentifier.class);
+      OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
+
+      when(CatalogUtils3.getDatasetIdentifier(
+              sparkSession, tableCatalog, identifier, tableProperties))
+          .thenThrow(new UnsupportedCatalogException("exception"));
+      when(datasetFactory.getDataset(di, schema, facets)).thenReturn(dataset);
+
+      assertEquals(
+          Collections.emptyList(),
+          PlanUtils3.fromDataSourceV2Relation(
+              datasetFactory, openLineageContext, dataSourceV2Relation, facets));
+    }
+  }
+
+  @Test
+  public void testFromDataSourceV2RelationWhenIdentifierEmpty() {
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.empty());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PlanUtils3.fromDataSourceV2Relation(
+                datasetFactory, openLineageContext, dataSourceV2Relation, new HashMap<>()));
+  }
+
+  @Test
+  public void testFromDataSourceV2RelationWhenCatalogEmpty() {
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(mock(Identifier.class)));
+    when(dataSourceV2Relation.catalog()).thenReturn(Option.empty());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PlanUtils3.fromDataSourceV2Relation(
+                datasetFactory, openLineageContext, dataSourceV2Relation, new HashMap<>()));
+  }
+
+  @Test
+  public void testIncludeProviderFacet() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      TableProviderFacet tableProviderFacet = new TableProviderFacet("iceberg", "parquet");
+      when(CatalogUtils3.getTableProviderFacet(tableCatalog, tableProperties))
+          .thenReturn(Optional.of(tableProviderFacet));
+
+      PlanUtils3.includeProviderFacet(tableCatalog, tableProperties, facets);
+      assertEquals(tableProviderFacet, facets.get("tableProvider"));
+    }
+  }
+
+  @Test
+  public void testIncludeProviderFacetWhenNoProvider() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      when(CatalogUtils3.getTableProviderFacet(tableCatalog, tableProperties))
+          .thenReturn(Optional.empty());
+
+      PlanUtils3.includeProviderFacet(tableCatalog, tableProperties, facets);
+      assertFalse(facets.containsKey("tableProvider"));
+    }
+  }
+
+  @Test
+  public void testGetDatasetIdentifier() {
+    DatasetIdentifier di = mock(DatasetIdentifier.class);
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      when(CatalogUtils3.getDatasetIdentifier(
+              sparkSession, tableCatalog, identifier, tableProperties))
+          .thenReturn(di);
+
+      assertEquals(
+          di,
+          PlanUtils3.getDatasetIdentifier(
+                  openLineageContext, tableCatalog, identifier, tableProperties)
+              .get());
+    }
+  }
+
+  @Test
+  public void testGetDatasetIdentifierWhenCatalogUnsupported() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      when(CatalogUtils3.getDatasetIdentifier(
+              sparkSession, tableCatalog, identifier, tableProperties))
+          .thenThrow(new UnsupportedCatalogException("exception"));
+
+      assertEquals(
+          Optional.empty(),
+          PlanUtils3.getDatasetIdentifier(
+              openLineageContext, tableCatalog, identifier, tableProperties));
+    }
+  }
+
+  @Test
+  public void testGetDatasetIdentifierWhenNoSparkSession() {
+    when(openLineageContext.getSparkSession()).thenReturn(Optional.empty());
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PlanUtils3.getDatasetIdentifier(
+                openLineageContext, tableCatalog, identifier, tableProperties));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Missing visitors for `OverwriteByExpression` and `OverwriteByPartition`. 

Closes tasks of: #368

### Solution

Implement missing visitors. Refactor utils classes to serve v2Commands visitors. This include moving providers' logic to handler classes to make visitors unaware of the provider specific details. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)