### PR TITLE
extend wait strategy for spark docker containers

### DIFF
--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/util/LogMessageWaitExtraTimeStrategy.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/util/LogMessageWaitExtraTimeStrategy.java
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.spark.agent.util;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import lombok.SneakyThrows;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+/**
+ * Custom wait strategy for running Spark Docker containers. It waits for defined logs to appear
+ * (like SparkShutdown hook) and waits extra time (specified as a parameter in millis), to give an
+ * asynchronous OpenLineage event more time to get delivered. It is used to prevent SparkContainers
+ * stop too early.
+ */
+public class LogMessageWaitExtraTimeStrategy extends LogMessageWaitStrategy {
+
+  private Duration extraWaitingTime = Duration.of(0, ChronoUnit.SECONDS);
+
+  public LogMessageWaitStrategy withExtraWaitingTime(Duration extraWaitingTime) {
+    this.extraWaitingTime = extraWaitingTime;
+    return this;
+  }
+
+  @Override
+  @SneakyThrows(InterruptedException.class)
+  protected void waitUntilReady() {
+    super.waitUntilReady();
+    Thread.sleep(extraWaitingTime.toMillis());
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Integreation tests randomly without any leading, generic cause.

Closes: #ISSUE-NUMBER

### Solution

Hypothesis: We run integration tests in docker and close docker containers when a log entry `Shutdown hook called.*` is collected. However it is still possible that OpenLineage event is sent at the same time and stops from being delievered. 

Solution: Extend `LogMessageWaitStrategy` to wait and extra time after shutdown hook log is collected. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)