### PR TITLE
Support Spark 3.2.1

### DIFF
--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -9,11 +9,11 @@ workflows:
       - build-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.1', '3.1.2' ]
+              spark-version: [ '2.4.6', '3.1.2', '3.2.1' ]
       - integration-test-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.1', '3.1.2' ]
+              spark-version: [ '2.4.6', '3.1.2', '3.2.1' ]
           requires:
             - build-integration-spark
       - publish-snapshot-integration-spark:

--- a/integration/spark/integrations/container/pysparkWriteDeltaTableVersionEnd.json
+++ b/integration/spark/integrations/container/pysparkWriteDeltaTableVersionEnd.json
@@ -6,7 +6,7 @@
   },
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/write_delta_table_version",
+    "name" : "/tmp/versioned_table",
     "facets" : {
       "dataSource" : {
         "name" : "file",

--- a/integration/spark/integrations/container/pysparkWriteDeltaTableVersionStart.json
+++ b/integration/spark/integrations/container/pysparkWriteDeltaTableVersionStart.json
@@ -6,7 +6,7 @@
   },
   "inputs": [ {
     "namespace" : "file",
-    "name" : "/tmp/warehouse/versioned_input_table",
+    "name" : "/tmp/versioned_input_table",
     "facets" : {
       "dataSource": {
         "name": "file",

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -37,14 +37,31 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
       OpenLineageContext context) {
     DatasetFactory<OpenLineage.OutputDataset> datasetFactory =
         DatasetFactory.output(context.getOpenLineage());
-    return ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
-        .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
-        .add(new SaveIntoDataSourceCommandVisitor(context))
-        .add(new AppendDataDatasetBuilder(context, datasetFactory))
-        .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
-        .add(new TableContentChangeDatasetBuilder(context))
-        .add(new CreateReplaceDatasetBuilder(context))
-        .add(new AlterTableDatasetBuilder(context))
-        .build();
+    ImmutableList.Builder builder =
+        ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
+            .add(new SaveIntoDataSourceCommandVisitor(context))
+            .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
+            .add(new TableContentChangeDatasetBuilder(context))
+            .add(new CreateReplaceDatasetBuilder(context));
+
+    if (hasAlterTableClass()) {
+      builder.add(new AlterTableDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
+
+  private boolean hasAlterTableClass() {
+    try {
+      Spark3DatasetBuilderFactory.class
+          .getClassLoader()
+          .loadClass("org.apache.spark.sql.catalyst.plans.logical.AlterTable");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
   }
 }

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -200,10 +200,31 @@ public class SparkContainerIntegrationTest {
             openLineageClientMockContainer,
             "testCTASDelta",
             "--packages",
-            "io.delta:delta-core_2.12:1.0.0",
+            getDeltaPackageName(),
             "/opt/spark_scripts/spark_delta.py");
     pyspark.start();
     verifyEvents("pysparkDeltaCTASComplete.json");
+  }
+
+  /*
+   * Alter table differs between Spark 3.1 and Spark 3.2.
+   * Delta support for 3.2 is also limited.
+   * These test should only apply for Spark 3.1
+   */
+  @EnabledIfSystemProperty(named = "spark.version", matches = "(3.1.*)")
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "spark_v2_alter.py:pysparkV2AlterTableStartEvent.json:pysparkV2AlterTableCompleteEvent.json:true",
+        "spark_write_delta_table_version.py:pysparkWriteDeltaTableVersionStart.json:pysparkWriteDeltaTableVersionEnd.json:false"
+      },
+      delimiter = ':')
+  public void testAlterTableSpark_3_1(
+      String pysparkScript,
+      String expectedStartEvent,
+      String expectedCompleteEvent,
+      String isIceberg) {
+    testV2Commands(pysparkScript, expectedStartEvent, expectedCompleteEvent, isIceberg);
   }
 
   @EnabledIfSystemProperty(named = "spark.version", matches = SPARK_3) // Spark version >= 3.*
@@ -220,9 +241,7 @@ public class SparkContainerIntegrationTest {
         "spark_v2_update.py:pysparkV2UpdateStartEvent.json:pysparkV2UpdateCompleteEvent.json:true",
         "spark_v2_merge_into_table.py:pysparkV2MergeIntoTableStartEvent.json:pysparkV2MergeIntoTableCompleteEvent.json:true",
         "spark_v2_drop.py:pysparkV2DropTableStartEvent.json:pysparkV2DropTableCompleteEvent.json:true",
-        "spark_v2_alter.py:pysparkV2AlterTableStartEvent.json:pysparkV2AlterTableCompleteEvent.json:true",
         "spark_v2_append.py:pysparkV2AppendDataStartEvent.json:pysparkV2AppendDataCompleteEvent.json:true",
-        "spark_write_delta_table_version.py:pysparkWriteDeltaTableVersionStart.json:pysparkWriteDeltaTableVersionEnd.json:false"
       },
       delimiter = ':')
   public void testV2Commands(
@@ -236,12 +255,29 @@ public class SparkContainerIntegrationTest {
             openLineageClientMockContainer,
             "testV2Commands",
             "--packages",
-            Boolean.valueOf(isIceberg)
-                ? "org.apache.iceberg:iceberg-spark3-runtime:0.12.0"
-                : "io.delta:delta-core_2.12:1.0.0",
+            Boolean.valueOf(isIceberg) ? getIcebergPackageName() : getDeltaPackageName(),
             "/opt/spark_scripts/" + pysparkScript);
     pyspark.start();
     verifyEvents(expectedStartEvent, expectedCompleteEvent);
+  }
+
+  private String getIcebergPackageName() {
+    String sparkVersion = System.getProperty("spark.version");
+    if (sparkVersion.startsWith("3.1")) {
+      return "org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:0.13.0";
+    } else if (sparkVersion.startsWith("3.2")) {
+      return "org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.13.0";
+    }
+    // return previously used package name
+    return "org.apache.iceberg:iceberg-spark3-runtime:0.12.0";
+  }
+
+  private String getDeltaPackageName() {
+    String sparkVersion = System.getProperty("spark.version");
+    if (sparkVersion.startsWith("3.2")) {
+      return "io.delta:delta-core_2.12:1.1.0";
+    }
+    return "io.delta:delta-core_2.12:1.0.0";
   }
 
   @Test
@@ -286,7 +322,7 @@ public class SparkContainerIntegrationTest {
             openLineageClientMockContainer,
             "testWriteIcebergTableVersion",
             "--packages",
-            "org.apache.iceberg:iceberg-spark3-runtime:0.12.0",
+            getIcebergPackageName(),
             "/opt/spark_scripts/spark_write_iceberg_table_version.py")
         .start();
     verifyEvents("pysparkWriteIcebergTableVersionEnd.json");

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -26,7 +26,7 @@ public class SparkContainerUtils {
       MockServerContainer mockServerContainer,
       String... command) {
     return new GenericContainer<>(
-            DockerImageName.parse("godatadriven/pyspark:" + System.getProperty("spark.version")))
+            DockerImageName.parse("bitnami/spark:" + System.getProperty("spark.version")))
         .withNetwork(network)
         .withNetworkAliases("spark")
         .withFileSystemBind("src/test/resources/test_data", "/test_data")
@@ -74,6 +74,7 @@ public class SparkContainerUtils {
         mockServerContainer,
         Stream.of(
                 new String[] {
+                  "./bin/spark-submit",
                   "--master",
                   "local",
                   "--conf",
@@ -86,6 +87,12 @@ public class SparkContainerUtils {
                   "spark.sql.warehouse.dir=/tmp/warehouse",
                   "--conf",
                   "spark.sql.shuffle.partitions=1",
+                  "--conf",
+                  "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby",
+                  "--conf",
+                  "spark.sql.warehouse.dir=/tmp/warehouse",
+                  "--conf",
+                  "spark.jars.ivy=/tmp/.ivy2/",
                   "--jars",
                   "/opt/libs/"
                       + System.getProperty("openlineage.spark.jar")

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -114,9 +114,9 @@ public class StaticExecutionContextFactory extends ContextFactory {
   }
 
   @Override
-  public ExecutionContext createSparkSQLExecutionContext(long executionId) {
+  public Optional<ExecutionContext> createSparkSQLExecutionContext(long executionId) {
     return Optional.ofNullable(SQLExecution.getQueryExecution(executionId))
-        .<SparkSQLExecutionContext>map(
+        .map(
             qe -> {
               SparkSession session = qe.sparkSession();
               SQLContext sqlContext = qe.sparkPlan().sqlContext();
@@ -170,20 +170,6 @@ public class StaticExecutionContextFactory extends ContextFactory {
                   }
                 }
               };
-            })
-        .orElseGet(
-            () -> {
-              OpenLineageContext olContext =
-                  OpenLineageContext.builder()
-                      .sparkContext(SparkContext.getOrCreate())
-                      .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
-                      .build();
-
-              return new SparkSQLExecutionContext(
-                  executionId,
-                  openLineageEventEmitter,
-                  olContext,
-                  new OpenLineageRunEventBuilder(olContext, new InternalEventHandlerFactory()));
             });
   }
 

--- a/integration/spark/src/test/resources/spark_scripts/spark_delta.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_delta.py
@@ -10,7 +10,6 @@ spark = SparkSession.builder \
     .appName("Open Lineage Integration Delta") \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("packages", "io.delta:delta-core_2.12:1.0.0") \
     .config("spark.sql.warehouse.dir", "file:/tmp/delta/") \
     .getOrCreate()
 spark.sparkContext.setLogLevel('info')

--- a/integration/spark/src/test/resources/spark_scripts/spark_v2_replace_table.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_v2_replace_table.py
@@ -11,7 +11,6 @@ spark = SparkSession.builder \
     .appName("Open Lineage Integration Delta") \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("packages", "io.delta:delta-core_2.12:1.0.0") \
     .getOrCreate()
 
 spark.sparkContext.setLogLevel('info')

--- a/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_write_delta_table_version.py
@@ -1,27 +1,25 @@
 import os
-from pyspark.sql import SparkSession
 
-os.makedirs("/tmp/v2", exist_ok=True)
+from pyspark.sql import SparkSession
 
 spark = SparkSession.builder \
     .master("local") \
     .appName("Open Lineage Integration Delta") \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("packages", "io.delta:delta-core_2.12:1.0.0") \
     .getOrCreate()
 
-spark.sql("CREATE TABLE versioned_table (a long, b long) USING delta LOCATION '/tmp/write_delta_table_version'") # VERSION 1
-spark.sql("ALTER TABLE versioned_table ADD COLUMNS (c long)")                                                    # VERSION 2
+spark.sql("CREATE TABLE versioned_table (a long, b long) USING delta LOCATION '/tmp/versioned_table'")      # VERSION 1
+spark.sql("ALTER TABLE versioned_table ADD COLUMNS (c long)")                                               # VERSION 2
 
 df = spark.createDataFrame([
     {'a': 1 },
     {'a': 2 }
-])
+]).repartition(1)
 df.createOrReplaceTempView('temp')
-spark.sql("CREATE TABLE versioned_input_table USING delta AS SELECT * FROM temp") # VERSION 1
-spark.sql("ALTER TABLE versioned_input_table ADD COLUMNS (b long)")               # VERSION 2
+spark.sql("CREATE TABLE versioned_input_table USING delta LOCATION '/tmp/versioned_input_table' AS SELECT * FROM temp") # VERSION 1
+spark.sql("ALTER TABLE versioned_input_table ADD COLUMNS (b long)")                                                     # VERSION 2
 spark.sql("INSERT INTO versioned_input_table VALUES (3,4)")
-spark.sql("ALTER TABLE versioned_input_table ADD COLUMNS (c long)")               # VERSION 3
+spark.sql("ALTER TABLE versioned_input_table ADD COLUMNS (c long)")                                                     # VERSION 3
 
 spark.sql("INSERT INTO versioned_table SELECT * FROM versioned_input_table")


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Support Spark version 3.2. 

### Solution

 * Include separate integration test run for Spark 3.2.1
 * Change docker image provider to `bitnami/spark` as previously used `godatadriven/pyspark` does not support latest spark versions. 
 * Match iceberg & delta versions in integrations test with Spark version. There are different iceberg/delta jars for Spark 3.1 and Spark 3.2
 * Exclude `alter table` integration test for Spark 3.2. Spark 3.2 introduced several alter table features. Supporting them in OpenLineage requires extra visitors/dataset builders which is outside the scope of this PR and should be done later. [616]

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modifcation(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)