### PR TITLE
Http and Kafka transports for python client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,5 +157,4 @@ gcloud-service-key.json
 
 *.java-version
 *.java_version
-
 *.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.6.2...HEAD)
+### Added
+* Python implements Transport interface - HTTP and Kafka transports are available [@mobuchowski](https://github.com/mobuchowski)
 
 ## [0.6.2](https://github.com/OpenLineage/OpenLineage/compare/0.6.1...0.6.2)
 ### Added

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 # OpenLineage-python
 
 To install from source, run:
@@ -9,8 +7,60 @@ $ python setup.py install
 ```
 
 ## Configuration
+### Config file
 
-OpenLineage client depends on environment variables:
+Main way of configuring OpenLineage Client is by yaml file, which contains all the
+details of how to connect to your OpenLineage backend. 
+
+Config file is located by
+1) looking at `OPENLINEAGE_CONFIG` environment variable
+2) looking for file `openlineage.yml` at current working directory
+3) looking for file `openlineage.yml` at `$HOME/.openlineage` directory.
+
+Different ways of connecting to OpenLineage backend are supported 
+by standarized `Transport` interface.  
+This is example config that specifies `http` transport:
+
+```yaml
+transport:
+  type: "http"
+  url: "https://backend:5000"
+  auth:
+    type: "api_key"
+    api_key: "f048521b-dfe8-47cd-9c65-0cb07d57591e"
+```
+
+`type` property is required. It can be one of the build-in transports, or custom one.
+There are three build-in transports, `http`, `kafka` or `console`. 
+Custom transports `type` is fully qualified class name that can be imported.
+
+Rest of the properties are defined by particular transport.  
+Specification of build-in ones are below.
+
+#### HTTP
+
+* `url` - required string parameter specifying
+* `timeout` - optional float parameter specifying timeout when sending event. By default 5 seconds.
+* `verify` optional boolean attribute specifying if client should verify TLS certificates of backend. By default true.
+* `auth` - optional dictionary specifying authentication options. Type property is required.
+    * `type`: required property if auth dictionary is set. Set to `api_key` or to fully qualified class name of your TokenProvider
+    * `api_key`: if `api_key` type is set, it sets value at `Authentication` HTTP header as `Bearer` 
+
+#### Kafka
+
+* `config` - required string parameter - dictionary that contains Kafka producer config as in [Kafka producer config](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration)
+* `topic` - required string parameter - topic on what events will be send
+* `flush` - optional boolean parameter - if it's set to True, then Kafka will flush after each event. By default set to true.
+
+
+### Custom transport
+
+To implement custom transport, follow instructions in `openlineage/client/transport/transport.py` file.
+
+### Config as env vars
+
+If there is no config file found, OpenLineage client looks at environment variables.  
+This way of configuring supports only `http` transport, and only subset of it's config.
 
 * `OPENLINEAGE_URL` - point to service which will consume OpenLineage events
 * `OPENLINEAGE_API_KEY` - set if consumer of OpenLineage events requires `Bearer` authentication key

--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-
+# flake8: noqa
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
 from openlineage.client.facet import set_producer

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -32,7 +32,7 @@ class OpenLineageClient:
         transport: Optional[Transport] = None,
     ):
         if url:
-            # Backwards compatibility: if URL is set, use old path to initialize
+            # Backwards compatibility: if URL or options is set, use old path to initialize
             # HTTP transport.
             if not options:
                 options = OpenLineageClientOptions()
@@ -50,13 +50,10 @@ class OpenLineageClient:
         options: OpenLineageClientOptions,
         session: Session
     ):
-        self.transport = HttpTransport(HttpConfig(
+        self.transport = HttpTransport(HttpConfig.from_options(
             url=url,
-            timeout=options.timeout,
-            verify=options.verify,
-            api_key=options.api_key,
-            session=session,
-            adapter=options.adapter
+            options=options,
+            session=session
         ))
 
     def emit(self, event: RunEvent):

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -1,17 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0.
 
-import os
 import logging
-from urllib.parse import urljoin
+from typing import Optional
 
 import attr
 from requests import Session
 from requests.adapters import HTTPAdapter
-from urllib3.util.url import parse_url
 
-from openlineage.client import constants
 from openlineage.client.run import RunEvent
-from openlineage.client.serde import Serde
+from openlineage.client.transport import Transport, get_default_factory
+from openlineage.client.transport.http import HttpTransport, HttpConfig
 
 
 @attr.s
@@ -27,55 +25,48 @@ log = logging.getLogger(__name__)
 
 class OpenLineageClient:
     def __init__(
-            self,
-            url: str,
-            options: OpenLineageClientOptions = OpenLineageClientOptions(),
-            session: Session = None
+        self,
+        url: Optional[str] = None,
+        options: Optional[OpenLineageClientOptions] = None,
+        session: Optional[Session] = None,
+        transport: Optional[Transport] = None,
     ):
-        url = url.strip()
-        try:
-            parsed = parse_url(url)
-            if not (parsed.scheme and parsed.netloc):
-                raise ValueError(f"Need valid url for OpenLineageClient, passed {url}")
-        except Exception as e:
-            raise ValueError(f"Need valid url for OpenLineageClient, passed {url}. Exception: {e}")
-        self.url = url
-        self.options = options
-        self.session = session if session else Session()
-        self.session.headers['Content-Type'] = 'application/json'
+        if url:
+            # Backwards compatibility: if URL is set, use old path to initialize
+            # HTTP transport.
+            if not options:
+                options = OpenLineageClientOptions()
+            if not session:
+                session = Session()
+            self._initialize_url(url, options, session)
+        elif transport:
+            self.transport = transport
+        else:
+            self.transport = get_default_factory().create()
 
-        if self.options.api_key:
-            self._add_auth(options.api_key)
-        if self.options.adapter:
-            self.session.mount(self.url, options.adapter)
+    def _initialize_url(
+        self,
+        url: str,
+        options: OpenLineageClientOptions,
+        session: Session
+    ):
+        self.transport = HttpTransport(HttpConfig(
+            url=url,
+            timeout=options.timeout,
+            verify=options.verify,
+            api_key=options.api_key,
+            session=session,
+            adapter=options.adapter
+        ))
 
     def emit(self, event: RunEvent):
-        data = Serde.to_json(event)
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(f"Sending openlineage event {event}")
-        resp = self.session.post(
-            urljoin(self.url, 'api/v1/lineage'),
-            data,
-            timeout=self.options.timeout,
-            verify=self.options.verify
-        )
-        resp.raise_for_status()
-        return resp
-
-    def _add_auth(self, api_key: str):
-        self.session.headers.update({
-            "Authorization": f"Bearer {api_key}"
-        })
+        if not isinstance(event, RunEvent):
+            raise ValueError("`emit` only accepts RunEvent class")
+        if not self.transport:
+            log.error("Tried to emit OpenLineage event, but transport is not configured.")
+        else:
+            self.transport.emit(event)
 
     @classmethod
     def from_environment(cls):
-        server_url = os.getenv("OPENLINEAGE_URL", constants.DEFAULT_OPENLINEAGE_URL)
-        if server_url:
-            log.info(f"Constructing openlineage client to send events to {server_url}")
-        return OpenLineageClient(
-            url=server_url,
-            options=OpenLineageClientOptions(
-                timeout=constants.DEFAULT_TIMEOUT_MS / 1000,
-                api_key=os.getenv("OPENLINEAGE_API_KEY", None)
-            )
-        )
+        return cls(transport=get_default_factory().create())

--- a/client/python/openlineage/client/constants.py
+++ b/client/python/openlineage/client/constants.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.7.0"
 
-DEFAULT_TIMEOUT_MS = 10000
+DEFAULT_TIMEOUT_MS = 5000
 DEFAULT_NAMESPACE_NAME = 'default'
 DEFAULT_OPENLINEAGE_URL = 'http://localhost:5000'
 DEFAULT_PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}/client/python"

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0.
-
-import os
 from typing import Dict, List, Optional
 
 import attr

--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -40,5 +40,8 @@ class Serde:
 
     @classmethod
     def to_json(cls, obj):
-        return json.dumps(cls.to_dict(obj), sort_keys=True,
-                          default=lambda o: f"<<non-serializable: {type(o).__qualname__}>>")
+        return json.dumps(
+            cls.to_dict(obj),
+            sort_keys=True,
+            default=lambda o: f"<<non-serializable: {type(o).__qualname__}>>"
+        )

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -5,10 +5,13 @@ from openlineage.client.transport.transport import Transport, Config, TransportF
 from openlineage.client.transport.factory import DefaultTransportFactory
 from openlineage.client.transport.http import HttpTransport, HttpConfig
 from openlineage.client.transport.kafka import KafkaTransport, KafkaConfig
+from openlineage.client.transport.console import ConsoleTransport
+
 
 _factory = DefaultTransportFactory()
 _factory.register_transport(HttpTransport.kind, HttpTransport)
 _factory.register_transport(KafkaTransport.kind, KafkaTransport)
+_factory.register_transport(ConsoleTransport.kind, ConsoleTransport)
 
 
 def get_default_factory():

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -1,0 +1,21 @@
+# flake8: noqa
+from typing import Type
+
+from openlineage.client.transport.transport import Transport, Config, TransportFactory
+from openlineage.client.transport.factory import DefaultTransportFactory
+from openlineage.client.transport.http import HttpTransport, HttpConfig
+from openlineage.client.transport.kafka import KafkaTransport, KafkaConfig
+
+_factory = DefaultTransportFactory()
+_factory.register_transport(HttpTransport.kind, HttpTransport)
+_factory.register_transport(KafkaTransport.kind, KafkaTransport)
+
+
+def get_default_factory():
+    return _factory
+
+
+# decorator to wrap transports with
+def register_transport(clazz: Type[Transport]):
+    _factory.register_transport(clazz.kind, clazz)
+    return clazz

--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0.
+import logging
+
+from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Transport, Config
+
+
+class ConsoleConfig(Config):
+    pass
+
+
+class ConsoleTransport(Transport):
+    kind = 'console'
+    config = ConsoleConfig
+
+    def __init__(self, config: ConsoleConfig):
+        self.log = logging.getLogger(__name__)
+
+    def emit(self, event: RunEvent):
+        self.log.info(Serde.to_json(event))

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -1,0 +1,102 @@
+import inspect
+import os
+import logging
+from typing import Type, Union, Optional
+
+from openlineage.client.transport.transport import Config, Transport, TransportFactory
+from openlineage.client.utils import try_import_from_string
+
+
+log = logging.getLogger(__name__)
+
+
+try:
+    import yaml
+except ImportError:
+    yaml = False
+
+
+class DefaultTransportFactory(TransportFactory):
+    def __init__(self):
+        self.transports = {}
+
+    def register_transport(self, type: str, clazz: Union[Type[Transport], str]):
+        self.transports[type] = clazz
+
+    def create(self) -> Optional[Transport]:
+        if yaml:
+            yml_config = self._try_config_from_yaml()
+            if yml_config:
+                return self._create_transport(yml_config)
+        # Fallback to setting HTTP transport from env variables
+        return self._try_http_from_env_config()
+
+    def _create_transport(self, config: dict):
+        transport_type = config['type']
+
+        if transport_type in self.transports:
+            transport_class = self.transports[transport_type]
+        else:
+            transport_class = transport_type
+
+        if isinstance(transport_class, str):
+            transport_class = try_import_from_string(transport_class)
+        if not inspect.isclass(transport_class) or not issubclass(transport_class, Transport):
+            raise TypeError(
+                f"Transport {transport_class} has to be class, and subclass of Transport"
+            )
+
+        config_class = transport_class.config
+
+        if isinstance(config_class, str):
+            config_class = try_import_from_string(config_class)
+        if not inspect.isclass(config_class) or not issubclass(config_class, Config):
+            raise TypeError(f"Config {config_class} has to be class, and subclass of Config")
+
+        return transport_class(config_class.from_dict(config))
+
+    def _try_config_from_yaml(self) -> Optional[dict]:
+        file = self._find_yaml()
+        if file:
+            try:
+                with open(file, 'r') as f:
+                    config = yaml.safe_load(f)
+                    return config['transport']
+            except Exception:
+                # Just move to read env vars
+                pass
+        return
+
+    @staticmethod
+    def _find_yaml() -> Optional[str]:
+        # Check current working directory:
+        try:
+            cwd = os.getcwd()
+            if 'openlineage.yml' in os.listdir(cwd):
+                return os.path.join(cwd, 'openlineage.yml')
+        except Exception:
+            # We can get different errors depending on system
+            pass
+
+        # Check $HOME/.openlineage dir
+        try:
+            path = os.path.expanduser("~/.openlineage")
+            if 'openlineage.yml' in os.listdir(path):
+                return os.path.join(path, 'openlineage.yml')
+        except Exception:
+            # We can get different errors depending on system
+            pass
+
+    @staticmethod
+    def _try_http_from_env_config() -> Optional[Transport]:
+        from openlineage.client.transport.http import HttpTransport, HttpConfig
+        # backwards compatibility: create Transport from
+        # OPENLINEAGE_URL and OPENLINEAGE_API_KEY
+        if 'OPENLINEAGE_URL' not in os.environ:
+            log.error("Did not find openlineage.yml and OPENLINEAGE_URL is not set")
+            return
+        config = HttpConfig(
+            url=os.environ['OPENLINEAGE_URL'],
+            api_key=os.environ.get('OPENLINEAGE_API_KEY', None)
+        )
+        return HttpTransport(config)

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0.
 import logging
 from urllib.parse import urljoin
 
 import attr
 
-from typing import Optional
+from typing import Optional, Dict
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -12,9 +13,37 @@ from urllib3.util import parse_url
 from openlineage.client.run import RunEvent
 from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Config, Transport
-from openlineage.client.utils import get_only_specified_fields
+from openlineage.client.utils import get_only_specified_fields, try_import_subclass_from_string
 
 log = logging.getLogger(__name__)
+
+
+class TokenProvider:
+    def __init__(self, config: Dict):
+        pass
+
+    def get_bearer(self) -> Optional[str]:
+        return None
+
+
+class ApiKeyTokenProvider(TokenProvider):
+    def __init__(self, config: Dict):
+        self.api_key = config['api_key']
+
+    def get_bearer(self) -> Optional[str]:
+        return f"Bearer {self.api_key}"
+
+
+def create_token_provider(auth: Dict) -> TokenProvider:
+    if 'type' in auth:
+        if auth['type'] == 'api_key':
+            return ApiKeyTokenProvider(auth)
+        try:
+            clazz = try_import_subclass_from_string(auth['type'], TokenProvider)
+            return clazz(auth)
+        except TypeError:
+            pass  # already logged
+    return TokenProvider({})
 
 
 @attr.s
@@ -23,18 +52,31 @@ class HttpConfig(Config):
     timeout: float = attr.ib(default=5.0)
     # check TLS certificates
     verify: bool = attr.ib(default=True)
-    api_key: Optional[str] = attr.ib(default=None)
-
+    auth: TokenProvider = attr.ib(factory=lambda: TokenProvider({}))
     # not set by TransportFactory
     session: Optional[Session] = attr.ib(factory=Session)
     # not set by TransportFactory
     adapter: Optional[HTTPAdapter] = attr.ib(default=None)
 
     @classmethod
-    def from_dict(cls, params: dict):
+    def from_dict(cls, params: dict) -> 'HttpConfig':
         if 'url' not in params:
             raise RuntimeError("`url` key not passed to HttpConfig")
-        return cls(**get_only_specified_fields(cls, params))
+        specified_dict = get_only_specified_fields(cls, params)
+        specified_dict['auth'] = create_token_provider(specified_dict.get('auth', {}))
+        return cls(**specified_dict)
+
+    @classmethod
+    def from_options(cls, url: str, options, session: Optional[Session]) -> 'HttpConfig':
+        return cls(
+            url=url,
+            timeout=options.timeout,
+            verify=options.verify,
+            auth=ApiKeyTokenProvider({"api_key": options.api_key})
+            if options.api_key else TokenProvider({}),
+            session=session if session else Session(),
+            adapter=options.adapter
+        )
 
 
 class HttpTransport(Transport):
@@ -54,10 +96,8 @@ class HttpTransport(Transport):
         self.session.headers['Content-Type'] = 'application/json'
         self.timeout = config.timeout
         self.verify = config.verify
-        self.api_key = config.api_key
 
-        if self.api_key:
-            self._add_auth(self.api_key)
+        self._add_auth(config.auth)
         if config.adapter:
             self.set_adapter(config.adapter)
 
@@ -77,7 +117,7 @@ class HttpTransport(Transport):
         resp.raise_for_status()
         return resp
 
-    def _add_auth(self, api_key: str):
+    def _add_auth(self, token_provider: TokenProvider):
         self.session.headers.update({
-            "Authorization": f"Bearer {api_key}"
+            "Authorization": token_provider.get_bearer()
         })

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -1,0 +1,83 @@
+import logging
+from urllib.parse import urljoin
+
+import attr
+
+from typing import Optional
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import parse_url
+
+from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Config, Transport
+from openlineage.client.utils import get_only_specified_fields
+
+log = logging.getLogger(__name__)
+
+
+@attr.s
+class HttpConfig(Config):
+    url: str = attr.ib()
+    timeout: float = attr.ib(default=5.0)
+    # check TLS certificates
+    verify: bool = attr.ib(default=True)
+    api_key: Optional[str] = attr.ib(default=None)
+
+    # not set by TransportFactory
+    session: Optional[Session] = attr.ib(factory=Session)
+    # not set by TransportFactory
+    adapter: Optional[HTTPAdapter] = attr.ib(default=None)
+
+    @classmethod
+    def from_dict(cls, params: dict):
+        if 'url' not in params:
+            raise RuntimeError("`url` key not passed to HttpConfig")
+        return cls(**get_only_specified_fields(cls, params))
+
+
+class HttpTransport(Transport):
+    kind = "http"
+    config = HttpConfig
+
+    def __init__(self, config: HttpConfig):
+        url = config.url.strip()
+        try:
+            parsed = parse_url(url)
+            if not (parsed.scheme and parsed.netloc):
+                raise ValueError(f"Need valid url for OpenLineageClient, passed {url}")
+        except Exception as e:
+            raise ValueError(f"Need valid url for OpenLineageClient, passed {url}. Exception: {e}")
+        self.url = url
+        self.session = config.session
+        self.session.headers['Content-Type'] = 'application/json'
+        self.timeout = config.timeout
+        self.verify = config.verify
+        self.api_key = config.api_key
+
+        if self.api_key:
+            self._add_auth(self.api_key)
+        if config.adapter:
+            self.set_adapter(config.adapter)
+
+    def set_adapter(self, adapter: HTTPAdapter):
+        self.session.mount(self.url, adapter)
+
+    def emit(self, event: RunEvent):
+        event = Serde.to_json(event)
+        if log.isEnabledFor(logging.DEBUG):
+            log.debug(f"Sending openlineage event {event}")
+        resp = self.session.post(
+            urljoin(self.url, 'api/v1/lineage'),
+            event,
+            timeout=self.timeout,
+            verify=self.verify
+        )
+        resp.raise_for_status()
+        return resp
+
+    def _add_auth(self, api_key: str):
+        self.session.headers.update({
+            "Authorization": f"Bearer {api_key}"
+        })

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -1,0 +1,47 @@
+from typing import Dict
+
+import attr
+
+from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Transport, Config
+from openlineage.client.utils import get_only_specified_fields
+
+
+@attr.s
+class KafkaConfig(Config):
+    # Kafka producer config
+    # https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration
+    config: Dict[str, str] = attr.ib()
+
+    # Topic on which we should send messages
+    topic: str = attr.ib()
+
+    # Flush by default. The process that emits can be killed in some cases - for example
+    # in Airflow integration.
+    flush: bool = attr.ib(default=True)
+
+    @classmethod
+    def from_dict(cls, params: dict):
+        if 'config' not in params:
+            raise RuntimeError("kafka `config` not passed to KafkaConfig")
+        if not isinstance(params['config'], dict):
+            raise RuntimeError("`config` passed to KafkaConfig must be dict")
+        return cls(**get_only_specified_fields(cls, params))
+
+
+# Very basic transport impl
+class KafkaTransport(Transport):
+    kind = "kafka"
+    config = KafkaConfig
+
+    def __init__(self, config: KafkaConfig):
+        import confluent_kafka as kafka
+        self.producer = kafka.Producer(config.config)
+        self.topic = config.topic
+        self.flush = config.flush
+
+    def emit(self, event: RunEvent):
+        self.producer.produce(topic=self.topic, value=Serde.to_json(event).encode('utf-8'))
+        if self.flush:
+            self.producer.flush(timeout=2)

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0.
 from typing import Dict
 
 import attr
@@ -17,8 +18,8 @@ class KafkaConfig(Config):
     # Topic on which we should send messages
     topic: str = attr.ib()
 
-    # Flush by default. The process that emits can be killed in some cases - for example
-    # in Airflow integration.
+    # Set to true if Kafka should flush after each event. The process that emits can be killed in
+    # some cases - for example in Airflow integration, so flushing is desirable there.
     flush: bool = attr.ib(default=True)
 
     @classmethod

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -1,0 +1,20 @@
+from openlineage.client.run import RunEvent
+
+
+class Config:
+    @classmethod
+    def from_dict(cls, params: dict):
+        return cls()
+
+
+class Transport:
+    kind = None
+    config = Config
+
+    def emit(self, event: RunEvent):
+        raise NotImplementedError()
+
+
+class TransportFactory:
+    def create(self) -> Transport:
+        pass

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -1,4 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0.
 from openlineage.client.run import RunEvent
+
+
+"""
+To implement custom Transport implement Config and Transport classes.
+
+Transport needs to
+ * specify class variable `config` that will point to Config class that Transport requires
+ * __init__ that will accept specified Config class instance
+ * implement `emit` method that will accept RunEvent
+
+Config file is read and parameters there are passed to `from_dict` classmethod.
+The config class can have more complex attributes, but needs to be able to
+instantiate them in `from_dict` method.
+
+DefaultTransportFactory instantiates custom transports by looking at `type` field in
+class config.
+"""
 
 
 class Config:

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -1,0 +1,29 @@
+import attr
+import importlib
+from warnings import warn
+
+
+def import_from_string(path: str):
+    try:
+        module_path, target = path.rsplit('.', 1)
+        module = importlib.import_module(module_path)
+        return getattr(module, target)
+    except Exception as e:
+        raise ImportError(f"Failed to import {path}") from e
+
+
+def try_import_from_string(path: str):
+    try:
+        return import_from_string(path)
+    except ImportError as e:
+        warn(e.msg)
+        return None
+
+
+# Filter dictionary to get only those key: value pairs that have
+# key specified in passed attr class
+def get_only_specified_fields(clazz, params: dict) -> dict:
+    field_keys = [item.name for item in attr.fields(clazz)]
+    return {
+        key: value for key, value in params.items() if key in field_keys
+    }

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0.
+import inspect
+from typing import Type
+
 import attr
 import importlib
 from warnings import warn
@@ -18,6 +22,15 @@ def try_import_from_string(path: str):
     except ImportError as e:
         warn(e.msg)
         return None
+
+
+def try_import_subclass_from_string(path: str, clazz: Type):
+    subclass = try_import_from_string(path)
+    if not inspect.isclass(subclass) or not issubclass(subclass, clazz):
+        raise TypeError(
+            f"Import path {path} - {str(subclass)} has to be class, and subclass of {str(clazz)}"
+        )
+    return subclass
 
 
 # Filter dictionary to get only those key: value pairs that have

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -12,10 +12,12 @@ with open("README.md") as readme_file:
 requirements = [
     "attrs>=19.3.0",
     "requests>=2.20.0",
+    "pyyaml>=5.1.0"
 ]
 
 extras_require = {
-    "tests": ["pytest", "pytest-cov", "mock", "flake8", "requests"],
+    "tests": ["pytest", "pytest-cov", "mock", "flake8", "requests", "pyyaml"],
+    "kafka": ["confluent-kafka"],
 }
 extras_require["dev"] = set(sum(extras_require.values(), []))
 

--- a/client/python/tests/config/config.yml
+++ b/client/python/tests/config/config.yml
@@ -1,0 +1,3 @@
+transport:
+  type: "tests.transport.FakeTransport"
+  something: "true"

--- a/client/python/tests/openlineage.yml
+++ b/client/python/tests/openlineage.yml
@@ -1,0 +1,3 @@
+transport:
+  type: "tests.transport.AccumulatingTransport"
+  something: "false"

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -34,17 +34,17 @@ def test_client_fails_to_create_with_wrong_url():
 
 def test_client_passes_to_create_with_valid_url():
     session = MagicMock()
-    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == \
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).transport.url == \
            "http://196.168.0.1"
-    assert OpenLineageClient(url="http://196.168.0.1", session=session).url == \
+    assert OpenLineageClient(url="http://196.168.0.1", session=session).transport.url == \
            "http://196.168.0.1"
-    assert OpenLineageClient(url="http://example.com  ", session=session).url == \
+    assert OpenLineageClient(url="http://example.com  ", session=session).transport.url == \
            "http://example.com"
-    assert OpenLineageClient(url=" http://example.com", session=session).url == \
+    assert OpenLineageClient(url=" http://example.com", session=session).transport.url == \
            "http://example.com"
-    assert OpenLineageClient(url="  http://marquez:5000  ", session=session).url == \
+    assert OpenLineageClient(url="  http://marquez:5000  ", session=session).transport.url == \
            "http://marquez:5000"
-    assert OpenLineageClient(url="  https://marquez  ", session=session).url == \
+    assert OpenLineageClient(url="  https://marquez  ", session=session).transport.url == \
            "https://marquez"
 
 
@@ -71,3 +71,19 @@ def test_client_sends_proper_json_with_minimal_event():
         timeout=5.0,
         verify=True
     )
+
+
+def test_client_uses_passed_transport():
+    transport = MagicMock()
+    client = OpenLineageClient(transport=transport)
+    assert client.transport == transport
+
+    client.emit(event=RunEvent(
+            RunState.START,
+            "2020-01-01",
+            Run("69f4acab-b87d-4fc0-b27b-8ea950370ff3"),
+            Job("openlineage", "job"),
+            "producer"
+        )
+    )
+    client.transport.emit.assert_called_once()

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -1,7 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0.
 import os
 from unittest.mock import patch
-
-import pytest
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.transport import DefaultTransportFactory, \
@@ -60,6 +59,17 @@ def test_factory_registers_transports_from_yaml(cwd):
     )
     transport = factory.create()
     assert isinstance(transport, AccumulatingTransport)
+
+
+@patch.dict(os.environ, {"OPENLINEAGE_CONFIG": "tests/config/config.yml"})
+def test_factory_registers_transports_from_yaml_config():
+    factory = DefaultTransportFactory()
+    factory.register_transport(
+        "fake",
+        clazz="tests.transport.FakeTransport"
+    )
+    transport = factory.create()
+    assert isinstance(transport, FakeTransport)
 
 
 def test_automatically_registers_http_kafka():

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport import DefaultTransportFactory, \
+    get_default_factory, KafkaTransport
+from openlineage.client.transport.http import HttpTransport
+from tests.transport import AccumulatingTransport, FakeTransport
+
+current_path = os.path.join(os.getcwd(), "tests")
+
+
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000"})
+def test_client_uses_default_http_factory():
+    client = OpenLineageClient()
+    assert isinstance(client.transport, HttpTransport)
+    assert client.transport.url == "http://mock-url:5000"
+
+
+@patch('openlineage.client.transport.factory.yaml')
+@patch('os.listdir')
+@patch('os.path.join')
+def test_factory_registers_new_transports(join, listdir, yaml):
+    listdir.return_value = "openlineage.yml"
+    yaml.safe_load.return_value = {"transport": {"type": "accumulating"}}
+
+    factory = DefaultTransportFactory()
+    factory.register_transport("accumulating", clazz=AccumulatingTransport)
+    transport = factory.create()
+    assert isinstance(transport, AccumulatingTransport)
+
+
+@patch('openlineage.client.transport.factory.yaml')
+@patch('os.listdir')
+@patch('os.path.join')
+def test_factory_registers_transports_from_string(join, listdir, yaml):
+    listdir.return_value = "openlineage.yml"
+    yaml.safe_load.return_value = {"transport": {"type": "accumulating"}}
+
+    factory = DefaultTransportFactory()
+    factory.register_transport(
+        "accumulating",
+        clazz="tests.transport.AccumulatingTransport"
+    )
+    transport = factory.create()
+    assert isinstance(transport, AccumulatingTransport)
+
+
+@patch.dict(os.environ, {})
+@patch('os.getcwd')
+def test_factory_registers_transports_from_yaml(cwd):
+    cwd.return_value = current_path
+
+    factory = DefaultTransportFactory()
+    factory.register_transport(
+        "accumulating",
+        clazz="tests.transport.AccumulatingTransport"
+    )
+    transport = factory.create()
+    assert isinstance(transport, AccumulatingTransport)
+
+
+def test_automatically_registers_http_kafka():
+    factory = get_default_factory()
+    assert HttpTransport in factory.transports.values()
+    assert KafkaTransport in factory.transports.values()
+
+
+@patch('openlineage.client.transport.factory.yaml')
+@patch('os.listdir')
+@patch('os.path.join')
+def test_transport_decorator_registers(join, listdir, yaml):
+    listdir.return_value = "openlineage.yml"
+    yaml.safe_load.return_value = {"transport": {"type": "fake"}}
+
+    transport = get_default_factory().create()
+    assert isinstance(transport, FakeTransport)

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -1,0 +1,64 @@
+import datetime
+import uuid
+from unittest.mock import patch
+
+from requests import Session
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.serde import Serde
+from openlineage.client.transport.http import HttpConfig, HttpTransport
+
+
+def test_http_loads_full_config():
+    config = HttpConfig.from_dict({
+        "type": "http",
+        "url": "http://backend:5000/api/v1/lineage",
+        "verify": False,
+        "api_key": "1500100900",
+    })
+
+    assert config.url == "http://backend:5000/api/v1/lineage"
+    assert config.verify is False
+    assert config.api_key == "1500100900"
+    assert isinstance(config.session, Session)
+    assert config.adapter is None
+
+
+def test_http_loads_minimal_config():
+    config = HttpConfig.from_dict({
+        "type": "http",
+        "url": "http://backend:5000/api/v1/lineage"
+    })
+    assert config.url == "http://backend:5000/api/v1/lineage"
+    assert config.verify is True
+    assert config.api_key is None
+    assert isinstance(config.session, Session)
+    assert config.adapter is None
+
+
+@patch("requests.Session")
+def test_client_with_http_transport_emits(session):
+    config = HttpConfig.from_dict({
+        "type": "http",
+        "url": "http://backend:5000",
+        "session": session
+    })
+    transport = HttpTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(uuid.uuid4())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.session.post.assert_called_once_with(
+        "http://backend:5000/api/v1/lineage",
+        Serde.to_json(event),
+        timeout=5.0,
+        verify=True
+    )

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0.
 import datetime
 import uuid
 from unittest.mock import patch
@@ -15,12 +16,15 @@ def test_http_loads_full_config():
         "type": "http",
         "url": "http://backend:5000/api/v1/lineage",
         "verify": False,
-        "api_key": "1500100900",
+        "auth": {
+            "type": "api_key",
+            "api_key": "1500100900"
+        },
     })
 
     assert config.url == "http://backend:5000/api/v1/lineage"
     assert config.verify is False
-    assert config.api_key == "1500100900"
+    assert config.auth.api_key == "1500100900"
     assert isinstance(config.session, Session)
     assert config.adapter is None
 
@@ -32,7 +36,7 @@ def test_http_loads_minimal_config():
     })
     assert config.url == "http://backend:5000/api/v1/lineage"
     assert config.verify is True
-    assert config.api_key is None
+    assert not hasattr(config.auth, 'api_key')
     assert isinstance(config.session, Session)
     assert config.adapter is None
 

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0.
 import datetime
 import uuid
 from unittest.mock import patch

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -1,0 +1,69 @@
+import datetime
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.serde import Serde
+from openlineage.client.transport.kafka import KafkaTransport, KafkaConfig
+
+
+def test_kafka_loads_full_config():
+    config = KafkaConfig.from_dict({
+        "type": "kafka",
+        "config": {"bootstrap.servers": "localhost:9092"},
+        "topic": "random-topic",
+        "flush": False
+    })
+
+    assert config.config['bootstrap.servers'] == "localhost:9092"
+    assert config.topic == "random-topic"
+    assert config.flush is False
+
+
+def test_kafka_loads_partial_config_with_defaults():
+    config = KafkaConfig.from_dict({
+        "type": "kafka",
+        "config": {"bootstrap.servers": "localhost:9092"},
+        "topic": "random-topic"
+    })
+
+    assert config.config['bootstrap.servers'] == "localhost:9092"
+    assert config.topic == "random-topic"
+    assert config.flush is True
+
+
+def test_kafka_load_config_fails_on_no_config():
+    with pytest.raises(TypeError):
+        KafkaConfig.from_dict({
+            "type": "kafka",
+            "config": {"bootstrap.servers": "localhost:9092"}
+        })
+
+
+@patch("confluent_kafka.Producer")
+def test_client_with_kafka_transport_emits(kafka):
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(uuid.uuid4())),
+        job=Job(namespace="kafka", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.producer.produce.assert_called_once_with(
+        topic='random-topic',
+        value=Serde.to_json(event).encode("utf-8")
+    )
+    transport.producer.flush.assert_called_once()

--- a/client/python/tests/transport.py
+++ b/client/python/tests/transport.py
@@ -1,0 +1,25 @@
+from openlineage.client.run import RunEvent
+from openlineage.client.transport import Transport, Config, register_transport
+
+
+class AccumulatingTransport(Transport):
+    kind = "accumulating"
+    config = Config
+
+    def __init__(self, config: Config):
+        self.events = []
+
+    def emit(self, event: RunEvent):
+        self.events.append(event)
+
+
+@register_transport
+class FakeTransport(Transport):
+    kind = "fake"
+    config = Config
+
+    def __init__(self, config: Config):
+        pass
+
+    def emit(self, event: RunEvent):
+        pass

--- a/client/python/tests/transport.py
+++ b/client/python/tests/transport.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0.
 from openlineage.client.run import RunEvent
 from openlineage.client.transport import Transport, Config, register_transport
 

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -1,28 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from unittest.mock import patch
 
 from openlineage.airflow.adapter import OpenLineageAdapter
 
 
+@patch.dict(os.environ, {
+    "MARQUEZ_URL": "http://marquez:5000",
+    "MARQUEZ_API_KEY": "api-key"
+})
 def test_create_client_from_marquez_url():
-    os.environ['MARQUEZ_URL'] = "http://marquez:5000"
-    os.environ['MARQUEZ_API_KEY'] = "test-api-key"
-
     client = OpenLineageAdapter().get_or_create_openlineage_client()
-    assert client.url == "http://marquez:5000"
-    assert client.options.api_key == "test-api-key"
-    del os.environ['MARQUEZ_URL']
-    del os.environ['MARQUEZ_API_KEY']
+    assert client.transport.url == "http://marquez:5000"
+    assert "Authorization" in client.transport.session.headers
+    assert client.transport.session.headers["Authorization"] == "Bearer api-key"
 
 
+@patch.dict(os.environ, {
+    "OPENLINEAGE_URL": "http://ol-api:5000",
+    "OPENLINEAGE_API_KEY": "api-key"
+})
 def test_create_client_from_ol_env():
-    os.environ['OPENLINEAGE_URL'] = "http://ol-api:5000"
-    os.environ['OPENLINEAGE_API_KEY'] = "api-key"
-
     client = OpenLineageAdapter().get_or_create_openlineage_client()
 
-    assert client.url == "http://ol-api:5000"
-    assert client.options.api_key == "api-key"
-    del os.environ['OPENLINEAGE_URL']
-    del os.environ['OPENLINEAGE_API_KEY']
+    assert client.transport.url == "http://ol-api:5000"
+    assert "Authorization" in client.transport.session.headers
+    assert client.transport.session.headers["Authorization"] == "Bearer api-key"

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import tempfile
+from unittest.mock import patch
 
 import pandas
 import pytest
@@ -18,6 +19,8 @@ from sqlalchemy import create_engine
 
 from openlineage.common.provider.great_expectations import OpenLineageValidationAction
 from openlineage.common.provider.great_expectations.results import GreatExpectationsAssertion
+
+current_env = os.environ
 
 project_config = DataContextConfig(
     datasources={
@@ -86,6 +89,7 @@ def test_db_file():
     os.remove(file)
 
 
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://localhost:5000", **current_env})
 def test_dataset_from_sql_source(test_db_file, tmpdir):
     connection_url = f'sqlite:///{test_db_file}'
     engine = create_engine(connection_url)
@@ -136,6 +140,7 @@ def test_dataset_from_sql_source(test_db_file, tmpdir):
                                                     'size')])
 
 
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://localhost:5000", **current_env})
 def test_dataset_from_custom_sql(test_db_file, tmpdir):
     connection_url = f'sqlite:///{test_db_file}'
     engine = create_engine(connection_url)
@@ -201,6 +206,7 @@ def test_dataset_from_custom_sql(test_db_file, tmpdir):
                ['dataQuality', 'greatExpectations_assertions', 'dataQualityMetrics'])
 
 
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://localhost:5000", **current_env})
 def test_dataset_from_pandas_source(tmpdir):
     data_file = tmpdir + '/data.json'
     json_data = [

--- a/integration/dagster/tests/test_adapter_client.py
+++ b/integration/dagster/tests/test_adapter_client.py
@@ -19,6 +19,6 @@ def test_custom_client_config():
     os.environ["OPENLINEAGE_API_KEY"] = "api-key"
     adapter = OpenLineageAdapter()
     assert adapter._client.transport.url == "http://ol-api:5000"
-    assert adapter._client.transport.api_key == "api-key"
+    assert adapter._client.transport.session.headers['Authorization'] == "Bearer api-key"
     del os.environ["OPENLINEAGE_URL"]
     del os.environ["OPENLINEAGE_API_KEY"]

--- a/integration/dagster/tests/test_adapter_client.py
+++ b/integration/dagster/tests/test_adapter_client.py
@@ -18,7 +18,7 @@ def test_custom_client_config():
     os.environ["OPENLINEAGE_URL"] = "http://ol-api:5000"
     os.environ["OPENLINEAGE_API_KEY"] = "api-key"
     adapter = OpenLineageAdapter()
-    assert adapter._client.url == "http://ol-api:5000"
-    assert adapter._client.options.api_key == "api-key"
+    assert adapter._client.transport.url == "http://ol-api:5000"
+    assert adapter._client.transport.api_key == "api-key"
     del os.environ["OPENLINEAGE_URL"]
     del os.environ["OPENLINEAGE_API_KEY"]

--- a/integration/dagster/tests/test_adapter_step.py
+++ b/integration/dagster/tests/test_adapter_step.py
@@ -22,8 +22,8 @@ from .conftest import PRODUCER
 
 
 @patch("openlineage.dagster.adapter.to_utc_iso_8601")
-@patch("openlineage.dagster.adapter.OpenLineageClient.emit")
-def test_start_pipeline(mock_client_emit, mock_to_utc_iso_8601):
+@patch("openlineage.dagster.adapter.OpenLineageClient.from_environment")
+def test_start_pipeline(mock_client, mock_to_utc_iso_8601):
     event_time = "2022-01-01T00:00:00.000000Z"
     mock_to_utc_iso_8601.return_value = event_time
 
@@ -37,7 +37,7 @@ def test_start_pipeline(mock_client_emit, mock_to_utc_iso_8601):
     adapter.start_step(pipeline_name, pipeline_run_id, timestamp, step_run_id, step_key)
 
     mock_to_utc_iso_8601.assert_called_once_with(timestamp)
-    mock_client_emit.assert_called_once_with(
+    mock_client.return_value.emit.assert_called_once_with(
         RunEvent(
             eventType=RunState.START,
             eventTime=event_time,
@@ -68,8 +68,8 @@ def test_start_pipeline(mock_client_emit, mock_to_utc_iso_8601):
 
 
 @patch("openlineage.dagster.adapter.to_utc_iso_8601")
-@patch("openlineage.dagster.adapter.OpenLineageClient.emit")
-def test_complete_step(mock_client_emit, mock_to_utc_iso_8601):
+@patch("openlineage.dagster.adapter.OpenLineageClient.from_environment")
+def test_complete_step(mock_client, mock_to_utc_iso_8601):
     event_time = "2022-01-01T00:00:00.000000Z"
     mock_to_utc_iso_8601.return_value = event_time
 
@@ -83,7 +83,7 @@ def test_complete_step(mock_client_emit, mock_to_utc_iso_8601):
     adapter.complete_step(pipeline_name, pipeline_run_id, timestamp, step_run_id, step_key)
 
     mock_to_utc_iso_8601.assert_called_once_with(timestamp)
-    mock_client_emit.assert_called_once_with(
+    mock_client.return_value.emit.assert_called_once_with(
         RunEvent(
             eventType=RunState.COMPLETE,
             eventTime=event_time,
@@ -114,8 +114,8 @@ def test_complete_step(mock_client_emit, mock_to_utc_iso_8601):
 
 
 @patch("openlineage.dagster.adapter.to_utc_iso_8601")
-@patch("openlineage.dagster.adapter.OpenLineageClient.emit")
-def test_fail_step(mock_client_emit, mock_to_utc_iso_8601):
+@patch("openlineage.dagster.adapter.OpenLineageClient.from_environment")
+def test_fail_step(mock_client, mock_to_utc_iso_8601):
     event_time = "2022-01-01T00:00:00.000000Z"
     mock_to_utc_iso_8601.return_value = event_time
 
@@ -129,7 +129,7 @@ def test_fail_step(mock_client_emit, mock_to_utc_iso_8601):
     adapter.fail_step(pipeline_name, pipeline_run_id, timestamp, step_run_id, step_key)
 
     mock_to_utc_iso_8601.assert_called_once_with(timestamp)
-    mock_client_emit.assert_called_once_with(
+    mock_client.return_value.emit.assert_called_once_with(
         RunEvent(
             eventType=RunState.FAIL,
             eventTime=event_time,

--- a/integration/dagster/tests/test_sensor_cursor.py
+++ b/integration/dagster/tests/test_sensor_cursor.py
@@ -9,26 +9,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import json
 import uuid
 from unittest.mock import patch
 
 from dagster import SensorDefinition, build_sensor_context, DagsterEventType
 from dagster.core.test_utils import instance_for_test
-
 from openlineage.dagster.cursor import OpenLineageCursor, RunningPipeline, RunningStep
-from openlineage.dagster.sensor import openlineage_sensor
 from .conftest import make_test_event_log_record
 
 
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000"})
 def test_basic_sensor_def():
+    from openlineage.dagster.sensor import openlineage_sensor  # noqa: E402
     sensor_def = openlineage_sensor()
     assert isinstance(sensor_def, SensorDefinition)
     assert not sensor_def.targets
 
 
+@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000"})
 @patch("openlineage.dagster.sensor.get_event_log_records")
 def test_cursor_update_with_after_storage_id(mock_event_log_records):
+    from openlineage.dagster.sensor import openlineage_sensor  # noqa: E402
     with instance_for_test() as instance:
         context = build_sensor_context(instance=instance, repository_name="hello")
         openlineage_sensor(after_storage_id=100).evaluate_tick(context)
@@ -43,6 +46,7 @@ def test_cursor_update_with_after_storage_id(mock_event_log_records):
 @patch("openlineage.dagster.sensor.make_step_run_id")
 @patch("openlineage.dagster.sensor.get_event_log_records")
 def test_cursor_update_with_successful_run(mock_event_log_records, mock_step_run_id, mock_adapter):  # noqa: E501
+    from openlineage.dagster.sensor import openlineage_sensor  # noqa: E402
     with instance_for_test() as instance:
         ol_sensor_def = openlineage_sensor(record_filter_limit=1)
 
@@ -124,6 +128,7 @@ def test_cursor_update_with_successful_run(mock_event_log_records, mock_step_run
 @patch("openlineage.dagster.sensor.make_step_run_id")
 @patch("openlineage.dagster.sensor.get_event_log_records")
 def test_cursor_update_with_failing_run(mock_event_log_records, mock_step_run_id, mock_adapter):
+    from openlineage.dagster.sensor import openlineage_sensor  # noqa: E402
     with instance_for_test() as instance:
         ol_sensor_def = openlineage_sensor(record_filter_limit=1)
 
@@ -204,6 +209,7 @@ def test_cursor_update_with_failing_run(mock_event_log_records, mock_step_run_id
 @patch("openlineage.dagster.sensor.make_step_run_id")
 @patch("openlineage.dagster.sensor.get_event_log_records")
 def test_cursor_update_with_exception_raised(mock_event_log_records, mock_step_run_id, mock_adapter):  # noqa: E501
+    from openlineage.dagster.sensor import openlineage_sensor  # noqa: E402
     with instance_for_test() as instance:
         pipeline_run_id = str(uuid.uuid4())
         step_key = "an_op"


### PR DESCRIPTION
This is draft implementation of Transport interface for Python proposed in #269 
Also, added very basic KafkaTransport in addition to HttpTransport.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)