### PR TITLE
modify table v2 commands

### DIFF
--- a/integration/spark/integrations/container/pysparkV2AlterTableCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2AlterTableCompleteEvent.json
@@ -1,0 +1,27 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.alter_table"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_alter/db.alter_table_test",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "string"
+        }, {
+          "name" : "c",
+          "type" : "string"
+        } ]
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkV2AlterTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2AlterTableStartEvent.json
@@ -1,0 +1,27 @@
+{
+  "eventType" : "START",
+  "job" : {
+    "namespace" : "testV2Commands",
+    "name" : "open_lineage_integration_v2_commands.alter_table"
+  },
+  "inputs" : [ ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_alter/db.alter_table_test",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "string"
+        }, {
+          "name" : "b",
+          "type" : "string"
+        } ]
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkV2DropTableCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2DropTableCompleteEvent.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testV2Commands",
+    "name": "open_lineage_integration_v2_commands.drop_table"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/v2_drop/db.drop_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "tableStateChange": {
+          "stateChange": "drop"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/integrations/container/pysparkV2DropTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2DropTableStartEvent.json
@@ -1,0 +1,23 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testV2Commands",
+    "name": "open_lineage_integration_v2_commands.drop_table"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/v2_drop/db.drop_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "tableStateChange": {
+          "stateChange": "drop"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -6,9 +6,11 @@ import io.openlineage.client.OpenLineage.Dataset;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.AlterTableVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateTableLikeCommandVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.DropTableVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeVisitor;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -26,6 +28,8 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
         .add(new DataSourceV2RelationVisitor(context, outputFactory))
         .add(new TableContentChangeVisitor(context))
         .add(new CreateTableLikeCommandVisitor(context))
+        .add(new DropTableVisitor(context))
+        .add(new AlterTableVisitor(context))
         .build();
   }
 

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableVisitor.java
@@ -1,0 +1,45 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.NonNull;
+import org.apache.spark.sql.catalyst.plans.logical.AlterTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+public class AlterTableVisitor extends QueryPlanVisitor<AlterTable, OpenLineage.OutputDataset> {
+
+  public AlterTableVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    TableCatalog tableCatalog;
+    AlterTable alterTable = ((AlterTable) x);
+    tableCatalog = alterTable.catalog();
+
+    Table table;
+    try {
+      table = alterTable.catalog().loadTable(alterTable.ident());
+    } catch (Exception e) {
+      return Collections.emptyList();
+    }
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(
+            context, tableCatalog, alterTable.ident(), table.properties());
+    if (di.isPresent()) {
+      return Collections.singletonList(outputDataset().getDataset(di.get(), table.schema()));
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -1,0 +1,51 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.plans.logical.DropTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+@Slf4j
+public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.OutputDataset> {
+
+  public DropTableVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    ResolvedTable resolvedTable = ((ResolvedTable) ((DropTable) x).child());
+    TableCatalog tableCatalog = resolvedTable.catalog();
+    Map<String, String> tableProperties = resolvedTable.table().properties();
+    Identifier identifier = resolvedTable.identifier();
+    StructType schema = resolvedTable.schema();
+
+    facetMap.put(
+        "tableStateChange", new TableStateChangeFacet(TableStateChangeFacet.StateChange.DROP));
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+
+    if (di.isPresent()) {
+      return Collections.singletonList(outputDataset().getDataset(di.get(), schema, facetMap));
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -284,7 +284,9 @@ public class SparkContainerIntegrationTest {
         "spark_v2_replace_table.py:pysparkV2ReplaceTableStartEvent.json:pysparkV2ReplaceTableCompleteEvent.json:false",
         "spark_v2_delete.py:pysparkV2DeleteStartEvent.json:pysparkV2DeleteCompleteEvent.json:true",
         "spark_v2_update.py:pysparkV2UpdateStartEvent.json:pysparkV2UpdateCompleteEvent.json:true",
-        "spark_v2_merge_into_table.py:pysparkV2MergeIntoTableStartEvent.json:pysparkV2MergeIntoTableCompleteEvent.json:true"
+        "spark_v2_merge_into_table.py:pysparkV2MergeIntoTableStartEvent.json:pysparkV2MergeIntoTableCompleteEvent.json:true",
+        "spark_v2_drop.py:pysparkV2DropTableStartEvent.json:pysparkV2DropTableCompleteEvent.json:true",
+        "spark_v2_alter.py:pysparkV2AlterTableStartEvent.json:pysparkV2AlterTableCompleteEvent.json:true"
       },
       delimiter = ':')
   public void testV2Commands(

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_alter.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_alter.py
@@ -1,0 +1,20 @@
+import os, time
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2_alter", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration V2 Commands") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.spark_catalog.type", "hive") \
+    .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.local.type", "hadoop") \
+    .config("spark.sql.catalog.local.warehouse", "/tmp/v2_alter") \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE local.db.alter_table_test (a string, b string) USING iceberg")
+spark.sql("INSERT INTO local.db.alter_table_test VALUES ('a', 'b')")
+spark.sql("ALTER TABLE local.db.alter_table_test RENAME COLUMN b TO c")

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_drop.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_drop.py
@@ -1,0 +1,20 @@
+import os, time
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2_drop", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration V2 Commands") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.spark_catalog.type", "hive") \
+    .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.local.type", "hadoop") \
+    .config("spark.sql.catalog.local.warehouse", "/tmp/v2_drop") \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE local.db.drop_table_test (a string, b string) USING iceberg")
+spark.sql("INSERT INTO local.db.drop_table_test VALUES ('a', 'b')")
+spark.sql("DROP TABLE local.db.drop_table_test")

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableVisitorTest.java
@@ -1,0 +1,103 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.List;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.plans.logical.AlterTable;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
+
+public class AlterTableVisitorTest {
+
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+          .build();
+
+  TableCatalog tableCatalog = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Table table = mock(Table.class);
+  Map<String, String> tableProperties = new HashMap<>();
+  DatasetIdentifier di = new DatasetIdentifier("table", "db");
+  Identifier identifier = mock(Identifier.class);
+  AlterTable alterTable = mock(AlterTable.class);
+  DatasetFactory<OpenLineage.OutputDataset> datasetFactory = mock(DatasetFactory.class);
+
+  AlterTableVisitor visitor = new AlterTableVisitor(openLineageContext);
+
+  @BeforeEach
+  public void setUp() {
+    when(alterTable.catalog()).thenReturn(tableCatalog);
+    when(alterTable.ident()).thenReturn(identifier);
+    when(table.schema()).thenReturn(schema);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApplyWhenTableNotFound() {
+    when(tableCatalog.loadTable(identifier)).thenThrow(mock(NoSuchTableException.class));
+    List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(alterTable);
+    assertEquals(0, outputDatasets.size());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApplyWhenNoDatasetIdentifier() {
+    when(tableCatalog.loadTable(identifier)).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              tableCatalog,
+              identifier,
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(alterTable);
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApply() {
+    when(tableCatalog.loadTable(identifier)).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              tableCatalog,
+              identifier,
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(alterTable);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals("table", outputDatasets.get(0).getName());
+      assertEquals("db", outputDatasets.get(0).getNamespace());
+    }
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitorTest.java
@@ -1,0 +1,98 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.agent.facets.TableStateChangeFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.plans.logical.DropTable;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
+
+public class DropTableVisitorTest {
+
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+          .build();
+
+  DropTableVisitor visitor = new DropTableVisitor(openLineageContext);
+
+  DropTable dropTable = mock(DropTable.class);
+  ResolvedTable resolvedTable = mock(ResolvedTable.class);
+  TableCatalog tableCatalog = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Table table = mock(Table.class);
+  Map<String, String> tableProperties = new HashMap<>();
+  DatasetIdentifier di = new DatasetIdentifier("table", "db");
+
+  @BeforeEach
+  public void setUp() {
+    when(dropTable.child()).thenReturn(resolvedTable);
+    when(resolvedTable.catalog()).thenReturn(tableCatalog);
+    when(resolvedTable.schema()).thenReturn(schema);
+    when(resolvedTable.table()).thenReturn(table);
+    when(resolvedTable.identifier()).thenReturn(Identifier.of(new String[] {"db"}, "table"));
+    when(table.properties())
+        .thenReturn(ScalaConversionUtils.<String, String>fromMap(tableProperties));
+    when(table.name()).thenReturn("db.table");
+  }
+
+  @Test
+  public void testApply() {
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              tableCatalog,
+              Identifier.of(new String[] {"db"}, "table"),
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(dropTable);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          new TableStateChangeFacet(TableStateChangeFacet.StateChange.DROP),
+          outputDatasets.get(0).getFacets().getAdditionalProperties().get("tableStateChange"));
+      assertEquals("table", outputDatasets.get(0).getName());
+      assertEquals("db", outputDatasets.get(0).getNamespace());
+    }
+  }
+
+  @Test
+  public void testApplyWhenNoIdentifierFound() {
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              tableCatalog,
+              Identifier.of(new String[] {"db"}, "table"),
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(dropTable);
+
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Missing Spark visitors for `AlterTable` and `DropTable`.

Closes: #368

### Solution

Implement missing visitors with unit tests and integration tests provided. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)