### PR TITLE
airflow: extract source code from BashOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.5.2...HEAD)
 
 ### Added
-* Extract source code of PythonOperator code similar to SQL facet [@mobuchowski](https://github.com/mobuchowski)
+* Extract source code of PythonOperator and BashOperator similar to SQL facet [@mobuchowski](https://github.com/mobuchowski)
 
 
 ## [0.5.2](https://github.com/OpenLineage/OpenLineage/compare/0.5.1...0.5.2)

--- a/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
@@ -1,0 +1,33 @@
+import os
+from typing import Optional, List
+
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.client.facet import SourceCodeJobFacet
+
+
+class BashExtractor(BaseExtractor):
+    """
+    This extractor provides visibility on what bash task does by extracting
+    executed bash command and putting it into SourceCodeJobFacet. It does not extract
+    datasets.
+    """
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ["BashOperator"]
+
+    def extract(self) -> Optional[TaskMetadata]:
+        if os.environ.get(
+            "OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE", "False"
+        ).lower() in ('true', '1', 't'):
+            return None
+
+        return TaskMetadata(
+            name=f"{self.operator.dag_id}.{self.operator.task_id}",
+            job_facets={
+                "sourceCode": SourceCodeJobFacet(
+                    "bash",
+                    # We're on worker and should have access to DAG files
+                    self.operator.bash_command
+                )
+            }
+        )

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -24,6 +24,10 @@ _extractors = list(
             try_import_from_string(
                 'openlineage.airflow.extractors.python_extractor.PythonExtractor'
             ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.bash_extractor.BashExtractor'
+            ),
+
         ],
     )
 )

--- a/integration/airflow/tests/extractors/test_bash_extractor.py
+++ b/integration/airflow/tests/extractors/test_bash_extractor.py
@@ -1,0 +1,33 @@
+import os
+from unittest.mock import patch
+
+from airflow.operators.bash_operator import BashOperator
+
+from openlineage.airflow.extractors.bash_extractor import BashExtractor
+from openlineage.airflow.extractors.example_dag import bash_task
+from openlineage.client.facet import SourceCodeJobFacet
+
+
+def test_extract_operator_bash_command():
+    operator = BashOperator(task_id='taskid', bash_command="exit 0")
+    extractor = BashExtractor(operator)
+    assert extractor.extract().job_facets['sourceCode'] == SourceCodeJobFacet("bash", "exit 0")
+
+
+def test_extract_dag_bash_command():
+    extractor = BashExtractor(bash_task)
+    assert extractor.extract().job_facets['sourceCode'] == \
+           SourceCodeJobFacet("bash", "ls -halt && exit 0")
+
+
+@patch.dict(os.environ, {"OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE": "True"})
+def test_extract_dag_bash_command_env_disables_on_true():
+    extractor = BashExtractor(bash_task)
+    assert extractor.extract() is None
+
+
+@patch.dict(os.environ, {"OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE": "asdftgeragdsfgawef"})
+def test_extract_dag_bash_command_env_does_not_disable_on_random_string():
+    extractor = BashExtractor(bash_task)
+    assert extractor.extract().job_facets['sourceCode'] == \
+           SourceCodeJobFacet("bash", "ls -halt && exit 0")

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -16,7 +16,7 @@ def test_env_extractors():
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
         'openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'
 
-    assert len(Extractors().extractors) == 7
+    assert len(Extractors().extractors) == 8
     del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']
 
 

--- a/integration/airflow/tests/integration/airflow/dags/custom_extractor.py
+++ b/integration/airflow/tests/integration/airflow/dags/custom_extractor.py
@@ -5,10 +5,10 @@ from openlineage.airflow.extractors import TaskMetadata
 from openlineage.airflow.extractors.base import BaseExtractor
 
 
