### PR TITLE
add DatasetLifecycleStateDatasetFacet to spec

### DIFF
--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -56,7 +56,7 @@ public class OpenLineageRunEventTest {
     OpenLineage.SQLJobFacet sqlJobFacet = ol.newSQLJobFacet("SELECT * FROM test");
 
     OpenLineage.JobFacets jobFacets =
-        ol.newJobFacets(sourceCodeLocationJobFacet, sqlJobFacet, documentationJobFacet);
+        ol.newJobFacets(sqlJobFacet, sourceCodeLocationJobFacet, documentationJobFacet);
     OpenLineage.Job job = ol.newJob("namespace", "jobName", jobFacets);
     List<OpenLineage.InputDataset> inputs =
         Arrays.asList(

--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -123,6 +123,8 @@ Example of valid name is `BigQueryStatisticsJobFacet` and it's key `bigQuery_sta
 
 - **dataSource**: Captures the Database instance containing this datasets (ex: Database schema. Object store bucket, ...)
 
+- **lifecycleState**: Captures the lifecycle states of the dataset like: alter, create, drop, overwrite, rename, truncate.
+
 #### Input Dataset Facets
 
 - **dataQualityMetrics**: Captures dataset level and column level data quality metrics when scanning a dataset whith a DataQuality library (row count, byte size, null count, distinct count, average, min, max, quantiles).

--- a/spec/facets/LifecycleStateChangeDatasetFacet.json
+++ b/spec/facets/LifecycleStateChangeDatasetFacet.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/LifecycleStateChangeDatasetFacet.json",
+  "$defs": {
+    "LifecycleStateChangeDatasetFacet": {
+      "allOf": [{
+        "$ref": "https://openlineage.io/spec/1-0-2/OpenLineage.json#/$defs/DatasetFacet"
+      }, {
+        "type": "object",
+        "properties": {
+          "lifecycleStateChange": {
+            "description": "The lifecycle state change.",
+            "type": "string",
+            "enum": ["ALTER", "CREATE", "DROP", "OVERWRITE", "RENAME", "TRUNCATE"]
+          },
+          "previousIdentifier": {
+            "description": "Previous name of the dataset in case of renaming it.",
+            "type": "object",
+            "properties": {
+              "name": {
+                "documentation": "Previous dataset name.",
+                "type": "string"
+              },
+              "namespace": {
+                "documentation": "Previous dataset namespace.",
+                "type": "string"
+              }
+            },
+            "required": ["name", "namespace"]
+          }
+        },
+        "required": ["lifecycleStateChange"]
+      }],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "lifecycleStateChange": {
+      "$ref": "#/$defs/LifecycleStateChangeDatasetFacet"
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Missing global facet within spec to describe dataset operations like `create`, `drop`, `overwrite`, etc. 

Closes: #518

### Solution

Add `DatasetLifecycleDatasetFacet` to spec. Then use it for Spark integration and implement within Marquez. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)