### PR TITLE
[INTEGRATION][Flink] Send real OpenLineage events using HTTP

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -1,15 +1,5 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -63,7 +53,6 @@ ext {
     assertjVersion = '3.20.2'
     junit5Version = '5.7.2'
     jacksonVersion = '2.6.7'
-    jacksonModuleScalaVersion = '2.6.7.1'
     jacksonDatatypeVersion = '2.6.7'
     jacksonDatabindVersion = '2.6.7.3'
     lombokVersion = '1.18.20'
@@ -94,18 +83,14 @@ dependencies {
     }
     compileOnly "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compileOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    compileOnly "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonModuleScalaVersion}"
 
     testImplementation platform('org.junit:junit-bom:5.7.1')
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation "org.testcontainers:mockserver:${testcontainersVersion}"
     testImplementation "org.testcontainers:kafka:${testcontainersVersion}"
     testImplementation "org.apache.kafka:kafka-clients:2.6.0"
-    testImplementation('org.mock-server:mockserver-client-java:5.11.2') {
-        exclude group: 'com.google.guava', module: 'guava'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.datatype'
-    }
+    testImplementation 'org.mock-server:mockserver-client-java:5.12.0'
+    testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.1.1'
     testCompile "org.assertj:assertj-core:${assertjVersion}"
     testCompile "org.junit.jupiter:junit-jupiter:${junit5Version}"
     testCompile "org.junit.jupiter:junit-jupiter-params:${junit5Version}"

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -297,9 +297,9 @@ assemble {
 
 task createVersionProperties(dependsOn: processResources) {
     doLast {
-        File dir = new File("$buildDir/resources/main/io/openlineage/flink/")
+        File dir = new File("$buildDir/resources/main/io/openlineage/flink/agent/client/")
         dir.mkdirs()
-        new File("$buildDir/resources/main/io/openlineage/flink/version.properties").withWriter { w ->
+        new File("$buildDir/resources/main/io/openlineage/flink/agent/client/version.properties").withWriter { w ->
             Properties p = new Properties()
             p['version'] = project.version.toString()
             p.store w, null

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
@@ -1,7 +1,9 @@
 package io.openlineage.flink
 
 class FlinkStatefulApplicationRunner {
-    private static String[] PARAMETERS = ["--input-topic", "io.openlineage.flink.kafka.input", "--output-topic", "io.openlineage.flink.kafka.output"]
+    private static String[] PARAMETERS = ["--input-topic", "io.openlineage.flink.kafka.input",
+                                          "--output-topic", "io.openlineage.flink.kafka.output",
+                                          "--flink.openlineage.url", "http://localhost:5000/api/v1/namespaces/flink_integration/"]
 
     static void main(String[] args) {
         FlinkStatefulApplication.main(PARAMETERS)

--- a/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -1,10 +1,8 @@
 package io.openlineage.flink;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
@@ -18,11 +16,6 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
  */
 @Slf4j
 public class TransformationUtils {
-
-  private final List<Object> sources = new ArrayList<>();
-  private final List<Object> sinks = new ArrayList<>();
-
-  private final Set<String> processedTransformations = new HashSet<>();
 
   public List<SinkLineage> convertToVisitable(List<Transformation<?>> transformations) {
     List<SinkLineage> lineages = new ArrayList<>();

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/ArgumentParser.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/ArgumentParser.java
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent;
+
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_API_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_API_VERSION_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_HOST_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_JOB_NAME_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_NAMESPACE_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_PARENT_RUN_ID_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_URL_KEY;
+import static io.openlineage.flink.utils.FlinkOpenLineageConfigs.FLINK_CONF_URL_PARAM_PREFIX;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URLEncodedUtils;
+
+@AllArgsConstructor
+@Slf4j
+@Getter
+@ToString
+public class ArgumentParser {
+  public static final ArgumentParser DEFAULTS = getDefaultArguments();
+
+  private final String host;
+  private final String version;
+  private final String namespace;
+  private final String jobName;
+  private final String parentRunId;
+  private final Optional<String> apiKey;
+  private final Optional<Map<String, String>> urlParams;
+
+  public static ArgumentParser parseConfiguration(Map<String, String> configuration) {
+    Optional<String> url = findConfigurationFor(configuration, FLINK_CONF_URL_KEY.getConfigPath());
+    if (url.isPresent()) {
+      return parse(url.get());
+    } else {
+      String host =
+          findConfigurationFor(
+              configuration, FLINK_CONF_HOST_KEY.getConfigPath(), DEFAULTS.getHost());
+      String version =
+          findConfigurationFor(
+              configuration, FLINK_CONF_API_VERSION_KEY.getConfigPath(), DEFAULTS.getVersion());
+      String namespace =
+          findConfigurationFor(
+              configuration, FLINK_CONF_NAMESPACE_KEY.getConfigPath(), DEFAULTS.getNamespace());
+      String jobName =
+          findConfigurationFor(
+              configuration, FLINK_CONF_JOB_NAME_KEY.getConfigPath(), DEFAULTS.getJobName());
+      String runId =
+          findConfigurationFor(
+              configuration,
+              FLINK_CONF_PARENT_RUN_ID_KEY.getConfigPath(),
+              DEFAULTS.getParentRunId());
+      Optional<String> apiKey =
+          findConfigurationFor(configuration, FLINK_CONF_API_KEY.getConfigPath())
+              .filter(str -> !str.isEmpty());
+      Optional<Map<String, String>> urlParams =
+          findFlinkUrlParams(configuration, FLINK_CONF_URL_PARAM_PREFIX.getConfigPath());
+      return new ArgumentParser(host, version, namespace, jobName, runId, apiKey, urlParams);
+    }
+  }
+
+  private static Optional<String> findConfigurationFor(Map<String, String> config, String name) {
+    Optional<String> parameter = Optional.ofNullable(config.get(name));
+    if (parameter.isEmpty()) {
+      return Optional.ofNullable(config.get("flink." + name));
+    }
+    return Optional.empty();
+  }
+
+  private static String findConfigurationFor(
+      Map<String, String> config, String name, String defaultValue) {
+    return findConfigurationFor(config, name).orElse(defaultValue);
+  }
+
+  private static Optional<Map<String, String>> findFlinkUrlParams(
+      Map<String, String> config, String prefix) {
+    Map<String, String> urlParams = new HashMap<>();
+    for (Map.Entry<String, String> entry : config.entrySet()) {
+      if (entry.getKey().startsWith("flink." + prefix + ".")) {
+        urlParams.put(entry.getKey().substring(prefix.length()), entry.getValue());
+      }
+    }
+    return urlParams.isEmpty() ? Optional.empty() : Optional.of(urlParams);
+  }
+
+  public static ArgumentParser parse(String clientUrl) {
+    URI uri = URI.create(clientUrl);
+    String host = uri.getScheme() + "://" + uri.getAuthority();
+
+    String path = uri.getPath();
+    String[] elements = path.split("/");
+    String version = get(elements, "api", 1, DEFAULTS.getVersion());
+    String namespace = get(elements, "namespaces", 3, DEFAULTS.getNamespace());
+    String jobName = get(elements, "jobs", 5, DEFAULTS.getJobName());
+    String runId = get(elements, "runs", 7, DEFAULTS.getParentRunId());
+
+    List<NameValuePair> nameValuePairList = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
+    Optional<String> apiKey = getApiKey(nameValuePairList);
+    Optional<Map<String, String>> urlParams = getUrlParams(nameValuePairList);
+
+    log.info(
+        String.format(
+            "%s/api/%s/namespaces/%s/jobs/%s/runs/%s", host, version, namespace, jobName, runId));
+
+    return new ArgumentParser(host, version, namespace, jobName, runId, apiKey, urlParams);
+  }
+
+  public static UUID getRandomUuid() {
+    return UUID.randomUUID();
+  }
+
+  private static Optional<String> getApiKey(List<NameValuePair> nameValuePairList) {
+    return Optional.ofNullable(getNamedParameter(nameValuePairList, "api_key"))
+        .filter(StringUtils::isNoneBlank);
+  }
+
+  public String getUrlParam(String urlParamName) {
+    String param = null;
+    if (urlParams.isPresent()) {
+      param = urlParams.get().get(urlParamName);
+    }
+    return param;
+  }
+
+  private static Optional<Map<String, String>> getUrlParams(List<NameValuePair> nameValuePairList) {
+    final Map<String, String> urlParams = new HashMap<>();
+    nameValuePairList.stream()
+        .filter(pair -> !(pair.getName().equals("api_key")))
+        .forEach(pair -> urlParams.put(pair.getName(), pair.getValue()));
+
+    return urlParams.isEmpty() ? Optional.empty() : Optional.ofNullable(urlParams);
+  }
+
+  protected static String getNamedParameter(List<NameValuePair> nameValuePairList, String param) {
+    for (NameValuePair nameValuePair : nameValuePairList) {
+      if (nameValuePair.getName().equalsIgnoreCase(param)) {
+        return nameValuePair.getValue();
+      }
+    }
+    return null;
+  }
+
+  private static String get(String[] elements, String name, int index, String defaultValue) {
+    boolean check = elements.length > index + 1 && name.equals(elements[index]);
+    if (check) {
+      return elements[index + 1];
+    } else {
+      log.warn("missing " + name + " in " + Arrays.toString(elements) + " at " + index);
+      return defaultValue;
+    }
+  }
+
+  private static ArgumentParser getDefaultArguments() {
+    return new ArgumentParser(
+        "", "v1", "default", "default", null, Optional.empty(), Optional.empty());
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/EventEmitter.java
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.agent.client.OpenLineageClient;
+import io.openlineage.flink.agent.client.OpenLineageHttpException;
+import io.openlineage.flink.agent.client.ResponseMessage;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.ForkJoinPool;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EventEmitter {
+  @Getter private OpenLineageClient client;
+  @Getter private URI lineageURI;
+  @Getter private String jobNamespace;
+  @Getter private String parentJobName;
+  @Getter private Optional<UUID> parentRunId;
+
+  private final ObjectMapper mapper = OpenLineageClient.createMapper();
+
+  public EventEmitter(ArgumentParser argument) throws URISyntaxException {
+    this.client = OpenLineageClient.create(argument.getApiKey(), ForkJoinPool.commonPool());
+    // Extract url parameters other than api_key to append to lineageURI
+    String queryParams = null;
+    if (argument.getUrlParams().isPresent()) {
+      Map<String, String> urlParams = argument.getUrlParams().get();
+
+      StringJoiner query = new StringJoiner("&");
+      urlParams.forEach((k, v) -> query.add(k + "=" + v));
+
+      queryParams = query.toString();
+    }
+
+    // Convert host to a URI to extract scheme and authority
+    URI hostURI = new URI(argument.getHost());
+    String uriPath = String.format("/api/%s/lineage", argument.getVersion());
+
+    this.lineageURI =
+        new URI(hostURI.getScheme(), hostURI.getAuthority(), uriPath, queryParams, null);
+    this.jobNamespace = argument.getNamespace();
+    this.parentJobName = argument.getJobName();
+    this.parentRunId = convertToUUID(argument.getParentRunId());
+    log.info(
+        String.format(
+            "Init OpenLineageContext: Args: %s URI: %s", argument, lineageURI.toString()));
+  }
+
+  public void emit(OpenLineage.RunEvent event) {
+    try {
+      // Todo: move to async client
+      log.debug("Posting LineageEvent {}", event);
+      ResponseMessage resp = client.post(lineageURI, event);
+      if (!resp.completedSuccessfully()) {
+        log.error(
+            "Could not emit lineage: {}",
+            mapper.writeValueAsString(event),
+            new OpenLineageHttpException(resp, resp.getError()));
+      } else {
+        log.info("Lineage completed successfully: {} {}", resp, mapper.writeValueAsString(event));
+      }
+    } catch (OpenLineageHttpException | JsonProcessingException e) {
+      log.error("Could not emit lineage w/ exception", e);
+    }
+  }
+
+  public void close() {
+    client.close();
+  }
+
+  private static Optional<UUID> convertToUUID(String uuid) {
+    try {
+      return Optional.ofNullable(uuid).map(UUID::fromString);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/EventEmitter.java
@@ -2,8 +2,6 @@
 
 package io.openlineage.flink.agent;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.agent.client.OpenLineageClient;
 import io.openlineage.flink.agent.client.OpenLineageHttpException;
@@ -26,7 +24,7 @@ public class EventEmitter {
   @Getter private String parentJobName;
   @Getter private Optional<UUID> parentRunId;
 
-  private final ObjectMapper mapper = OpenLineageClient.createMapper();
+  //  private final ObjectMapper mapper = OpenLineageClient.createMapper();
 
   public EventEmitter(ArgumentParser argument) throws URISyntaxException {
     this.client = OpenLineageClient.create(argument.getApiKey(), ForkJoinPool.commonPool());
@@ -61,14 +59,14 @@ public class EventEmitter {
       log.debug("Posting LineageEvent {}", event);
       ResponseMessage resp = client.post(lineageURI, event);
       if (!resp.completedSuccessfully()) {
-        log.error(
-            "Could not emit lineage: {}",
-            mapper.writeValueAsString(event),
-            new OpenLineageHttpException(resp, resp.getError()));
+        //        log.error(
+        //            "Could not emit lineage: {}",
+        //            mapper.writeValueAsString(event),
+        //            new OpenLineageHttpException(resp, resp.getError()));
       } else {
-        log.info("Lineage completed successfully: {} {}", resp, mapper.writeValueAsString(event));
+        log.info("Lineage completed successfully: {} {}", resp, "mapper.writeValueAsString(event)");
       }
-    } catch (OpenLineageHttpException | JsonProcessingException e) {
+    } catch (OpenLineageHttpException /* | JsonProcessingException */ e) {
       log.error("Could not emit lineage w/ exception", e);
     }
   }

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/HttpError.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/HttpError.java
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class HttpError {
+  protected Integer code;
+  @NonNull protected String message;
+  protected String details;
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/OpenLineageClient.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/OpenLineageClient.java
@@ -1,0 +1,223 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent.client;
+
+import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.client5.http.async.methods.BasicHttpRequests;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.Message;
+import org.apache.hc.core5.http.nio.AsyncRequestProducer;
+import org.apache.hc.core5.http.nio.entity.AsyncEntityProducers;
+import org.apache.hc.core5.http.nio.entity.StringAsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.support.BasicRequestProducer;
+import org.apache.hc.core5.http.nio.support.BasicResponseConsumer;
+
+@Slf4j
+public class OpenLineageClient {
+
+  public static final URI OPEN_LINEAGE_CLIENT_URI = getUri();
+  public static final String OPEN_LINEAGE_PARENT_FACET_URI =
+      "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/ParentRunFacet";
+  public static final String OPEN_LINEAGE_DATASOURCE_FACET =
+      "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/DatasourceDatasetFacet";
+  public static final String OPEN_LINEAGE_SCHEMA_FACET_URI =
+      "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/SchemaDatasetFacet";
+
+  private final CloseableHttpAsyncClient http;
+  private final ExecutorService executorService;
+  private final Optional<String> apiKey;
+  @Getter protected static final ObjectMapper objectMapper = createMapper();
+
+  public OpenLineageClient(
+      CloseableHttpAsyncClient http, Optional<String> apiKey, ExecutorService executorService) {
+    this.http = http;
+    this.executorService = executorService;
+    this.http.start();
+    this.apiKey = apiKey;
+  }
+
+  public static OpenLineageClient create(
+      final Optional<String> apiKey, ExecutorService executorService) {
+    final CloseableHttpAsyncClient http = HttpAsyncClients.createDefault();
+    return new OpenLineageClient(http, apiKey, executorService);
+  }
+
+  public <T> ResponseMessage post(URI uri, Object obj) throws OpenLineageHttpException {
+    return post(uri, obj, String.class);
+  }
+
+  public <T> ResponseMessage<T> post(URI uri, Object obj, Class<T> clazz)
+      throws OpenLineageHttpException {
+    return post(uri, obj, getTypeReference(clazz));
+  }
+
+  public <T> ResponseMessage<T> post(URI uri, Object obj, TypeReference<T> ref)
+      throws OpenLineageHttpException {
+    return executeSync(BasicHttpRequests.post(uri), obj, ref);
+  }
+
+  public <T> ResponseMessage<T> executeSync(HttpRequest request, Object obj, TypeReference<T> ref)
+      throws OpenLineageHttpException {
+    CompletableFuture<ResponseMessage<T>> future = executeAsync(request, obj, ref);
+    try {
+      ResponseMessage<T> message =
+          (ResponseMessage<T>)
+              future
+                  .exceptionally(
+                      (resp) -> {
+                        return new ResponseMessage(
+                            0, null, new HttpError(0, resp.getMessage(), resp.toString()));
+                      })
+                  .get();
+      if (message == null) {
+        return new ResponseMessage(0, null, new HttpError(0, "unknown error", "unknown error"));
+      }
+      return message;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new OpenLineageHttpException(e);
+    }
+  }
+
+  public CompletableFuture<ResponseMessage<Void>> postAsync(URI uri, Object obj) {
+    return postAsync(uri, obj, Void.class);
+  }
+
+  public <T> CompletableFuture<ResponseMessage<T>> postAsync(URI uri, Object obj, Class<T> clazz) {
+    return postAsync(uri, obj, getTypeReference(clazz));
+  }
+
+  public <T> CompletableFuture<ResponseMessage<T>> postAsync(
+      URI uri, Object obj, TypeReference<T> ref) {
+    return executeAsync(BasicHttpRequests.post(uri), obj, ref);
+  }
+
+  protected <T> CompletableFuture<ResponseMessage<T>> executeAsync(
+      HttpRequest request, Object obj, TypeReference<T> ref) {
+    addAuthToReqIfKeyPresent(request);
+
+    try {
+      String jsonBody = objectMapper.writeValueAsString(obj);
+      final AsyncRequestProducer requestProducer =
+          new BasicRequestProducer(
+              request, AsyncEntityProducers.create(jsonBody, ContentType.APPLICATION_JSON));
+
+      Future<Message<HttpResponse, String>> future =
+          http.execute(
+              requestProducer, new BasicResponseConsumer<>(new StringAsyncEntityConsumer()), null);
+      return CompletableFuture.supplyAsync(
+          () -> {
+            try {
+              Message<HttpResponse, String> message = future.get();
+              return createMessage(message, ref);
+            } catch (ExecutionException | InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+          },
+          executorService);
+
+    } catch (JsonProcessingException e) {
+      log.error("Could not serialize to json object - {}", obj);
+      CompletableFuture<ResponseMessage<T>> completableFuture = new CompletableFuture<>();
+      completableFuture.completeExceptionally(e);
+      return completableFuture;
+    }
+  }
+
+  private <T> ResponseMessage<T> createMessage(
+      Message<HttpResponse, String> message, TypeReference<T> ref) {
+    if (!completedSuccessfully(message)) {
+      return new ResponseMessage<>(
+          message.getHead().getCode(),
+          null,
+          objectMapper.convertValue(message.getBody(), HttpError.class));
+    }
+
+    return new ResponseMessage<>(
+        message.getHead().getCode(), objectMapper.convertValue(message.getBody(), ref), null);
+  }
+
+  private boolean completedSuccessfully(Message<HttpResponse, String> message) {
+    final int code = message.getHead().getCode();
+    if (code >= 400 && code < 600) { // non-2xx
+      return false;
+    }
+    return true;
+  }
+
+  public static ObjectMapper createMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.setSerializationInclusion(Include.NON_NULL);
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+    return mapper;
+  }
+
+  private void addAuthToReqIfKeyPresent(final HttpRequest request) {
+    if (apiKey.isPresent()) {
+      request.addHeader(AUTHORIZATION, "Bearer " + apiKey.get());
+    }
+  }
+
+  protected static String getUserAgent() {
+    return "openlineage-java" + "/1.0";
+  }
+
+  private static URI getUri() {
+    return URI.create(
+        String.format(
+            "https://github.com/OpenLineage/OpenLineage/tree/%s/integration/flink", getVersion()));
+  }
+
+  private static String getVersion() {
+    try {
+      Properties properties = new Properties();
+      InputStream is = OpenLineageClient.class.getResourceAsStream("version.properties");
+      properties.load(is);
+      return properties.getProperty("version");
+    } catch (IOException exception) {
+      return "main";
+    }
+  }
+
+  private <T> TypeReference<T> getTypeReference(Class<T> clazz) {
+    return new TypeReference<T>() {
+      @Override
+      public Type getType() {
+        return clazz;
+      }
+    };
+  }
+
+  public void close() {
+    try {
+      http.close();
+    } catch (IOException e) {
+      e.printStackTrace(System.out);
+    }
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/OpenLineageHttpException.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/OpenLineageHttpException.java
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent.client;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+public final class OpenLineageHttpException extends Throwable {
+  private static final long serialVersionUID = 1L;
+
+  @Getter private Integer code;
+  @Getter private String message;
+  @Getter private String details;
+
+  /** Constructs a {@code OpenLineageHttpException} with the HTTP error {@code error}. */
+  public OpenLineageHttpException(@NonNull ResponseMessage resp, final HttpError error) {
+    super(error == null ? "unknown error" : error.getMessage());
+    if (error != null) {
+      this.code = error.getCode();
+      this.message = error.getMessage();
+      this.details = error.getDetails();
+    } else {
+      this.code = resp.getResponseCode();
+      this.message = resp.getBody() == null ? "unknown" : resp.getBody().toString();
+      this.details = "";
+    }
+  }
+
+  public OpenLineageHttpException(final Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/ResponseMessage.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/ResponseMessage.java
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+package io.openlineage.flink.agent.client;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.Value;
+
+@Value
+@ToString
+public class ResponseMessage<T> {
+  @Getter protected int responseCode;
+  @Getter protected T body;
+  @Getter protected HttpError error;
+
+  public boolean completedSuccessfully() {
+    if (responseCode >= 400 && responseCode < 600 || responseCode == 0) { // non-2xx
+      return false;
+    }
+    return true;
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
@@ -1,0 +1,14 @@
+package io.openlineage.flink.agent.lifecycle;
+
+import java.util.List;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobClient;
+
+public interface ExecutionContext {
+
+  void onJobSubmitted(JobClient jobClient, List<Transformation<?>> transformations);
+
+  void onJobExecuted(
+      JobExecutionResult jobExecutionResult, List<Transformation<?>> transformations);
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContext.java
@@ -1,0 +1,97 @@
+package io.openlineage.flink.agent.lifecycle;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.SinkLineage;
+import io.openlineage.flink.TransformationUtils;
+import io.openlineage.flink.agent.EventEmitter;
+import io.openlineage.flink.agent.client.OpenLineageClient;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.visitor.Visitor;
+import io.openlineage.flink.visitor.VisitorFactory;
+import io.openlineage.flink.visitor.VisitorFactoryImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobClient;
+
+@Slf4j
+public class FlinkExecutionContext implements ExecutionContext {
+
+  private final JobID jobId;
+  private final EventEmitter eventEmitter;
+  private final OpenLineageContext openLineageContext;
+
+  public FlinkExecutionContext(JobID jobId, EventEmitter eventEmitter) {
+    this.jobId = jobId;
+    this.eventEmitter = eventEmitter;
+    this.openLineageContext =
+        OpenLineageContext.builder()
+            .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+            .build();
+  }
+
+  @Override
+  public void onJobSubmitted(JobClient jobClient, List<Transformation<?>> transformations) {
+    log.debug("JobClient - jobId: {}", jobClient.getJobID());
+
+    TransformationUtils converter = new TransformationUtils();
+    List<SinkLineage> sinkLineages = converter.convertToVisitable(transformations);
+
+    VisitorFactory visitorFactory = new VisitorFactoryImpl();
+    List<OpenLineage.InputDataset> inputDatasets = new ArrayList<>();
+    List<OpenLineage.OutputDataset> outputDatasets = new ArrayList<>();
+
+    for (var lineage : sinkLineages) {
+      inputDatasets.addAll(getInputDatasets(visitorFactory, lineage.getSources()));
+      outputDatasets.addAll(getOutputDatasets(visitorFactory, lineage.getSink()));
+    }
+
+    OpenLineage.RunEvent runEvent =
+        openLineageContext
+            .getOpenLineage()
+            .newRunEventBuilder()
+            .inputs(inputDatasets)
+            .outputs(outputDatasets)
+            .build();
+
+    log.debug("Posting event for onJobSubmitted {}: {}", jobId, runEvent);
+    eventEmitter.emit(runEvent);
+  }
+
+  @Override
+  public void onJobExecuted(
+      JobExecutionResult jobExecutionResult, List<Transformation<?>> transformations) {}
+
+  private List<OpenLineage.InputDataset> getInputDatasets(
+      VisitorFactory visitorFactory, List<Object> sources) {
+    List<OpenLineage.InputDataset> inputDatasets = new ArrayList<>();
+    List<Visitor<OpenLineage.InputDataset>> inputVisitors =
+        visitorFactory.getInputVisitors(openLineageContext);
+
+    for (var transformation : sources) {
+      inputDatasets.addAll(
+          inputVisitors.stream()
+              .filter(inputVisitor -> inputVisitor.isDefinedAt(transformation))
+              .map(inputVisitor -> inputVisitor.apply(transformation))
+              .flatMap(List::stream)
+              .collect(Collectors.toList()));
+    }
+    return inputDatasets;
+  }
+
+  private List<OpenLineage.OutputDataset> getOutputDatasets(
+      VisitorFactory visitorFactory, Object sink) {
+    List<Visitor<OpenLineage.OutputDataset>> outputVisitors =
+        visitorFactory.getOutputVisitors(openLineageContext);
+
+    return outputVisitors.stream()
+        .filter(inputVisitor -> inputVisitor.isDefinedAt(sink))
+        .map(inputVisitor -> inputVisitor.apply(sink))
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -1,12 +1,10 @@
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 /**
  * Context holder with references to several required objects during construction of an OpenLineage
@@ -21,13 +19,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 @Builder
 public class OpenLineageContext {
   UUID runUuid = UUID.randomUUID();
-
-  /**
-   * Optional {@link StreamExecutionEnvironment} instance, that is the context in which a streaming
-   * program is executed.
-   */
-  @Builder.Default @NonNull
-  Optional<StreamExecutionEnvironment> streamExecutionEnvironment = Optional.empty();
 
   /**
    * A non-null, preconfigured {@link OpenLineage} client instance for constructing OpenLineage

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/FlinkOpenLineageConfigs.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/FlinkOpenLineageConfigs.java
@@ -1,0 +1,22 @@
+package io.openlineage.flink.utils;
+
+public enum FlinkOpenLineageConfigs {
+  FLINK_CONF_URL_KEY("openlineage.url"),
+  FLINK_CONF_HOST_KEY("openlineage.host"),
+  FLINK_CONF_API_VERSION_KEY("openlineage.version"),
+  FLINK_CONF_NAMESPACE_KEY("openlineage.namespace"),
+  FLINK_CONF_JOB_NAME_KEY("openlineage.parentJobName"),
+  FLINK_CONF_PARENT_RUN_ID_KEY("openlineage.parentRunId"),
+  FLINK_CONF_API_KEY("openlineage.apiKey"),
+  FLINK_CONF_URL_PARAM_PREFIX("openlineage.url.param");
+
+  private final String configPath;
+
+  FlinkOpenLineageConfigs(String configPath) {
+    this.configPath = configPath;
+  }
+
+  public String getConfigPath() {
+    return configPath;
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/OpenLineageFlinkJobListenerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/OpenLineageFlinkJobListenerTest.java
@@ -1,0 +1,34 @@
+package io.openlineage.flink;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.agent.EventEmitter;
+import io.openlineage.flink.agent.lifecycle.ExecutionContext;
+import io.openlineage.flink.agent.lifecycle.FlinkExecutionContext;
+import java.util.ArrayList;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.JobClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class OpenLineageFlinkJobListenerTest {
+
+  @Test
+  void shouldEmitOnlyOneRunEventOnJobSubmitted() {
+    JobID jobId = mock(JobID.class);
+    JobClient jobClient = mock(JobClient.class);
+    EventEmitter emitter = mock(EventEmitter.class);
+    ExecutionContext context = new FlinkExecutionContext(jobId, emitter);
+
+    context.onJobSubmitted(jobClient, new ArrayList<>());
+
+    ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
+        ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+
+    verify(emitter, times(1)).emit(lineageEvent.capture());
+    System.out.println(lineageEvent);
+  }
+}


### PR DESCRIPTION
Signed-off-by: mr-yusupov <ziyoiddin.yusupov@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

For the current state of the Flink integration we want to send the lineage events to OpenLineage server.
Further we will integrate another implementation for HTTP client, once Spark part will migrate into that.

Closes: [#562](https://github.com/OpenLineage/OpenLineage/issues/562)

### Solution

Most of the code are taken from Spark integration part, tweaked to work with Flink codebase.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)