### PR TITLE
implement input visitors for v2 commands

### DIFF
--- a/integration/spark/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
@@ -4,10 +4,52 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.atomic_create_table_as_select"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2/db.source1",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "a",
+            "type": "long"
+          },
+          {
+            "name": "b",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  }, {
+    "namespace" : "file",
+    "name" : "/tmp/v2/db.source2",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "a",
+            "type": "long"
+          },
+          {
+            "name": "b",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/v2/db.tbl",
+    "name" : "/tmp/v2/db.target",
     "facets" : {
       "dataSource" : {
         "name" : "file",

--- a/integration/spark/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
@@ -4,10 +4,52 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.atomic_create_table_as_select"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2/db.source1",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "a",
+            "type": "long"
+          },
+          {
+            "name": "b",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  }, {
+    "namespace" : "file",
+    "name" : "/tmp/v2/db.source2",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields": [
+          {
+            "name": "a",
+            "type": "long"
+          },
+          {
+            "name": "b",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/v2/db.tbl",
+    "name" : "/tmp/v2/db.target",
     "facets" : {
       "dataSource" : {
         "name" : "file",

--- a/integration/spark/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
@@ -4,7 +4,25 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.replace_data"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_merge/db.updates",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "event_id",
+          "type" : "long"
+        }, {
+          "name" : "updated_at",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/v2_merge/db.events",

--- a/integration/spark/integrations/container/pysparkV2MergeIntoTableStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2MergeIntoTableStartEvent.json
@@ -4,7 +4,25 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.replace_data"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_merge/db.updates",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "event_id",
+          "type" : "long"
+        }, {
+          "name" : "updated_at",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/v2_merge/db.events",

--- a/integration/spark/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
@@ -4,7 +4,28 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.overwrite_partitions_dynamic"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.source",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        }, {
+          "name" : "c",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/v2_overwrite/db.tbl",

--- a/integration/spark/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
+++ b/integration/spark/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
@@ -4,7 +4,28 @@
     "namespace" : "testV2Commands",
     "name" : "open_lineage_integration_v2_commands.overwrite_partitions_dynamic"
   },
-  "inputs" : [ ],
+  "inputs" : [  {
+    "namespace" : "file",
+    "name" : "/tmp/v2_overwrite/db.source",
+    "facets" : {
+      "dataSource": {
+        "name": "file",
+        "uri": "file"
+      },
+      "schema": {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        }, {
+          "name" : "c",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/v2_overwrite/db.tbl",

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -3,6 +3,7 @@ package io.openlineage.spark.agent.lifecycle;
 import com.google.common.collect.ImmutableList;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.Dataset;
+import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -10,6 +11,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.AlterTableVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateTableLikeCommandVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.DropTableVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeVisitor;
 import java.util.List;
@@ -30,6 +32,17 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
         .add(new CreateTableLikeCommandVisitor(context))
         .add(new DropTableVisitor(context))
         .add(new AlterTableVisitor(context))
+        .build();
+  }
+
+  @Override
+  public List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> getInputVisitors(
+      OpenLineageContext context) {
+    DatasetFactory<InputDataset> inputFactory = DatasetFactory.input(context.getOpenLineage());
+    return ImmutableList.<PartialFunction<LogicalPlan, List<InputDataset>>>builder()
+        .addAll(super.getInputVisitors(context))
+        .add(new DataSourceV2RelationVisitor(context, inputFactory))
+        .add(new DataSourceV2ScanRelationVisitor(context, inputFactory))
         .build();
   }
 

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationVisitor.java
@@ -1,0 +1,34 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
+
+/**
+ * Find {@link org.apache.spark.sql.sources.BaseRelation}s and {@link
+ * org.apache.spark.sql.connector.catalog.Table} that implement the {@link DatasetSource} interface.
+ */
+@Slf4j
+public class DataSourceV2ScanRelationVisitor<D extends OpenLineage.Dataset>
+    extends QueryPlanVisitor<DataSourceV2ScanRelation, D> {
+
+  private final DatasetFactory<D> factory;
+
+  public DataSourceV2ScanRelationVisitor(OpenLineageContext context, DatasetFactory<D> factory) {
+    super(context);
+    this.factory = factory;
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan logicalPlan) {
+    DataSourceV2ScanRelation dataSourceV2ScanRelation = (DataSourceV2ScanRelation) logicalPlan;
+    return PlanUtils3.fromDataSourceV2Relation(
+        factory, context, dataSourceV2ScanRelation.relation());
+  }
+}

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_create_as_select.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_create_as_select.py
@@ -20,5 +20,7 @@ df = spark.createDataFrame([
     {'a': 3, 'b': 4}
 ])
 df.createOrReplaceTempView('temp')
+spark.sql("CREATE TABLE local.db.source1 USING iceberg AS SELECT * FROM temp")
+spark.sql("CREATE TABLE local.db.source2 USING iceberg AS SELECT * FROM temp")
 
-spark.sql("CREATE TABLE local.db.tbl USING iceberg AS SELECT * FROM temp")
+spark.sql("CREATE TABLE local.db.target USING iceberg AS (SELECT * FROM local.db.source1 UNION SELECT * FROM local.db.source2)")

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_partitions.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_overwrite_partitions.py
@@ -22,9 +22,10 @@ df = spark.createDataFrame([
     {'a': 4, 'b': 5, 'c': 6}
 ])
 df.createOrReplaceTempView('temp')
+spark.sql("CREATE TABLE local.db.source USING iceberg AS SELECT * FROM temp")
 
 spark.sql("CREATE TABLE local.db.tbl (a long, b  long) PARTITIONED BY (c long)")
 spark.sql("INSERT INTO local.db.tbl PARTITION (c=1) VALUES (2, 3)")
-spark.sql("INSERT OVERWRITE TABLE local.db.tbl PARTITION(c) SELECT * FROM temp")
+spark.sql("INSERT OVERWRITE TABLE local.db.tbl PARTITION(c) SELECT * FROM local.db.source")
 
 

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationScanVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationScanVisitorTest.java
@@ -1,0 +1,40 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class DataSourceV2RelationScanVisitorTest {
+
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  DatasetFactory<OpenLineage.OutputDataset> datasetFactory = mock(DatasetFactory.class);
+  DataSourceV2ScanRelationVisitor visitor =
+      new DataSourceV2ScanRelationVisitor(openLineageContext, datasetFactory);
+  LogicalPlan logicalPlan = mock(DataSourceV2ScanRelation.class);
+  DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
+
+  @Test
+  public void testApply() {
+    when(((DataSourceV2ScanRelation) logicalPlan).relation()).thenReturn(dataSourceV2Relation);
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      visitor.apply(logicalPlan);
+      mocked.verify(
+          () ->
+              PlanUtils3.fromDataSourceV2Relation(
+                  datasetFactory, openLineageContext, dataSourceV2Relation),
+          times(1));
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Input dataset information due to missing input visitors. 

Relates to: #462

### Solution

Implement input visitors and include the gathered input datasets in integration tests. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)