### PR TITLE
Abstract query plan builder approach to exposing SparkListenerEvents to node visitors

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -23,9 +23,7 @@ import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveTableVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KafkaRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
-import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
-import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SqlDWDatabricksVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.TruncateTableCommandVisitor;
 import io.openlineage.spark.api.DatasetFactory;
@@ -41,7 +39,6 @@ abstract class BaseVisitorFactory implements VisitorFactory {
       List<PartialFunction<LogicalPlan, List<D>>> getBaseCommonVisitors(
           OpenLineageContext context, DatasetFactory<D> factory) {
     List<PartialFunction<LogicalPlan, List<D>>> list = new ArrayList<>();
-    list.add(new LogicalRelationVisitor(context, factory));
     list.add(new LogicalRDDVisitor(context, factory));
     if (BigQueryNodeVisitor.hasBigQueryClasses()) {
       list.add(new BigQueryNodeVisitor(context, factory));
@@ -80,7 +77,6 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(new InsertIntoDataSourceDirVisitor(context));
     list.add(new InsertIntoDataSourceVisitor(context));
     list.add(new InsertIntoHadoopFsRelationVisitor(context));
-    list.add(new SaveIntoDataSourceCommandVisitor(context));
     list.add(new CreateDataSourceTableAsSelectCommandVisitor(context));
     list.add(new AppendDataVisitor(context));
     list.add(new InsertIntoDirVisitor(context));

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -3,12 +3,12 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.Dataset;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.lifecycle.plan.AlterTableAddColumnsCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.AlterTableRenameCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.AppendDataVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeVisitor;
-import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateHiveTableAsSelectCommandVisitor;
@@ -35,9 +35,8 @@ import scala.PartialFunction;
 
 abstract class BaseVisitorFactory implements VisitorFactory {
 
-  protected <D extends OpenLineage.Dataset>
-      List<PartialFunction<LogicalPlan, List<D>>> getBaseCommonVisitors(
-          OpenLineageContext context, DatasetFactory<D> factory) {
+  protected <D extends Dataset> List<PartialFunction<LogicalPlan, List<D>>> getBaseCommonVisitors(
+      OpenLineageContext context, DatasetFactory<D> factory) {
     List<PartialFunction<LogicalPlan, List<D>>> list = new ArrayList<>();
     list.add(new LogicalRDDVisitor(context, factory));
     if (BigQueryNodeVisitor.hasBigQueryClasses()) {
@@ -52,16 +51,14 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     return list;
   }
 
-  public abstract <D extends OpenLineage.Dataset>
-      List<PartialFunction<LogicalPlan, List<D>>> getCommonVisitors(
-          OpenLineageContext context, DatasetFactory<D> factory);
+  public abstract <D extends Dataset> List<PartialFunction<LogicalPlan, List<D>>> getCommonVisitors(
+      OpenLineageContext context, DatasetFactory<D> factory);
 
   @Override
   public List<PartialFunction<LogicalPlan, List<InputDataset>>> getInputVisitors(
       OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> inputVisitors =
         new ArrayList<>(getCommonVisitors(context, DatasetFactory.input(context.getOpenLineage())));
-    inputVisitors.add(new CommandPlanVisitor(context));
     return inputVisitors;
   }
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
@@ -1,0 +1,26 @@
+package io.openlineage.spark.agent.lifecycle;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collection;
+import java.util.List;
+import scala.PartialFunction;
+
+/**
+ * Provides input and output dataset builders
+ *
+ * <p>All common {@link AbstractQueryPlanDatasetBuilder} need to be grouped and passed into {@link
+ * DatasetBuilderFactory#getInputBuilders(io.openlineage.spark.api.OpenLineageContext)} or {@link
+ * DatasetBuilderFactory#getOutputBuilders(io.openlineage.spark.api.OpenLineageContext)} in order to
+ * produce within OpenLineage event {@link OpenLineage.InputDataset} and {@link
+ * OpenLineage.OutputDataset} respectively.
+ */
+public interface DatasetBuilderFactory {
+
+  Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+      OpenLineageContext context);
+
+  Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+      OpenLineageContext context);
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
@@ -1,0 +1,30 @@
+package io.openlineage.spark.agent.lifecycle;
+
+import org.apache.spark.package$;
+
+public class DatasetBuilderFactoryProvider {
+
+  private static final String SPARK2_FACTORY_NAME =
+      "io.openlineage.spark.agent.lifecycle.Spark2DatasetBuilderFactory";
+  private static final String SPARK3_FACTORY_NAME =
+      "io.openlineage.spark.agent.lifecycle.Spark3DatasetBuilderFactory";
+
+  static DatasetBuilderFactory getInstance() {
+    return getInstance(package$.MODULE$.SPARK_VERSION());
+  }
+
+  static DatasetBuilderFactory getInstance(String version) {
+    try {
+      if (version.startsWith("2.")) {
+        return (DatasetBuilderFactory) Class.forName(SPARK2_FACTORY_NAME).newInstance();
+      } else {
+        return (DatasetBuilderFactory) Class.forName(SPARK3_FACTORY_NAME).newInstance();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format(
+              "Can't instantiate dataset builder factory factory for version: %s", version),
+          e);
+    }
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -129,6 +129,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new LogicalRelationVisitor(
                     context, DatasetFactory.input(context.getOpenLineage()), true))
             .add(new CommandPlanVisitor(context))
+            .addAll(DatasetBuilderFactoryProvider.getInstance().getInputBuilders(context))
             .build();
     context.getInputDatasetBuilders().addAll(builders);
     return builders;
@@ -146,6 +147,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new LogicalRelationVisitor(
                     context, DatasetFactory.output(context.getOpenLineage()), false))
             .add(new SaveIntoDataSourceCommandVisitor(context))
+            .addAll(DatasetBuilderFactoryProvider.getInstance().getInputBuilders(context))
             .build();
     context.getOutputDatasetBuilders().addAll(outputDatasetBuilders);
     return outputDatasetBuilders;

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -340,7 +340,7 @@ class OpenLineageRunEventBuilder {
     log.info(
         "Visiting query plan {} with input dataset builders {}",
         openLineageContext.getQueryExecution(),
-        inputDatasetQueryPlanVisitors);
+        inputDatasetBuilders);
 
     Function1<LogicalPlan, Collection<InputDataset>> inputVisitor =
         visitLogicalPlan(PlanUtils.merge(inputDatasetQueryPlanVisitors));
@@ -456,7 +456,14 @@ class OpenLineageRunEventBuilder {
         .flatMap(
             event ->
                 builders.stream()
-                    .filter(pfn -> pfn.isDefinedAt(event))
+                    .filter(
+                        pfn -> {
+                          try {
+                            return pfn.isDefinedAt(event);
+                          } catch (ClassCastException e) {
+                            return false;
+                          }
+                        })
                     .map(pfn -> pfn.apply(event))
                     .flatMap(Collection::stream));
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -167,7 +167,7 @@ class OpenLineageRunEventBuilder {
   @NonNull private final Collection<CustomFacetBuilder<?, ? extends JobFacet>> jobFacetBuilders;
 
   private final UnknownEntryFacetListener unknownEntryFacetListener =
-      new UnknownEntryFacetListener();
+      UnknownEntryFacetListener.getInstance();
   private final Map<Integer, ActiveJob> jobMap = new HashMap<>();
   private final Map<Integer, Stage> stageMap = new HashMap<>();
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -35,10 +35,16 @@ import scala.collection.JavaConversions;
  * which may point to parseable data sources.
  */
 @Slf4j
-class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
+public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
 
   private final Map<LogicalPlan, Object> visitedNodes = new IdentityHashMap<>();
   private final LogicalPlanSerializer planSerializer = new LogicalPlanSerializer();
+
+  private static final UnknownEntryFacetListener INSTANCE = new UnknownEntryFacetListener();
+
+  public static UnknownEntryFacetListener getInstance() {
+    return INSTANCE;
+  }
 
   @Override
   public void accept(LogicalPlan logicalPlan) {

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataVisitor.java
@@ -6,6 +6,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -23,7 +24,8 @@ public class AppendDataVisitor extends QueryPlanVisitor<AppendData, OpenLineage.
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     // Needs to cast to logical plan despite IntelliJ claiming otherwise.
-    return PlanUtils.applyFirst(
-        context.getOutputDatasetQueryPlanVisitors(), (LogicalPlan) ((AppendData) x).table());
+    return new ArrayList<>(
+        PlanUtils.applyAll(
+            context.getOutputDatasetQueryPlanVisitors(), (LogicalPlan) ((AppendData) x).table()));
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
@@ -3,19 +3,23 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoDir;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand;
 import org.apache.spark.sql.execution.datasources.InsertIntoDataSourceCommand;
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand;
+import scala.Function1;
 import scala.PartialFunction;
 
 /**
@@ -24,14 +28,18 @@ import scala.PartialFunction;
  * normally by calling {@link LogicalPlan#collect(PartialFunction)}, but children that aren't
  * exposed get skipped in the collect call, so we need to root them out here.
  */
-public class CommandPlanVisitor extends QueryPlanVisitor<LogicalPlan, OpenLineage.InputDataset> {
+public class CommandPlanVisitor
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, LogicalPlan, InputDataset> {
+
+  public static final Function1<LogicalPlan, List<InputDataset>> EMPTY_COLLECTION_FN =
+      ScalaConversionUtils.toScalaFn(lp -> Collections.emptyList());
 
   public CommandPlanVisitor(OpenLineageContext context) {
-    super(context);
+    super(context, true);
   }
 
   @Override
-  public boolean isDefinedAt(LogicalPlan x) {
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
     return x instanceof SaveIntoDataSourceCommand
         || x instanceof InsertIntoDir
         || x instanceof InsertIntoDataSourceCommand
@@ -39,17 +47,39 @@ public class CommandPlanVisitor extends QueryPlanVisitor<LogicalPlan, OpenLineag
   }
 
   @Override
+  public boolean isDefinedAt(SparkListenerEvent x) {
+    return super.isDefinedAt(x)
+        && context
+            .getQueryExecution()
+            .filter(qe -> isDefinedAtLogicalPlan(qe.optimizedPlan()))
+            .isPresent();
+  }
+
+  @Override
   public List<OpenLineage.InputDataset> apply(LogicalPlan x) {
     Optional<LogicalPlan> input = getInput(x);
-    PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>> inputVisitors =
+    PartialFunction<LogicalPlan, Collection<OpenLineage.InputDataset>> inputVisitors =
         PlanUtils.merge(context.getInputDatasetQueryPlanVisitors());
     return input
         .map(
             in ->
                 ScalaConversionUtils.fromSeq(in.collect(inputVisitors)).stream()
-                    .flatMap(List::stream)
+                    .flatMap(Collection::stream)
                     .collect(Collectors.toList()))
         .orElseGet(Collections::emptyList);
+  }
+
+  @Override
+  public List<InputDataset> apply(SparkListenerEvent event) {
+    Optional<LogicalPlan> input =
+        context.getQueryExecution().flatMap(qe -> getInput(qe.optimizedPlan()));
+    PartialFunction<LogicalPlan, Collection<InputDataset>> delegateFn =
+        delegate(
+            context.getInputDatasetQueryPlanVisitors(), context.getInputDatasetBuilders(), event);
+    return input.map(in -> in.collect(delegateFn)).map(ScalaConversionUtils::fromSeq)
+        .orElse(Collections.emptyList()).stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   private Optional<LogicalPlan> getInput(LogicalPlan x) {

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
@@ -28,7 +28,7 @@ public class InsertIntoDataSourceVisitor
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     InsertIntoDataSourceCommand command = (InsertIntoDataSourceCommand) x;
 
-    return PlanUtils.applyFirst(
+    return PlanUtils.applyAll(
             context.getOutputDatasetQueryPlanVisitors(), command.logicalRelation())
         .stream()
         // constructed datasets don't include the output stats, so add that facet here

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitor.java
@@ -5,14 +5,16 @@ package io.openlineage.spark.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.JdbcUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
@@ -20,7 +22,6 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import scala.collection.JavaConversions;
-import scala.runtime.AbstractFunction0;
 
 /**
  * {@link LogicalPlan} visitor that attempts to extract a {@link OpenLineage.Dataset} from a {@link
@@ -49,7 +50,7 @@ import scala.runtime.AbstractFunction0;
  */
 @Slf4j
 public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
-    extends QueryPlanVisitor<LogicalRelation, D> {
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, LogicalRelation, D> {
 
   private final DatasetFactory<D> datasetFactory;
 
@@ -59,7 +60,7 @@ public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
   }
 
   @Override
-  public boolean isDefinedAt(LogicalPlan x) {
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
     return x instanceof LogicalRelation
         && (((LogicalRelation) x).relation() instanceof HadoopFsRelation
             || ((LogicalRelation) x).relation() instanceof JDBCRelation
@@ -67,8 +68,7 @@ public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
   }
 
   @Override
-  public List<D> apply(LogicalPlan x) {
-    LogicalRelation logRel = (LogicalRelation) x;
+  public List<D> apply(LogicalRelation logRel) {
     if (logRel.relation() instanceof HadoopFsRelation) {
       return handleHadoopFsRelation(logRel);
     } else if (logRel.relation() instanceof JDBCRelation) {
@@ -79,7 +79,7 @@ public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
     throw new IllegalArgumentException(
         "Expected logical plan to be either HadoopFsRelation, JDBCRelation, "
             + "or CatalogTable but was "
-            + x);
+            + logRel);
   }
 
   private List<D> handleCatalogTable(LogicalRelation logRel) {
@@ -121,13 +121,7 @@ public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
             .jdbcOptions()
             .parameters()
             .get(JDBCOptions.JDBC_TABLE_NAME())
-            .getOrElse(
-                new AbstractFunction0<String>() {
-                  @Override
-                  public String apply() {
-                    return "COMPLEX";
-                  }
-                });
+            .getOrElse(ScalaConversionUtils.toScalaFn(() -> "COMPLEX"));
     // strip the jdbc: prefix from the url. this leaves us with a url like
     // postgresql://<hostname>:<port>/<database_name>?params
     // we don't parse the URI here because different drivers use different connection

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitor.java
@@ -54,8 +54,9 @@ public class LogicalRelationVisitor<D extends OpenLineage.Dataset>
 
   private final DatasetFactory<D> datasetFactory;
 
-  public LogicalRelationVisitor(OpenLineageContext context, DatasetFactory<D> datasetFactory) {
-    super(context);
+  public LogicalRelationVisitor(
+      OpenLineageContext context, DatasetFactory<D> datasetFactory, boolean searchDependencies) {
+    super(context, searchDependencies);
     this.datasetFactory = datasetFactory;
   }
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -5,17 +5,18 @@ package io.openlineage.spark.agent.lifecycle.plan;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.QueryPlanVisitor;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -34,24 +35,30 @@ import scala.Option;
  */
 @Slf4j
 public class SaveIntoDataSourceCommandVisitor
-    extends QueryPlanVisitor<SaveIntoDataSourceCommand, OpenLineage.OutputDataset> {
+    extends AbstractQueryPlanDatasetBuilder<
+        SparkListenerEvent, SaveIntoDataSourceCommand, OutputDataset> {
 
   public SaveIntoDataSourceCommandVisitor(OpenLineageContext context) {
     super(context);
   }
 
   @Override
-  public boolean isDefinedAt(LogicalPlan x) {
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
     return context.getSparkSession().isPresent()
         && x instanceof SaveIntoDataSourceCommand
         && (((SaveIntoDataSourceCommand) x).dataSource() instanceof SchemaRelationProvider
             || ((SaveIntoDataSourceCommand) x).dataSource() instanceof RelationProvider);
   }
 
+  public List<OutputDataset> apply(SaveIntoDataSourceCommand cmd) {
+    return Collections.emptyList();
+  }
+
   @Override
-  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event) {
     BaseRelation relation;
-    SaveIntoDataSourceCommand command = (SaveIntoDataSourceCommand) x;
+    SaveIntoDataSourceCommand command =
+        (SaveIntoDataSourceCommand) context.getQueryExecution().get().optimizedPlan();
 
     // Kafka has some special handling because the Source and Sink relations require different
     // options. A KafkaRelation for writes uses the "topic" option, while the same relation for
@@ -64,7 +71,11 @@ public class SaveIntoDataSourceCommandVisitor
     // as other impls of CreatableRelationProvider may not be able to be handled in the generic way.
     if (KafkaRelationVisitor.isKafkaSource(command.dataSource())) {
       return KafkaRelationVisitor.createKafkaDatasets(
-          outputDataset(), command.dataSource(), command.options(), command.mode(), x.schema());
+          outputDataset(),
+          command.dataSource(),
+          command.options(),
+          command.mode(),
+          command.schema());
     }
 
     if (command.dataSource().getClass().getName().contains("DeltaDataSource")) {
@@ -82,7 +93,7 @@ public class SaveIntoDataSourceCommandVisitor
         relation = p.createRelation(sqlContext, command.options());
       } else {
         SchemaRelationProvider p = (SchemaRelationProvider) command.dataSource();
-        relation = p.createRelation(sqlContext, command.options(), x.schema());
+        relation = p.createRelation(sqlContext, command.options(), command.schema());
       }
     } catch (Exception ex) {
       // Bad detection of errors in scala
@@ -96,12 +107,12 @@ public class SaveIntoDataSourceCommandVisitor
       }
       throw ex;
     }
-    return Optional.ofNullable(
-            PlanUtils.applyFirst(
-                context.getOutputDatasetQueryPlanVisitors(),
-                new LogicalRelation(
-                    relation, relation.schema().toAttributes(), Option.empty(), x.isStreaming())))
-        .orElse(Collections.emptyList()).stream()
+    return PlanUtils.matchNode(
+            context.getOutputDatasetBuilders(),
+            event,
+            new LogicalRelation(
+                relation, relation.schema().toAttributes(), Option.empty(), command.isStreaming()))
+        .stream()
         // constructed datasets don't include the output stats, so add that facet here
         .map(
             ds -> {

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractPartial.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractPartial.java
@@ -4,6 +4,7 @@ package io.openlineage.spark.api;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 /**
  * Non-public interface - a generalization of {@link scala.PartialFunction$} that can be extended
@@ -26,6 +27,9 @@ interface AbstractPartial<T> {
     Type[] typeArgs = ((ParameterizedType) genericSuperclass).getActualTypeArguments();
     if (typeArgs != null && typeArgs.length > 0) {
       Type arg = typeArgs[0];
+      if (arg instanceof TypeVariable) {
+        return false;
+      }
       return ((Class) arg).isAssignableFrom(x.getClass());
     }
     return false;

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -7,6 +7,7 @@ import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -122,6 +123,9 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
     Type[] typeArgs = ((ParameterizedType) genericSuperclass).getActualTypeArguments();
     if (typeArgs != null && typeArgs.length > 1) {
       Type arg = typeArgs[1];
+      if (arg instanceof TypeVariable) {
+        return false;
+      }
       return ((Class) arg).isAssignableFrom(logicalPlan.getClass());
     }
     return false;

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -1,0 +1,96 @@
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.Dataset;
+import io.openlineage.spark.agent.lifecycle.UnknownEntryFacetListener;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * {@link AbstractQueryPlanDatasetBuilder} serves as a bridge between the Abstract*DatasetBuilders
+ * and {@link QueryPlanVisitor}s. This base class provides the capability to trigger on a specific
+ * {@link org.apache.spark.scheduler.SparkListenerEvent} rather than visiting the query plan for
+ * every spark event (such as {@link org.apache.spark.scheduler.SparkListenerStageSubmitted}).
+ * Additionally, the triggering {@link org.apache.spark.scheduler.SparkListenerEvent} can be
+ * utilized during processing of the {@link LogicalPlan} nodes (e.g., reading Spark properties set
+ * in {@link SparkListenerJobStart#properties()}).
+ *
+ * @param <T>
+ * @param <P>
+ * @param <D>
+ */
+public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, D extends Dataset>
+    extends AbstractGenericArgPartialFunction<T, D> {
+  protected final OpenLineageContext context;
+  private final UnknownEntryFacetListener unknownEntryFacetListener =
+      UnknownEntryFacetListener.getInstance();
+
+  public AbstractQueryPlanDatasetBuilder(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
+    return DatasetFactory.output(context.getOpenLineage());
+  }
+
+  protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
+    return DatasetFactory.input(context.getOpenLineage());
+  }
+
+  public abstract List<D> apply(P p);
+
+  public List<D> apply(T event) {
+    return context
+        .getQueryExecution()
+        .map(
+            qe ->
+                ScalaConversionUtils.fromSeq(qe.optimizedPlan().collect(asQueryPlanVisitor(event)))
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList()))
+        .orElseGet(Collections::emptyList);
+  }
+
+  public <L extends LogicalPlan> QueryPlanVisitor<L, D> asQueryPlanVisitor(T event) {
+    AbstractQueryPlanDatasetBuilder<T, P, D> builder = this;
+    return new QueryPlanVisitor<L, D>(context) {
+      @Override
+      public boolean isDefinedAt(LogicalPlan x) {
+        return isDefinedAtLogicalPlan(x);
+      }
+
+      @Override
+      public List<D> apply(LogicalPlan x) {
+        unknownEntryFacetListener.accept(x);
+        return builder.apply((P) x);
+      }
+    };
+  }
+
+  /**
+   * Similar to the logic in {@link AbstractPartial}, this reads the type from the <i>second</i>
+   * generic argument on the class, if it is present and non-null.
+   *
+   * @param logicalPlan
+   * @return
+   */
+  protected boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
+    Type genericSuperclass = getClass().getGenericSuperclass();
+    if (!(genericSuperclass instanceof ParameterizedType)) {
+      return false;
+    }
+    Type[] typeArgs = ((ParameterizedType) genericSuperclass).getActualTypeArguments();
+    if (typeArgs != null && typeArgs.length > 1) {
+      Type arg = typeArgs[1];
+      return ((Class) arg).isAssignableFrom(logicalPlan.getClass());
+    }
+    return false;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
@@ -1,0 +1,29 @@
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+
+/**
+ * {@link AbstractQueryPlanDatasetBuilder} serves as an extension of {@link
+ * AbstractQueryPlanDatasetBuilder} which gets applied only for START OpenLineage events. Filtering
+ * is done by verifying subclass of {@link org.apache.spark.scheduler.SparkListenerEvent}.
+ *
+ * @param <P>
+ */
+public abstract class AbstractQueryPlanInputDatasetBuilder<P extends LogicalPlan>
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, P, OpenLineage.InputDataset> {
+
+  public AbstractQueryPlanInputDatasetBuilder(
+      OpenLineageContext context, boolean searchDependencies) {
+    super(context, searchDependencies);
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    return event instanceof SparkListenerJobStart
+        || event instanceof SparkListenerSQLExecutionStart;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -1,0 +1,28 @@
+package io.openlineage.spark.api;
+
+import io.openlineage.client.OpenLineage;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+
+/**
+ * {@link AbstractQueryPlanDatasetBuilder} serves as an extension of {@link
+ * AbstractQueryPlanDatasetBuilder} which gets applied only for COMPLETE OpenLineage events.
+ * Filtering is done by verifying subclass of {@link org.apache.spark.scheduler.SparkListenerEvent}
+ *
+ * @param <P>
+ */
+public abstract class AbstractQueryPlanOutputDatasetBuilder<P extends LogicalPlan>
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, P, OpenLineage.OutputDataset> {
+
+  public AbstractQueryPlanOutputDatasetBuilder(
+      OpenLineageContext context, boolean searchDependencies) {
+    super(context, searchDependencies);
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    return event instanceof SparkListenerJobEnd || event instanceof SparkListenerSQLExecutionEnd;
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -6,6 +6,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -71,6 +72,10 @@ public class OpenLineageContext {
    */
   @Default @NonNull
   List<PartialFunction<LogicalPlan, List<OutputDataset>>> outputDatasetQueryPlanVisitors =
+      new ArrayList<>();
+
+  @Default @NonNull
+  List<PartialFunction<Object, Collection<OutputDataset>>> outputDatasetBuilders =
       new ArrayList<>();
 
   /** Optional {@link QueryExecution} for runs that are Spark SQL queries. */

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -65,6 +65,9 @@ public class OpenLineageContext {
   List<PartialFunction<LogicalPlan, List<InputDataset>>> inputDatasetQueryPlanVisitors =
       new ArrayList<>();
 
+  @Default @NonNull
+  List<PartialFunction<Object, Collection<InputDataset>>> inputDatasetBuilders = new ArrayList<>();
+
   /**
    * A non-null, but potentially empty, list of {@link LogicalPlan} visitors that can extract {@link
    * OutputDataset}s from plan nodes. Useful for delegating from general output visitors to more

--- a/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
+++ b/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
@@ -1,0 +1,23 @@
+package io.openlineage.spark.agent.lifecycle;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collection;
+import java.util.List;
+import scala.PartialFunction;
+
+public class Spark2DatasetBuilderFactory implements DatasetBuilderFactory {
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+      OpenLineageContext context) {
+    return ImmutableList.<PartialFunction<Object, List<OpenLineage.InputDataset>>>builder().build();
+  }
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+      OpenLineageContext context) {
+    return ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+        .build();
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -1,0 +1,23 @@
+package io.openlineage.spark.agent.lifecycle;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collection;
+import java.util.List;
+import scala.PartialFunction;
+
+public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+      OpenLineageContext context) {
+    return ImmutableList.<PartialFunction<Object, List<OpenLineage.InputDataset>>>builder().build();
+  }
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+      OpenLineageContext context) {
+    return ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+        .build();
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
@@ -94,7 +94,7 @@ class LogicalRelationVisitorTest {
             .queryExecution(qe)
             .build();
     LogicalRelationVisitor<OutputDataset> visitor =
-        new LogicalRelationVisitor<>(context, DatasetFactory.output(openLineage));
+        new LogicalRelationVisitor<>(context, DatasetFactory.output(openLineage), true);
     List<OutputDataset> datasets =
         visitor.apply(new SparkListenerJobStart(1, 1, Seq$.MODULE$.empty(), null));
     assertEquals(1, datasets.size());

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationVisitorTest.java
@@ -7,16 +7,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.agent.client.OpenLineageClient;
 import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.List;
 import org.apache.spark.Partition;
 import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
@@ -50,10 +53,7 @@ class LogicalRelationVisitorTest {
         "mysql://localhost/sparkdata"
       })
   void testApply(String connectionUri) {
-    LogicalRelationVisitor visitor =
-        new LogicalRelationVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+    OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
     String jdbcUrl = "jdbc:" + connectionUri;
     String sparkTableName = "my_spark_table";
     JDBCRelation relation =
@@ -69,8 +69,9 @@ class LogicalRelationVisitorTest {
                     .$plus$eq(Tuple2.apply("driver", Driver.class.getName()))
                     .result()),
             session);
-    List<OpenLineage.Dataset> datasets =
-        visitor.apply(
+    QueryExecution qe = mock(QueryExecution.class);
+    when(qe.optimizedPlan())
+        .thenReturn(
             new LogicalRelation(
                 relation,
                 Seq$.MODULE$
@@ -86,8 +87,18 @@ class LogicalRelationVisitorTest {
                     .result(),
                 Option.empty(),
                 false));
+    OpenLineageContext context =
+        OpenLineageContext.builder()
+            .sparkContext(mock(SparkContext.class))
+            .openLineage(openLineage)
+            .queryExecution(qe)
+            .build();
+    LogicalRelationVisitor<OutputDataset> visitor =
+        new LogicalRelationVisitor<>(context, DatasetFactory.output(openLineage));
+    List<OutputDataset> datasets =
+        visitor.apply(new SparkListenerJobStart(1, 1, Seq$.MODULE$.empty(), null));
     assertEquals(1, datasets.size());
-    OpenLineage.Dataset ds = datasets.get(0);
+    OutputDataset ds = datasets.get(0);
     assertEquals(connectionUri, ds.getNamespace());
     assertEquals(sparkTableName, ds.getName());
     assertEquals(URI.create(connectionUri), ds.getFacets().getDataSource().getUri());

--- a/integration/spark/src/test/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -1,0 +1,112 @@
+package io.openlineage.spark.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import scala.PartialFunction;
+
+class AbstractQueryPlanDatasetBuilderTest {
+
+  @Test
+  public void testIsDefinedOnSparkListenerEvent() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+    InputDataset expected = openLineage.newInputDataset("namespace", "the_name", null, null);
+
+    OpenLineageContext context = createContext(session, openLineage);
+    AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
+        new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
+            context) {
+          @Override
+          public List<InputDataset> apply(LocalRelation logicalPlan) {
+            return Collections.singletonList(expected);
+          }
+        };
+
+    Assertions.assertFalse(
+        ((PartialFunction) builder).isDefinedAt(new SparkListenerStageCompleted(null)));
+    Assertions.assertTrue(
+        ((PartialFunction) builder).isDefinedAt(new SparkListenerJobEnd(1, 2, null)));
+  }
+
+  @Test
+  public void testApplyOnSparkListenerEvent() {
+    SparkSession session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+    OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+    InputDataset expected = openLineage.newInputDataset("namespace", "the_name", null, null);
+
+    OpenLineageContext context = createContext(session, openLineage);
+    AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
+        new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
+            context) {
+          @Override
+          public List<InputDataset> apply(LocalRelation local) {
+            return Collections.singletonList(expected);
+          }
+        };
+
+    SparkListenerJobEnd jobEnd = new SparkListenerJobEnd(1, 2, null);
+    Assertions.assertTrue(((PartialFunction) builder).isDefinedAt(jobEnd));
+    Collection<InputDataset> datasets = builder.apply(jobEnd);
+    assertThat(datasets).isNotEmpty().contains(expected);
+  }
+
+  private OpenLineageContext createContext(SparkSession session, OpenLineage openLineage) {
+    QueryExecution queryExecution =
+        session
+            .createDataFrame(
+                Arrays.asList(new GenericRow(new Object[] {1, "hello"})),
+                new StructType(
+                    new StructField[] {
+                      new StructField(
+                          "count",
+                          IntegerType$.MODULE$,
+                          false,
+                          new Metadata(new scala.collection.immutable.HashMap<>())),
+                      new StructField(
+                          "word",
+                          StringType$.MODULE$,
+                          false,
+                          new Metadata(new scala.collection.immutable.HashMap<>()))
+                    }))
+            .queryExecution();
+
+    OpenLineageContext context =
+        OpenLineageContext.builder()
+            .sparkContext(
+                SparkContext.getOrCreate(new SparkConf().setAppName("test").setMaster("local")))
+            .openLineage(openLineage)
+            .queryExecution(queryExecution)
+            .build();
+    return context;
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -41,7 +41,7 @@ class AbstractQueryPlanDatasetBuilderTest {
     OpenLineageContext context = createContext(session, openLineage);
     AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
         new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
-            context) {
+            context, true) {
           @Override
           public List<InputDataset> apply(LocalRelation logicalPlan) {
             return Collections.singletonList(expected);
@@ -67,7 +67,7 @@ class AbstractQueryPlanDatasetBuilderTest {
     OpenLineageContext context = createContext(session, openLineage);
     AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
         new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
-            context) {
+            context, true) {
           @Override
           public List<InputDataset> apply(LocalRelation local) {
             return Collections.singletonList(expected);


### PR DESCRIPTION
### Problem
An alternative approach to https://github.com/OpenLineage/OpenLineage/pull/548 , this introduces a new base class `AbstractQueryPlanDatasetBuilder`, which can trigger on specific `SparkListenerEvent`s (or other events, like `StageInfo` or whatever) and can apply the node visiting logic either with or without the triggering event present. To validate potential use, I refactored the `LogicalPlanVisitor` and the `SaveIntoDataSourceCommandVisitor` to both extend the base class and updated tests accordingly.

I like this approach because it avoids adding mutable fields the QueryPlanVisitors - a base class I already think ought to be deprecated in favor of the more general `AbstractInputDatasetBuilder` and `AbstractOutputDatasetBuilder` base classes. There's not a strong reason to handle the `LogicalPlan` nodes separately from every other event except for that's how it was being done when we started. I think an approach like this will allow us to deprecate the `QueryPlanVisitors` (rather than complicating the base class and further entangling implementations with dependencies that will make it harder to migrate later), while still providing the full functionality required, which as I understand them are

1. Trigger functions only on certain Spark events
2. Expose the triggering event along with the `LogicalPlan` node matched by the partial function
3. Allow the function to produce either `InputDataset`s or `OutputDataset`s as appropriate. 

Note that this approach is incomplete - I'm leaving this PR in draft mode so we can evaluate it and decide whether to continue this approach. 

This solves #484 

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)