### PR TITLE
ci: run javadoc as part of build task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
       - run: ./gradlew --no-daemon --stacktrace build
       - run: ./gradlew --no-daemon jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
+      - run: ./gradlew javadoc
       - store_test_results:
           path: client/java/build/test-results/test
       - store_artifacts:
@@ -179,6 +180,7 @@ jobs:
           when: on_fail
           command: cat integration/spark/build/test-results/test/TEST-*.xml
       - run: ./gradlew --no-daemon jacocoTestReport
+      - run: ./gradlew javadoc
       - store_test_results:
           path: integration/spark/build/test-results/test
       - store_artifacts:


### PR DESCRIPTION
Javadoc is ran as part of publish task. To catch javadoc errors on pull request level, run javadoc as part of ci build task.
  
Also, fix current javadoc errors.


Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>