### PR TITLE
Update Airflow integration tests to pip install during Docker build

### DIFF
--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -5,24 +5,30 @@ COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
+RUN printf "airflow-provider-great-expectations==0.0.8\ngreat-expectations==0.13.42\ndbt-bigquery==0.20.1\noauthlib==2.1.0\n" > /opt/bitnami/airflow/requirements.txt
+RUN ls /whl/openlineage* >> /opt/bitnami/airflow/requirements.txt
 USER 1001
-RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
 
 FROM bitnami/airflow-worker:1.10.15 AS worker
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
+RUN printf "airflow-provider-great-expectations==0.0.8\ngreat-expectations==0.13.42\ndbt-bigquery==0.20.1\noauthlib==2.1.0\n" > /opt/bitnami/airflow/requirements.txt
+RUN ls /whl/openlineage* >> /opt/bitnami/airflow/requirements.txt
 USER 1001
-RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
 
 FROM bitnami/airflow:1.10.15 AS airflow
 COPY --from=build /app/wheel /whl
 USER root
 RUN apt-get update && \
     apt-get install -y git build-essential
+RUN printf "airflow-provider-great-expectations==0.0.8\ngreat-expectations==0.13.42\ndbt-bigquery==0.20.1\noauthlib==2.1.0\n" > /opt/bitnami/airflow/requirements.txt
+RUN ls /whl/openlineage* >> /opt/bitnami/airflow/requirements.txt
 USER 1001
-RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip
+RUN cd /opt/bitnami/airflow/ && . ./venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt
 
 FROM openlineage-airflow-base:latest AS integration
 COPY integration-requirements.txt integration-requirements.txt

--- a/integration/airflow/tests/integration/docker-compose.yml
+++ b/integration/airflow/tests/integration/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - ./airflow/logs:/opt/airflow/logs
       - ./airflow/dags:/opt/bitnami/airflow/dags
       - ./airflow/config/log_config.py:/opt/bitnami/airflow/config/log_config.py
-      - ./requirements.txt:/bitnami/python/requirements.txt
       - ./gcloud:/opt/config/gcloud
       - ./data:/opt/data
     depends_on:
@@ -71,11 +70,11 @@ services:
       - ./airflow/logs:/opt/airflow/logs
       - ./airflow/dags:/opt/bitnami/airflow/dags
       - ./airflow/config/log_config.py:/opt/bitnami/airflow/config/log_config.py
-      - ./requirements.txt:/bitnami/python/requirements.txt
       - ./gcloud:/opt/config/gcloud
       - ./data:/opt/data
     depends_on:
       - airflow_worker
+      - postgres
 
   airflow_worker:
     build:
@@ -101,9 +100,11 @@ services:
       - ./airflow/logs:/opt/airflow/logs
       - ./airflow/dags:/opt/bitnami/airflow/dags
       - ./airflow/config/log_config.py:/opt/bitnami/airflow/config/log_config.py
-      - ./requirements.txt:/bitnami/python/requirements.txt
       - ./gcloud:/opt/config/gcloud
       - ./data:/opt/data
+    depends_on:
+      - postgres
+      - redis
 
   backend:
     build:

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -23,18 +23,7 @@ if [[ -n "$CI" ]]; then
   chmod 644 gcloud/gcloud-service-key.json
 fi
 
-# maybe overkill
 OPENLINEAGE_AIRFLOW_WHL=$(docker run openlineage-airflow-base:latest sh -c "ls /whl/openlineage*")
-OPENLINEAGE_AIRFLOW_WHL_ALL=$(docker run openlineage-airflow-base:latest sh -c "ls /whl/*")
-
-# Add revision to requirements.txt
-cat > requirements.txt <<EOL
-airflow-provider-great-expectations==0.0.8
-great-expectations==0.13.42
-dbt-bigquery==0.20.1
-${OPENLINEAGE_AIRFLOW_WHL}
-EOL
-
 
 # Add revision to integration-requirements.txt
 cat > integration-requirements.txt <<EOL
@@ -49,5 +38,5 @@ python-dateutil==2.8.2
 ${OPENLINEAGE_AIRFLOW_WHL}
 EOL
 
-docker-compose down
+docker-compose down -v
 docker-compose up -V --build --force-recreate --exit-code-from integration


### PR DESCRIPTION
### Problem
Airflow integration tests run `pip install` on startup of the Docker images, so every single integration test run requires downloading and installing a ton of python packages before the tests start. This change moves the `pip install` step into the Docker image building. CI runs will still run the `pip install` at the start of every integration test run as the images are built from scratch each time. However, developers can run integration tests repeatedly without downloading and installing dependencies each time, saving minutes on each integration test run. In the future, we might also consider docker image caching in CI to reduce the integration test time for PRs and merges as well.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)