### PR TITLE
dbt: enable jinja2 do extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 ### Fixed
 * Catch possible failures when emitting events and log them [@mobuchowski](https://github.com/mobuchowski)
 
+### Fixed
+* dbt: jinja2 code using do extensions does not crash [@mobuchowski](https://github.com/mobuchowski)
+
+
 ## [0.6.0](https://github.com/OpenLineage/OpenLineage/compare/0.5.2...0.6.0)
 ### Added
 * Extract source code of PythonOperator code similar to SQL facet [@mobuchowski](https://github.com/mobuchowski)
@@ -27,7 +31,6 @@
 * Added `UnknownOperatorAttributeRunFacet` to Airflow integration to record operators that don't produce lineage [@collado-mike](https://github.com/collado-mike)
 
 ### Fixed
-
 * Airflow: increase import timeout in tests, fix exit from integration [@mobuchowski](https://github.com/mobuchowski)
 * Reduce logging level for import errors to info [@rossturk](https://github.com/rossturk)
 * Remove AWS secret keys and extraneous Snowflake parameters from connection uri [@collado-mike](https://github.com/collado-mike)

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -300,7 +300,10 @@ class DbtArtifactProcessor:
 
     @staticmethod
     def setup_jinja() -> Environment:
-        env = Environment(undefined=SkipUndefined)
+        env = Environment(
+            extensions=["jinja2.ext.do"],
+            undefined=SkipUndefined
+        )
         # When using env vars for Redshift port, it must be "{{ env_var('PORT') | as_number }}"
         # otherwise Redshift driver will complain, hence the need to add the "as_number" filter
         env.filters.update({"as_number": lambda x: x})


### PR DESCRIPTION
dbt's configuration enables do extension: https://github.com/dbt-labs/dbt-core/blob/8f50eee330ea34dd6aaba40993a01a380373fa32/core/dbt/clients/jinja.py#L466

We should do the same.  

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)