### PR TITLE
Add and implement (output) DatasetVersionDatasetFacet for Spark

### DIFF
--- a/integration/spark/integrations/container/pysparkWriteDeltaTableVersionDoesNotAttachToInputEnd.json
+++ b/integration/spark/integrations/container/pysparkWriteDeltaTableVersionDoesNotAttachToInputEnd.json
@@ -1,0 +1,51 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testWriteDeltaTableVersion",
+    "name" : "open_lineage_integration_delta.append_data_exec_v1"
+  },
+  "inputs": [ {
+    "namespace" : "file",
+    "name" : "/tmp/write_delta_table_version",
+    "outputFacets" : {
+      "datasetVersion" : {
+      }
+    }
+  }, {
+    "namespace" : "file",
+    "name" : "/tmp/write_delta_table_version",
+    "outputFacets" : {
+      "datasetVersion" : {
+      }
+    }
+
+  } ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/write_delta_table_version",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "integer"
+        }, {
+          "name" : "b",
+          "type" : "integer"
+        } ]
+      },
+      "tableProvider" : {
+        "provider" : "delta",
+        "format" : "parquet"
+      }
+    },
+    "outputFacets" : {
+      "datasetVersion" : {
+        "datasetVersion" : "1"
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkWriteDeltaTableVersionEnd.json
+++ b/integration/spark/integrations/container/pysparkWriteDeltaTableVersionEnd.json
@@ -1,0 +1,35 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testWriteDeltaTableVersion",
+    "name" : "open_lineage_integration_delta.append_data_exec_v1"
+  },
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/write_delta_table_version",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "integer"
+        }, {
+          "name" : "b",
+          "type" : "integer"
+        } ]
+      },
+      "tableProvider" : {
+        "provider" : "delta",
+        "format" : "parquet"
+      }
+    },
+    "outputFacets" : {
+      "datasetVersion" : {
+        "datasetVersion" : "1"
+      }
+    }
+  } ]
+}

--- a/integration/spark/integrations/container/pysparkWriteIcebergTableVersionEnd.json
+++ b/integration/spark/integrations/container/pysparkWriteIcebergTableVersionEnd.json
@@ -1,0 +1,29 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testWriteIcebergTableVersion",
+    "name" : "open_lineage_integration_iceberg.append_data"
+  },
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/write_iceberg_table_version/db.table",
+    "facets" : {
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "integer"
+        }, {
+          "name" : "b",
+          "type" : "integer"
+        } ]
+      },
+      "tableProvider" : {
+        "provider" : "iceberg",
+        "format" : "parquet"
+      }
+    },
+    "outputFacets" : {
+      "datasetVersion" : {}
+    }
+  } ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -76,6 +76,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
       log.info("No execution info {}", olContext);
       return;
     }
