### PR TITLE
airflow: expose parent run information as macros in Airflow 2

### DIFF
--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -1,0 +1,72 @@
+import os
+
+from openlineage.airflow.utils import JobIdMapping, openlineage_job_name, safe_import_airflow
+
+_JOB_NAMESPACE = os.getenv('OPENLINEAGE_NAMESPACE', 'default')
+
+
+def get_create_session():
+    return safe_import_airflow(
+        airflow_1_path="airflow.utils.db.create_session",
+        airflow_2_path="airflow.utils.session.create_session",
+    )
+
+
+def lineage_run_id(run_id, task):
+    """
+    Macro function which returns the generated run id for a given task. This
+    can be used to forward the run id from a task to a child run so the job
+    hierarchy is preserved. Invoke as a jinja template, e.g.
+
+    PythonOperator(
+        task_id='render_template',
+        python_callable=my_task_function,
+        op_args=['{{ lineage_run_id(run_id, task) }}'], # lineage_run_id macro invoked
+        provide_context=False,
+        dag=dag
+    )
+
+    :param run_id:
+    :param task:
+    :return:
+    """
+    with get_create_session()() as session:
+        name = openlineage_job_name(task.dag_id, task.task_id)
+        ids = JobIdMapping.get(name, run_id, session)
+        if ids is None:
+            return ""
+        elif isinstance(ids, list):
+            return "" if len(ids) == 0 else ids[0]
+        else:
+            return str(ids)
+
+
+def lineage_parent_id(run_id, task):
+    """
+    Macro function which returns the generated job and run id for a given task. This
+    can be used to forward the ids from a task to a child run so the job
+    hierarchy is preserved. Child run can create ParentRunFacet from those ids.
+    Invoke as a jinja template, e.g.
+
+    PythonOperator(
+        task_id='render_template',
+        python_callable=my_task_function,
+        op_args=['{{ lineage_parent_id(run_id, task) }}'], # lineage_run_id macro invoked
+        provide_context=False,
+        dag=dag
+    )
+
+    :param run_id:
+    :param task:
+    :return:
+    """
+    with get_create_session()() as session:
+        job_name = openlineage_job_name(task.dag_id, task.task_id)
+        ids = JobIdMapping.get(job_name, run_id, session)
+        if ids is None:
+            return ""
+        elif isinstance(ids, list):
+            run_id = "" if len(ids) == 0 else ids[0]
+        else:
+            run_id = str(ids)
+        return f"{_JOB_NAMESPACE}/{job_name}/{run_id}"

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -4,9 +4,12 @@ from pkg_resources import parse_version
 
 
 # Provide empty plugin for older version
+from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0.dev0"):
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
+        macros = [lineage_run_id, lineage_parent_id]
 else:
     from openlineage.airflow import listener
 
@@ -14,3 +17,4 @@ else:
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
         listeners = [listener]
+        macros = [lineage_run_id, lineage_parent_id]

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -29,6 +29,10 @@ log = logging.getLogger(__name__)
 _NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
+def openlineage_job_name(dag_id: str, task_id: str) -> str:
+    return f'{dag_id}.{task_id}'
+
+
 class JobIdMapping:
     # job_name here is OL job name - aka combination of dag_id and task_id
 


### PR DESCRIPTION
In Airflow 1.10 integration, we've added two lineage related macros, that allow to pass parent run information to the child job. 

This PR exposes those macros to an Airflow 2.0+ environment, via [Airflow plugin](https://airflow.apache.org/docs/apache-airflow/stable/plugins.html)

Call target of those macros is slightly different than for 1.10 integration. It's not exposed directly, but via `macros.OpenLineagePlugin` namespace - so full macro call looks like that: 

```jinja2
{{ macros.OpenLineagePlugin.lineage_parent_id(run_id, task) }}
```

Closes: https://github.com/OpenLineage/OpenLineage/issues/521

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)