### PR TITLE
flink: extract sources/sinks from transformation tree

### DIFF
--- a/integration/flink/README.md
+++ b/integration/flink/README.md
@@ -10,14 +10,14 @@ Maven:
 <dependency>
     <groupId>io.openlineage</groupId>
     <artifactId>openlineage-flink</artifactId>
-    <version>0.5.1</version>
+    <version>0.6.1</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```groovy
-implementation 'io.openlineage:openlineage-flink:0.5.1'
+implementation 'io.openlineage:openlineage-flink:0.6.1'
 ```
 
 ## Getting started

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -76,6 +76,11 @@ dependencies {
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
+    implementation("io.openlineage:openlineage-java:${project.version}"){
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.datatype'
+    }
+
     implementation "org.apache.flink:flink-java:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -52,8 +52,8 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: "com.diffplug.spotless"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 archivesBaseName='openlineage-flink'
@@ -94,7 +94,7 @@ dependencies {
     }
     compileOnly "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compileOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    compileOnly "com.fasterxml.jackson.module:jackson-module-scala_2.11:${jacksonModuleScalaVersion}"
+    compileOnly "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonModuleScalaVersion}"
 
     testImplementation platform('org.junit:junit-bom:5.7.1')
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
@@ -143,7 +143,7 @@ def commonTestConfiguration = {
     systemProperties = [
             'junit.platform.output.capture.stdout': 'true',
             'junit.platform.output.capture.stderr': 'true',
-            'openlineage.flink.jar': "${archivesBaseName}-${project.version}.jar",
+            '.flink.jar': "${archivesBaseName}-${project.version}.jar",
     ]
     classpath =  project.sourceSets.test.runtimeClasspath
 }

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -1,11 +1,16 @@
 buildscript {
     repositories {
-        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
+        classpath 'com.adarshr:gradle-test-logger-plugin:2.1.1'
         classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.12.1'
     }
 }
+
 
 plugins {
     id "com.github.davidmc24.gradle.plugin.avro" version "1.3.0"
@@ -19,6 +24,7 @@ group 'io.openlineage.flink'
 version '1.0-SNAPSHOT'
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
         url "https://packages.confluent.io/maven/"

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
-version=0.6.0-SNAPSHOT
+version=0.7.0-SNAPSHOT
 flink.version=1.14.2
 org.gradle.jvmargs=-Xmx1G

--- a/integration/flink/settings.gradle
+++ b/integration/flink/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'openlineage-flink'
 
+include 'examples:stateful'

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -1,116 +1,123 @@
 package io.openlineage.flink;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.visitor.Visitor;
+import io.openlineage.flink.visitor.VisitorFactory;
+import io.openlineage.flink.visitor.VisitorFactoryImpl;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
-import org.apache.flink.connector.kafka.sink.KafkaSink;
-import org.apache.flink.connector.kafka.source.KafkaSource;
-import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.transformations.OneInputTransformation;
-import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.streaming.api.transformations.SinkTransformation;
-import org.apache.flink.streaming.api.transformations.SourceTransformation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Slf4j
 public class OpenLineageFlinkJobListener implements JobListener {
 
     private final StreamExecutionEnvironment executionEnvironment;
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenLineageFlinkJobListener.class);
-
+    private final OpenLineageContext openLineageContext;
 
     public OpenLineageFlinkJobListener(StreamExecutionEnvironment executionEnvironment) {
+        makeTransformationsUnclearableList(executionEnvironment);
         this.executionEnvironment = executionEnvironment;
+        this.openLineageContext = OpenLineageContext.builder()
+                .streamExecutionEnvironment(Optional.of(executionEnvironment))
+                .openLineage(new OpenLineage(URI.create("")))
+                .build();
+    }
+
+    @Override
+    public void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable) {
+        if (jobClient != null) {
+            log.info("JobId: {}", jobClient.getJobID());
+            Field transformationsField = FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
+            try {
+                List<Transformation<?>> transformations = (List<Transformation<?>>) transformationsField.get(executionEnvironment);
+                VisitorFactory visitorFactory = new VisitorFactoryImpl();
+
+                List<OpenLineage.InputDataset> inputDatasets = getInputDatasets(visitorFactory, transformations);
+                List<OpenLineage.OutputDataset> outputDatasets = getOutputDatasets(visitorFactory, transformations);
+
+                createRunEventAndEmit(inputDatasets, outputDatasets);
+            } catch (IllegalAccessException e) {
+                log.error("Can't access the field. ", e);
+            }
+        }
+    }
+
+    private void createRunEventAndEmit(List<OpenLineage.InputDataset> inputDatasets, List<OpenLineage.OutputDataset> outputDatasets) {
+        OpenLineage.RunEvent runEvent = openLineageContext
+                .getOpenLineage()
+                .newRunEventBuilder()
+                .inputs(inputDatasets)
+                .outputs(outputDatasets).build();
+
+        log.info("RunEvent: {}", runEvent);
+    }
+
+    private List<OpenLineage.InputDataset> getInputDatasets(VisitorFactory visitorFactory, List<Transformation<?>> transformations) {
+        List<OpenLineage.InputDataset> inputDataSets = new ArrayList<>();
+        List<Visitor<Transformation<?>, OpenLineage.InputDataset>> inputVisitors = visitorFactory.getInputVisitors(openLineageContext);
+
+        for (Transformation<?> transformation : transformations) {
+            inputDataSets.addAll(inputVisitors.stream()
+                    .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
+                    .map(inputVisitor -> inputVisitor.apply(transformation))
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+        }
+        return inputDataSets;
+    }
+
+    private List<OpenLineage.OutputDataset> getOutputDatasets(VisitorFactory visitorFactory, List<Transformation<?>> transformations) {
+        List<OpenLineage.OutputDataset> outputDatasets = new ArrayList<>();
+        List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> inputVisitors = visitorFactory.getOutputVisitors(openLineageContext);
+
+        for (Transformation<?> transformation : transformations) {
+            outputDatasets.addAll(inputVisitors.stream()
+                    .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
+                    .map(inputVisitor -> inputVisitor.apply(transformation))
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+        }
+        return outputDatasets;
+    }
+
+    @Override
+    public void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
+        log.info("JobExecutionResult: {}", jobExecutionResult);
+    }
+
+    private void makeTransformationsUnclearableList(StreamExecutionEnvironment executionEnvironment) {
         try {
             Field transformations = FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
             ArrayList<Transformation<?>> previousTransformationList = (ArrayList<Transformation<?>>) FieldUtils.readField(transformations, executionEnvironment, true);
             List<Transformation<?>> transformationList = new UnclearableList<>(previousTransformationList);
             FieldUtils.writeField(transformations, executionEnvironment, transformationList, true);
         } catch (IllegalAccessException e) {
-            LOGGER.error("Failed to rewrite transforamtions");
+            log.error("Failed to rewrite transformations");
         }
-    }
-
-    @Override
-    public void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable) {
-        if (jobClient != null) {
-            LOGGER.info("JobId: {}", jobClient.getJobID());
-            Field transformationsField = FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
-            try {
-                List<Transformation> transformations = (List<Transformation>) transformationsField.get(executionEnvironment);
-                transformations.forEach(transformation -> {
-                    if (transformation instanceof OneInputTransformation) {
-                        extractKafkaSourceTopics(transformation);
-                    } else if (transformation instanceof SinkTransformation) {
-                        extractKafkaSinkTopics(transformation);
-                    }
-                });
-            } catch (IllegalAccessException e) {
-                LOGGER.error("Can't access the field. ", e);
-            }
-        }
-    }
-
-    private void extractKafkaSourceTopics(Transformation transformation) {
-        transformation.getInputs().stream()
-                .map(partitionTransformation -> ((PartitionTransformation) partitionTransformation).getInputs())
-                .forEach(inputs -> ((List<SourceTransformation>) inputs).forEach(sourceTransformation -> {
-                            KafkaSource kafkaSource = (KafkaSource) ((SourceTransformation) sourceTransformation).getSource();
-                            Field subscriberField = FieldUtils.getField(KafkaSource.class, "subscriber", true);
-                            try {
-                                KafkaSubscriber kafkaSubscriber = (KafkaSubscriber) subscriberField.get(kafkaSource);
-                                Field topicsField = FieldUtils.getField(kafkaSubscriber.getClass().asSubclass(kafkaSubscriber.getClass()), "topics", true);
-                                List<String> topics = (List<String>) topicsField.get(kafkaSubscriber);
-                                topics.forEach(topic -> LOGGER.info("Kafka input topic: {}", topic));
-                            } catch (IllegalAccessException e) {
-                                LOGGER.error("Can't access the field. ", e);
-                            }
-                        })
-                );
-    }
-
-    private void extractKafkaSinkTopics(Transformation transformation) {
-        KafkaSink kafkaSink = (KafkaSink) ((SinkTransformation)transformation).getSink();
-        Field recordSerializerField = FieldUtils.getField(KafkaSink.class, "recordSerializer", true);
-        try {
-            KafkaRecordSerializationSchema serializationSchema = (KafkaRecordSerializationSchema) recordSerializerField.get(kafkaSink);
-            Field topicSelectorField = FieldUtils.getField(serializationSchema.getClass().asSubclass(serializationSchema.getClass()), "topicSelector", true);
-            Field topicSelectorFunctionField = FieldUtils.getField(topicSelectorField.get(serializationSchema).getClass().asSubclass(topicSelectorField.get(serializationSchema).getClass()), "topicSelector", true);
-            Function function = (Function) topicSelectorFunctionField.get(topicSelectorField.get(serializationSchema));
-            LOGGER.error("Kafka output topic: {}", function.apply(null));
-        } catch (IllegalAccessException e) {
-            LOGGER.error("Can't access the field. ", e);
-        }
-    }
-
-
-
-    @Override
-    public void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
-        LOGGER.info("JobExecutionResult: {}", jobExecutionResult);
     }
 
     static class UnclearableList<T> extends ArrayList<T> {
-
         public UnclearableList(Collection<T> collection) {
             super(collection);
-            LOGGER.warn("Created unclearableList");
+            log.info("Created un-clearableList");
         }
-
         @Override
         public void clear() {
-            LOGGER.info("Trying to clear unclearable list");
+            log.info("Trying to clear un-clearable list");
         }
     }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -5,6 +5,16 @@ import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.visitor.Visitor;
 import io.openlineage.flink.visitor.VisitorFactory;
 import io.openlineage.flink.visitor.VisitorFactoryImpl;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -13,111 +23,129 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
