### PR TITLE
Enabled SparkListenerJobStart events to trigger open lineage events

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -145,10 +145,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
             jobStart);
 
     log.debug("Posting event for start {}: {}", executionId, event);
-    // don't send start events yet - uncomment this when the tests are updated to handle both
-    // sql execution start events and job start events
-
-    //    eventEmitter.emit(event);
+    eventEmitter.emit(event);
   }
 
   @Override

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -92,6 +92,6 @@ public class OpenLineageSparkListenerTest {
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
 
-    verify(emitter, times(1)).emit(lineageEvent.capture());
+    verify(emitter, times(2)).emit(lineageEvent.capture());
   }
 }

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -170,10 +170,10 @@ public class SparkReadWriteIntegTest {
 
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(3))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(4))
         .emit(lineageEvent.capture());
     List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
-    assertThat(events.get(1).getRun().getFacets().getAdditionalProperties())
+    assertThat(events.get(2).getRun().getFacets().getAdditionalProperties())
         .hasEntrySatisfying(
             TestOpenLineageEventHandlerFactory.TEST_FACET_KEY,
             facet ->
@@ -183,12 +183,12 @@ public class SparkReadWriteIntegTest {
                         "additionalProperties",
                         InstanceOfAssertFactories.map(String.class, Object.class))
                     .containsKey("message"));
-    List<OpenLineage.InputDataset> inputs = events.get(1).getInputs();
+    List<OpenLineage.InputDataset> inputs = events.get(2).getInputs();
     assertEquals(1, inputs.size());
     assertEquals("bigquery", inputs.get(0).getNamespace());
     assertEquals(BigQueryUtil.friendlyTableName(tableId), inputs.get(0).getName());
 
-    List<OpenLineage.OutputDataset> outputs = events.get(1).getOutputs();
+    List<OpenLineage.OutputDataset> outputs = events.get(2).getOutputs();
     assertEquals(1, outputs.size());
     OpenLineage.OutputDataset output = outputs.get(0);
     assertEquals("file", output.getNamespace());
@@ -227,7 +227,7 @@ public class SparkReadWriteIntegTest {
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
 
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(5))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(6))
         .emit(lineageEvent.capture());
     List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
     ObjectAssert<RunEvent> completionEvent =
@@ -313,7 +313,7 @@ public class SparkReadWriteIntegTest {
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
 
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(7))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(8))
         .emit(lineageEvent.capture());
     List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
     Optional<OpenLineage.RunEvent> completionEvent =
@@ -378,9 +378,9 @@ public class SparkReadWriteIntegTest {
 
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(3))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(4))
         .emit(lineageEvent.capture());
-    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(1);
+    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(2);
     assertThat(completeEvent).hasFieldOrPropertyWithValue("eventType", "COMPLETE");
     assertThat(completeEvent.getInputs())
         .singleElement()
@@ -423,9 +423,9 @@ public class SparkReadWriteIntegTest {
     StaticExecutionContextFactory.waitForExecutionEnd();
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(3))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(4))
         .emit(lineageEvent.capture());
-    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(1);
+    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(2);
     assertThat(completeEvent).hasFieldOrPropertyWithValue("eventType", "COMPLETE");
     String kafkaNamespace =
         "kafka://"
@@ -469,9 +469,9 @@ public class SparkReadWriteIntegTest {
     StaticExecutionContextFactory.waitForExecutionEnd();
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(3))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(4))
         .emit(lineageEvent.capture());
-    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(1);
+    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(2);
     assertThat(completeEvent).hasFieldOrPropertyWithValue("eventType", "COMPLETE");
     String kafkaNamespace =
         "kafka://"


### PR DESCRIPTION
Signed-off-by: Michael Collado <collado.mike@gmail.com>

### Problem
Some properties are only accessible from the `SparkListenerJobStart` event, but that event never triggers OpenLineage events for Spark SQL jobs. This enables those events and updates the expected counts in unit tests accordingly.

Closes: #501

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)