### PR TITLE
Fix build.gradle to work better with IntelliJ classpaths

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -176,12 +176,29 @@ dependencies {
 }
 
 sourceSets {
-    main.java.srcDirs = ["src/main/common/java", "src/main/spark2/java"]
-    test.java.srcDirs = ["src/test/common/java", "src/test/spark2/java"]
+    main.java.srcDirs = ["src/main/common/java"]
+    test.java.srcDirs = ["src/test/common/java"]
 
-    spark3{
+    spark2 {
         java {
-            srcDirs = ["src/main/common/java", "src/main/spark3/java"]
+            srcDirs = ["src/main/spark2/java"]
+            compileClasspath = sourceSets.main.compileClasspath + sourceSets.main.output
+            annotationProcessorPath = configurations.lombok
+            destinationDirectory.set(file("$buildDir/classes/java/main/"))
+        }
+    }
+    spark2Test {
+        java {
+            srcDirs = ["src/test/spark2/java"]
+            compileClasspath = sourceSets.test.compileClasspath + sourceSets.test.output
+            annotationProcessorPath = configurations.lombok
+            destinationDirectory.set(file("$buildDir/classes/java/test/"))
+        }
+    }
+
+    spark3 {
+        java {
+            srcDirs = ["src/main/spark3/java"]
             compileClasspath = configurations.spark3 + sourceSets.main.output
             annotationProcessorPath = configurations.lombok
             destinationDirectory.set(file("$buildDir/classes/java/main/"))
@@ -191,7 +208,7 @@ sourceSets {
     spark3Test {
         java {
             srcDirs = ["src/test/common/java", "src/test/spark3/java"]
-            compileClasspath = configurations.spark3Test + sourceSets.main.output
+            compileClasspath = configurations.spark3Test + sourceSets.main.output + sourceSets.test.output + sourceSets.spark3.output
             annotationProcessorPath = configurations.lombok
             destinationDirectory.set(file("$buildDir/classes/java/test/"))
         }
@@ -234,7 +251,8 @@ def commonTestConfiguration = {
             'openlineage.spark.jar': "${archivesBaseName}-${project.version}.jar",
             'kafka.package.version': kafkaPackage(scalaVersion, project.getProperty('spark.version'))
     ]
-    classpath =  project.sourceSets.test.runtimeClasspath + (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
+    classpath =  project.sourceSets.test.runtimeClasspath +
+            (isSpark3 ? configurations.spark3Test : configurations.spark2Test)
 }
 
 test {


### PR DESCRIPTION
### Problem
The project setup, with separate Spark 2/3 main and test classpaths builds, but isn't correctly interpreted by IntellIJ, meaning editors can't auto-complete or run certain tests in the IDE. This updates the build to have separate `main` and `test` modules that can be depended on by both Spark2 and Spark3 modules in IntellIJ so that everything can be built and run directly in the IDE.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)