### PR TITLE
Makes corrections to QueryPlanVisitors for dealing with DeltaDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * dbt: job namespaces for given dbt run match each other [@mobuchowski](https://github.com/mobuchowski)
 * Fix Breaking SnowflakeOperator Changes from OSS Airflow [@denimalpaca](https://github.com/denimalpaca)
 
+### Fixed
+* Made corrections to account for DeltaDataSource handling [@collado-mike](https://github.com/collado-mike)
+
 ## [0.5.1](https://github.com/OpenLineage/OpenLineage/compare/0.4.0...0.5.1)
 ### Added
 * Support for dbt-spark adapter [@mobuchowski](https://github.com/mobuchowski)

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -207,8 +207,8 @@ sourceSets {
     }
 }
 
-compileJava.finalizedBy compileSpark3Java
-compileTestJava.finalizedBy compileSpark3TestJava
+compileJava.finalizedBy compileSpark2Java, compileSpark3Java
+compileTestJava.finalizedBy compileSpark2TestJava, compileSpark3TestJava
 
 task sourceJar(type: Jar) {
     classifier 'sources'

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -36,6 +36,7 @@ import org.apache.spark.SparkEnv$;
 import org.apache.spark.rdd.PairRDDFunctions;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
@@ -274,6 +275,12 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     sparkSqlExecutionRegistry.clear();
     rddExecutionRegistry.clear();
     outputs.clear();
+  }
+
+  @Override
+  public void onApplicationEnd(SparkListenerApplicationEnd applicationEnd) {
+    close();
+    super.onApplicationEnd(applicationEnd);
   }
 
   /** To close the underlying resources. */

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
@@ -2,14 +2,17 @@
 
 package io.openlineage.spark.agent;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.spark.agent.client.OpenLineageClient;
 import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Optional;
 import net.bytebuddy.agent.ByteBuddyAgent;
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.SparkSession$;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -20,6 +23,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 
 /**
  * JUnit extension that invokes the {@link SparkAgent} by installing the {@link ByteBuddyAgent} to
@@ -45,6 +49,14 @@ public class SparkAgentTestExtension
   @Override
   public void beforeEach(ExtensionContext context) throws Exception {
     Mockito.reset(OPEN_LINEAGE_SPARK_CONTEXT);
+    Mockito.doAnswer(
+            (arg) -> {
+              LoggerFactory.getLogger(getClass())
+                  .info("Emit called with arg {}", BeanUtils.describe(arg));
+              return null;
+            })
+        .when(OPEN_LINEAGE_SPARK_CONTEXT)
+        .emit(any(RunEvent.class));
   }
 
   @Override

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceIntegrationTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceIntegrationTest.java
@@ -1,0 +1,80 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.LongType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class DeltaDataSourceIntegrationTest {
+
+  @Test
+  public void testInsertIntoDeltaSource(@TempDir Path tempDir, SparkSession spark)
+      throws IOException, InterruptedException, TimeoutException {
+    StructType tableSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("name", StringType$.MODULE$, false, Metadata.empty()),
+              new StructField("age", LongType$.MODULE$, false, Metadata.empty())
+            });
+    Dataset<Row> df =
+        spark.createDataFrame(
+            Arrays.asList(
+                new GenericRowWithSchema(new Object[] {"john", 25L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"sam", 22L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"alicia", 35L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"bob", 47L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"jordan", 52L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"liz", 19L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"marcia", 83L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"maria", 40L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"luis", 8L}, tableSchema),
+                new GenericRowWithSchema(new Object[] {"gabriel", 30L}, tableSchema)),
+            tableSchema);
+
+    String deltaDir = tempDir.resolve("deltaData").toAbsolutePath().toString();
+    df.write().format("delta").option("path", deltaDir).mode(SaveMode.Overwrite).save();
+    // wait for event processing to complete
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, Mockito.atLeast(2))
+        .emit(lineageEvent.capture());
+    List<RunEvent> events = lineageEvent.getAllValues();
+    Optional<RunEvent> completionEvent =
+        events.stream()
+            .filter(e -> e.getEventType().equals("COMPLETE") && !e.getOutputs().isEmpty())
+            .findFirst();
+    assertTrue(completionEvent.isPresent());
+    OpenLineage.RunEvent event = completionEvent.get();
+    List<OpenLineage.OutputDataset> outputs = event.getOutputs();
+    assertEquals(1, outputs.size());
+    assertEquals("file", outputs.get(0).getNamespace());
+    assertEquals(deltaDir, outputs.get(0).getName());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class DeltaDataSourceTest {
     List<RunEvent> events = lineageEvent.getAllValues();
     Optional<RunEvent> completionEvent =
         events.stream()
-            .filter(e -> e.getEventType().equals("COMPLETE") && !e.getOutputs().isEmpty())
+            .filter(e -> e.getEventType().equals(EventType.COMPLETE) && !e.getOutputs().isEmpty())
             .findFirst();
     assertTrue(completionEvent.isPresent());
     OpenLineage.RunEvent event = completionEvent.get();

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DeltaDataSourceTest.java
@@ -30,7 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @ExtendWith(SparkAgentTestExtension.class)
-public class DeltaDataSourceIntegrationTest {
+public class DeltaDataSourceTest {
 
   @Test
   public void testInsertIntoDeltaSource(@TempDir Path tempDir, SparkSession spark)


### PR DESCRIPTION
### Problem
Address both https://github.com/OpenLineage/OpenLineage/issues/458 and https://github.com/OpenLineage/OpenLineage/issues/459 . This corrects the Hadoop Configuration construction for underlying LogicalRelations and also adds specific handling for Delta relations to the `SaveIntoDataSourceCommandVisitor`.  

As part of the latter fix, I needed to tweak how the tests manage the permits for the test execution. The Delta source ends up triggering multiple events, which need to run simultaneously, so multiple open permits became necessary. I picked `5` as a random number of permits to support. It's arbitrary and can be changed if needed.

Closes: #458 and #459

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)