### PR TITLE
ci: airflow integration tests running on matrix of versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  integration-test-integration-airflow:
+  integration-test-integration-airflow-1-10:
     working_directory: ~/openlineage/integration/
     machine: true
     resource_class: large
@@ -323,7 +323,11 @@ jobs:
       - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
       - run: ./airflow/tests/integration/docker/up.sh
 
-  integration-test-integration-airflow-2:
+
+  integration-test-integration-airflow:
+    parameters:
+      airflow-image:
+        type: string
     working_directory: ~/openlineage/integration/
     machine: true
     resource_class: large
@@ -334,7 +338,7 @@ jobs:
       - run: ../.circleci/get-docker-compose.sh
       - run: cp -r ../client/python python
       - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
-      - run: ./airflow/tests/integration/docker/up-2.sh
+      - run: AIRFLOW_IMAGE=<< parameters.airflow-image >> ./airflow/tests/integration/docker/up-2.sh
 
   unit-test-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
@@ -475,7 +479,7 @@ workflows:
             - unit-test-integration-common
       - unit-test-integration-airflow-1
       - unit-test-integration-airflow-2
-      - integration-test-integration-airflow:
+      - integration-test-integration-airflow-1-10:
           context: integration-tests
           requires:
             - unit-test-integration-airflow-1
@@ -484,7 +488,10 @@ workflows:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
-      - integration-test-integration-airflow-2:
+      - integration-test-integration-airflow:
+          matrix:
+            parameters:
+              airflow-image: ['apache/airflow:2.1.3', 'apache/airflow:2.2.3']
           context: integration-tests
           requires:
             - unit-test-integration-airflow-2

--- a/integration/airflow/tests/integration/Dockerfile.2
+++ b/integration/airflow/tests/integration/Dockerfile.2
@@ -1,6 +1,7 @@
+ARG AIRFLOW_IMAGE=apache/airflow:2.2.3
 FROM openlineage-airflow-base:latest AS build
 
-FROM apache/airflow:2.1.3 AS airflow
+FROM $AIRFLOW_IMAGE AS airflow
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \

--- a/integration/airflow/tests/integration/data/dbt/profiles/profiles.yml
+++ b/integration/airflow/tests/integration/data/dbt/profiles/profiles.yml
@@ -6,7 +6,7 @@ bigquery:
             method: service-account
             keyfile: /opt/config/gcloud/gcloud-service-key.json
             project: openlineage-ci
-            dataset: dbt_test1
+            dataset: "{{ env_var('BIGQUERY_DBT_DATASET') }}"
             threads: 2
             timeout_seconds: 300
             location: EU

--- a/integration/airflow/tests/integration/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/docker-compose-2.yml
@@ -5,7 +5,9 @@ x-airflow-base: &airflow-base
     context: .
     target: airflow
     dockerfile: Dockerfile.2
-  environment:
+    args:
+      AIRFLOW_IMAGE: ${AIRFLOW_IMAGE}
+  environment: &airflow-common-env
     DB_BACKEND: postgresql+psycopg2
     DB_HOST: postgres
     DB_PORT: 5432
@@ -24,6 +26,8 @@ x-airflow-base: &airflow-base
     AIRFLOW_CONN_FOOD_DELIVERY_DB: postgres://food_delivery:food_delivery@postgres:5432/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=openlineage-ci&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "False"
+    BIGQUERY_PREFIX: ${BIGQUERY_PREFIX}
+    BIGQUERY_DBT_DATASET: ${BIGQUERY_DBT_DATASET}_dbt
     GOOGLE_APPLICATION_CREDENTIALS: /opt/config/gcloud/gcloud-service-key.json
     OPENLINEAGE_URL: http://backend:5000
     OPENLINEAGE_NAMESPACE: food_delivery
@@ -40,27 +44,17 @@ services:
       context: .
       target: integration
       dockerfile: Dockerfile.2
+      args:
+        AIRFLOW_IMAGE: ${AIRFLOW_IMAGE}
+    environment:
+      BIGQUERY_PREFIX: ${BIGQUERY_PREFIX}
+      BIGQUERY_DBT_DATASET: ${BIGQUERY_DBT_DATASET}_dbt
     volumes:
       - ./docker/wait-for-it.sh:/wait-for-it.sh
     depends_on:
