### PR TITLE
[INTEGRATION][Dagster] Handle updated EventLogEntry in OpenLineage sensor unit test

### DIFF
--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -146,7 +146,6 @@ def _handle_pipeline_event(
         _ADAPTER.start_pipeline(pipeline_name, pipeline_run_id, timestamp, repository_name)
         running_pipelines[pipeline_run_id] = RunningPipeline(repository_name=repository_name)
     elif dagster_event_type == DagsterEventType.RUN_SUCCESS:
-        running_pipelines.get(pipeline_run_id)
         _ADAPTER.complete_pipeline(pipeline_name, pipeline_run_id, timestamp, repository_name)
         running_pipelines.pop(pipeline_run_id, None)
     elif dagster_event_type == DagsterEventType.RUN_FAILURE:

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -26,7 +26,7 @@ DAGSTER_VERSION = "0.13.8"
 requirements = [
     "attrs>=19.3",
     "cattrs",
-    "dagster>=0.13.8,<0.14.3",
+    f"dagster>={DAGSTER_VERSION}",
     f"openlineage-python=={__version__}",
 ]
 


### PR DESCRIPTION
### Problem

In Dagster 0.14.3, `message` field was removed from EventLogEntry per https://github.com/dagster-io/dagster/pull/6769. This is Dagster's internal change that should not affect the functionality of the OpenLineage sensor, but the unit test helper function that creates a mock EventLogEntry needs an update to handle this differently based on Dagster version.

### Solution

Update unit test to handle removed `message` field in EventLogEntry based on Dagster version

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)