### PR TITLE
Update bundle jar to exclude slf4j dependency

### DIFF
--- a/integration/airflow/tests/integration/Dockerfile.2
+++ b/integration/airflow/tests/integration/Dockerfile.2
@@ -5,9 +5,7 @@ COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
-RUN mkdir -p /opt/airflow
 COPY data /opt/data
-RUN chown -R airflow:airflow /opt/airflow
 RUN chmod -R 777 /opt/data
 USER airflow
 COPY requirements.txt requirements.txt

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -362,8 +362,10 @@ shadowJar {
     relocate 'javassist', 'openlineage.javassist'
     relocate 'org.apache.hc', 'openlineage.hc'
     relocate 'com.fasterxml.jackson.datatype.jsr310', 'openlineage.jackson.datatype.jsr310'
-    relocate 'org.slf4j', 'openlineage.slf4j'
     relocate 'org.apache.commons.codec', 'openlineage.commons.codec'
+    dependencies {
+        exclude(dependency('org.slf4j::'))
+    }
 
     manifest {
         attributes(


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem
Logging is broken in the bundled jar due to renaming slf4j dependency.

Closes: #477

### Solution
Removes Slf4j dependency from the bundled jar, as it's always present in a Spark environment. It is left as a transitive dependency so that it should always be available for downstream consumers.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)