### PR TITLE
airflow: add external query id facet

### DIFF
--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -189,3 +189,9 @@ class SourceCodeJobFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return SCHEMA_URI + "#/definitions/SourceCodeJobFacet"
+
+
+@attr.s
+class ExternalQueryRunFacet(BaseFacet):
+    externalQueryId: str = attr.ib()
+    source: str = attr.ib()

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -92,7 +92,12 @@ class OpenLineageAdapter:
             eventType=RunState.START,
             eventTime=event_time,
             run=self._build_run(
-                run_id, parent_run_id, job_name, nominal_start_time, nominal_end_time, run_facets
+                run_id,
+                parent_run_id,
+                job_name,
+                nominal_start_time,
+                nominal_end_time,
+                run_facets=run_facets
             ),
             job=self._build_job(
                 job_name, job_description, code_location, task.job_facets
@@ -123,7 +128,8 @@ class OpenLineageAdapter:
             eventType=RunState.COMPLETE,
             eventTime=end_time,
             run=self._build_run(
-                run_id
+                run_id,
+                run_facets=task.run_facets
             ),
             job=self._build_job(
                 job_name, job_facets=task.job_facets
@@ -152,7 +158,8 @@ class OpenLineageAdapter:
             eventType=RunState.FAIL,
             eventTime=end_time,
             run=self._build_run(
-                run_id
+                run_id,
+                run_facets=task.run_facets
             ),
             job=self._build_job(
                 job_name
@@ -170,7 +177,7 @@ class OpenLineageAdapter:
         job_name: Optional[str] = None,
         nominal_start_time: Optional[str] = None,
         nominal_end_time: Optional[str] = None,
-        custom_facets: Dict[str, Type[BaseFacet]] = None
+        run_facets: Dict[str, BaseFacet] = None
     ) -> Run:
         facets = {}
         if nominal_start_time:
@@ -184,8 +191,8 @@ class OpenLineageAdapter:
                 job_name
             )})
 
-        if custom_facets:
-            facets.update(custom_facets)
+        if run_facets:
+            facets.update(run_facets)
 
         return Run(run_id, facets)
 

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -7,7 +7,6 @@ from typing import Optional, List
 
 import attr
 
-from openlineage.airflow.facets import ExternalQueryJobFacet
 from openlineage.client.facet import SqlJobFacet
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider, BigQueryErrorRunFacet
 from openlineage.common.sql import SqlParser
@@ -70,10 +69,7 @@ class BigQueryExtractor(BaseExtractor):
         output = stats.output
         run_facets = stats.run_facets
         job_facets = {
-            "sql": SqlJobFacet(context.sql),
-            "externalQuery": ExternalQueryJobFacet(
-                externalQueryId=bigquery_job_id, source="bigquery"
-            )
+            "sql": SqlJobFacet(context.sql)
         }
 
         return TaskMetadata(
@@ -88,7 +84,7 @@ class BigQueryExtractor(BaseExtractor):
         bigquery_job_id = task_instance.xcom_pull(
             task_ids=task_instance.task_id, key='job_id')
 
-        log.info(f"bigquery_job_id: {bigquery_job_id}")
+        log.debug(f"bigquery_job_id: {bigquery_job_id}")
         return bigquery_job_id
 
     def parse_sql_context(self) -> SqlContext:

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -34,16 +34,10 @@ class SnowflakeExtractor(PostgresExtractor):
         return 'snowflake'
 
     def _get_database(self) -> str:
-        if hasattr(self.operator, 'get_db_hook'):
-            return self.operator.get_db_hook()._get_conn_params()['database']
-        else:
-            return self.operator.get_hook()._get_conn_params()['database']
+        return self._get_hook()._get_conn_params()['database']
 
     def _get_authority(self) -> str:
-        if hasattr(self.operator, 'get_db_hook'):
-            return self.operator.get_db_hook()._get_conn_params()['account']
-        else:
-            return self.operator.get_hook()._get_conn_params()['account']
+        return self._get_hook()._get_conn_params()['account']
 
     def _get_hook(self):
         if hasattr(self.operator, 'get_db_hook'):
@@ -56,3 +50,8 @@ class SnowflakeExtractor(PostgresExtractor):
 
     def _get_connection_uri(self):
         return get_connection_uri(self.conn)
+
+    def _get_query_ids(self) -> List[str]:
+        if hasattr(self.operator, 'query_ids'):
+            return self.operator.query_ids
+        return []

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -27,9 +27,3 @@ class AirflowVersionRunFacet(BaseFacet):
 @attr.s
 class AirflowRunArgsRunFacet(BaseFacet):
     externalTrigger: bool = attr.ib(default=False)
-
-
-@attr.s
-class ExternalQueryJobFacet(BaseFacet):
-    externalQueryId: str = attr.ib()
-    source: str = attr.ib()

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -27,3 +27,9 @@ class AirflowVersionRunFacet(BaseFacet):
 @attr.s
 class AirflowRunArgsRunFacet(BaseFacet):
     externalTrigger: bool = attr.ib(default=False)
+
+
+@attr.s
+class ExternalQueryJobFacet(BaseFacet):
+    externalQueryId: str = attr.ib()
+    source: str = attr.ib()

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -69,7 +69,7 @@ class Backend:
             run_id=run_id,
             job_name=job_name,
             end_time=DagUtils.to_iso_8601(self._now_ms()),
-            task=task_metadata
+            task=task_metadata,
         )
 
     def _extract_metadata(self, dag_id, dagrun, task, task_instance=None):

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -14,6 +14,7 @@ from airflow.models import TaskInstance, DAG
 from airflow.utils.state import State
 
 from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
