### PR TITLE
[Integration][Airflow] Complete Fix of Snowflake Extractor get_hook() Bug

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -45,11 +45,11 @@ class SnowflakeExtractor(PostgresExtractor):
         else:
             return self.operator.get_hook()._get_conn_params()['account']
 
-    def _get_db_hook(self):
-        return self.operator.get_db_hook()
-
     def _get_hook(self):
-        return self.operator.get_hook()
+        if hasattr(self.operator, 'get_db_hook'):
+            return self.operator.get_db_hook()
+        else:
+            return self.operator.get_hook()
 
     def _conn_id(self):
         return self.operator.snowflake_conn_id


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

In #507, an incorrect fix was made to the Snowflake Extractor to
allow for the operator's new `get_db_hook()` method. This PR
corrects the earlier mistake and enables the desired functionality.

Closes: #500 

### Solution

The previously added `get_db_hook()` method to the Snowflake Extractor is replaced with a check for the existence of that method in the underlying Operator, then the correct version of the underlying method is called by `_get_hook()`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)