### PR TITLE
spec: add source code job facet

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -305,7 +305,7 @@ class OpenLineageRunEventBuilder {
     RunFacetsBuilder runFacetsBuilder = openLineage.newRunFacetsBuilder();
     parentRunFacet.ifPresent(runFacetsBuilder::parent);
     OpenLineage.JobFacets jobFacets =
-        buildFacets(nodes, jobFacetBuilders, openLineage.newJobFacets(null, null, null));
+        buildFacets(nodes, jobFacetBuilders, openLineage.newJobFacetsBuilder().build());
     List<InputDataset> inputDatasets = buildInputDatasets(nodes);
     List<OutputDataset> outputDatasets = buildOutputDatasets(nodes);
     openLineageContext

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -58,7 +58,11 @@ public class OpenLineageRunEventTest {
     OpenLineage.SQLJobFacet sqlJobFacet = ol.newSQLJobFacet("SELECT * FROM test");
 
     OpenLineage.JobFacets jobFacets =
-        ol.newJobFacets(sqlJobFacet, sourceCodeLocationJobFacet, documentationJobFacet);
+        ol.newJobFacetsBuilder()
+            .sourceCodeLocation(sourceCodeLocationJobFacet)
+            .sql(sqlJobFacet)
+            .documentation(documentationJobFacet)
+            .build();
     OpenLineage.Job job = ol.newJob("namespace", "jobName", jobFacets);
     List<OpenLineage.InputDataset> inputs =
         Arrays.asList(

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -117,6 +117,8 @@ Example of valid name is `BigQueryStatisticsJobFacet` and it's key `bigQuery_sta
 
 - **sourceCodeLocation**: Captures the source code location and version (example: git sha) of the job.
 
+- **sourceCode**: Captures language (ex. python) and actual source code of the job.
+
 - **sql**: Capture the SQL query if this job is a SQL query.
 
 #### Dataset Facets

--- a/spec/facets/SourceCodeJobFacet.json
+++ b/spec/facets/SourceCodeJobFacet.json
@@ -1,0 +1,31 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$id" : "https://openlineage.io/spec/facets/1-0-0/SourceCodeJobFacet.json",
+  "$defs" : {
+    "SourceCodeJobFacet" : {
+      "allOf" : [ {
+        "$ref" : "https://openlineage.io/spec/1-0-2/OpenLineage.json#/$defs/JobFacet"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "language" : {
+            "description" : "Language in which source code of this job was written.",
+            "type" : "string"
+          },
+          "sourceCode" : {
+            "description" : "Source code of this job.",
+            "type" : "string"
+          }
+        },
+        "required" : [ "language", "sourceCode" ]
+      } ],
+      "type" : "object"
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "sourceCode" : {
+      "$ref" : "#/$defs/SourceCodeJobFacet"
+    }
+  }
+}


### PR DESCRIPTION
Standarize facet that would hold source code of a job. 
Right now, it will be used by code produced by Airflow's bash/python operators:
https://github.com/OpenLineage/OpenLineage/issues/520
https://github.com/OpenLineage/OpenLineage/issues/516

Also, changed unfortunate use of `newJobFacets` in Spark that depends on a number of standarized job facets - so that adding one makes it incompatible with new library. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [x] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)