### PR TITLE
[INTEGRATION][SPARK] Support Databricks Proprietary Delta Catalog 

### DIFF
--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -20,6 +20,7 @@ public class CatalogUtils3 {
         Arrays.asList(
             new IcebergHandler(),
             new DeltaHandler(),
+            new DatabricksDeltaHandler(),
             new JdbcHandler(),
             new V2SessionCatalogHandler());
     return handlers.stream().filter(CatalogHandler::hasClasses).collect(Collectors.toList());

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
@@ -1,0 +1,95 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import io.openlineage.spark.agent.facets.TableProviderFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import scala.Option;
+
+/**
+ * The DatabricksDeltaHandler is intended to support Databricks' custom DeltaCatalog which has the
+ * class name of com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog rather than the open
+ * source class name of org.apache.spark.sql.delta.catalog.DeltaCatalog. It is used in the same way
+ * as the {@link DeltaHandler}.
+ */
+@Slf4j
+public class DatabricksDeltaHandler implements CatalogHandler {
+  public boolean hasClasses() {
+    try {
+      DeltaHandler.class
+          .getClassLoader()
+          .loadClass("com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isClass(TableCatalog tableCatalog) {
+    return tableCatalog
+        .getClass()
+        .getCanonicalName()
+        .equals("com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog");
+  }
+
+  @Override
+  public DatasetIdentifier getDatasetIdentifier(
+      SparkSession session,
+      TableCatalog tableCatalog,
+      Identifier identifier,
+      Map<String, String> properties) {
+
+    Optional<String> location;
+    boolean isPathIdentifier = false;
+    try {
+      isPathIdentifier =
+          (boolean) MethodUtils.invokeMethod(tableCatalog, true, "isPathIdentifier", identifier);
+    } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+      // DO Nothing
+    }
+
+    if (isPathIdentifier) {
+      location = Optional.of(identifier.name());
+    } else {
+      location = Optional.ofNullable(properties.get("location"));
+    }
+    // Delta uses spark2 catalog when location isn't specified.
+    Path path =
+        new Path(
+            location.orElse(
+                session
+                    .sessionState()
+                    .catalog()
+                    .defaultTablePath(
+                        TableIdentifier.apply(
+                            identifier.name(),
+                            Option.apply(
+                                Arrays.stream(identifier.namespace())
+                                    .reduce((x, y) -> y)
+                                    .orElse(null))))
+                    .toString()));
+    log.info(path.toString());
+    return PathUtils.fromPath(path, "file");
+  }
+
+  public Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
+    return Optional.of(new TableProviderFacet("delta", "parquet")); // Delta is always parquet
+  }
+
+  @Override
+  public String getName() {
+    return "delta";
+  }
+}


### PR DESCRIPTION
### Problem

Databricks appears to use a proprietary Delta Catalog class. As a result, it seems that the `DeltaHandler` in the Spark Integration misses / fails to process some commands when using Spark SQL and Delta tables.

Closes: #487 

### Solution

Introduces a DatabricksDeltaHandler similar to DeltaHandler. The major difference being a reference to Databrick's proprietary class for Delta "com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog"

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)