### PR TITLE
make visitors use DatasetFacet instead of DefaultDatasetFacet

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
@@ -28,7 +28,7 @@ public class CreateDataSourceTableAsSelectCommandVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     CreateDataSourceTableAsSelectCommand command = (CreateDataSourceTableAsSelectCommand) x;
     CatalogTable catalogTable = command.table();
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap =
+    Map<String, OpenLineage.DatasetFacet> facetMap =
         Collections.singletonMap("tableStateChange", new TableStateChangeFacet(StateChange.CREATE));
 
     return Collections.singletonList(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
@@ -28,7 +28,7 @@ public class CreateDataSourceTableCommandVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     CreateDataSourceTableCommand command = (CreateDataSourceTableCommand) x;
     CatalogTable catalogTable = command.table();
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap =
+    Map<String, OpenLineage.DatasetFacet> facetMap =
         Collections.singletonMap("tableStateChange", new TableStateChangeFacet(StateChange.CREATE));
 
     return Collections.singletonList(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
@@ -35,7 +35,7 @@ public class CreateHiveTableAsSelectCommandVisitor
     CatalogTable table = command.tableDesc();
     DatasetIdentifier di = PathUtils.fromCatalogTable(table);
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap =
+    Map<String, OpenLineage.DatasetFacet> facetMap =
         Collections.singletonMap("tableStateChange", new TableStateChangeFacet(StateChange.CREATE));
 
     return Collections.singletonList(outputDataset().getDataset(di, schema, facetMap));

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
@@ -28,7 +28,7 @@ public class CreateTableCommandVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     CreateTableCommand command = (CreateTableCommand) x;
     CatalogTable catalogTable = command.table();
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap =
+    Map<String, OpenLineage.DatasetFacet> facetMap =
         Collections.singletonMap("tableStateChange", new TableStateChangeFacet(StateChange.CREATE));
 
     return Collections.singletonList(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
@@ -1,7 +1,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.DefaultDatasetFacet;
 import io.openlineage.spark.agent.facets.TableStateChangeFacet;
 import io.openlineage.spark.agent.facets.TableStateChangeFacet.StateChange;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
@@ -30,7 +29,7 @@ public class InsertIntoDataSourceDirVisitor
     InsertIntoDataSourceDirCommand command = (InsertIntoDataSourceDirCommand) x;
     // URI is required by the InsertIntoDataSourceDirCommand
     DatasetIdentifier di = PathUtils.fromURI(command.storage().locationUri().get(), "file");
-    Map<String, DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         command.overwrite()
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
@@ -30,7 +30,7 @@ public class InsertIntoDirVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoDir cmd = (InsertIntoDir) x;
     Optional<URI> optionalUri = ScalaConversionUtils.asJavaOptional(cmd.storage().locationUri());
-    Map<String, OpenLineage.DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         cmd.overwrite()
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -27,7 +27,7 @@ public class InsertIntoHadoopFsRelationVisitor
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoHadoopFsRelationCommand command = (InsertIntoHadoopFsRelationCommand) x;
-    Map<String, OpenLineage.DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         (SaveMode.Overwrite == command.mode())
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
@@ -30,7 +30,7 @@ public class InsertIntoHiveDirVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoHiveDirCommand cmd = (InsertIntoHiveDirCommand) x;
     Optional<URI> optionalUri = ScalaConversionUtils.asJavaOptional(cmd.storage().locationUri());
-    Map<String, OpenLineage.DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         cmd.overwrite()
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
@@ -40,7 +40,7 @@ public class InsertIntoHiveTableVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoHiveTable cmd = (InsertIntoHiveTable) x;
     CatalogTable table = cmd.table();
-    Map<String, OpenLineage.DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         cmd.overwrite()
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -54,7 +54,7 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
     CatalogTable table = command.tableDesc();
     DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
-    Map<String, OpenLineage.DefaultDatasetFacet> facets =
+    Map<String, OpenLineage.DatasetFacet> facets =
         (SaveMode.Overwrite == command.mode())
             ? Collections.singletonMap(
                 "tableStateChange", new TableStateChangeFacet(StateChange.OVERWRITE))

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/DatasetFactory.java
@@ -135,9 +135,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @return
    */
   public D getDataset(
-      DatasetIdentifier ident,
-      StructType schema,
-      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+      DatasetIdentifier ident, StructType schema, Map<String, OpenLineage.DatasetFacet> facets) {
     OpenLineage.DatasetFacetsBuilder builder =
         openLineage
             .newDatasetFacetsBuilder()

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitor.java
@@ -48,7 +48,7 @@ public class CreateReplaceVisitor extends QueryPlanVisitor<LogicalPlan, OpenLine
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     TableCatalog tableCatalog;
     Map<String, String> tableProperties;
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
     Identifier identifier;
     StructType schema;
     TableStateChangeFacet.StateChange stateChange;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -5,7 +5,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.DefaultDatasetFacet;
 import io.openlineage.spark.agent.facets.TableStateChangeFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
@@ -51,7 +50,7 @@ public class CreateTableLikeCommandVisitor
                   ScalaConversionUtils.<URI>asJavaOptional(command.fileFormat().locationUri())
                       .orElse(defaultLocation);
               DatasetIdentifier di = PathUtils.fromURI(location, "file");
-              Map<String, DefaultDatasetFacet> facetMap =
+              Map<String, OpenLineage.DatasetFacet> facetMap =
                   singletonMap("tableStateChange", new TableStateChangeFacet(CREATE));
               return singletonList(outputDataset().getDataset(di, source.schema(), facetMap));
             })

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -29,7 +29,7 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
     ResolvedTable resolvedTable = ((ResolvedTable) ((DropTable) x).child());
     TableCatalog tableCatalog = resolvedTable.catalog();
     Map<String, String> tableProperties = resolvedTable.table().properties();

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitor.java
@@ -45,7 +45,7 @@ public class TableContentChangeVisitor
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     NamedRelation table;
-    Map<String, OpenLineage.DefaultDatasetFacet> facetMap = new HashMap<>();
+    Map<String, OpenLineage.DatasetFacet> facetMap = new HashMap<>();
 
     // INSERT OVERWRITE TABLE SQL statement is translated into InsertIntoTable logical operator.
     if (x instanceof OverwriteByExpression) {
@@ -75,7 +75,7 @@ public class TableContentChangeVisitor
         outputDataset(), context, (DataSourceV2Relation) table, facetMap);
   }
 
-  private void includeOverwriteFacet(Map<String, OpenLineage.DefaultDatasetFacet> facetMap) {
+  private void includeOverwriteFacet(Map<String, OpenLineage.DatasetFacet> facetMap) {
     facetMap.put("tableStateChange", new TableStateChangeFacet(OVERWRITE));
   }
 }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -48,7 +48,7 @@ public class PlanUtils3 {
   public static void includeProviderFacet(
       TableCatalog catalog,
       Map<String, String> properties,
-      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+      Map<String, OpenLineage.DatasetFacet> facets) {
     Optional<TableProviderFacet> providerFacet =
         CatalogUtils3.getTableProviderFacet(catalog, properties);
     if (providerFacet.isPresent()) {
@@ -65,7 +65,7 @@ public class PlanUtils3 {
       DatasetFactory<D> datasetFactory,
       OpenLineageContext context,
       DataSourceV2Relation relation,
-      Map<String, OpenLineage.DefaultDatasetFacet> facets) {
+      Map<String, OpenLineage.DatasetFacet> facets) {
 
     if (relation.identifier().isEmpty()) {
       throw new IllegalArgumentException(

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeVisitorTest.java
@@ -129,7 +129,7 @@ public class TableContentChangeVisitorTest {
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       visitor.apply(logicalPlan);
 
-      Map<String, OpenLineage.DefaultDatasetFacet> expectedFacets;
+      Map<String, OpenLineage.DatasetFacet> expectedFacets;
       if (stateChange == null) {
         expectedFacets = Collections.emptyMap();
       } else {

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -38,7 +38,7 @@ public class PlanUtils3Test {
   TableCatalog tableCatalog = mock(TableCatalog.class);
   Identifier identifier = mock(Identifier.class);
   StructType schema = mock(StructType.class);
-  Map<String, OpenLineage.DefaultDatasetFacet> facets;
+  Map<String, OpenLineage.DatasetFacet> facets;
   Table table = mock(Table.class);
   Map<String, String> tableProperties;
 


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Visitors use DefaultDatasetFacet instead of DatasetFacet which is an interface. 

Closes: [#525](https://github.com/OpenLineage/OpenLineage/issues/525)

### Solution

Make visitors use interface instead.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)