-class BashExtractor(BaseExtractor):
+class CustomExtractor(BaseExtractor):
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
-        return ['BashOperator']
+        return ['CustomOperator']
 
     def extract(self) -> Union[Optional[TaskMetadata], List[TaskMetadata]]:
         return TaskMetadata(

--- a/integration/airflow/tests/integration/airflow/dags/custom_extractor_dag.py
+++ b/integration/airflow/tests/integration/airflow/dags/custom_extractor_dag.py
@@ -1,10 +1,11 @@
 import os
+from typing import Any
 
-from airflow.operators.bash_operator import BashOperator
+from airflow.models import BaseOperator
 from airflow.utils.dates import days_ago
 from openlineage.client import set_producer
 
-os.environ["OPENLINEAGE_EXTRACTOR_BashOperator"] = 'custom_extractor.BashExtractor'
+os.environ["OPENLINEAGE_EXTRACTOR_CustomOperator"] = 'custom_extractor.CustomExtractor'
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 from airflow.version import version as AIRFLOW_VERSION
@@ -32,8 +33,14 @@ dag = DAG(
     description='Test dag.'
 )
 
-t1 = BashOperator(
+
+class CustomOperator(BaseOperator):
+    def execute(self, context: Any):
+        for i in range(10):
+            print(i)
+
+
+t1 = CustomOperator(
     task_id='custom_extractor',
-    bash_command="ls -halt",
     dag=dag
 )

--- a/integration/airflow/tests/integration/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/docker-compose-2.yml
@@ -27,7 +27,7 @@ x-airflow-common: &airflow-common
     GOOGLE_APPLICATION_CREDENTIALS: /opt/config/gcloud/gcloud-service-key.json
     OPENLINEAGE_URL: http://backend:5000
     OPENLINEAGE_NAMESPACE: food_delivery
-    OPENLINEAGE_EXTRACTOR_BashOperator: custom_extractor.BashExtractor
+    OPENLINEAGE_EXTRACTOR_CustomOperator: custom_extractor.CustomExtractor
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
       - ./airflow/logs:/opt/airflow/logs

--- a/integration/airflow/tests/integration/requests/source_code.json
+++ b/integration/airflow/tests/integration/requests/source_code.json
@@ -1,40 +1,54 @@
-[{
+[
+  {
     "eventType": "START",
     "job": {
-        "facets": {
-          "sourceCode": {
-            "language": "python",
-            "source": "def callable():\n    print(10)\n"
-          }
-        },
-        "name": "source_code_dag.python_task",
-        "namespace": "food_delivery"
+      "facets": {
+        "sourceCode": {
+          "language": "python",
+          "source": "def callable():\n    print(10)\n"
+        }
+      },
+      "name": "source_code_dag.python_task",
+      "namespace": "food_delivery"
     }
-},
-{
+  },
+  {
     "eventType": "START",
     "job": {
-        "name": "source_code_dag.bash_task",
-        "namespace": "food_delivery"
+      "facets": {
+        "sourceCode": {
+          "language": "bash",
+          "source": "ls -halt && exit 0"
+        }
+      },
+      "name": "source_code_dag.bash_task",
+      "namespace": "food_delivery"
     }
-},
-{
+  },
+  {
     "eventType": "COMPLETE",
     "job": {
-        "facets": {
-          "sourceCode": {
-            "language": "python",
-            "source": "def callable():\n    print(10)\n"
-          }
-        },
-        "name": "source_code_dag.python_task",
-        "namespace": "food_delivery"
+      "facets": {
+        "sourceCode": {
+          "language": "python",
+          "source": "def callable():\n    print(10)\n"
+        }
+      },
+      "name": "source_code_dag.python_task",
+      "namespace": "food_delivery"
     }
-},
-{
-	"eventType": "COMPLETE",
-	"job": {
-        "name": "source_code_dag.bash_task",
-		"namespace": "food_delivery"
-	}
-}]
+  },
+  {
+    "eventType": "COMPLETE",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "bash",
+          "source": "ls -halt && exit 0"
+        }
+      },
+      "name": "source_code_dag.bash_task",
+      "namespace": "food_delivery"
+    }
+  }
+]


### PR DESCRIPTION
Similar to https://github.com/OpenLineage/OpenLineage/pull/529, include bash_command 
used by BashOperator as job facet.

Closes: https://github.com/OpenLineage/OpenLineage/issues/520

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)