+from openlineage.airflow.facets import ExternalQueryJobFacet
 from openlineage.airflow.utils import safe_import_airflow, choose_based_on_version
 from openlineage.client.facet import OutputStatisticsOutputDatasetFacet
 from openlineage.common.provider.bigquery import BigQueryJobRunFacet, \
@@ -131,6 +132,11 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             billedBytes=111149056,
             properties=json.dumps(job_details)
         ) == task_meta.run_facets['bigQuery_job']
+
+        assert ExternalQueryJobFacet(
+            externalQueryId=bq_job_id,
+            source="bigquery"
+        ) == task_meta.job_facets['externalQuery']
 
         mock_client.return_value.close.assert_called()
 

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -14,9 +14,8 @@ from airflow.models import TaskInstance, DAG
 from airflow.utils.state import State
 
 from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
-from openlineage.airflow.facets import ExternalQueryJobFacet
 from openlineage.airflow.utils import safe_import_airflow, choose_based_on_version
-from openlineage.client.facet import OutputStatisticsOutputDatasetFacet
+from openlineage.client.facet import OutputStatisticsOutputDatasetFacet, ExternalQueryRunFacet
 from openlineage.common.provider.bigquery import BigQueryJobRunFacet, \
     BigQueryStatisticsDatasetFacet, BigQueryErrorRunFacet
 from openlineage.common.utils import get_from_nullable_chain
@@ -126,17 +125,17 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             size=321
         ) == task_meta.outputs[0].outputFacets['outputStatistics']
 
-        assert len(task_meta.run_facets) == 1
+        assert len(task_meta.run_facets) == 2
         assert BigQueryJobRunFacet(
             cached=False,
             billedBytes=111149056,
             properties=json.dumps(job_details)
         ) == task_meta.run_facets['bigQuery_job']
 
-        assert ExternalQueryJobFacet(
+        assert ExternalQueryRunFacet(
             externalQueryId=bq_job_id,
             source="bigquery"
-        ) == task_meta.job_facets['externalQuery']
+        ) == task_meta.run_facets['externalQuery']
 
         mock_client.return_value.close.assert_called()
 
@@ -216,9 +215,14 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         assert task_meta.inputs is not None
         assert task_meta.outputs is not None
 
-        assert len(task_meta.run_facets) == 1
+        assert len(task_meta.run_facets) == 2
         assert task_meta.run_facets['bigQuery_job'] \
                == BigQueryJobRunFacet(cached=True)