-      - airflow
+      - airflow_scheduler
       - backend
     entrypoint: ["./wait-for-it.sh", "backend:5000", "--", "./entrypoint.sh"]
-
-  airflow:
-    <<: *airflow-base
-    ports:
-      - "8080:8080"
-    command: webserver
-    depends_on:
-      - airflow_scheduler
-      - postgres
-    healthcheck:
-      test: [ "CMD", "curl", "--fail", "http://localhost:8080/health" ]
-      interval: 10s
-      timeout: 10s
-      retries: 5
-    restart: always
 
   airflow_scheduler:
     <<: *airflow-base

--- a/integration/airflow/tests/integration/docker-compose.yml
+++ b/integration/airflow/tests/integration/docker-compose.yml
@@ -26,6 +26,8 @@ x-airflow-base: &airflow-base
     OPENLINEAGE_NAMESPACE: food_delivery
     OPENLINEAGE_URL: http://backend:5000
     OPENLINEAGE_EXTRACTOR_CustomOperator: custom_extractor.CustomExtractor
+    BIGQUERY_PREFIX: airflow_1
+    BIGQUERY_DBT_DATASET: airflow_1_dbt
   volumes:
     - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
     - ./airflow/dags:/opt/airflow/dags
@@ -42,6 +44,9 @@ services:
     depends_on:
       - airflow
       - backend
+    environment:
+      - BIGQUERY_PREFIX=airflow_1
+      - BIGQUERY_DBT_DATASET=airflow_1_dbt
     entrypoint: ["./wait-for-it.sh", "postgres:5432", "--", "./entrypoint.sh"]
 
   airflow:

--- a/integration/airflow/tests/integration/docker/up-2.sh
+++ b/integration/airflow/tests/integration/docker/up-2.sh
@@ -49,6 +49,15 @@ python-dateutil==2.8.2
 ${OPENLINEAGE_AIRFLOW_WHL}
 EOL
 
+# string operator: from variable AIRFLOW_IMAGE
+#  ##   <-- greedy front trim
+#  *    <-- matches anything
+#  :    <-- until the last ':'
+AIRFLOW_VERSION=${AIRFLOW_IMAGE##*:}
+
+export BIGQUERY_PREFIX=${AIRFLOW_VERSION//./_}
+export BIGQUERY_DBT_DATASET=${AIRFLOW_VERSION//./_}_dbt
+
 docker-compose -f docker-compose-2.yml down
 docker-compose -f docker-compose-2.yml up --build --abort-on-container-exit airflow_init postgres
 docker-compose -f docker-compose-2.yml up --build --exit-code-from integration --scale airflow_init=0

--- a/integration/airflow/tests/integration/requests/bigquery.json
+++ b/integration/airflow/tests/integration/requests/bigquery.json
@@ -41,7 +41,7 @@
     "job": {
         "facets": {
             "sql": {
-                "query": "\n    CREATE TABLE IF NOT EXISTS `openlineage-ci.airflow_integration.popular_orders_day_of_week` (\n      order_day_of_week INTEGER NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
+                "query": "\n    CREATE TABLE IF NOT EXISTS `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (\n      order_day_of_week INTEGER NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
             }
         },
         "name": "bigquery_orders_popular_day_of_week.bigquery_if_not_exists",
@@ -70,7 +70,7 @@
                 ]
             }
 		},
-		"name": "openlineage-ci.airflow_integration.popular_orders_day_of_week",
+		"name": "openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week",
 		"namespace": "bigquery"
 	}]
 },
@@ -91,7 +91,7 @@
                 ]
             }
 		},
-		"name": "openlineage-ci.airflow_integration.top_delivery_times",
+		"name": "openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times",
 		"namespace": "bigquery"
 	},
     {
@@ -117,13 +117,13 @@
                 ]
             }
 		},
-		"name": "openlineage-ci.airflow_integration.popular_orders_day_of_week",
+		"name": "openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week",
 		"namespace": "bigquery"
 	}],
 	"job": {
 		"facets": {
 			"sql": {
-				"query": "\n    INSERT INTO `openlineage-ci.airflow_integration.popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM airflow_integration.top_delivery_times\n    GROUP BY order_placed_on;"
+				"query": "\n    INSERT INTO `openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times\n    GROUP BY order_placed_on;"
 			}
 		},
 		"name": "bigquery_orders_popular_day_of_week.bigquery_insert",
@@ -148,7 +148,7 @@
 				}]
 			}
 		},
