### PR TITLE
python: drop support for 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           fi
           touch workflow_files.txt
           FILES=$(sort workflow_files.txt | uniq | tr "\n" " ")
-
+            
           # If no changes, generate a no-op build
           if [ "$FILES" == "" ]; then
             echo '{"workflows": {"no-op": {"jobs": ["workflow_complete"]}}}' | yq -P eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -24,7 +24,7 @@ jobs:
   unit-test-client-python:
     working_directory: ~/openlineage/client/python
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - run: pip install -e .[dev]
@@ -35,7 +35,7 @@ jobs:
   build-client-python:
     working_directory: ~/openlineage/client/python
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     parameters:
       build_tag:
         default: ""
@@ -187,7 +187,7 @@ jobs:
   unit-test-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - *install_python_client
@@ -199,7 +199,7 @@ jobs:
   build-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -213,7 +213,7 @@ jobs:
   build-integration-dbt:
     working_directory: ~/openlineage/integration/dbt
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -263,13 +263,13 @@ jobs:
   unit-test-integration-airflow-1:
     working_directory: ~/openlineage/integration/airflow
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
       - run: pip install --upgrade pip==20.2.4
-      - run: pip install -e .[dev,airflow-1] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15/constraints-3.6.txt"
+      - run: pip install -e .[dev,airflow-1] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15/constraints-3.7.txt"
       - run: flake8 --exclude tests/integration,tests/failures
       - run: airflow initdb
       - run: pytest --cov=openlineage --ignore tests/integration --ignore tests/failures tests/
@@ -278,12 +278,12 @@ jobs:
   unit-test-integration-airflow-2:
     working_directory: ~/openlineage/integration/airflow
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - *install_python_client
       - *install_integration_common
-      - run: pip install -e .[dev,airflow-2] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-2.1.3/constraints-3.6.txt"
+      - run: pip install -e .[dev,airflow-2] --constraint="https://raw.githubusercontent.com/apache/airflow/constraints-2.1.3/constraints-3.7.txt"
       - run: flake8 --exclude tests/integration,tests/failures
       - run: airflow db init
       - run: pytest --cov=openlineage --ignore tests/integration --ignore tests/failures --ignore tests/test_openlineage_dag.py tests/
@@ -292,7 +292,7 @@ jobs:
   build-integration-airflow:
     working_directory: ~/openlineage/integration/airflow
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -307,7 +307,8 @@ jobs:
 
   integration-test-integration-airflow-1-10:
     working_directory: ~/openlineage/integration/
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     resource_class: large
     steps:
       - *checkout_project_root
@@ -327,7 +328,8 @@ jobs:
       airflow-image:
         type: string
     working_directory: ~/openlineage/integration/
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     resource_class: large
     steps:
       - *checkout_project_root
@@ -343,7 +345,8 @@ jobs:
 
   integration-test-integration-airflow-failure:
     working_directory: ~/openlineage/integration/
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - *checkout_project_root
       - run: ../.circleci/get-docker-compose.sh
@@ -357,7 +360,7 @@ jobs:
   unit-test-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - *install_python_client
@@ -369,7 +372,7 @@ jobs:
   build-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -384,7 +387,7 @@ jobs:
   publish-snapshot-python:
     working_directory: ~/openlineage
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - attach_workspace:
@@ -395,7 +398,7 @@ jobs:
   release-python:
     working_directory: ~/openlineage
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.7
     steps:
       - *checkout_project_root
       - attach_workspace:
@@ -457,7 +460,8 @@ jobs:
 
   workflow_complete:
     working_directory: ~/openlineage
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run: echo "Complete"
 

--- a/.circleci/workflows/openlineage-integration-dagster.yml
+++ b/.circleci/workflows/openlineage-integration-dagster.yml
@@ -3,7 +3,7 @@ workflows:
     jobs:
       - unit-test-integration-dagster:
           requires:
-            - build-client-python
+            - unit-test-client-python
       - build-integration-dagster:
           filters:
             branches:

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -25,7 +25,7 @@ A library that integrates [Airflow `DAGs`]() with [OpenLineage](https://openline
 
 ## Requirements
 
-- [Python 3.6.0](https://www.python.org/downloads)
+- [Python 3.7](https://www.python.org/downloads)
 - [Airflow 1.10.12+](https://pypi.org/project/apache-airflow)
 - (experimental) [Airflow 2.1+](https://pypi.org/project/apache-airflow)
 

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -56,7 +56,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/dagster/README.md
+++ b/integration/dagster/README.md
@@ -13,7 +13,7 @@ and emits them to an OpenLineage backend.
 
 ## Requirements
 
-- [Python 3.6.0](https://www.python.org/downloads)
+- [Python 3.7](https://www.python.org/downloads)
 - [Dagster 0.13.8+](https://dagster.io/)
 
 ## Installation

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -26,7 +26,7 @@ DAGSTER_VERSION = "0.13.8"
 requirements = [
     "attrs>=19.3",
     "cattrs",
-    f"dagster>={DAGSTER_VERSION}",
+    f"dagster>={DAGSTER_VERSION},<=0.14.5",
     f"openlineage-python=={__version__}",
 ]
 
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -13,7 +13,7 @@ Wrapper script for dbt for automatic metadata collection
 
 ## Requirements
 
-- [Python >= 3.6](https://www.python.org/downloads)
+- [Python >= 3.7](https://www.python.org/downloads)
 - [dbt >= 0.20](https://www.getdbt.com/)
 
 Right now, `openlineage-dbt` only supports `bigquery`, `snowflake`, `spark` and `redshift` dbt adapters.

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="openlineage",
 )


### PR DESCRIPTION
Support for Python 3.6 ended 3 months ago.

Also, minor fixes to CI jobs. Remove dependency on wheel for running Dagster unit tests, and replace deprecated CI images with supported ones.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