+
+        assert ExternalQueryRunFacet(
+            externalQueryId=bq_job_id,
+            source="bigquery"
+        ) == task_meta.run_facets['externalQuery']
 
     @mock.patch(choose_based_on_version(
         airflow_1_version="airflow.contrib.operators.bigquery_operator.BigQueryHook",

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -139,7 +139,7 @@ def test_extract_query_ids(get_connection, mock_get_table_schemas):
 
     task_metadata = SnowflakeExtractor(TASK).extract()
 
-    assert task_metadata.job_facets["externalQuery"].externalQueryId == "1500100900"
+    assert task_metadata.run_facets["externalQuery"].externalQueryId == "1500100900"
 
 
 @mock.patch('snowflake.connector.connect')

--- a/integration/airflow/tests/integration/requests/bigquery.json
+++ b/integration/airflow/tests/integration/requests/bigquery.json
@@ -42,14 +42,18 @@
         "facets": {
             "sql": {
                 "query": "\n    CREATE TABLE IF NOT EXISTS `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (\n      order_day_of_week INTEGER NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
-            },
-            "externalQuery": {
-                "externalQueryId": "{{ any(result) }}",
-                "source": "bigquery"
             }
         },
         "name": "bigquery_orders_popular_day_of_week.bigquery_if_not_exists",
         "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "externalQuery": {
+              "externalQueryId": "{{ any(result) }}",
+              "source": "bigquery"
+            }
+        }
     },
     "outputs": [{
 		"facets": {
@@ -128,15 +132,19 @@
 		"facets": {
 			"sql": {
 				"query": "\n    INSERT INTO `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times\n    GROUP BY order_placed_on;"
-			},
-            "externalQuery": {
-                "externalQueryId": "{{ any(result) }}",
-                "source": "bigquery"
-            }
+			}
 		},
 		"name": "bigquery_orders_popular_day_of_week.bigquery_insert",
 		"namespace": "food_delivery"
 	},
+    "run": {
+        "facets": {
+            "externalQuery": {
+              "externalQueryId": "{{ any(result) }}",
+              "source": "bigquery"
+            }
+        }
+    },
 	"outputs": [{
 		"facets": {
 			"dataSource": {

--- a/integration/airflow/tests/integration/requests/bigquery.json
+++ b/integration/airflow/tests/integration/requests/bigquery.json
@@ -42,6 +42,10 @@
         "facets": {
             "sql": {
                 "query": "\n    CREATE TABLE IF NOT EXISTS `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (\n      order_day_of_week INTEGER NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
+            },
+            "externalQuery": {
+                "externalQueryId": "{{ any(result) }}",
+                "source": "bigquery"
             }
         },
         "name": "bigquery_orders_popular_day_of_week.bigquery_if_not_exists",
@@ -124,7 +128,11 @@
 		"facets": {
 			"sql": {
 				"query": "\n    INSERT INTO `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times\n    GROUP BY order_placed_on;"
-			}
+			},
+            "externalQuery": {
+                "externalQueryId": "{{ any(result) }}",
+                "source": "bigquery"
+            }
 		},
 		"name": "bigquery_orders_popular_day_of_week.bigquery_insert",
 		"namespace": "food_delivery"

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -13,7 +13,8 @@ from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbTableSchema, DbColumn, DbTableName
 from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.utils import get_from_nullable_chain
-from openlineage.client.facet import BaseFacet, OutputStatisticsOutputDatasetFacet
+from openlineage.client.facet import BaseFacet, OutputStatisticsOutputDatasetFacet, \
+    ExternalQueryRunFacet
 
 _BIGQUERY_CONN_URL = 'bigquery'
 
@@ -104,7 +105,10 @@ class BigQueryDatasetsProvider:
                 run_stat_facet, dataset_stat_facet = self._get_output_statistics(props)
 
                 run_facets.update({
-                    "bigQuery_job": run_stat_facet
+                    "bigQuery_job": run_stat_facet,
+                    "externalQuery": ExternalQueryRunFacet(
+                        externalQueryId=job_id, source="bigquery"
+                    )
                 })
                 inputs = self._get_input_from_bq(props)
                 output = self._get_output_from_bq(props)

--- a/integration/common/tests/bigquery/test_bigquery.py
+++ b/integration/common/tests/bigquery/test_bigquery.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
+from openlineage.client.facet import ExternalQueryRunFacet
 from openlineage.common.dataset import Dataset, Source, Field
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider, BigQueryJobRunFacet
 
@@ -39,6 +40,10 @@ def test_bq_job_information():
             cached=False,
             billedBytes=111149056,
             properties=json.dumps(job_details)
+        ),
+        'externalQuery': ExternalQueryRunFacet(
+            externalQueryId='job_id',
+            source='bigquery'
         )
     }
     assert statistics.inputs == [


### PR DESCRIPTION
Jobs that run on external systems like BigQuery or Snowflake are identified by their query id.
Add facet that exposes this collected query id, so that OpenLineage job run can be associated with that external job. 

This PR implements this for BigQueryOperator and SnowflakeOperator. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
 
Closes: https://github.com/OpenLineage/OpenLineage/issues/517

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)