### PR TITLE
Fixed build.gradle to rename all bundled dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * airflow: fix import failures when dependencies for bigquery, dbt, great_expectations extractors are missing [@lukaszlaszko](https://github.com/lukaszlaszko)
+* Fixed openlineage-spark jar to correctly rename bundled dependencies [@collado-mike](https://github.com/collado-mike)
 
 ## [0.4.0](https://github.com/OpenLineage/OpenLineage/releases/tag/0.4.0) - 2021-12-13
 

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -351,11 +351,16 @@ signing {
 }
 
 shadowJar {
+    minimize()
     classifier = ''
     // avoid conflict with any client version of that lib
     relocate 'com.github.ok2c.hc5', 'openlineage.com.github.ok2c.hc5'
     relocate 'org.apache.httpcomponents.client5', 'openlineage.org.apache.httpcomponents.client5'
     relocate 'javassist', 'openlineage.javassist'
+    relocate 'org.apache.hc', 'openlineage.hc'
+    relocate 'com.fasterxml.jackson.datatype.jsr310', 'openlineage.jackson.datatype.jsr310'
+    relocate 'org.slf4j', 'openlineage.slf4j'
+    relocate 'org.apache.commons.codec', 'openlineage.commons.codec'
 
     manifest {
         attributes(


### PR DESCRIPTION
### Problem
The `openlineage-spark` jar currently bundles its dependencies using the `shadowJar` plugin. Unfortunately, several dependencies are being bundled without being renamed, causing classpath conflicts at runtime.

### Solution
This fixes the build to rename all bundled dependencies and adds the `minimize()` call to omit dependencies that don't actually need to be bundled. The diff in the jar contents can be seen in this gist: https://gist.github.com/collado-mike/a59bbf32e41b42be10f55819c9b25d7c


- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)