-		"name": "openlineage-ci.airflow_integration.popular_orders_day_of_week",
+		"name": "openlineage-ci.airflow_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week",
 		"namespace": "bigquery"
 	}]
 }]

--- a/integration/airflow/tests/integration/requests/dbt.json
+++ b/integration/airflow/tests/integration/requests/dbt.json
@@ -5,13 +5,13 @@
         "run": {},
         "job": {
             "facets": {},
-            "name": "openlineage-ci.dbt_test1.testproject.money_received",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.money_received",
             "namespace": "food_delivery"
         },
         "outputs": [
             {
                 "facets": {},
-                "name": "openlineage-ci.dbt_test1.money_received",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_received",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }
@@ -23,13 +23,13 @@
         "run": {},
         "job": {
             "facets": {},
-            "name": "openlineage-ci.dbt_test1.testproject.money_send",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.money_send",
             "namespace": "food_delivery"
         },
         "outputs": [
             {
                 "facets": {},
-                "name": "openlineage-ci.dbt_test1.money_send",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_send",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }
@@ -40,24 +40,24 @@
         "inputs": [
             {
                 "facets": {},
-                "name": "openlineage-ci.dbt_test1.money_received",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_received",
                 "namespace": "bigquery"
             },
             {
                 "facets": {},
-                "name": "openlineage-ci.dbt_test1.money_send",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_send",
                 "namespace": "bigquery"
             }
         ],
         "job": {
             "facets": {},
-            "name": "openlineage-ci.dbt_test1.testproject.balance",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.balance",
             "namespace": "food_delivery"
         },
         "outputs": [
             {
                 "facets": {},
-                "name": "openlineage-ci.dbt_test1.balance",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.balance",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }
@@ -77,10 +77,10 @@
         "job": {
             "facets": {
                 "sql": {
-                    "query": "select\n    users.user_id,\n    transactions.currency,\n    sum(transactions.amount) as amount\nfrom `openlineage-ci`.`dbt_test1`.`users`\nleft join `openlineage-ci`.`dbt_test1`.`transactions`\non users.user_id=transactions.user_id\nwhere leg='c'\ngroup by user_id, currency"
+                    "query": "select\n    users.user_id,\n    transactions.currency,\n    sum(transactions.amount) as amount\nfrom `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`users`\nleft join `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`transactions`\non users.user_id=transactions.user_id\nwhere leg='c'\ngroup by user_id, currency"
                 }
             },
-            "name": "openlineage-ci.dbt_test1.testproject.money_received",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.money_received",
             "namespace": "food_delivery"
         },
         "outputs": [
@@ -104,7 +104,7 @@
                         ]
                     }
                 },
-                "name": "openlineage-ci.dbt_test1.money_received",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_received",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }
@@ -124,10 +124,10 @@
         "job": {
             "facets": {
                 "sql": {
-                    "query": "select\n    users.user_id,\n    transactions.currency,\n    sum(transactions.amount) as amount\nfrom `openlineage-ci`.`dbt_test1`.`users`\nleft join `openlineage-ci`.`dbt_test1`.`transactions`\non users.user_id=transactions.user_id\nwhere leg='b'\ngroup by user_id, currency"
+                    "query": "select\n    users.user_id,\n    transactions.currency,\n    sum(transactions.amount) as amount\nfrom `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`users`\nleft join `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`transactions`\non users.user_id=transactions.user_id\nwhere leg='b'\ngroup by user_id, currency"
                 }
             },
-            "name": "openlineage-ci.dbt_test1.testproject.money_send",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.money_send",
             "namespace": "food_delivery"
         },
         "outputs": [
@@ -151,7 +151,7 @@
                         ]
                     }
                 },
-                "name": "openlineage-ci.dbt_test1.money_send",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_send",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }
@@ -188,7 +188,7 @@
                         ]
                     }
                 },
-                "name": "openlineage-ci.dbt_test1.money_received",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_received",
                 "namespace": "bigquery"
             },
             {
@@ -211,17 +211,17 @@
                         ]
                     }
                 },
