### PR TITLE
[INTEGRATION][Dagster] Handle updated PipelineRun in OpenLineage sensor unit test

### DIFF
--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -77,6 +77,7 @@ def make_pipeline_run_with_external_pipeline_origin(
         repository_name: str,
 ):
     return PipelineRun(
+        pipeline_name="test",
         execution_plan_snapshot_id="123",
         external_pipeline_origin=ExternalPipelineOrigin(
             external_repository_origin=ExternalRepositoryOrigin(


### PR DESCRIPTION
### Problem

In Dagster 0.14.4, `pipeline_name` was changed from an optional argument to a required argument of PipelineRun per https://github.com/dagster-io/dagster/pull/6917. This is Dagster's internal change that should not affect the functionality of the OpenLineage sensor, but the unit test helper function that creates a PipelineRun needs an update to include the required argument.

### Solution

Update unit test helper method to include the required `pipeline_name` argument in PipelineRun.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)