+
     RunEvent event =
         runEventBuilder.buildRun(
             buildParentFacet(),

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
@@ -135,9 +135,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @return
    */
   public D getDataset(
-      DatasetIdentifier ident,
-      StructType schema,
-      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+      DatasetIdentifier ident, StructType schema, Map<String, OpenLineage.DatasetFacet> facets) {
     OpenLineage.DatasetFacetsBuilder builder =
         openLineage
             .newDatasetFacetsBuilder()

--- a/integration/spark/src/main/resources/META-INF/services/io.openlineage.spark.api.OpenLineageEventHandlerFactory
+++ b/integration/spark/src/main/resources/META-INF/services/io.openlineage.spark.api.OpenLineageEventHandlerFactory
@@ -1,0 +1,1 @@
+io.openlineage.spark3.agent.lifecycle.plan.Spark3EventHandlerFactory

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -21,7 +21,7 @@ import scala.PartialFunction;
 class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
 
   @Override
-  public List<PartialFunction<LogicalPlan, List<OpenLineage.OutputDataset>>> getOutputVisitors(
+  public List<PartialFunction<LogicalPlan, List<OutputDataset>>> getOutputVisitors(
       OpenLineageContext context) {
     DatasetFactory<OutputDataset> outputFactory = DatasetFactory.output(context.getOpenLineage());
     return ImmutableList.<PartialFunction<LogicalPlan, List<OutputDataset>>>builder()

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionDatasetFacetUtils.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionDatasetFacetUtils.java
@@ -1,0 +1,60 @@
+package io.openlineage.spark3.agent.facets.builder;
+
+import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
+
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.delta.files.TahoeLogFileIndex;
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+class DatasetVersionDatasetFacetUtils {
+
+  /**
+   * Check if we have all the necessary properties in DataSourceV2Relation to get dataset version.
+   */
+  public static Optional<String> extractVersionFromDataSourceV2Relation(
+      DataSourceV2Relation table) {
+    if (table.identifier().isEmpty()) {
+      log.warn("Couldn't find identifier for dataset in plan " + table);
+      return Optional.empty();
+    }
+    Identifier identifier = table.identifier().get();
+
+    if (table.catalog().isEmpty() || !(table.catalog().get() instanceof TableCatalog)) {
+      log.warn("Couldn't find catalog for dataset in plan " + table);
+      return Optional.empty();
+    }
+    TableCatalog tableCatalog = (TableCatalog) table.catalog().get();
+
+    Map<String, String> tableProperties = table.table().properties();
+    return CatalogUtils3.getDatasetVersion(tableCatalog, identifier, tableProperties);
+  }
+
+  /**
+   * Delta uses LogicalRelation's HadoopFsRelation as a logical plan's leaf. It implements FileIndex
+   * using TahoeLogFileIndex that contains DeltaLog, which can be used to get dataset's snapshot.
+   */
+  public static Optional<String> extractVersionFromLogicalRelation(
+      LogicalRelation logicalRelation) {
+    if (logicalRelation.relation() instanceof HadoopFsRelation) {
+      HadoopFsRelation fsRelation = (HadoopFsRelation) logicalRelation.relation();
+      asJavaOptional(logicalRelation.catalogTable());
+      if (logicalRelation.catalogTable().isDefined()
+          && logicalRelation.catalogTable().get().provider().isDefined()
+          && logicalRelation.catalogTable().get().provider().get().equalsIgnoreCase("delta")) {
+        if (fsRelation.location() instanceof TahoeLogFileIndex) {
+          TahoeLogFileIndex fileIndex = (TahoeLogFileIndex) fsRelation.location();
+          return Optional.of(Long.toString(fileIndex.getSnapshot().version()));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionOutputDatasetFacetBuilder.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionOutputDatasetFacetBuilder.java
@@ -1,0 +1,71 @@
+package io.openlineage.spark3.agent.facets.builder;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.V2WriteCommand;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+
+/**
+ * {@link CustomFacetBuilder} that generates a {@link OpenLineage.DatasetVersionDatasetFacet} if a
+ * {@link org.apache.spark.sql.execution.QueryExecution} is present and underlying system (ex.
+ * Delta, Iceberg) supports it.
+ *
+ * <p>To make sure we're getting right version, we need to get the output dataset's version after
+ * we've written it. There's no point in gettting this on START event - the version does not yet
+ * exist.
+ */
+@Slf4j
+@AllArgsConstructor
+public class DatasetVersionOutputDatasetFacetBuilder
+    extends CustomFacetBuilder<SparkListenerSQLExecutionEnd, OpenLineage.DatasetFacet> {
+
+  @NonNull protected final OpenLineageContext context;
+
+  @Override
+  public boolean isDefinedAt(Object x) {
+    if (!context.getQueryExecution().isPresent()) {
+      return false;
+    }
+    LogicalPlan plan = context.getQueryExecution().get().optimizedPlan();
+    return (x instanceof SparkListenerSQLExecutionEnd)
+        && (plan instanceof V2WriteCommand)
+        && ((((V2WriteCommand) plan).table() instanceof DataSourceV2Relation)
+            || (((V2WriteCommand) plan).table() instanceof LogicalRelation));
+  }
+
+  @Override
+  protected void build(
+      SparkListenerSQLExecutionEnd event,
+      BiConsumer<String, ? super OpenLineage.DatasetFacet> consumer) {
+    LogicalPlan logicalPlan = context.getQueryExecution().get().optimizedPlan();
+
+    Optional<DataSourceV2Relation> maybeTable = PlanUtils3.getDataSourceV2Relation(logicalPlan);
+    maybeTable
+        .flatMap(DatasetVersionDatasetFacetUtils::extractVersionFromDataSourceV2Relation)
+        .ifPresent(
+            version ->
+                consumer.accept(
+                    "datasetVersion",
+                    context.getOpenLineage().newDatasetVersionDatasetFacet(version)));
+
+    if (logicalPlan instanceof LogicalRelation) {
+      DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(
+              (LogicalRelation) logicalPlan)
+          .ifPresent(
+              version ->
+                  consumer.accept(
+                      "datasetVersion",
+                      context.getOpenLineage().newDatasetVersionDatasetFacet(version)));
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitor.java
@@ -48,7 +48,7 @@ public class CreateReplaceVisitor extends QueryPlanVisitor<LogicalPlan, OpenLine
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     TableCatalog tableCatalog;
     Map<String, String> tableProperties;
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
     Identifier identifier;
     StructType schema;
     TableStateChangeFacet.StateChange stateChange;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationVisitor.java
@@ -5,14 +5,16 @@ import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
 
 /**
  * Find {@link org.apache.spark.sql.sources.BaseRelation}s and {@link
- * org.apache.spark.sql.connector.catalog.Table} that implement the {@link DatasetSource} interface.
+ * org.apache.spark.sql.connector.catalog.Table}.
  *
  * <p>Note that while the {@link DataSourceV2Relation} is a {@link
  * org.apache.spark.sql.catalyst.analysis.NamedRelation}, the returned name is that of the source,
@@ -20,7 +22,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
  */
 @Slf4j
 public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
-    extends QueryPlanVisitor<DataSourceV2Relation, D> {
+    extends QueryPlanVisitor<LogicalPlan, D> {
 
   private final DatasetFactory<D> factory;
 
@@ -30,8 +32,20 @@ public class DataSourceV2RelationVisitor<D extends OpenLineage.Dataset>
   }
 
   @Override
+  public boolean isDefinedAt(LogicalPlan logicalPlan) {
+    return logicalPlan instanceof DataSourceV2Relation
+        || logicalPlan instanceof DataSourceV2ScanRelation;
+  }
+
+  @Override
   public List<D> apply(LogicalPlan logicalPlan) {
-    return PlanUtils3.fromDataSourceV2Relation(
-        factory, context, (DataSourceV2Relation) logicalPlan);
+    if (logicalPlan instanceof DataSourceV2Relation) {
+      return PlanUtils3.fromDataSourceV2Relation(
+          factory, context, (DataSourceV2Relation) logicalPlan);
+    } else if (logicalPlan instanceof DataSourceV2ScanRelation) {
+      return PlanUtils3.fromDataSourceV2Relation(
+          factory, context, ((DataSourceV2ScanRelation) logicalPlan).relation());
+    }
+    return Collections.emptyList();
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -29,7 +29,7 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
     ResolvedTable resolvedTable = ((ResolvedTable) ((DropTable) x).child());
     TableCatalog tableCatalog = resolvedTable.catalog();
     Map<String, String> tableProperties = resolvedTable.table().properties();

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/Spark3EventHandlerFactory.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/Spark3EventHandlerFactory.java
@@ -1,0 +1,57 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacet;
+import io.openlineage.client.OpenLineage.DatasetVersionDatasetFacet;
+import io.openlineage.client.OpenLineage.OutputDatasetFacet;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
+import io.openlineage.spark3.agent.facets.builder.DatasetVersionOutputDatasetFacetBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import lombok.AllArgsConstructor;
+import org.apache.spark.package$;
+
+public class Spark3EventHandlerFactory implements OpenLineageEventHandlerFactory {
+  @Override
+  public List<CustomFacetBuilder<?, ? extends OutputDatasetFacet>> createOutputDatasetFacetBuilders(
+      OpenLineageContext context) {
+    if (package$.MODULE$.SPARK_VERSION().startsWith("2")) {
+      return Collections.emptyList();
+    }
+    return ImmutableList.of(
+        new DatasetVersionFacetConverter<>(
+            context, new DatasetVersionOutputDatasetFacetBuilder(context)));
+  }
+
+  @AllArgsConstructor
+  private static class DatasetVersionFacetConverter<T>
+      extends CustomFacetBuilder<T, OpenLineage.OutputDatasetFacet> {
+    private final OpenLineageContext context;
+    private final CustomFacetBuilder<T, OpenLineage.DatasetFacet> parent;
+
+    @Override
+    public boolean isDefinedAt(Object x) {
+      return parent.isDefinedAt(x);
+    }
+
+    @Override
+    protected void build(T event, BiConsumer<String, ? super OutputDatasetFacet> consumer) {
+      parent.accept(event, wrappingConsumer(consumer));
+    }
+
+    private BiConsumer<String, DatasetFacet> wrappingConsumer(
+        BiConsumer<String, ? super OutputDatasetFacet> consumer) {
+      return (s, x) -> {
+        OutputDatasetFacet facet = context.getOpenLineage().newOutputDatasetFacet();
+        facet
+            .getAdditionalProperties()
+            .put("datasetVersion", ((DatasetVersionDatasetFacet) x).getDatasetVersion());
+        consumer.accept("datasetVersion", facet);
+      };
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
@@ -8,11 +8,12 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.IcebergHandler;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.spark.sql.catalyst.analysis.NamedRelation;
 import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -44,38 +45,26 @@ public class TableContentChangeVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    NamedRelation table;
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
+
+    Optional<DataSourceV2Relation> table = PlanUtils3.getDataSourceV2Relation(x);
+    if (!table.isPresent()) {
+      return Collections.emptyList();
+    }
 
     // INSERT OVERWRITE TABLE SQL statement is translated into InsertIntoTable logical operator.
     if (x instanceof OverwriteByExpression) {
-      table = ((OverwriteByExpression) x).table();
       includeOverwriteFacet(facetMap);
-    } else if (x instanceof InsertIntoStatement) {
-      table = (NamedRelation) ((InsertIntoStatement) x).table();
-      if (((InsertIntoStatement) x).overwrite()) {
-        includeOverwriteFacet(facetMap);
-      }
-    } else if (new IcebergHandler().hasClasses() && x instanceof ReplaceData) {
-      // DELETE FROM on ICEBERG HAS START ELEMENT WITH ReplaceData AND COMPLETE ONE WITH
-      // DeleteFromTable
-      table = ((ReplaceData) x).table();
-    } else if (x instanceof DeleteFromTable) {
-      table = (NamedRelation) ((DeleteFromTable) x).table();
-    } else if (x instanceof UpdateTable) {
-      table = (NamedRelation) ((UpdateTable) x).table();
-    } else if (x instanceof MergeIntoTable) {
-      table = (NamedRelation) ((MergeIntoTable) x).targetTable();
-    } else {
-      table = ((OverwritePartitionsDynamic) x).table();
+    } else if (x instanceof InsertIntoStatement && ((InsertIntoStatement) x).overwrite()) {
+      includeOverwriteFacet(facetMap);
+    } else if (x instanceof OverwritePartitionsDynamic) {
       includeOverwriteFacet(facetMap);
     }
 
-    return PlanUtils3.fromDataSourceV2Relation(
-        outputDataset(), context, (DataSourceV2Relation) table, facetMap);
+    return PlanUtils3.fromDataSourceV2Relation(outputDataset(), context, table.get(), facetMap);
   }
 
-  private void includeOverwriteFacet(Map<String, OpenLineage.DefaultDatasetFacet> facetMap) {
+  private void includeOverwriteFacet(Map<String, OpenLineage.DatasetFacet> facetMap) {
     facetMap.put("tableStateChange", new TableStateChangeFacet(OVERWRITE));
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
@@ -23,5 +23,11 @@ public interface CatalogHandler {
     return Optional.empty();
   }
 
+  /** Try to find string that uniquely identifies version of a dataset. */
+  default Optional<String> getDatasetVersion(
+      TableCatalog catalog, Identifier identifier, Map<String, String> properties) {
+    return Optional.empty();
+  }
+
   String getName();
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -60,6 +60,14 @@ public class CatalogUtils3 {
         : Optional.empty();
   }
 
+  public static Optional<String> getDatasetVersion(
+      TableCatalog catalog, Identifier identifier, Map<String, String> properties) {
+    Optional<CatalogHandler> catalogHandler = getCatalogHandler(catalog);
+    return catalogHandler.isPresent()
+        ? catalogHandler.get().getDatasetVersion(catalog, identifier, properties)
+        : Optional.empty();
+  }
+
   public static Optional<CatalogHandler> getCatalogHandlerByProvider(String provider) {
     return catalogHandlers.stream()
         .filter(handler -> handler.getName().equalsIgnoreCase(provider))

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -6,13 +6,16 @@ import io.openlineage.spark.agent.util.PathUtils;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.delta.catalog.DeltaCatalog;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 import scala.Option;
 
 @Slf4j
@@ -69,6 +72,19 @@ public class DeltaHandler implements CatalogHandler {
 
   public Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
     return Optional.of(new TableProviderFacet("delta", "parquet")); // Delta is always parquet
+  }
+
+  @SneakyThrows
+  public Optional<String> getDatasetVersion(
+      TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
+    DeltaCatalog deltaCatalog = (DeltaCatalog) tableCatalog;
+    Table table = deltaCatalog.loadTable(identifier);
+
+    if (table instanceof DeltaTableV2) {
+      DeltaTableV2 deltaTable = (DeltaTableV2) table;
+      return Optional.of(Long.toString(deltaTable.snapshot().version()));
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -332,6 +333,46 @@ public class SparkContainerIntegrationTest {
   public void testOptimizedCreateAsSelectAndLoad() {
     runPysparkContainerWithDefaultConf("testOptimizedCreateAsSelectAndLoad", "spark_octas_load.py");
     verifyEvents("pysparkOCTASStart.json", "pysparkOCTASEnd.json");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "spark.version", matches = SPARK_3) // Spark version >= 3.*
+  public void testWriteDeltaTableVersion() {
+    makePysparkContainerWithDefaultConf(
+            "testWriteDeltaTableVersion",
+            "--packages",
+            "io.delta:delta-core_2.12:1.0.0",
+            "/opt/spark_scripts/spark_write_delta_table_version.py")
+        .start();
+    verifyEvents("pysparkWriteDeltaTableVersionEnd.json");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "spark.version", matches = SPARK_3) // Spark version >= 3.*
+  public void testWriteDeltaTableVersionDoesNotAttachToInput() {
+    makePysparkContainerWithDefaultConf(
+      "testWriteDeltaTableVersion",
+      "--packages",
+      "io.delta:delta-core_2.12:1.0.0",
+      "/opt/spark_scripts/spark_write_delta_table_version_does_not_attach.py")
+      .start();
+    Assertions.assertThrows(
+      AssertionError.class,
+      () -> verifyEvents("pysparkWriteDeltaTableVersionDoesNotAttachToInputEnd.json")
+    );
+  }
+
+
+  @Test
+  @EnabledIfSystemProperty(named = "spark.version", matches = SPARK_3) // Spark version >= 3.*
+  public void testWriteIcebergTableVersion() {
+    makePysparkContainerWithDefaultConf(
+            "testWriteIcebergTableVersion",
+            "--packages",
+            "org.apache.iceberg:iceberg-spark3-runtime:0.12.0",
+            "/opt/spark_scripts/spark_write_iceberg_table_version.py")
+        .start();
+    verifyEvents("pysparkWriteIcebergTableVersionEnd.json");
   }
 
   @Test

--- a/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version.py
@@ -1,0 +1,15 @@
+import os
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Delta") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("packages", "io.delta:delta-core_2.12:1.0.0") \
+    .getOrCreate()
+
+spark.sql("CREATE TABLE versioned_table (a int, b int) USING delta LOCATION '/tmp/write_delta_table_version'")
+spark.sql("INSERT INTO versioned_table VALUES (1, 2)")

--- a/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version_does_not_attach.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version_does_not_attach.py
@@ -1,0 +1,20 @@
+import os
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Delta") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("packages", "io.delta:delta-core_2.12:1.0.0") \
+    .getOrCreate()
+
+spark.sql("CREATE TABLE first_source (a int, b int) USING delta LOCATION '/tmp/write_delta_table_version_first_source'")
+spark.sql("CREATE TABLE second_source (a int, b int) USING delta LOCATION '/tmp/write_delta_table_version_second_source'")
+spark.sql("INSERT INTO first_source VALUES (1, 2)")
+spark.sql("INSERT INTO second_source VALUES (1, 2)")
+
+spark.sql("CREATE TABLE versioned_table (a int, b int) USING delta LOCATION '/tmp/write_delta_table_version'")
+spark.sql("INSERT INTO versioned_table (SELECT * FROM first_source UNION ALL SELECT * FROM second_source)")

--- a/integration/spark/src/test/resources/spark_scripts/spark_write_iceberg_table_version.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_write_iceberg_table_version.py
@@ -1,0 +1,16 @@
+import os
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/v2", exist_ok=True)
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Iceberg") \
+    .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog") \
+    .config("spark.sql.catalog.local.type", "hadoop") \
+    .config("spark.sql.catalog.local.warehouse", "/tmp/write_iceberg_table_version") \
+    .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions") \
+    .getOrCreate()
+
+spark.sql("CREATE TABLE local.db.table (a int, b int) USING iceberg")
+spark.sql("INSERT INTO local.db.table VALUES (1, 2)")

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionOutputDatasetFacetBuilderTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/facets/builder/DatasetVersionOutputDatasetFacetBuilderTest.java
@@ -1,0 +1,93 @@
+package io.openlineage.spark3.agent.facets.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.plans.logical.AppendData;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.delta.catalog.DeltaCatalog;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+public class DatasetVersionOutputDatasetFacetBuilderTest {
+  QueryExecution queryExecution = mock(QueryExecution.class);
+
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+          .queryExecution(queryExecution)
+          .build();
+
+  DataSourceV2Relation table = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+  AppendData plan = mock(AppendData.class);
+  Identifier identifier = Identifier.of(new String[] {}, "table");
+
+  @BeforeEach
+  public void setUp() {
+    when(plan.table()).thenReturn(table);
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    when(table.identifier()).thenReturn(Option.apply(identifier));
+    when(table.table().properties()).thenReturn(Collections.emptyMap());
+  }
+
+  @Test
+  void testExtractIcebergDatasetVersionFacet() throws NoSuchTableException {
+    TableCatalog catalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+
+    when(table.catalog()).thenReturn(Option.apply(catalog));
+
+    when(catalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table()).thenReturn(mock(org.apache.iceberg.Table.class));
+    when(sparkTable.table().currentSnapshot()).thenReturn(mock(org.apache.iceberg.Snapshot.class));
+    when(sparkTable.table().currentSnapshot().snapshotId()).thenReturn(1500100900L);
+    checkBuilder();
+  }
+
+  @Test
+  void testExtractDeltaDatasetVersionFacet() {
+    DeltaCatalog catalog = mock(DeltaCatalog.class);
+    DeltaTableV2 deltaTable = mock(DeltaTableV2.class, RETURNS_DEEP_STUBS);
+
+    when(table.catalog()).thenReturn(Option.apply(catalog));
+    when(catalog.loadTable(identifier)).thenReturn(deltaTable);
+    when(deltaTable.snapshot().version()).thenReturn(1500100900L);
+    checkBuilder();
+  }
+
+  void checkBuilder() {
+    DatasetVersionOutputDatasetFacetBuilder builder =
+        new DatasetVersionOutputDatasetFacetBuilder(openLineageContext);
+
+    List<OpenLineage.DatasetFacet> facets = new ArrayList<>();
+    builder.build(SparkListenerSQLExecutionEnd.apply(1L, 1L), (s, v) -> facets.add(v));
+
+    assertThat(facets).hasSize(1);
+    assertThat(facets.get(0))
+        .isInstanceOfSatisfying(
+            OpenLineage.DatasetVersionDatasetFacet.class,
+            facet -> assertThat(facet.getDatasetVersion()).isEqualTo("1500100900"));
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -102,6 +103,10 @@ public class TableContentChangeVisitorTest {
     when(logicalPlan.overwrite()).thenReturn(false);
 
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      mocked
+          .when(() -> PlanUtils3.getDataSourceV2Relation(logicalPlan))
+          .thenReturn(Optional.of(dataSourceV2Relation));
+
       visitor.apply(logicalPlan);
       mocked.verify(
           () ->
@@ -127,9 +132,12 @@ public class TableContentChangeVisitorTest {
 
   private void verify(LogicalPlan logicalPlan, TableStateChangeFacet.StateChange stateChange) {
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      mocked
+          .when(() -> PlanUtils3.getDataSourceV2Relation(logicalPlan))
+          .thenReturn(Optional.of(dataSourceV2Relation));
       visitor.apply(logicalPlan);
 
-      Map<String, OpenLineage.DefaultDatasetFacet> expectedFacets;
+      Map<String, OpenLineage.DatasetFacet> expectedFacets;
       if (stateChange == null) {
         expectedFacets = Collections.emptyMap();
       } else {

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -1,6 +1,37 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
-public class DeltaHandlerTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-  // FIXME: write test
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.delta.catalog.DeltaCatalog;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class DeltaHandlerTest {
+  @Test
+  public void testGetVersionString() {
+    DeltaCatalog deltaCatalog = mock(DeltaCatalog.class);
+    DeltaTableV2 deltaTable = mock(DeltaTableV2.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+
+    DeltaHandler deltaHandler = new DeltaHandler();
+
+    when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
+    when(deltaTable.snapshot().version()).thenReturn(2L);
+
+    Optional<String> version =
+        deltaHandler.getDatasetVersion(deltaCatalog, identifier, Collections.emptyMap());
+
+    assertTrue(version.isPresent());
+    assertEquals(version.get(), "2");
+  }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -1,6 +1,8 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -11,7 +13,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
 import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,5 +86,21 @@ public class IcebergHandlerTest {
         icebergHandler.getTableProviderFacet(new HashMap<>());
     assertEquals("iceberg", tableProviderFacet.get().getProvider());
     assertEquals("", tableProviderFacet.get().getFormat());
+  }
+
+  @Test
+  public void testGetVersionString() throws NoSuchTableException {
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().currentSnapshot().snapshotId()).thenReturn(1500100900L);
+
+    Optional<String> version =
+        icebergHandler.getDatasetVersion(sparkCatalog, identifier, Collections.emptyMap());
+
+    assertTrue(version.isPresent());
+    assertEquals(version.get(), "1500100900");
   }
 }

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -38,7 +38,7 @@ public class PlanUtils3Test {
   TableCatalog tableCatalog = mock(TableCatalog.class);
   Identifier identifier = mock(Identifier.class);
   StructType schema = mock(StructType.class);
-  Map<String, OpenLineage.DefaultDatasetFacet> facets;
+  Map<String, OpenLineage.DatasetFacet> facets;
   Table table = mock(Table.class);
   Map<String, String> tableProperties;
 

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -123,6 +123,8 @@ Example of valid name is `BigQueryStatisticsJobFacet` and it's key `bigQuery_sta
 
 - **dataSource**: Captures the Database instance containing this datasets (ex: Database schema. Object store bucket, ...)
 
+- **version**: Captures the dataset version when versioning is defined by database (ex. Iceberg snapshot ID)
+
 #### Input Dataset Facets
 
 - **dataQualityMetrics**: Captures dataset level and column level data quality metrics when scanning a dataset whith a DataQuality library (row count, byte size, null count, distinct count, average, min, max, quantiles).

--- a/spec/facets/DatasetVersionDatasetFacet.json
+++ b/spec/facets/DatasetVersionDatasetFacet.json
@@ -1,0 +1,33 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$id" : "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json",
+  "$defs" : {
+    "DatasetVersionDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/1-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "datasetVersion": {
+              "description": "The version of the dataset.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "datasetVersion"
+          ]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "version" : {
+      "$ref" : "#/$defs/DatasetVersionDatasetFacet"
+    }
+  }
+}


### PR DESCRIPTION
This commit adds `DatasetVersionDatasetFacet` to OpenLineage spec.

It implements this facet for v2 writes in Apache Spark for output datasets, where provider is Iceberg or Delta.
In both cases, we use their implementation of `TableCatalog` to get their internal dataset versions. 

The implementation utilizes new facet builder API for output dataset facets. This allows the main class of this commit: `DatasetVersionOutputDatasetFacetBuilder` to listen only on `SparkListenerSQLExecutionEnd` event, which is emitted only when writing to dataset, both data and metadata is complete. Other events, like `SparkListenerJobEnd` do not have this property. 

This PR will someday be followed with implementation of this facet for input datasets. The main blocker is that we can't use current structure of `CustomFacetBuilder` that attaches resulting facet to any dataset. There can be multiple input datasets, and they can have different versions, or have no explicit version. Issue is described here: https://github.com/OpenLineage/OpenLineage/issues/484

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