-                "name": "openlineage-ci.dbt_test1.money_send",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.money_send",
                 "namespace": "bigquery"
             }
         ],
         "job": {
             "facets": {
                 "sql": {
-                    "query": "select\n    ifnull(money_received.user_id, money_send.user_id) as user_id,\n    ifnull(money_received.currency, money_send.currency) as currency,\n    ifnull(money_received.amount, 0) - ifnull(money_send.amount, 0) as balance\nfrom `openlineage-ci`.`dbt_test1`.`money_received`\nfull outer join `openlineage-ci`.`dbt_test1`.`money_send`\non money_received.user_id=money_send.user_id\nand money_received.currency=money_send.currency"
+                    "query": "select\n    ifnull(money_received.user_id, money_send.user_id) as user_id,\n    ifnull(money_received.currency, money_send.currency) as currency,\n    ifnull(money_received.amount, 0) - ifnull(money_send.amount, 0) as balance\nfrom `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`money_received`\nfull outer join `openlineage-ci`.`{{ env_var('BIGQUERY_DBT_DATASET') }}`.`money_send`\non money_received.user_id=money_send.user_id\nand money_received.currency=money_send.currency"
                 }
             },
-            "name": "openlineage-ci.dbt_test1.testproject.balance",
+            "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.testproject.balance",
             "namespace": "food_delivery"
         },
         "outputs": [
@@ -245,7 +245,7 @@
                         ]
                     }
                 },
-                "name": "openlineage-ci.dbt_test1.balance",
+                "name": "openlineage-ci.{{ env_var('BIGQUERY_DBT_DATASET') }}.balance",
                 "namespace": "bigquery",
                 "outputFacets": {}
             }

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import pendulum
 import datetime
 from airflow.models import Connection
+from pkg_resources import parse_version
 
 from openlineage.airflow.utils import (
     url_to_https,
@@ -95,3 +96,17 @@ def test_pendulum_to_iso_8601():
 
     tz = pendulum.timezone("America/Los_Angeles")
     assert "2021-08-05T19:05:01.000000Z" == DagUtils.to_iso_8601(tz.convert(dt))
+
+
+def test_parse_version():
+    assert parse_version("2.3.0") >= parse_version("2.3.0.dev0")
+    assert parse_version("2.3.0.dev0") >= parse_version("2.3.0.dev0")
+    assert parse_version("2.3.0.beta1") >= parse_version("2.3.0.dev0")
+    assert parse_version("2.3.1") >= parse_version("2.3.0.dev0")
+    assert parse_version("2.4.0") >= parse_version("2.3.0.dev0")
+    assert parse_version("3.0.0") >= parse_version("2.3.0.dev0")
+    assert parse_version("2.2.0") < parse_version("2.3.0.dev0")
+    assert parse_version("2.1.3") < parse_version("2.3.0.dev0")
+    assert parse_version("2.2.4") < parse_version("2.3.0.dev0")
+    assert parse_version("1.10.15") < parse_version("2.3.0.dev0")
+    assert parse_version("2.2.4.dev0") < parse_version("2.3.0.dev0")

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -1,18 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0.
-import typing
+import os
 import logging
 from dateutil.parser import parse
 from jinja2 import Environment
+from typing import Any, Optional
 
 
 log = logging.getLogger(__name__)
 
 
-def any(result: typing.Any):
+def any(result: Any):
     return result
 
 
-def is_datetime(result: typing.Any):
+def is_datetime(result: Any):
     try:
         x = parse(result)  # noqa
         return "true"
@@ -21,10 +22,25 @@ def is_datetime(result: typing.Any):
     return "false"
 
 
+def env_var(var: str, default: Optional[str] = None) -> str:
+    """The env_var() function. Return the environment variable named 'var'.
+    If there is no such environment variable set, return the default.
+    If the default is None, raise an exception for an undefined variable.
+    """
+    if var in os.environ:
+        return os.environ[var]
+    elif default is not None:
+        return default
+    else:
+        msg = f"Env var required but not provided: '{var}'"
+        raise Exception(msg)
+
+
 def setup_jinja() -> Environment:
     env = Environment()
     env.globals['any'] = any
     env.globals['is_datetime'] = is_datetime
+    env.globals['env_var'] = env_var
     return env
 
 


### PR DESCRIPTION
In unmerged PR https://github.com/OpenLineage/OpenLineage/pull/508 that implements Airflow Plugin based integration, I've added matrix for integration tests to run those on multiple Airflow versions at once. This PR backports this capability, since Airflow Plugin PR won't be merged until Airflow 2.3 release.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/538