### PR TITLE
dbt: make 'enclosing' job namespace match internal jobs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Proxy backend example using `Kafka` [@wslulciuc](https://github.com/wslulciuc)
 
+### Fixed
+
+* dbt: job namespaces for given dbt run match each other [@mobuchowski](https://github.com/mobuchowski)
+
 ## [0.5.1](https://github.com/OpenLineage/OpenLineage/compare/0.4.0...0.5.1)
 ### Added
 * Support for dbt-spark adapter [@mobuchowski](https://github.com/mobuchowski)

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -156,6 +156,7 @@ class DbtArtifactProcessor:
         self,
         producer: str,
         project_dir: str,
+        job_namespace: str,
         profile_name: Optional[str] = None,
         target: Optional[str] = None,
         skip_errors: bool = False,
@@ -169,7 +170,7 @@ class DbtArtifactProcessor:
         self.jinja_environment = None
         self.logger = logger
 
-        self.job_namespace = ""
+        self.job_namespace = job_namespace
         self.dataset_namespace = ""
         self.skip_errors = skip_errors
         self.project = self.load_yaml_with_jinja(os.path.join(project_dir, 'dbt_project.yml'))
@@ -220,7 +221,6 @@ class DbtArtifactProcessor:
 
         self.extract_adapter_type(profile)
         self.extract_dataset_namespace(profile)
-        self.extract_job_namespace(profile)
 
         nodes = {}
         # Filter non-model or test nodes
@@ -655,12 +655,6 @@ class DbtArtifactProcessor:
 
     def extract_dataset_namespace(self, profile: Dict):
         self.dataset_namespace = self.extract_namespace(profile)
-
-    def extract_job_namespace(self, profile: Dict):
-        self.job_namespace = os.environ.get(
-            'OPENLINEAGE_NAMESPACE',
-            self.extract_namespace(profile)
-        )
 
     def extract_namespace(self, profile: Dict) -> str:
         """Extract namespace from profile's type"""

--- a/integration/common/tests/dbt/build/result.json
+++ b/integration/common/tests/dbt/build/result.json
@@ -3,7 +3,7 @@
 	    "eventTime": "{{ is_datetime(result) }}",
         "eventType": "START",
         "job": {
-            "namespace": "bigquery",
+            "namespace": "job-namespace",
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.run"
         },
         "run": {
@@ -15,7 +15,7 @@
         "eventType": "START",
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.test",
-            "namespace": "bigquery"
+            "namespace": "job-namespace"
         },
         "run": {
             "runId": "{{ any(result) }}"
@@ -34,7 +34,7 @@
         "job": {
             "facets": {},
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.run",
-            "namespace": "bigquery"
+            "namespace": "job-namespace"
         },
         "inputs": [],
         "run": {
@@ -83,7 +83,7 @@
         "job": {
             "facets": {},
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.test",
-            "namespace": "bigquery"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "run": {

--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -33,7 +33,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/env_vars/result.json
+++ b/integration/common/tests/dbt/env_vars/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "redshift://foo_host:1111",
+		"namespace": "ol-namespace",
 		"name": "foo_db_name.foo_schema.dbt_test.test_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -33,7 +33,7 @@
 		}
 	},
 	"job": {
-		"namespace": "redshift://foo_host:1111",
+		"namespace": "ol-namespace",
 		"name": "foo_db_name.foo_schema.dbt_test.test_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -25,7 +25,7 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {}
 	},
@@ -45,7 +45,7 @@
 		"facets": {}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {}
 	},
@@ -77,7 +77,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
 		"facets": {
 			"sql": {
@@ -123,7 +123,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
 		"facets": {
 			"sql": {
@@ -181,7 +181,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_orders"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -21,7 +21,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_payments"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -37,7 +37,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -53,7 +53,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.orders"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -75,7 +75,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -109,7 +109,7 @@
 		}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_orders",
 		"facets": {
 			"sql": {
@@ -157,7 +157,7 @@
 		}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_payments",
 		"facets": {
 			"sql": {
@@ -207,7 +207,7 @@
 		}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.stg_customers",
 		"facets": {
 			"sql": {
@@ -250,7 +250,7 @@
 		}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.orders",
 		"facets": {
 			"sql": {
@@ -353,7 +353,7 @@
 		}
 	},
 	"job": {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "job-namespace",
 		"name": "DEMO_DB.public.jaffle_shop.customers",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/profiles/result.json
+++ b/integration/common/tests/dbt/profiles/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_prod1.dbt_test.test_model"
 	},
 	"inputs": [{
@@ -32,7 +32,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_prod1.dbt_test.test_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -5,7 +5,7 @@
 		"runId": "{{ any(result) }}"
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model"
 	},
 	"inputs": [{
@@ -32,7 +32,7 @@
 		}
 	},
 	"job": {
-		"namespace": "bigquery",
+		"namespace": "job-namespace",
 		"name": "random-gcp-project.dbt_test1.dbt_test.test_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/spark/odbc/result.json
+++ b/integration/common/tests/dbt/spark/odbc/result.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"job": {
-		"namespace": "spark://adb-1500100900.22.azuredatabricks.net:443",
+		"namespace": "job-namespace",
 		"name": "db.schema.small.my_first_dbt_model",
 		"facets": {
 			"sql": {
@@ -54,7 +54,7 @@
 		}
 	},
 	"job": {
-		"namespace": "spark://adb-1500100900.22.azuredatabricks.net:443",
+		"namespace": "job-namespace",
 		"name": "db.schema.small.my_second_dbt_model",
 		"facets": {
 			"sql": {
@@ -112,7 +112,7 @@
 		}
 	},
 	"job": {
-		"namespace": "spark://adb-1500100900.22.azuredatabricks.net:443",
+		"namespace": "job-namespace",
 		"name": "db.schema.small.my_first_dbt_model",
 		"facets": {
 			"sql": {
@@ -154,7 +154,7 @@
 		}
 	},
 	"job": {
-		"namespace": "spark://adb-1500100900.22.azuredatabricks.net:443",
+		"namespace": "job-namespace",
 		"name": "db.schema.small.my_second_dbt_model",
 		"facets": {
 			"sql": {

--- a/integration/common/tests/dbt/spark/thrift/result.json
+++ b/integration/common/tests/dbt/spark/thrift/result.json
@@ -10,7 +10,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_customers.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -67,7 +67,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_orders.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -129,7 +129,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_payments.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -289,7 +289,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.customers.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -438,7 +438,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.orders.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -585,7 +585,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.orders.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -628,7 +628,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_customers.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -676,7 +676,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_payments.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -727,7 +727,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_orders.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -770,7 +770,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.customers.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -796,7 +796,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_customers.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -853,7 +853,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_orders.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -915,7 +915,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.stg_payments.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -1075,7 +1075,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.customers.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -1221,7 +1221,7 @@
                 }
             },
             "name": "db.default.jaffle_shop.orders.build.run",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [
             {
@@ -1365,7 +1365,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.orders.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -1408,7 +1408,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_customers.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -1456,7 +1456,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_payments.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -1504,7 +1504,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.stg_orders.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -1547,7 +1547,7 @@
         "job": {
             "facets": {},
             "name": "db.default.jaffle_shop.customers.build.test",
-            "namespace": "spark://localhost:10000"
+            "namespace": "job-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -10,7 +10,7 @@
         ],
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_third_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -29,7 +29,7 @@
         ],
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -48,7 +48,7 @@
         ],
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -67,7 +67,7 @@
         ],
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -115,7 +115,7 @@
         "job": {
             "facets": {},
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_third_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -159,7 +159,7 @@
         ],
         "job": {
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_parallel_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -206,7 +206,7 @@
         "job": {
             "facets": {},
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_second_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -272,7 +272,7 @@
         "job": {
             "facets": {},
             "name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model",
-            "namespace": "bigquery"
+            "namespace": "dbt-test-namespace"
         },
         "outputs": [],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -49,6 +49,7 @@ def serialize(inst, field, value):
 def test_dbt_parse_and_compare_event(path, parent_run_metadata):
     processor = DbtArtifactProcessor(
         producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        job_namespace='job-namespace',
         project_dir=path
     )
     processor.dbt_run_metadata = parent_run_metadata
@@ -75,6 +76,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
 
     processor = DbtArtifactProcessor(
         producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        job_namespace='dbt-test-namespace',
         project_dir='tests/dbt/test',
     )
     processor.dbt_run_metadata = parent_run_metadata
@@ -98,7 +100,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         "DB_NAME": "foo_db_name",
         "USER_NAME": "foo_user",
         "PASSWORD": "foo_password",
-        "SCHEMA": "foo_schema"
+        "SCHEMA": "foo_schema",
     }
 )
 def test_dbt_parse_profile_with_env_vars(mock_uuid, parent_run_metadata):
@@ -110,6 +112,7 @@ def test_dbt_parse_profile_with_env_vars(mock_uuid, parent_run_metadata):
         producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
         project_dir='tests/dbt/env_vars',
         target='prod',
+        job_namespace="ol-namespace"
     )
     processor.dbt_run_metadata = parent_run_metadata
 
@@ -219,6 +222,7 @@ def test_seed_snapshot_nodes_do_not_throw():
     processor = DbtArtifactProcessor(
         producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
         project_dir='tests/dbt/test',
+        job_namespace='job-namespace'
     )
 
     # Should just skip processing

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -35,9 +35,9 @@ def setup_client() -> Optional[OpenLineageClient]:
 
 def dbt_run_event(
     state: RunState,
+    job_name: str,
+    job_namespace: str,
     run_id: str = str(uuid.uuid4()),
-    job_namespace: str = 'dbt',
-    job_name: str = f"dbt-run-{str(uuid.uuid4())}",
     parent: Optional[ParentRunMetadata] = None
 ) -> RunEvent:
     return RunEvent(
@@ -57,10 +57,11 @@ def dbt_run_event(
     )
 
 
-def dbt_run_event_start(job_name: str, parent_run_metadata: ParentRunMetadata) -> RunEvent:
+def dbt_run_event_start(job_name: str, job_namespace: str, parent_run_metadata: ParentRunMetadata) -> RunEvent:
     return dbt_run_event(
         state=RunState.START,
         job_name=job_name,
+        job_namespace=job_namespace,
         parent=parent_run_metadata
     )
 
@@ -73,9 +74,9 @@ def dbt_run_event_end(
 ) -> RunEvent:
     return dbt_run_event(
         state=RunState.COMPLETE,
-        run_id=run_id,
         job_namespace=job_namespace,
         job_name=job_name,
+        run_id=run_id,
         parent=parent_run_metadata
     )
 
@@ -102,6 +103,10 @@ def main():
     # We can get this if we have been orchestrated by an external system like airflow
     parent_id = os.getenv("OPENLINEAGE_PARENT_ID")
     parent_run_metadata = None
+    job_namespace = os.environ.get(
+        'OPENLINEAGE_NAMESPACE',
+        'dbt'
+    )
 
     client = OpenLineageClient.from_environment()
 
@@ -116,6 +121,7 @@ def main():
     processor = DbtArtifactProcessor(
         producer=PRODUCER,
         target=target,
+        job_namespace=job_namespace,
         project_dir=project_dir,
         profile_name=profile_name,
         logger=logger
@@ -125,6 +131,7 @@ def main():
     # both the start and complete events for dbt models won't get emitted until end of execution.
     dbt_run_event = dbt_run_event_start(
         job_name=f"dbt-run-{processor.project['name']}",
+        job_namespace=job_namespace,
         parent_run_metadata=parent_run_metadata
     )
     dbt_run_metadata = ParentRunMetadata(


### PR DESCRIPTION
When job namespace is provided by `OPENLINEAGE_NAMESPACE` env variable, use it both as job namespace for "enclosing" dbt job name, as for each individual model or test job namespace.

If the job isn't provided, default to `dbt` name. We can't default to dataset namespace as was done before that change, because dataset namespace is extracted after dbt run, and we're emitting enclosing event before we've run `dbt` at all - to signify that dbt is running.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/509

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)