### PR TITLE
ci: run most expensive jobs on large resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
         type: string
     working_directory: ~/openlineage/integration/spark
     machine: true
+    resource_class: large
     environment:
       TESTCONTAINERS_RYUK_DISABLED: "true"
       JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
@@ -238,6 +239,7 @@ jobs:
         type: string
     working_directory: ~/openlineage/integration/spark
     machine: true
+    resource_class: large
     environment:
       TESTCONTAINERS_RYUK_DISABLED: "true"
       JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
@@ -311,6 +313,7 @@ jobs:
   integration-test-integration-airflow:
     working_directory: ~/openlineage/integration/
     machine: true
+    resource_class: large
     steps:
       - *checkout_project_root
       - gcp-cli/install
@@ -323,6 +326,7 @@ jobs:
   integration-test-integration-airflow-2:
     working_directory: ~/openlineage/integration/
     machine: true
+    resource_class: large
     steps:
       - *checkout_project_root
       - gcp-cli/install

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -229,7 +229,7 @@ tasks.register('copyDependencies', Copy) {
 
 def commonTestConfiguration = {
     forkEvery 1
-    maxParallelForks 3
+    maxParallelForks 5
     testLogging {
         events "passed", "skipped", "failed"
         showStandardStreams = true


### PR DESCRIPTION
Some tests are slow, among other things, due to being CPU starved.

Move them to large resource class with 4 CPUs compared to 2 on medium. 
Overall total duration moved from ~30 minutes to ~20 minutes.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>