### PR TITLE
Spark extension docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Support for dbt-spark adapter [@mobuchowski](https://github.com/mobuchowski)
+* Add Spark extensibility API with support for custom Dataset and custom facet builders [@collado-mike](https://github.com/collado-mike)
 
 ### Fixed
 * airflow: fix import failures when dependencies for bigquery, dbt, great_expectations extractors are missing [@lukaszlaszko](https://github.com/lukaszlaszko)

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -168,6 +168,7 @@ class MyDatasetDetector extends QueryPlanVisitor<MyDataset, OutputDataset> {
 ```
 
 ## API
+The following APIs are still evolving and may change over time, based on user feedback.
 
 ###[`OpenLineageEventHandlerFactory`](src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java)
 This interface defines the main entrypoint to the extension codebase. Custom implementations

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -152,3 +152,170 @@ To run the integration tests, from the current directory run:
 ```sh
 ./gradlew shadowJar
 ```
+
+# Extending
+The Spark library is intended to support extension by supporting custom implementations of a handful
+of interfaces. Nearly every extension interface extends or mimics Scala's `PartialFunction`. The
+`isDefinedAt(Object x)` method determines whether a given input is a valid input to the function. 
+A default implementation of `isDefinedAt(Object x)` is provided, which checks the generic type 
+arguments of the concrete class, if concrete type arguments are given, and determines if the input
+argument matches the generic type. For example the following class is automatically defined for an 
+input argument of type `MyDataset`
+
+```
+class MyDatasetDetector extends QueryPlanVisitor<MyDataset, OutputDataset> {
+}
+```
+
+## API
+
+###[`OpenLineageEventHandlerFactory`](src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java)
+This interface defines the main entrypoint to the extension codebase. Custom implementations
+are registered by following Java's [`ServiceLoader` conventions](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
+A file called `io.openlineage.spark.api.OpenLineageEventHandlerFactory` must exist in the 
+application or jar's `META-INF/service` directory. Each line of that file must be the fully 
+qualified class name of a concrete implementation of `OpenLineageEventHandlerFactory`. More than one
+implementation can be present in a single file. This might be useful to separate extensions that 
+are targeted toward different environments - e.g., one factory may contain Azure-specific extensions,
+while another factory may contain GCP extensions. 
+
+The `OpenLineageEventHandlerFactory` interface makes heavy use of default methods. Implementations 
+may override any or all of the following methods
+```java
+/**
+ * Return a collection of QueryPlanVisitors that can generate InputDatasets from a LogicalPlan node
+ */
+Collection<PartialFunction<LogicalPlan, List<InputDataset>>> createInputDatasetQueryPlanVisitors(OpenLineageContext context);
+
+/**
+ * Return a collection of QueryPlanVisitors that can generate OutputDatasets from a LogicalPlan node
+ */
+Collection<PartialFunction<LogicalPlan, List<OutputDataset>>> createOutputDatasetQueryPlanVisitors(OpenLineageContext context);
+
+/**
+ * Return a collection of PartialFunctions that can generate InputDatasets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(OpenLineageContext context);
+
+/**
+ * Return a collection of PartialFunctions that can generate OutputDatasets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(OpenLineageContext context);
+
+/**
+ * Return a collection of CustomFacetBuilders that can generate InputDatasetFacets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */ 
+Collection<CustomFacetBuilder<?, ? extends InputDatasetFacet>> createInputDatasetFacetBuilders(OpenLineageContext context);
+
+/**
+ * Return a collection of CustomFacetBuilders that can generate OutputDatasetFacets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>createOutputDatasetFacetBuilders(OpenLineageContext context);
+
+/**
+ * Return a collection of CustomFacetBuilders that can generate DatasetFacets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(OpenLineageContext context);
+
+/**
+ * Return a collection of CustomFacetBuilders that can generate RunFacets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(OpenLineageContext context);
+
+/**
+ * Return a collection of CustomFacetBuilders that can generate JobFacets from one of the 
+ * pre-defined Spark types accessible from SparkListenerEvents (see below)
+ */
+Collection<CustomFacetBuilder<?, ? extends JobFacet>> createJobFacetBuilders(OpenLineageContext context);
+```
+
+See the [`OpenLineageEventHandlerFactory` javadocs](src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java)
+for specifics on each method.
+
+
+### [`QueryPlanVisitor`](src/main/common/java/io/openlineage/spark/api/QueryPlanVisitor.java)
+QueryPlanVisitors evaluate nodes of a Spark `LogicalPlan` and attempt to generate `InputDataset`s or
+`OutputDataset`s from the information found in the `LogicalPlan` nodes. This is the most common 
+abstraction present in the OpenLineage Spark library and many examples can be found in the 
+`io.openlineage.spark.agent.lifecycle.plan` package - examples include the 
+[`BigQueryNodeVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeVisitor.java),
+the [`KafkaRelationVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java)
+and the [`InsertIntoHiveTableVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java).
+
+`QueryPlanVisitor`s implement Scala's `PartialFunction` interface and are tested against every node
+of a Spark query's optimized `LogicalPlan`. Each invocation will expect either an `InputDataset` 
+or an `OutputDataset`. If a node can be either an `InputDataset` or an `OutputDataset`, the 
+constructor should accept a `DatasetFactory` so that the correct dataset type is generated at 
+runtime. 
+
+`QueryPlanVisitor`s can attach facets to the Datasets created, e.g., `SchemaDatasetFacet` and
+`DatasourceDatasetFacet` are typically attached to the dataset when it is created. Custom facets
+can also be attached, though `CustomFacetBuilder`s _may_ override facets attached directly to the 
+dataset.
+
+### [`InputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java) and [`OutputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java)
+Similar to the `QueryPlanVisitor`s, `InputDatasetBuilder`s and `OutputDatasetBuilder`s are 
+`PartialFunction`s defined for a specific input (see below for the list of Spark listener events and
+scheduler objects that can be passed to a builder) that can generate either an `InputDataset` or an 
+`OutputDataset`. Though not strictly necessary, the abstract base classes
+[`AbstractInputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java) 
+and [`AbstractOutputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java)
+are available for builders to extend.
+
+### [`CustomFacetBuilder`](src/main/common/java/io/openlineage/spark/api/CustomFacetBuilder.java)
+CustomFacetBuilders evaluate Spark event types and scheduler objects (see below) to construct custom
+facets. CustomFacetBuilders are used to create `InputDatsetFacet`s, `OutputDatsetFacet`s,
+`DatsetFacet`s, `RunFacet`s, and `JobFacet`s. A few examples can be found in the 
+[`io.openlineage.spark.agent.facets.builder`](src/main/common/java/io/openlineage/spark/agent/facets/builder)
+package, including the [`ErrorFacetBuilder`](src/main/common/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilder.java)
+and the [`LogicalPlanRunFacetBuilder`](src/main/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java).
+`CustomFacetBuilder`s are not `PartialFunction` implementations, but do define the `isDefinedAt(Object)`
+method to determine whether a given input is valid for the function. They implement the `BiConsumer`
+interface, accepting the valid input argument, and a `BiConsumer<String, Facet>` consumer, which 
+accepts the name and value of any custom facet that should be attached to the OpenLineage run.
+There is no limit to the number of facets that can be reported by a given `CustomFacetBuilder`. 
+Facet names that conflict will overwrite previously reported facets if they are reported for the 
+same Spark event.
+Though not strictly necessary, the following abstract base classes are available for extension:
+* [`AbstractJobFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java)
+* [`AbstractRunFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractRunFacetBuilder.java)
+* [`AbstractInputDatasetFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetFacetBuilder.java)
+* [`AbstractOutputDatasetFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java)
+* [`AbstractDatasetFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java)
+
+Input/Output/Dataset facets returned are attached to _any_ Input/Output Dataset found for a given 
+Spark event. Typically, a Spark job only has one `OutputDataset`, so any `OutputDatasetFacet` 
+generated will be attached to that `OutputDataset`. However, Spark jobs often have multiple
+`InputDataset`s. Typically, an `InputDataset` is read within a single Spark `Stage`, and any metrics
+pertaining to that dataset may be present in the `StageInfo#taskMetrics()` for that `Stage`. 
+Accumulators pertaining to a dataset should be reported in the task metrics for a stage so that the
+`CustomFacetBuilder` can match against the `StageInfo` and retrieve the task metrics for that stage
+when generating the `InputDatasetFacet`. Other facet information is often found by analyzing the
+`RDD` that reads the raw data for a dataset. `CustomFacetBuilder`s that generate these facets should
+be defined for the specific subclass of `RDD` that is used to read the target dataset - e.g., 
+`HadoopRDD`, `BigQueryRDD`, or `JdbcRDD`. 
+
+### Function Argument Types
+`CustomFacetBuilder`s and dataset builders can be defined for the following set of Spark listener 
+event types and scheduler types:
+
+* `org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart`
+* `org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd`
+* `org.apache.spark.scheduler.SparkListenerJobStart`
+* `org.apache.spark.scheduler.SparkListenerJobEnd`
+* `org.apache.spark.rdd.RDD`
+* `org.apache.spark.scheduler.Stage`
+* `org.apache.spark.scheduler.StageInfo`
+* `org.apache.spark.scheduler.ActiveJob`
+
+Note that `RDD`s are "unwrapped" prior to being evaluated by builders, so there's no need to, e.g., 
+check a `MapPartitionsRDD`'s dependencies. The `RDD` for each `Stage` can be evaluated when a
+`org.apache.spark.scheduler.SparkListenerStageCompleted` event occurs. When a 
+`org.apache.spark.scheduler.SparkListenerJobEnd` event is encountered, the last `Stage` for the
+`ActiveJob` can be evaluated. 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -65,16 +65,16 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
    */
   private <T> List<T> generate(
       Collection<OpenLineageEventHandlerFactory> factories,
-      Function<OpenLineageEventHandlerFactory, List<T>> supplier) {
+      Function<OpenLineageEventHandlerFactory, Collection<T>> supplier) {
     return StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(factories.iterator(), Spliterator.IMMUTABLE), false)
-        .flatMap(supplier.andThen(List::stream))
+        .flatMap(supplier.andThen(Collection::stream))
         .collect(Collectors.toList());
   }
 
   @Override
-  public List<PartialFunction<LogicalPlan, List<InputDataset>>> createInputDatasetQueryPlanVisitors(
-      OpenLineageContext context) {
+  public Collection<PartialFunction<LogicalPlan, List<InputDataset>>>
+      createInputDatasetQueryPlanVisitors(OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<InputDataset>>> inputDatasets =
         visitorFactory.getInputVisitors(context);
 
@@ -91,7 +91,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
   }
 
   @Override
-  public List<PartialFunction<LogicalPlan, List<OutputDataset>>>
+  public Collection<PartialFunction<LogicalPlan, List<OutputDataset>>>
       createOutputDatasetQueryPlanVisitors(OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<OutputDataset>>> outputDatasets =
         visitorFactory.getOutputVisitors(context);
@@ -110,27 +110,27 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
   }
 
   @Override
-  public List<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(
+  public Collection<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(
       OpenLineageContext context) {
     return generate(eventHandlerFactories, factory -> factory.createInputDatasetBuilder(context));
   }
 
   @Override
-  public List<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(
+  public Collection<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(
       OpenLineageContext context) {
     return generate(eventHandlerFactories, factory -> factory.createOutputDatasetBuilder(context));
   }
 
   @Override
-  public List<CustomFacetBuilder<?, ? extends InputDatasetFacet>> createInputDatasetFacetBuilders(
-      OpenLineageContext context) {
+  public Collection<CustomFacetBuilder<?, ? extends InputDatasetFacet>>
+      createInputDatasetFacetBuilders(OpenLineageContext context) {
     return generate(
         eventHandlerFactories, factory -> factory.createInputDatasetFacetBuilders(context));
   }
 
   @Override
-  public List<CustomFacetBuilder<?, ? extends OutputDatasetFacet>> createOutputDatasetFacetBuilders(
-      OpenLineageContext context) {
+  public Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
+      createOutputDatasetFacetBuilders(OpenLineageContext context) {
     return ImmutableList.<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>builder()
         .addAll(
             generate(
@@ -141,13 +141,13 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
   }
 
   @Override
-  public List<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(
+  public Collection<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(
       OpenLineageContext context) {
     return generate(eventHandlerFactories, factory -> factory.createDatasetFacetBuilders(context));
   }
 
   @Override
-  public List<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(
+  public Collection<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(
       OpenLineageContext context) {
     return ImmutableList.<CustomFacetBuilder<?, ? extends RunFacet>>builder()
         .addAll(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -43,6 +43,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -135,31 +136,33 @@ class OpenLineageRunEventBuilder {
   @NonNull private final OpenLineageContext openLineageContext;
 
   @NonNull
-  private final List<PartialFunction<Object, List<OpenLineage.InputDataset>>> inputDatasetBuilders;
+  private final Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>>
+      inputDatasetBuilders;
 
   @NonNull
-  private final List<PartialFunction<LogicalPlan, List<InputDataset>>>
+  private final Collection<PartialFunction<LogicalPlan, List<InputDataset>>>
       inputDatasetQueryPlanVisitors;
 
   @NonNull
-  private final List<PartialFunction<Object, List<OpenLineage.OutputDataset>>>
-      outputDatasetBuilders;
+  private final Collection<PartialFunction<Object, List<OutputDataset>>> outputDatasetBuilders;
 
   @NonNull
-  private final List<PartialFunction<LogicalPlan, List<OutputDataset>>>
+  private final Collection<PartialFunction<LogicalPlan, List<OutputDataset>>>
       outputDatasetQueryPlanVisitors;
 
-  @NonNull private final List<CustomFacetBuilder<?, ? extends DatasetFacet>> datasetFacetBuilders;
+  @NonNull
+  private final Collection<CustomFacetBuilder<?, ? extends DatasetFacet>> datasetFacetBuilders;
 
   @NonNull
-  private final List<CustomFacetBuilder<?, ? extends InputDatasetFacet>> inputDatasetFacetBuilders;
+  private final Collection<CustomFacetBuilder<?, ? extends InputDatasetFacet>>
+      inputDatasetFacetBuilders;
 
   @NonNull
-  private final List<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
+  private final Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
       outputDatasetFacetBuilders;
 
-  @NonNull private final List<CustomFacetBuilder<?, ? extends RunFacet>> runFacetBuilders;
-  @NonNull private final List<CustomFacetBuilder<?, ? extends JobFacet>> jobFacetBuilders;
+  @NonNull private final Collection<CustomFacetBuilder<?, ? extends RunFacet>> runFacetBuilders;
+  @NonNull private final Collection<CustomFacetBuilder<?, ? extends JobFacet>> jobFacetBuilders;
 
   private final UnknownEntryFacetListener unknownEntryFacetListener =
       new UnknownEntryFacetListener();
@@ -443,7 +446,7 @@ class OpenLineageRunEventBuilder {
   }
 
   private <T> Stream<T> buildDatasets(
-      List<Object> nodes, List<PartialFunction<Object, List<T>>> builders) {
+      List<Object> nodes, Collection<PartialFunction<Object, List<T>>> builders) {
     PartialFunction<Object, List<T>> fn = PlanUtils.merge(builders);
     return nodes.stream()
         .flatMap(
@@ -480,7 +483,9 @@ class OpenLineageRunEventBuilder {
    * @return
    */
   private <T, F> F buildFacets(
-      List<Object> events, List<CustomFacetBuilder<?, ? extends T>> builders, F facetsContainer) {
+      List<Object> events,
+      Collection<CustomFacetBuilder<?, ? extends T>> builders,
+      F facetsContainer) {
     Map<String, T> facetsMap =
         objectMapper.convertValue(facetsContainer, new TypeReference<Map<String, T>>() {});
     events.forEach(event -> builders.forEach(fn -> fn.accept(event, facetsMap::put)));
@@ -491,7 +496,8 @@ class OpenLineageRunEventBuilder {
    * Create a new instance of the facets container with all values merged from the original
    * facetsContainer and the given facets Map, with precedence given to the facets Map.
    *
-   * @see #buildFacets(List, List, Object) for reasoning behind the map &lt;-&gt; object conversion
+   * @see #buildFacets(List, Collection, Object) for reasoning behind the map &lt;-&gt; object
+   *     conversion
    * @param facetsMap
    * @param facetsContainer
    * @param klass

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -5,6 +5,7 @@ import io.openlineage.spark.agent.client.OpenLineageClient;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -57,7 +58,8 @@ public class PlanUtils {
    * @param <R>
    * @return
    */
-  public static <T, R> PartialFunction<T, R> merge(List<? extends PartialFunction<T, R>> fns) {
+  public static <T, R> PartialFunction<T, R> merge(
+      Collection<? extends PartialFunction<T, R>> fns) {
     return fns.stream()
         .map(
             pfn ->

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java
@@ -5,15 +5,15 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * {@link CustomFacetBuilder} that generates {@link io.openlineage.client.OpenLineage.RunFacet}s
- * from input events.
+ * Abstract base class for {@link scala.PartialFunction}s that return a {@link
+ * OpenLineage.DatasetFacet}.
  *
  * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
- *     be passed to this builder.
+ *     be passed to this function.
  * @param <T>
  */
 @RequiredArgsConstructor
-public abstract class AbstractRunFacetBuilder<T>
-    extends CustomFacetBuilder<T, OpenLineage.RunFacet> {
+public abstract class AbstractDatasetFacetBuilder<T>
+    extends AbstractGenericArgPartialFunction<T, OpenLineage.DatasetFacet> {
   @NonNull protected final OpenLineageContext context;
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
  * Abstract base class for {@link scala.PartialFunction}s that return an {@link
  * io.openlineage.client.OpenLineage.InputDataset}.
  *
- * @see io.openlineage.spark.agent.OpenLineageEventHandler for a list of event types that may be
- *     passed to this function.
+ * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
+ *     be passed to this function.
  * @param <T>
  */
 @RequiredArgsConstructor

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetFacetBuilder.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
  * {@link CustomFacetBuilder} that generates {@link
  * io.openlineage.client.OpenLineage.InputDatasetFacet}s from input events.
  *
- * @see io.openlineage.spark.agent.OpenLineageEventHandler for a list of event types that may be
- *     passed to this builder.
+ * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
+ *     be passed to this builder.
  * @param <T>
  */
 @RequiredArgsConstructor

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
  * {@link CustomFacetBuilder} that generates {@link io.openlineage.client.OpenLineage.RunFacet}s
  * from input events.
  *
- * @see io.openlineage.spark.agent.OpenLineageEventHandler for a list of event types that may be
- *     passed to this builder.
+ * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
+ *     be passed to this builder.
  * @param <T>
  */
 @RequiredArgsConstructor

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
  * Abstract base class for {@link scala.PartialFunction}s that return an {@link
  * io.openlineage.client.OpenLineage.OutputDataset}.
  *
- * @see io.openlineage.spark.agent.OpenLineageEventHandler for a list of event types that may be
- *     passed to this function.
+ * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
+ *     be passed to this function.
  * @param <T>
  */
 @RequiredArgsConstructor

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
  * {@link CustomFacetBuilder} that generates {@link
  * io.openlineage.client.OpenLineage.OutputDatasetFacet}s from input events.
  *
- * @see io.openlineage.spark.agent.OpenLineageEventHandler for a list of event types that may be
- *     passed to this builder.
+ * @see io.openlineage.spark.api.OpenLineageEventHandlerFactory for a list of event types that may
+ *     be passed to this builder.
  * @param <T>
  */
 @RequiredArgsConstructor

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/CustomFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/CustomFacetBuilder.java
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
  *   <li>{@link org.apache.spark.sql.execution.QueryExecution}
  * </ul>
  *
+ * @apiNote This interface is evolving and may change in future releases
  * @param <T>
  * @param <F>
  */

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -29,6 +29,10 @@ import scala.PartialFunction;
  * lists. As {@link QueryPlanVisitor}s require a reference to the {@link OpenLineageContext}, the
  * lists will always be added to after the {@link QueryPlanVisitor}s are constructed. Thus, copies
  * should never be made of the lists, as it should be assumed such copies will be incomplete.
+ *
+ * <p>This API is evolving and may change in future releases
+ *
+ * @apiNote This interface is evolving and may change in future releases
  */
 @Value
 @Builder

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
@@ -44,6 +44,10 @@ import scala.PartialFunction;
  * function's logic to complete. For example, if the function requires a {@link
  * org.apache.spark.scheduler.SparkListenerJobEnd}, it should be defined for that type, not the
  * generic {@link org.apache.spark.scheduler.SparkListenerEvent} type.
+ *
+ * <p>This interface is evolving and may change in future releases.
+ *
+ * @apiNote This interface is evolving and may change in future releases
  */
 public interface OpenLineageEventHandlerFactory {
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
@@ -7,55 +7,184 @@ import io.openlineage.client.OpenLineage.JobFacet;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.OutputDatasetFacet;
 import io.openlineage.client.OpenLineage.RunFacet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.apache.spark.scheduler.StageInfo;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import scala.PartialFunction;
 
-/** Factory for the builders that generate OpenLineage components and facets from Spark events. */
+/**
+ * Factory for the builders that generate OpenLineage components and facets from Spark events.
+ * Factories will be created once at the beginning of a Spark application (when the {@link
+ * org.apache.spark.scheduler.SparkListenerApplicationStart} event fires). Each of the createXXX
+ * methods will be invoked once per OpenLineage run - this may translate to a single {@link
+ * org.apache.spark.sql.execution.QueryExecution} or a single {@link
+ * org.apache.spark.scheduler.ActiveJob}. Each createXXX method is supplied with an {@link
+ * OpenLineageContext}, which will contain references to the {@link org.apache.spark.SparkContext}
+ * and other references that may be useful to builders that need access to information about the
+ * Spark application.
+ *
+ * <p>The {@link #createInputDatasetQueryPlanVisitors(OpenLineageContext)} and {@link
+ * #createOutputDatasetQueryPlanVisitors(OpenLineageContext)} methods return {@link
+ * PartialFunction}s that are defined for {@link LogicalPlan} nodes. All other methods return {@link
+ * PartialFunction}s or {@link CustomFacetBuilder}s (which mirror {@link PartialFunction}) that may
+ * require other Spark application objects to construct the OpenLineage model objects. These other
+ * types include
+ *
+ * <ul>
+ *   <li>{@link org.apache.spark.scheduler.SparkListenerEvent}s
+ *   <li>{@link org.apache.spark.rdd.RDD}
+ *   <li>{@link org.apache.spark.scheduler.Stage}
+ *   <li>{@link org.apache.spark.scheduler.StageInfo}
+ * </ul>
+ *
+ * The {@link PartialFunction#isDefinedAt(Object)} method should define which types the functions
+ * are defined for. The function should be defined for the most specific type that is needed for the
+ * function's logic to complete. For example, if the function requires a {@link
+ * org.apache.spark.scheduler.SparkListenerJobEnd}, it should be defined for that type, not the
+ * generic {@link org.apache.spark.scheduler.SparkListenerEvent} type.
+ */
 public interface OpenLineageEventHandlerFactory {
 
-  default List<PartialFunction<LogicalPlan, List<InputDataset>>>
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to a single {@link
+   * LogicalPlan} node to construct an {@link InputDataset}. {@link PartialFunction} implementations
+   * will typically extend {@link QueryPlanVisitor}.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<PartialFunction<LogicalPlan, List<InputDataset>>>
       createInputDatasetQueryPlanVisitors(OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<PartialFunction<LogicalPlan, List<OutputDataset>>>
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to a single {@link
+   * LogicalPlan} node to construct an {@link OutputDataset}. {@link PartialFunction}
+   * implementations will typically extend {@link QueryPlanVisitor}.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<PartialFunction<LogicalPlan, List<OutputDataset>>>
       createOutputDatasetQueryPlanVisitors(OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct an {@link InputDataset}. Typically, implementations should extend {@link
+   * AbstractInputDatasetBuilder}.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(
       OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct an {@link OutputDataset}. Typically, implementations should extend {@link
+   * AbstractOutputDatasetBuilder}.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(
       OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<CustomFacetBuilder<?, ? extends InputDatasetFacet>> createInputDatasetFacetBuilders(
-      OpenLineageContext context) {
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct an {@link InputDatasetFacet}s. {@link InputDatasetFacet}s created by these functions
+   * may be attached to <i>any</i> {@link InputDataset} defined for the current context - typically,
+   * there is only one {@link InputDataset} defined for a single Spark {@link
+   * org.apache.spark.scheduler.Stage}. {@link PartialFunction}s defined for a {@link
+   * org.apache.spark.scheduler.Stage} or {@link org.apache.spark.scheduler.StageInfo} can be
+   * matched to a specific {@link InputDataset} if the required facet information is available. For
+   * example, a facet detailing the number of records read for an {@link InputDataset} can be
+   * constructed from the {@link StageInfo#taskMetrics()} returned by the stage where that dataset
+   * is read. If a user wants to ensure the {@link InputDatasetFacet} is targeted to a specific
+   * {@link InputDataset}, they should implement a builder that returns an {@link InputDataset} and
+   * directly attach the facet. Merging the dataset and its facets can be handled separately.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<CustomFacetBuilder<?, ? extends InputDatasetFacet>>
+      createInputDatasetFacetBuilders(OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct an {@link OutputDatasetFacet}s. {@link OutputDatasetFacet}s created by these
+   * functions may be attached to <i>any</i> {@link OutputDataset} defined for the current context -
+   * typically, there is only one {@link OutputDataset} defined for a given Spark application. If a
+   * user wants to ensure the {@link OutputDatasetFacet} is targeted to a specific {@link
+   * OutputDataset}, they should implement a builder that returns an {@link OutputDataset} and
+   * directly attach the facet. Merging the dataset and its facets can be handled separately.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
       createOutputDatasetFacetBuilders(OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct an {@link DatasetFacet}s. {@link DatasetFacet}s created by these functions may be
+   * attached to <i>any</i> {@link io.openlineage.client.OpenLineage.Dataset} defined for the
+   * current context - this will include any {@link InputDataset} or {@link OutputDataset} found in
+   * the current context. If a user wants to ensure the {@link DatasetFacet} is targeted to a
+   * specific {@link OutputDataset} or {@link InputDataset}, they should implement a builder that
+   * returns an {@link io.openlineage.client.OpenLineage.Dataset} and directly attach the facet.
+   * Merging the dataset and its facets can be handled separately.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(
       OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct a {@link RunFacet} which will be attached to the current {@link
+   * io.openlineage.client.OpenLineage.RunEvent}
+   *
+   * @param context
+   * @return
+   */
+  default Collection<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(
       OpenLineageContext context) {
     return Collections.emptyList();
   }
 
-  default List<CustomFacetBuilder<?, ? extends JobFacet>> createJobFacetBuilders(
+  /**
+   * Create a collection of {@link PartialFunction}s that may be applied to various Spark
+   * application events and other objects (see class javadocs) that can contain information used to
+   * construct a {@link JobFacet} which will be attached to the current {@link
+   * io.openlineage.client.OpenLineage.Job}.
+   *
+   * @param context
+   * @return
+   */
+  default Collection<CustomFacetBuilder<?, ? extends JobFacet>> createJobFacetBuilders(
       OpenLineageContext context) {
     return Collections.emptyList();
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
@@ -115,6 +115,7 @@ public interface OpenLineageEventHandlerFactory {
    * is read. If a user wants to ensure the {@link InputDatasetFacet} is targeted to a specific
    * {@link InputDataset}, they should implement a builder that returns an {@link InputDataset} and
    * directly attach the facet. Merging the dataset and its facets can be handled separately.
+   * Typically, implementations should extend {@link AbstractInputDatasetFacetBuilder}.
    *
    * @param context
    * @return
@@ -133,6 +134,7 @@ public interface OpenLineageEventHandlerFactory {
    * user wants to ensure the {@link OutputDatasetFacet} is targeted to a specific {@link
    * OutputDataset}, they should implement a builder that returns an {@link OutputDataset} and
    * directly attach the facet. Merging the dataset and its facets can be handled separately.
+   * Typically, implementations should extend {@link AbstractOutputDatasetFacetBuilder}.
    *
    * @param context
    * @return
@@ -151,7 +153,8 @@ public interface OpenLineageEventHandlerFactory {
    * the current context. If a user wants to ensure the {@link DatasetFacet} is targeted to a
    * specific {@link OutputDataset} or {@link InputDataset}, they should implement a builder that
    * returns an {@link io.openlineage.client.OpenLineage.Dataset} and directly attach the facet.
-   * Merging the dataset and its facets can be handled separately.
+   * Merging the dataset and its facets can be handled separately. Typically, implementations should
+   * extend {@link AbstractDatasetFacetBuilder}.
    *
    * @param context
    * @return
@@ -165,7 +168,8 @@ public interface OpenLineageEventHandlerFactory {
    * Create a collection of {@link PartialFunction}s that may be applied to various Spark
    * application events and other objects (see class javadocs) that can contain information used to
    * construct a {@link RunFacet} which will be attached to the current {@link
-   * io.openlineage.client.OpenLineage.RunEvent}
+   * io.openlineage.client.OpenLineage.RunEvent} Typically, implementations should extend {@link
+   * AbstractRunFacetBuilder}.
    *
    * @param context
    * @return
@@ -179,7 +183,8 @@ public interface OpenLineageEventHandlerFactory {
    * Create a collection of {@link PartialFunction}s that may be applied to various Spark
    * application events and other objects (see class javadocs) that can contain information used to
    * construct a {@link JobFacet} which will be attached to the current {@link
-   * io.openlineage.client.OpenLineage.Job}.
+   * io.openlineage.client.OpenLineage.Job}. Typically, implementations should extend {@link
+   * AbstractJobFacetBuilder}.
    *
    * @param context
    * @return

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactoryTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactoryTest.java
@@ -8,7 +8,7 @@ import io.openlineage.spark.agent.client.OpenLineageClient;
 import io.openlineage.spark.agent.util.TestOpenLineageEventHandlerFactory.TestRunFacetBuilder;
 import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.util.List;
+import java.util.Collection;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.AfterAll;
@@ -39,7 +39,7 @@ class InternalEventHandlerFactoryTest {
 
   @Test
   public void testHasTestRunFacet() {
-    List<CustomFacetBuilder<?, ? extends RunFacet>> runFacetBuilders =
+    Collection<CustomFacetBuilder<?, ? extends RunFacet>> runFacetBuilders =
         new InternalEventHandlerFactory().createRunFacetBuilders(context);
     assertThat(runFacetBuilders)
         .isNotEmpty()


### PR DESCRIPTION
### Problem

Javadocs and user facing docs to wrap up #447. Most of the update is centered on documentation for extension authors. However, I did notice a couple of discrepancies with the original design that needed to be fixed before extension authors start using the new APIs. Notably, the factory methods should return `Collection` rather than `List` and we were missing the `AbstractDatasetFacetBuilder` base class. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)