-import javax.annotation.Nullable;
-import java.lang.reflect.Field;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 @Slf4j
 public class OpenLineageFlinkJobListener implements JobListener {
 
-    private final StreamExecutionEnvironment executionEnvironment;
-    private final OpenLineageContext openLineageContext;
+  private final StreamExecutionEnvironment executionEnvironment;
+  private final OpenLineageContext openLineageContext;
 
-    public OpenLineageFlinkJobListener(StreamExecutionEnvironment executionEnvironment) {
-        makeTransformationsUnclearableList(executionEnvironment);
-        this.executionEnvironment = executionEnvironment;
-        this.openLineageContext = OpenLineageContext.builder()
-                .streamExecutionEnvironment(Optional.of(executionEnvironment))
-                .openLineage(new OpenLineage(URI.create("")))
-                .build();
+  public OpenLineageFlinkJobListener(StreamExecutionEnvironment executionEnvironment) {
+    makeTransformationsArchivedList(executionEnvironment);
+    this.executionEnvironment = executionEnvironment;
+    this.openLineageContext =
+        OpenLineageContext.builder()
+            .streamExecutionEnvironment(Optional.of(executionEnvironment))
+            .openLineage(new OpenLineage(URI.create("")))
+            .build();
+  }
+
+  @Override
+  public void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable) {
+    if (jobClient != null) {
+      log.debug("JobId: {}", jobClient.getJobID());
+      Field transformationsField =
+          FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
+      try {
+        List<Transformation<?>> transformations =
+          ((ArchivedList<Transformation<?>>) transformationsField.get(executionEnvironment)).getArchive();
+        TransformationUtils converter = new TransformationUtils();
+
+        List<SinkLineage> sinkLineages = converter.convertToVisitable(transformations);
+        VisitorFactory visitorFactory = new VisitorFactoryImpl();
+
+        for (var lineage : sinkLineages) {
+          List<OpenLineage.InputDataset> inputDatasets =
+              getInputDatasets(visitorFactory, lineage.getSources());
+          List<OpenLineage.OutputDataset> outputDatasets =
+              getOutputDatasets(visitorFactory, lineage.getSink());
+          createRunEventAndEmit(inputDatasets, outputDatasets);
+        }
+
+      } catch (IllegalAccessException e) {
+        log.error("Can't access the field. ", e);
+      }
+    }
+  }
+
+  private void createRunEventAndEmit(
+      List<OpenLineage.InputDataset> inputDatasets,
+      List<OpenLineage.OutputDataset> outputDatasets) {
+    OpenLineage.RunEvent runEvent =
+        openLineageContext
+            .getOpenLineage()
+            .newRunEventBuilder()
+            .inputs(inputDatasets)
+            .outputs(outputDatasets)
+            .build();
+
+    log.debug("RunEvent: {}", runEvent);
+  }
+
+  private List<OpenLineage.InputDataset> getInputDatasets(
+      VisitorFactory visitorFactory, List<Object> sources) {
+    List<OpenLineage.InputDataset> inputDatasets = new ArrayList<>();
+    List<Visitor<OpenLineage.InputDataset>> inputVisitors =
+        visitorFactory.getInputVisitors(openLineageContext);
+
+    for (var transformation : sources) {
+      inputDatasets.addAll(
+          inputVisitors.stream()
+              .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
+              .map(inputVisitor -> inputVisitor.apply(transformation))
+              .flatMap(List::stream)
+              .collect(Collectors.toList()));
+    }
+    return inputDatasets;
+  }
+
+  private List<OpenLineage.OutputDataset> getOutputDatasets(
+      VisitorFactory visitorFactory, Object sink) {
+    List<OpenLineage.OutputDataset> outputDatasets = new ArrayList<>();
+    List<Visitor<OpenLineage.OutputDataset>> outputVisitors =
+        visitorFactory.getOutputVisitors(openLineageContext);
+
+    outputDatasets.addAll(
+        outputVisitors.stream()
+            .filter(inputVisitor -> inputVisitor.isDefinedAt(sink))
+            .map(inputVisitor -> inputVisitor.apply(sink))
+            .flatMap(List::stream)
+            .collect(Collectors.toList()));
+    return outputDatasets;
+  }
+
+  @Override
+  public void onJobExecuted(
+      @Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
+    log.debug("JobExecutionResult: {}", jobExecutionResult);
+  }
+
+  private void makeTransformationsArchivedList(StreamExecutionEnvironment executionEnvironment) {
+    try {
+      Field transformations =
+          FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
+      ArrayList<Transformation<?>> previousTransformationList =
+          (ArrayList<Transformation<?>>)
+              FieldUtils.readField(transformations, executionEnvironment, true);
+      List<Transformation<?>> transformationList =
+          new ArchivedList<>(previousTransformationList);
+      FieldUtils.writeField(transformations, executionEnvironment, transformationList, true);
+    } catch (IllegalAccessException e) {
+      log.error("Failed to rewrite transformations");
+    }
+  }
+
+  static class ArchivedList<T> extends ArrayList<T> {
+    @Getter
+    List<T> archive;
+
+    public ArchivedList(Collection<T> collection) {
+      super(collection);
     }
 
     @Override
-    public void onJobSubmitted(@Nullable JobClient jobClient, @Nullable Throwable throwable) {
-        if (jobClient != null) {
-            log.info("JobId: {}", jobClient.getJobID());
-            Field transformationsField = FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
-            try {
-                List<Transformation<?>> transformations = (List<Transformation<?>>) transformationsField.get(executionEnvironment);
-                VisitorFactory visitorFactory = new VisitorFactoryImpl();
-
-                List<OpenLineage.InputDataset> inputDatasets = getInputDatasets(visitorFactory, transformations);
-                List<OpenLineage.OutputDataset> outputDatasets = getOutputDatasets(visitorFactory, transformations);
-
-                createRunEventAndEmit(inputDatasets, outputDatasets);
-            } catch (IllegalAccessException e) {
-                log.error("Can't access the field. ", e);
-            }
-        }
+    public void clear() {
+      archive = new ArrayList<>(this);
+      clear();
     }
-
-    private void createRunEventAndEmit(List<OpenLineage.InputDataset> inputDatasets, List<OpenLineage.OutputDataset> outputDatasets) {
-        OpenLineage.RunEvent runEvent = openLineageContext
-                .getOpenLineage()
-                .newRunEventBuilder()
-                .inputs(inputDatasets)
-                .outputs(outputDatasets).build();
-
-        log.info("RunEvent: {}", runEvent);
-    }
-
-    private List<OpenLineage.InputDataset> getInputDatasets(VisitorFactory visitorFactory, List<Transformation<?>> transformations) {
-        List<OpenLineage.InputDataset> inputDataSets = new ArrayList<>();
-        List<Visitor<Transformation<?>, OpenLineage.InputDataset>> inputVisitors = visitorFactory.getInputVisitors(openLineageContext);
-
-        for (Transformation<?> transformation : transformations) {
-            inputDataSets.addAll(inputVisitors.stream()
-                    .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
-                    .map(inputVisitor -> inputVisitor.apply(transformation))
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList()));
-        }
-        return inputDataSets;
-    }
-
-    private List<OpenLineage.OutputDataset> getOutputDatasets(VisitorFactory visitorFactory, List<Transformation<?>> transformations) {
-        List<OpenLineage.OutputDataset> outputDatasets = new ArrayList<>();
-        List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> inputVisitors = visitorFactory.getOutputVisitors(openLineageContext);
-
-        for (Transformation<?> transformation : transformations) {
-            outputDatasets.addAll(inputVisitors.stream()
-                    .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
-                    .map(inputVisitor -> inputVisitor.apply(transformation))
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList()));
-        }
-        return outputDatasets;
-    }
-
-    @Override
-    public void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
-        log.info("JobExecutionResult: {}", jobExecutionResult);
-    }
-
-    private void makeTransformationsUnclearableList(StreamExecutionEnvironment executionEnvironment) {
-        try {
-            Field transformations = FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
-            ArrayList<Transformation<?>> previousTransformationList = (ArrayList<Transformation<?>>) FieldUtils.readField(transformations, executionEnvironment, true);
-            List<Transformation<?>> transformationList = new UnclearableList<>(previousTransformationList);
-            FieldUtils.writeField(transformations, executionEnvironment, transformationList, true);
-        } catch (IllegalAccessException e) {
-            log.error("Failed to rewrite transformations");
-        }
-    }
-
-    static class UnclearableList<T> extends ArrayList<T> {
-        public UnclearableList(Collection<T> collection) {
-            super(collection);
-            log.info("Created un-clearableList");
-        }
-        @Override
-        public void clear() {
-            log.info("Trying to clear un-clearable list");
-        }
-    }
+  }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
@@ -1,0 +1,15 @@
+package io.openlineage.flink;
+
+import java.util.List;
+import lombok.Value;
+
+@Value
+public class SinkLineage {
+  // Can be implementation of org.apache.flink.api.connector.source.Source
+  // or org.apache.flink.streaming.api.functions.source.SourceFunction
+  List<Object> sources;
+
+  // Can be implementation of org.apache.flink.api.connector.sink2.Sink
+  // or org.apache.flink.streaming.api.functions.sink.SinkFunction
+  Object sink;
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -1,0 +1,85 @@
+package io.openlineage.flink;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
+import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.SinkTransformation;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+
+/**
+ * Transform list-of-connected-dags-like structure to list of sources and sinks TODO: have to
+ * preserve DAG information for precise source-to-sink dataset mappings
+ */
+@Slf4j
+public class TransformationUtils {
+
+  private final List<Object> sources = new ArrayList<>();
+  private final List<Object> sinks = new ArrayList<>();
+
+  private final Set<String> processedTransformations = new HashSet<>();
+
+  public List<SinkLineage> convertToVisitable(List<Transformation<?>> transformations) {
+    List<SinkLineage> lineages = new ArrayList<>();
+    for (Transformation<?> transformation : transformations) {
+      var sinkLineage = processSink(transformation);
+      sinkLineage.ifPresent(lineages::add);
+    }
+    return lineages;
+  }
+
+  public Optional<SinkLineage> processSink(Transformation<?> transformation) {
+    List<Object> sources = new ArrayList<>();
+    Object sink;
+    if (transformation instanceof SinkTransformation) {
+      sink = processSinkTransformation(transformation);
+    } else if (transformation instanceof LegacySinkTransformation) {
+      sink = processLegacySinkTransformation(transformation);
+    } else {
+      return Optional.empty();
+    }
+
+    // Java streams do not like the unchecked generic casts we're doing here.
+    // So, with regular for we go.
+    List<Transformation<?>> predecessors = transformation.getTransitivePredecessors();
+    for (var predecessor : predecessors) {
+      var source = processSource(predecessor);
+      source.ifPresent(sources::add);
+    }
+    return Optional.of(new SinkLineage(sources, sink));
+  }
+
+  public Optional<Object> processSource(Transformation<?> transformation) {
+    if (transformation instanceof SourceTransformation) {
+      return Optional.of(processSourceTransformation(transformation));
+    } else if (transformation instanceof LegacySourceTransformation) {
+      return Optional.of(processLegacySourceTransformation(transformation));
+    }
+    return Optional.empty();
+  }
+
+  public Object processSourceTransformation(Transformation<?> genericTransformation) {
+    SourceTransformation transformation = (SourceTransformation) genericTransformation;
+    return transformation.getSource();
+  }
+
+  public Object processLegacySourceTransformation(Transformation<?> genericTransformation) {
+    LegacySourceTransformation transformation = (LegacySourceTransformation) genericTransformation;
+    return transformation.getOperator().getUserFunction();
+  }
+
+  public Object processSinkTransformation(Transformation<?> genericTransformation) {
+    SinkTransformation transformation = (SinkTransformation) genericTransformation;
+    return transformation.getSink();
+  }
+
+  public Object processLegacySinkTransformation(Transformation<?> genericTransformation) {
+    LegacySinkTransformation transformation = (LegacySinkTransformation) genericTransformation;
+    return transformation.getOperator().getUserFunction();
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -1,23 +1,17 @@
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
-import java.util.Optional;
-import java.util.UUID;
-
 /**
  * Context holder with references to several required objects during construction of an OpenLineage
  * {@link io.openlineage.client.OpenLineage.RunEvent}. An {@link OpenLineageContext} should be
  * created once for every detected Flink job execution.
- *
- * <p>It should be assumed that the lists of input and output {@link QueryPlanVisitor} are mutable
- * lists. As {@link QueryPlanVisitor}s require a reference to the {@link OpenLineageContext}, the
- * lists will always be added to after the {@link QueryPlanVisitor}s are constructed. Thus, copies
- * should never be made of the lists, as it should be assumed such copies will be incomplete.
  *
  * <p>This API is evolving and may change in future releases
  *
@@ -26,17 +20,18 @@ import java.util.UUID;
 @Value
 @Builder
 public class OpenLineageContext {
-    UUID runUuid = UUID.randomUUID();
+  UUID runUuid = UUID.randomUUID();
 
-    /**
-     * Optional {@link StreamExecutionEnvironment} instance, that is the context in which a streaming program is executed.
-     */
-    @Builder.Default
-    @NonNull Optional<StreamExecutionEnvironment> streamExecutionEnvironment = Optional.empty();
+  /**
+   * Optional {@link StreamExecutionEnvironment} instance, that is the context in which a streaming
+   * program is executed.
+   */
+  @Builder.Default @NonNull
+  Optional<StreamExecutionEnvironment> streamExecutionEnvironment = Optional.empty();
 
-    /**
-     * A non-null, preconfigured {@link OpenLineage} client instance for constructing OpenLineage
-     * model objects
-     */
-    @NonNull OpenLineage openLineage;
+  /**
+   * A non-null, preconfigured {@link OpenLineage} client instance for constructing OpenLineage
+   * model objects
+   */
+  @NonNull OpenLineage openLineage;
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -1,0 +1,42 @@
+package io.openlineage.flink.api;
+
+import io.openlineage.client.OpenLineage;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Context holder with references to several required objects during construction of an OpenLineage
+ * {@link io.openlineage.client.OpenLineage.RunEvent}. An {@link OpenLineageContext} should be
+ * created once for every detected Flink job execution.
+ *
+ * <p>It should be assumed that the lists of input and output {@link QueryPlanVisitor} are mutable
+ * lists. As {@link QueryPlanVisitor}s require a reference to the {@link OpenLineageContext}, the
+ * lists will always be added to after the {@link QueryPlanVisitor}s are constructed. Thus, copies
+ * should never be made of the lists, as it should be assumed such copies will be incomplete.
+ *
+ * <p>This API is evolving and may change in future releases
+ *
+ * @apiNote This interface is evolving and may change in future releases
+ */
+@Value
+@Builder
+public class OpenLineageContext {
+    UUID runUuid = UUID.randomUUID();
+
+    /**
+     * Optional {@link StreamExecutionEnvironment} instance, that is the context in which a streaming program is executed.
+     */
+    @Builder.Default
+    @NonNull Optional<StreamExecutionEnvironment> streamExecutionEnvironment = Optional.empty();
+
+    /**
+     * A non-null, preconfigured {@link OpenLineage} client instance for constructing OpenLineage
+     * model objects
+     */
+    @NonNull OpenLineage openLineage;
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
@@ -1,7 +1,6 @@
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
-
 import java.net.URI;
 
 public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
@@ -38,13 +37,14 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
 
   public D getDataset(String name, String namespace) {
     OpenLineage.DatasetFacetsBuilder builder =
-            openLineage
-                    .newDatasetFacetsBuilder()
-                    .dataSource(openLineage
-                            .newDatasourceDatasetFacetBuilder()
-                            .uri(URI.create(""))
-                            .name(namespace)
-                            .build());
+        openLineage
+            .newDatasetFacetsBuilder()
+            .dataSource(
+                openLineage
+                    .newDatasourceDatasetFacetBuilder()
+                    .uri(URI.create(""))
+                    .name(namespace)
+                    .build());
     return getDataset(name, namespace, builder.build());
   }
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
@@ -1,0 +1,54 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+
+import java.net.URI;
+
+public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
+  private final OpenLineage openLineage;
+
+  private DatasetFactory(OpenLineage openLineage) {
+    this.openLineage = openLineage;
+  }
+
+  abstract OpenLineage.Builder<D> datasetBuilder(
+      String name, String namespace, OpenLineage.DatasetFacets datasetFacet);
+
+  public static DatasetFactory<OpenLineage.InputDataset> input(OpenLineage client) {
+    return new DatasetFactory<OpenLineage.InputDataset>(client) {
+      public OpenLineage.Builder<OpenLineage.InputDataset> datasetBuilder(
+          String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {
+        return client.newInputDatasetBuilder().namespace(namespace).name(name).facets(datasetFacet);
+      }
+    };
+  }
+
+  public static DatasetFactory<OpenLineage.OutputDataset> output(OpenLineage client) {
+    return new DatasetFactory<OpenLineage.OutputDataset>(client) {
+      public OpenLineage.Builder<OpenLineage.OutputDataset> datasetBuilder(
+          String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {
+        return client
+            .newOutputDatasetBuilder()
+            .namespace(namespace)
+            .name(name)
+            .facets(datasetFacet);
+      }
+    };
+  }
+
+  public D getDataset(String name, String namespace) {
+    OpenLineage.DatasetFacetsBuilder builder =
+            openLineage
+                    .newDatasetFacetsBuilder()
+                    .dataSource(openLineage
+                            .newDatasourceDatasetFacetBuilder()
+                            .uri(URI.create(""))
+                            .name(namespace)
+                            .build());
+    return getDataset(name, namespace, builder.build());
+  }
+
+  public D getDataset(String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {
+    return datasetBuilder(name, namespace, datasetFacet).build();
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -1,0 +1,57 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+import org.apache.flink.streaming.api.transformations.SinkTransformation;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class KafkaSinkVisitor extends Visitor<Transformation<?>, OpenLineage.OutputDataset> {
+
+    public KafkaSinkVisitor(@NonNull OpenLineageContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isDefinedAt(Transformation<?> transformation) {
+        return transformation instanceof SinkTransformation;
+    }
+
+    @Override
+    public List<OpenLineage.OutputDataset> apply(Transformation<?> transformation) {
+        if (transformation instanceof SinkTransformation) {
+            KafkaSink<?> kafkaSink = (KafkaSink<?>) ((SinkTransformation<?,?,?,?>)transformation).getSink();
+            Field recordSerializerField = FieldUtils.getField(KafkaSink.class, "recordSerializer", true);
+            try {
+                KafkaRecordSerializationSchema<?> serializationSchema = (KafkaRecordSerializationSchema<?>) recordSerializerField.get(kafkaSink);
+                Field topicSelectorField = FieldUtils.getField(serializationSchema.getClass().asSubclass(serializationSchema.getClass()), "topicSelector", true);
+                Field topicSelectorFunctionField = FieldUtils.getField(topicSelectorField.get(serializationSchema).getClass().asSubclass(topicSelectorField.get(serializationSchema).getClass()), "topicSelector", true);
+                Function<?,?> function = (Function<?,?>) topicSelectorFunctionField.get(topicSelectorField.get(serializationSchema));
+                Field kafkaProducerConfig = FieldUtils.getField(KafkaSink.class, "kafkaProducerConfig", true);
+                Properties properties = (Properties) kafkaProducerConfig.get(kafkaSink);
+                String bootStrapServers = properties.getProperty("bootstrap.servers");
+                String kafkaTopic = (String) function.apply(null);
+
+                log.info("Kafka output topic: {}", kafkaTopic);
+
+                return Collections.singletonList(outputDataset().getDataset(kafkaTopic, bootStrapServers));
+            } catch (IllegalAccessException e) {
+                log.error("Can't access the field. ", e);
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -2,56 +2,62 @@ package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.OpenLineageContext;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
-import org.apache.flink.connector.kafka.sink.KafkaSink;
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-import org.apache.flink.streaming.api.transformations.SinkTransformation;
-
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
 
 @Slf4j
-public class KafkaSinkVisitor extends Visitor<Transformation<?>, OpenLineage.OutputDataset> {
+public class KafkaSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
 
-    public KafkaSinkVisitor(@NonNull OpenLineageContext context) {
-        super(context);
+  public KafkaSinkVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public boolean isDefinedAt(Object sink) {
+    return sink instanceof KafkaSink;
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(Object kafkaSink) {
+    Field recordSerializerField = FieldUtils.getField(KafkaSink.class, "recordSerializer", true);
+    try {
+      KafkaRecordSerializationSchema<?> serializationSchema =
+          (KafkaRecordSerializationSchema<?>) recordSerializerField.get(kafkaSink);
+      Field topicSelectorField =
+          FieldUtils.getField(
+              serializationSchema.getClass().asSubclass(serializationSchema.getClass()),
+              "topicSelector",
+              true);
+      Field topicSelectorFunctionField =
+          FieldUtils.getField(
+              topicSelectorField
+                  .get(serializationSchema)
+                  .getClass()
+                  .asSubclass(topicSelectorField.get(serializationSchema).getClass()),
+              "topicSelector",
+              true);
+      Function<?, ?> function =
+          (Function<?, ?>)
+              topicSelectorFunctionField.get(topicSelectorField.get(serializationSchema));
+      Field kafkaProducerConfig = FieldUtils.getField(KafkaSink.class, "kafkaProducerConfig", true);
+      Properties properties = (Properties) kafkaProducerConfig.get(kafkaSink);
+      String bootStrapServers = properties.getProperty("bootstrap.servers");
+      String kafkaTopic = (String) function.apply(null);
+
+      log.debug("Kafka output topic: {}", kafkaTopic);
+
+      return Collections.singletonList(outputDataset().getDataset(kafkaTopic, bootStrapServers));
+    } catch (IllegalAccessException e) {
+      log.error("Can't access the field. ", e);
     }
-
-    @Override
-    public boolean isDefinedAt(Transformation<?> transformation) {
-        return transformation instanceof SinkTransformation;
-    }
-
-    @Override
-    public List<OpenLineage.OutputDataset> apply(Transformation<?> transformation) {
-        if (transformation instanceof SinkTransformation) {
-            KafkaSink<?> kafkaSink = (KafkaSink<?>) ((SinkTransformation<?,?,?,?>)transformation).getSink();
-            Field recordSerializerField = FieldUtils.getField(KafkaSink.class, "recordSerializer", true);
-            try {
-                KafkaRecordSerializationSchema<?> serializationSchema = (KafkaRecordSerializationSchema<?>) recordSerializerField.get(kafkaSink);
-                Field topicSelectorField = FieldUtils.getField(serializationSchema.getClass().asSubclass(serializationSchema.getClass()), "topicSelector", true);
-                Field topicSelectorFunctionField = FieldUtils.getField(topicSelectorField.get(serializationSchema).getClass().asSubclass(topicSelectorField.get(serializationSchema).getClass()), "topicSelector", true);
-                Function<?,?> function = (Function<?,?>) topicSelectorFunctionField.get(topicSelectorField.get(serializationSchema));
-                Field kafkaProducerConfig = FieldUtils.getField(KafkaSink.class, "kafkaProducerConfig", true);
-                Properties properties = (Properties) kafkaProducerConfig.get(kafkaSink);
-                String bootStrapServers = properties.getProperty("bootstrap.servers");
-                String kafkaTopic = (String) function.apply(null);
-
-                log.info("Kafka output topic: {}", kafkaTopic);
-
-                return Collections.singletonList(outputDataset().getDataset(kafkaTopic, bootStrapServers));
-            } catch (IllegalAccessException e) {
-                log.error("Can't access the field. ", e);
-            }
-        }
-        return Collections.emptyList();
-    }
+    return Collections.emptyList();
+  }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -2,73 +2,50 @@ package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.OpenLineageContext;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.connector.kafka.source.KafkaSource;
-import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
-import org.apache.flink.streaming.api.transformations.OneInputTransformation;
-import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.streaming.api.transformations.SourceTransformation;
-
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 
 @Slf4j
-public class KafkaSourceVisitor extends Visitor<Transformation<?>, OpenLineage.InputDataset>  {
+public class KafkaSourceVisitor extends Visitor<OpenLineage.InputDataset> {
 
-    public KafkaSourceVisitor(@NonNull OpenLineageContext context) {
-        super(context);
+  public KafkaSourceVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public boolean isDefinedAt(Object source) {
+    return source instanceof KafkaSource;
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(Object kafkaSource) {
+    var source = (KafkaSource<?>) kafkaSource;
+    try {
+      Field subscriberField = FieldUtils.getField(KafkaSource.class, "subscriber", true);
+      KafkaSubscriber kafkaSubscriber = (KafkaSubscriber) subscriberField.get(source);
+      Field topicsField =
+          FieldUtils.getField(
+              kafkaSubscriber.getClass().asSubclass(kafkaSubscriber.getClass()), "topics", true);
+      List<String> topics = (List<String>) topicsField.get(kafkaSubscriber);
+      Field props = FieldUtils.getField(KafkaSource.class, "props", true);
+      Properties properties = (Properties) props.get(source);
+      String bootStrapServers = properties.getProperty("bootstrap.servers");
+
+      topics.forEach(topic -> log.debug("Kafka input topic: {}", topic));
+      return topics.stream()
+          .map(topic -> inputDataset().getDataset(topic, bootStrapServers))
+          .collect(Collectors.toList());
+    } catch (IllegalAccessException e) {
+      log.error("Can't access the field. ", e);
     }
-
-    @Override
-    public boolean isDefinedAt(Transformation<?> transformation) {
-        return transformation instanceof OneInputTransformation;
-    }
-
-    @Override
-    public List<OpenLineage.InputDataset> apply(Transformation<?> transformation) {
-        try {
-            Optional<KafkaSource<?>> kafkaSource = convertIntoKafkaSource(transformation);
-            if (kafkaSource.isPresent()) {
-                Field subscriberField = FieldUtils.getField(KafkaSource.class, "subscriber", true);
-                KafkaSubscriber kafkaSubscriber = (KafkaSubscriber) subscriberField.get(kafkaSource.get());
-                Field topicsField = FieldUtils.getField(kafkaSubscriber.getClass().asSubclass(kafkaSubscriber.getClass()), "topics", true);
-                List<String> topics = (List<String>) topicsField.get(kafkaSubscriber);
-                Field props = FieldUtils.getField(KafkaSource.class, "props", true);
-                Properties properties = (Properties) props.get(kafkaSource.get());
-                String bootStrapServers = properties.getProperty("bootstrap.servers");
-
-                topics.forEach(topic -> log.info("Kafka input topic: {}", topic));
-                return topics.stream()
-                        .map(topic -> inputDataset()
-                        .getDataset(topic, bootStrapServers))
-                        .collect(Collectors.toList());
-            }
-        } catch (IllegalAccessException e) {
-            log.error("Can't access the field. ", e);
-        }
-        return Collections.emptyList();
-    }
-
-    private Optional<KafkaSource<?>> convertIntoKafkaSource(Transformation<?> transformation) {
-        if (transformation instanceof OneInputTransformation) {
-            return transformation.getInputs()
-                    .stream()
-                    .filter(PartitionTransformation.class::isInstance)
-                    .findAny()
-                    .map(t -> (PartitionTransformation<?>)t)
-                    .map(partitionTransformation -> partitionTransformation.getInputs().get(0))
-                    .filter(SourceTransformation.class::isInstance)
-                    .map(source -> ((SourceTransformation<?, ?, ?>) source).getSource())
-                    .map(kf -> (KafkaSource<?>) kf);
-        }
-        return Optional.empty();
-    }
+    return Collections.emptyList();
+  }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -1,0 +1,74 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class KafkaSourceVisitor extends Visitor<Transformation<?>, OpenLineage.InputDataset>  {
+
+    public KafkaSourceVisitor(@NonNull OpenLineageContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isDefinedAt(Transformation<?> transformation) {
+        return transformation instanceof OneInputTransformation;
+    }
+
+    @Override
+    public List<OpenLineage.InputDataset> apply(Transformation<?> transformation) {
+        try {
+            Optional<KafkaSource<?>> kafkaSource = convertIntoKafkaSource(transformation);
+            if (kafkaSource.isPresent()) {
+                Field subscriberField = FieldUtils.getField(KafkaSource.class, "subscriber", true);
+                KafkaSubscriber kafkaSubscriber = (KafkaSubscriber) subscriberField.get(kafkaSource.get());
+                Field topicsField = FieldUtils.getField(kafkaSubscriber.getClass().asSubclass(kafkaSubscriber.getClass()), "topics", true);
+                List<String> topics = (List<String>) topicsField.get(kafkaSubscriber);
+                Field props = FieldUtils.getField(KafkaSource.class, "props", true);
+                Properties properties = (Properties) props.get(kafkaSource.get());
+                String bootStrapServers = properties.getProperty("bootstrap.servers");
+
+                topics.forEach(topic -> log.info("Kafka input topic: {}", topic));
+                return topics.stream()
+                        .map(topic -> inputDataset()
+                        .getDataset(topic, bootStrapServers))
+                        .collect(Collectors.toList());
+            }
+        } catch (IllegalAccessException e) {
+            log.error("Can't access the field. ", e);
+        }
+        return Collections.emptyList();
+    }
+
+    private Optional<KafkaSource<?>> convertIntoKafkaSource(Transformation<?> transformation) {
+        if (transformation instanceof OneInputTransformation) {
+            return transformation.getInputs()
+                    .stream()
+                    .filter(PartitionTransformation.class::isInstance)
+                    .findAny()
+                    .map(t -> (PartitionTransformation<?>)t)
+                    .map(partitionTransformation -> partitionTransformation.getInputs().get(0))
+                    .filter(SourceTransformation.class::isInstance)
+                    .map(source -> ((SourceTransformation<?, ?, ?>) source).getSource())
+                    .map(kf -> (KafkaSource<?>) kf);
+        }
+        return Optional.empty();
+    }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
@@ -1,0 +1,29 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import lombok.NonNull;
+import org.apache.flink.api.dag.Transformation;
+
+import java.util.List;
+
+public abstract class Visitor<T extends Transformation<?>, D extends OpenLineage.Dataset> {
+    @NonNull
+    protected final OpenLineageContext context;
+
+    public Visitor(@NonNull OpenLineageContext context) {
+        this.context = context;
+    }
+
+    protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
+        return DatasetFactory.output(context.getOpenLineage());
+    }
+
+    protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
+        return DatasetFactory.input(context.getOpenLineage());
+    }
+
+    public abstract boolean isDefinedAt(T transformation);
+
+    public abstract List<D> apply(T t);
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
@@ -2,28 +2,25 @@ package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.OpenLineageContext;
-import lombok.NonNull;
-import org.apache.flink.api.dag.Transformation;
-
 import java.util.List;
+import lombok.NonNull;
 
-public abstract class Visitor<T extends Transformation<?>, D extends OpenLineage.Dataset> {
-    @NonNull
-    protected final OpenLineageContext context;
+public abstract class Visitor<D extends OpenLineage.Dataset> {
+  @NonNull protected final OpenLineageContext context;
 
-    public Visitor(@NonNull OpenLineageContext context) {
-        this.context = context;
-    }
+  public Visitor(@NonNull OpenLineageContext context) {
+    this.context = context;
+  }
 
-    protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
-        return DatasetFactory.output(context.getOpenLineage());
-    }
+  protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
+    return DatasetFactory.output(context.getOpenLineage());
+  }
 
-    protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
-        return DatasetFactory.input(context.getOpenLineage());
-    }
+  protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
+    return DatasetFactory.input(context.getOpenLineage());
+  }
 
-    public abstract boolean isDefinedAt(T transformation);
+  public abstract boolean isDefinedAt(Object object);
 
-    public abstract List<D> apply(T t);
+  public abstract List<D> apply(Object object);
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
@@ -1,0 +1,14 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import org.apache.flink.api.dag.Transformation;
+
+import java.util.List;
+
+public interface VisitorFactory {
+
+    List<Visitor<Transformation<?>, OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context);
+
+    List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context);
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
@@ -2,13 +2,11 @@ package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.OpenLineageContext;
-import org.apache.flink.api.dag.Transformation;
-
 import java.util.List;
 
 public interface VisitorFactory {
 
-    List<Visitor<Transformation<?>, OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context);
+  List<Visitor<OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context);
 
-    List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context);
+  List<Visitor<OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context);
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -1,0 +1,21 @@
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.OpenLineageContext;
+import org.apache.flink.api.dag.Transformation;
+
+import java.util.Collections;
+import java.util.List;
+
+public class VisitorFactoryImpl implements VisitorFactory {
+
+    @Override
+    public List<Visitor<Transformation<?>, OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context) {
+        return Collections.singletonList(new KafkaSourceVisitor(context));
+    }
+
+    @Override
+    public List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context) {
+        return Collections.singletonList(new KafkaSinkVisitor(context));
+    }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -2,20 +2,18 @@ package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.OpenLineageContext;
-import org.apache.flink.api.dag.Transformation;
-
 import java.util.Collections;
 import java.util.List;
 
 public class VisitorFactoryImpl implements VisitorFactory {
 
-    @Override
-    public List<Visitor<Transformation<?>, OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context) {
-        return Collections.singletonList(new KafkaSourceVisitor(context));
-    }
+  @Override
+  public List<Visitor<OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context) {
+    return Collections.singletonList(new KafkaSourceVisitor(context));
+  }
 
-    @Override
-    public List<Visitor<Transformation<?>, OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context) {
-        return Collections.singletonList(new KafkaSinkVisitor(context));
-    }
+  @Override
+  public List<Visitor<OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context) {
+    return Collections.singletonList(new KafkaSinkVisitor(context));
+  }
 }


### PR DESCRIPTION
Currently, Flink integration makes visitors look at transformations - the internal flink representation of stream graph - to extract proper sources and sinks. This PR extracts responsibility of doing this to separate class, which only gathers sinks and lists of sources that are connected to this sink. We can ignore transformations happening in the middle, since Flink contains method to gather all transient "parent" transformations, so we get true lineage for particular sink - we won't assign wrong source in case we had disjointed job tree - which is possible in Flink.

Closes: https://github.com/OpenLineage/OpenLineage/issues/561