### PR TITLE
include input integration tests

### DIFF
--- a/integration/spark/integrations/container/pysparkCTASEnd.json
+++ b/integration/spark/integrations/container/pysparkCTASEnd.json
@@ -4,7 +4,25 @@
     "namespace" : "testCreateAsSelectAndLoad",
     "name" : "open_lineage_integration_cta_s_load.execute_create_hive_table_as_select_command"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/ctas_load/temp",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/ctas_load/tbl1",

--- a/integration/spark/integrations/container/pysparkCTASStart.json
+++ b/integration/spark/integrations/container/pysparkCTASStart.json
@@ -4,7 +4,25 @@
     "namespace" : "testCreateAsSelectAndLoad",
     "name" : "open_lineage_integration_cta_s_load.execute_create_hive_table_as_select_command"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/ctas_load/temp",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/ctas_load/tbl1",

--- a/integration/spark/integrations/container/pysparkDeltaCTASComplete.json
+++ b/integration/spark/integrations/container/pysparkDeltaCTASComplete.json
@@ -5,6 +5,25 @@
     "name": "open_lineage_integration_delta.atomic_create_table_as_select",
     "namespace": "testCTASDelta"
   },
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/delta/temp",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs": [
     {
       "facets": {
@@ -28,7 +47,7 @@
           "stateChange" : "create"
         }
       },
-      "name": "/tmp/delta",
+      "name": "/tmp/delta/tbl",
       "namespace": "file"
     }
   ],

--- a/integration/spark/integrations/container/pysparkOCTASEnd.json
+++ b/integration/spark/integrations/container/pysparkOCTASEnd.json
@@ -4,7 +4,25 @@
     "namespace" : "testOptimizedCreateAsSelectAndLoad",
     "name" : "open_lineage_integration_octa_s_load.execute_optimized_create_hive_table_as_select_command"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/ctas_load/temp",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/ctas_load/tbl2",

--- a/integration/spark/integrations/container/pysparkOCTASStart.json
+++ b/integration/spark/integrations/container/pysparkOCTASStart.json
@@ -4,7 +4,25 @@
     "namespace" : "testOptimizedCreateAsSelectAndLoad",
     "name" : "open_lineage_integration_octa_s_load.execute_optimized_create_hive_table_as_select_command"
   },
-  "inputs" : [ ],
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/ctas_load/temp",
+    "facets" : {
+      "dataSource" : {
+        "name" : "file",
+        "uri" : "file"
+      },
+      "schema" : {
+        "fields" : [ {
+          "name" : "a",
+          "type" : "long"
+        }, {
+          "name" : "b",
+          "type" : "long"
+        } ]
+      }
+    }
+  } ],
   "outputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/ctas_load/tbl2",

--- a/integration/spark/src/test/resources/spark_scripts/spark_ctas_load.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_ctas_load.py
@@ -18,7 +18,7 @@ df = spark.createDataFrame([
     {'a': 3, 'b': 4}
 ])
 
-df.createOrReplaceTempView('temp')
+df.write.saveAsTable('temp')
 
 spark.sql("CREATE TABLE tbl1 USING hive LOCATION '/tmp/ctas_load/tbl1' AS SELECT a, b FROM temp")
 

--- a/integration/spark/src/test/resources/spark_scripts/spark_delta.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_delta.py
@@ -9,6 +9,7 @@ spark = SparkSession.builder \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
     .config("packages", "io.delta:delta-core_2.12:1.0.0") \
+    .config("spark.sql.warehouse.dir", "file:/tmp/delta/") \
     .getOrCreate()
 spark.sparkContext.setLogLevel('info')
 
@@ -16,6 +17,6 @@ df = spark.createDataFrame([
     {'a': 1, 'b': 2},
     {'a': 3, 'b': 4}
 ])
-df.createOrReplaceTempView('temp')
+df.write.saveAsTable('temp')
 
-spark.sql("CREATE TABLE tbl USING delta LOCATION '/tmp/delta' AS SELECT * FROM temp")
+spark.sql("CREATE TABLE tbl USING delta LOCATION '/tmp/delta/tbl' AS SELECT * FROM temp")

--- a/integration/spark/src/test/resources/spark_scripts/spark_octas_load.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_octas_load.py
@@ -17,6 +17,6 @@ df = spark.createDataFrame([
     {'a': 3, 'b': 4}
 ])
 
-df.createOrReplaceTempView('temp')
+df.write.saveAsTable('temp')
 
 spark.sql("CREATE TABLE tbl2 STORED AS PARQUET LOCATION '/tmp/ctas_load/tbl2' AS SELECT a, b FROM temp")


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Input dataset information due to missing input visitors for non v2 commands

Closes: #462

### Solution

Include collected inputs information in integration tests.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)