### PR TITLE
Delta improvements

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -243,7 +243,8 @@ def commonTestConfiguration = {
             'junit.platform.output.capture.stderr': 'true',
             'spark.version'                       : project.getProperty('spark.version'),
             'openlineage.spark.jar': "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version': kafkaPackage(scalaVersion, project.getProperty('spark.version'))
+            'kafka.package.version': kafkaPackage(scalaVersion, project.getProperty('spark.version')),
+            'mockserver.logLevel': 'ERROR'
     ]
     classpath =  project.sourceSets.test.runtimeClasspath +
             (isSpark3 ? configurations.spark3Test : configurations.spark2Test)

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java
@@ -7,6 +7,7 @@ import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.function.BiConsumer;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 
@@ -26,6 +27,7 @@ public class LogicalPlanRunFacetBuilder extends CustomFacetBuilder<Object, Logic
   public boolean isDefinedAt(Object x) {
     return (x instanceof SparkListenerSQLExecutionEnd
             || x instanceof SparkListenerSQLExecutionStart
+            || x instanceof SparkListenerJobStart
             || x instanceof SparkListenerJobEnd)
         && openLineageContext.getQueryExecution().isPresent();
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -59,7 +59,9 @@ abstract class BaseVisitorFactory implements VisitorFactory {
       OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> inputVisitors =
         new ArrayList<>(getCommonVisitors(context, DatasetFactory.input(context.getOpenLineage())));
-    inputVisitors.add(new SqlExecutionRDDVisitor(context));
+    if (VisitorFactory.classPresent("org.apache.spark.sql.execution.SQLExecutionRDD")) {
+      inputVisitors.add(new SqlExecutionRDDVisitor(context));
+    }
     return inputVisitors;
   }
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -24,6 +24,7 @@ import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SqlDWDatabricksVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.SqlExecutionRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.TruncateTableCommandVisitor;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -58,6 +59,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
       OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> inputVisitors =
         new ArrayList<>(getCommonVisitors(context, DatasetFactory.input(context.getOpenLineage())));
+    inputVisitors.add(new SqlExecutionRDDVisitor(context));
     return inputVisitors;
   }
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/VisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/VisitorFactory.java
@@ -18,6 +18,16 @@ import scala.PartialFunction;
  */
 interface VisitorFactory {
 
+  static boolean classPresent(String className) {
+    try {
+      Thread.currentThread().getContextClassLoader().loadClass(className);
+      return true;
+    } catch (Exception e) {
+      // swallow
+    }
+    return false;
+  }
+
   List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> getInputVisitors(
       OpenLineageContext context);
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
@@ -1,0 +1,72 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.spark.rdd.HadoopRDD;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.FileScanRDD;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Base node visitor for classes that extract {@link org.apache.spark.sql.Dataset}s from {@link
+ * RDD}s. File-based {@link RDD}s, including {@link HadoopRDD} and {@link FileScanRDD} are handled
+ * by the {@link #findInputDatasets(List, StructType)} method.
+ *
+ * @param <T>
+ * @param <D>
+ */
+public abstract class AbstractRDDNodeVisitor<T extends LogicalPlan, D extends OpenLineage.Dataset>
+    extends QueryPlanVisitor<T, D> {
+
+  protected final DatasetFactory<D> datasetFactory;
+
+  public AbstractRDDNodeVisitor(
+      @NonNull OpenLineageContext context, DatasetFactory<D> datasetFactory) {
+    super(context);
+    this.datasetFactory = datasetFactory;
+  }
+
+  protected List<D> findInputDatasets(List<RDD<?>> fileRdds, StructType schema) {
+    return fileRdds.stream()
+        .flatMap(
+            rdd -> {
+              if (rdd instanceof HadoopRDD) {
+                HadoopRDD hadoopRDD = (HadoopRDD) rdd;
+                Path[] inputPaths = FileInputFormat.getInputPaths(hadoopRDD.getJobConf());
+                Configuration hadoopConf = hadoopRDD.getConf();
+                return Arrays.stream(inputPaths)
+                    .map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
+              } else if (rdd instanceof FileScanRDD) {
+                FileScanRDD fileScanRDD = (FileScanRDD) rdd;
+                return ScalaConversionUtils.fromSeq(fileScanRDD.filePartitions()).stream()
+                    .flatMap(fp -> Arrays.stream(fp.files()))
+                    .map(f -> new Path(f.filePath()).getParent())
+                    .filter(Objects::nonNull);
+              } else {
+                return Stream.empty();
+              }
+            })
+        .distinct()
+        .map(
+            p -> {
+              // TODO- refactor this to return a single partitioned dataset based on static
+              // static partitions in the relation
+              return datasetFactory.getDataset(p.toUri(), schema);
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -41,9 +41,7 @@ public class AppendDataDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event) {
-    // Needs to cast to logical plan despite IntelliJ claiming otherwise.
-    AppendData appendData = (AppendData) context.getQueryExecution().get().optimizedPlan();
+  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, AppendData appendData) {
     LogicalPlan logicalPlan = (LogicalPlan) (appendData).table();
 
     return delegate(

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
@@ -70,9 +70,8 @@ public class CommandPlanVisitor
   }
 
   @Override
-  public List<InputDataset> apply(SparkListenerEvent event) {
-    Optional<LogicalPlan> input =
-        context.getQueryExecution().flatMap(qe -> getInput(qe.optimizedPlan()));
+  public List<InputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
+    Optional<LogicalPlan> input = getInput(plan);
     PartialFunction<LogicalPlan, Collection<InputDataset>> delegateFn =
         delegate(
             context.getInputDatasetQueryPlanVisitors(), context.getInputDatasetBuilders(), event);

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
@@ -3,25 +3,16 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.agent.lifecycle.Rdds;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark.api.QueryPlanVisitor;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Stack;
-import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configuration;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.spark.Dependency;
 import org.apache.spark.rdd.HadoopRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.LogicalRDD;
-import scala.collection.Seq;
 
 /**
  * {@link LogicalPlan} visitor that attempts to extract {@link Path}s from a {@link HadoopRDD}
@@ -29,57 +20,23 @@ import scala.collection.Seq;
  * org.apache.spark.sql.execution.datasources.HadoopFsRelation}, but works with {@link RDD}s that
  * are converted to {@link org.apache.spark.sql.Dataset}s.
  */
+@Slf4j
 public class LogicalRDDVisitor<D extends OpenLineage.Dataset>
-    extends QueryPlanVisitor<LogicalRDD, D> {
-  private final DatasetFactory<D> datasetFactory;
+    extends AbstractRDDNodeVisitor<LogicalRDD, D> {
 
   public LogicalRDDVisitor(OpenLineageContext context, DatasetFactory<D> datasetFactory) {
-    super(context);
-    this.datasetFactory = datasetFactory;
+    super(context, datasetFactory);
   }
 
   @Override
   public boolean isDefinedAt(LogicalPlan x) {
-    return x instanceof LogicalRDD && !findHadoopRdds((LogicalRDD) x).isEmpty();
-  }
-
-  private List<HadoopRDD> findHadoopRdds(LogicalRDD rdd) {
-    RDD root = rdd.rdd();
-    List<HadoopRDD> ret = new ArrayList<>();
-    Stack<RDD> deps = new Stack<>();
-    deps.add(root);
-    while (!deps.isEmpty()) {
-      RDD cur = deps.pop();
-      Seq<Dependency> dependencies = cur.getDependencies();
-      deps.addAll(
-          ScalaConversionUtils.fromSeq(dependencies).stream()
-              .map(Dependency::rdd)
-              .collect(Collectors.toList()));
-      if (cur instanceof HadoopRDD) {
-        ret.add((HadoopRDD) cur);
-      }
-    }
-    return ret;
+    return x instanceof LogicalRDD && !Rdds.findFileLikeRdds(((LogicalRDD) x).rdd()).isEmpty();
   }
 
   @Override
   public List<D> apply(LogicalPlan x) {
     LogicalRDD logicalRdd = (LogicalRDD) x;
-    List<HadoopRDD> hadoopRdds = findHadoopRdds(logicalRdd);
-    return hadoopRdds.stream()
-        .flatMap(
-            rdd -> {
-              Path[] inputPaths = FileInputFormat.getInputPaths(rdd.getJobConf());
-              Configuration hadoopConf = rdd.getConf();
-              return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
-            })
-        .distinct()
-        .map(
-            p -> {
-              // TODO- refactor this to return a single partitioned dataset based on static
-              // static partitions in the relation
-              return datasetFactory.getDataset(p.toUri(), logicalRdd.schema());
-            })
-        .collect(Collectors.toList());
+    List<RDD<?>> fileRdds = Rdds.findFileLikeRdds(logicalRdd.rdd());
+    return findInputDatasets(fileRdds, logicalRdd.schema());
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -60,14 +60,14 @@ public class SaveIntoDataSourceCommandVisitor
   }
 
   public List<OutputDataset> apply(SaveIntoDataSourceCommand cmd) {
-    return Collections.emptyList();
+    // intentionally unimplemented
+    throw new UnsupportedOperationException("apply(LogicalPlay) is not implemented");
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event) {
+  public List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, SaveIntoDataSourceCommand command) {
     BaseRelation relation;
-    SaveIntoDataSourceCommand command =
-        (SaveIntoDataSourceCommand) context.getQueryExecution().get().optimizedPlan();
 
     // Kafka has some special handling because the Source and Sink relations require different
     // options. A KafkaRelation for writes uses the "topic" option, while the same relation for

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
@@ -1,0 +1,40 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.Rdds;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.LogicalRDD;
+import org.apache.spark.sql.execution.SQLExecutionRDD;
+
+public class SqlExecutionRDDVisitor extends AbstractRDDNodeVisitor<LogicalRDD, InputDataset> {
+
+  public SqlExecutionRDDVisitor(@NonNull OpenLineageContext context) {
+    super(context, DatasetFactory.input(context.getOpenLineage()));
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan x) {
+    return x instanceof LogicalRDD && !findSqlExecution((LogicalRDD) x).isEmpty();
+  }
+
+  private Collection<SQLExecutionRDD> findSqlExecution(LogicalRDD logicalRDD) {
+    Set<RDD<?>> rdds = Rdds.flattenRDDs(logicalRDD.rdd());
+    return rdds.stream()
+        .filter(rdd -> rdd instanceof SQLExecutionRDD)
+        .map(SQLExecutionRDD.class::cast)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<InputDataset> apply(LogicalPlan x) {
+    return findInputDatasets(Rdds.findFileLikeRdds(((LogicalRDD) x).rdd()), x.schema());
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -53,7 +53,7 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
 
   public abstract List<D> apply(P p);
 
-  public List<D> apply(T event) {
+  public final List<D> apply(T event) {
     return context
         .getQueryExecution()
         .map(
@@ -83,9 +83,13 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
       @Override
       public List<D> apply(LogicalPlan x) {
         unknownEntryFacetListener.accept(x);
-        return builder.apply((P) x);
+        return builder.apply(event, (P) x);
       }
     };
+  }
+
+  protected List<D> apply(T event, P plan) {
+    return apply(plan);
   }
 
   protected PartialFunction<LogicalPlan, Collection<D>> delegate(

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
@@ -89,7 +89,7 @@ class LogicalPlanRunFacetBuilderTest {
     assertThat(
             builder.isDefinedAt(
                 new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
-        .isFalse();
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Problem
Some minimal work to address https://github.com/OpenLineage/OpenLineage/issues/617 , this makes some small improvements to issues I found debugging Delta table queries. Specifically, when writing into Delta tables I found 

1. The `SaveIntoDataSourceCommandVisitor` overrode the `AbstractQueryPlanDatasetBuilder`'s apply method which adds the LogicalPlan node to the `UnknownEntryFacetListener`, causing the LogicalPlan node to always be present in the `spark_unknown` facet
2. The `SparkListenerJobStart` event doesn't trigger the `LogicalPlanRunFacetBuilder`
3. `SQLExecutionRDD`s and `ShuffledRowRDD` aren't handled by the `LogicalRDDVisitor`, meaning QueryExecutions that reference those RDDs don't find their underlying sources.

That latter issue actually can cause a break in lineage. 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)