### PR TITLE
Fix SqlDwDatabricksVisitor for Spark2

### DIFF
--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -65,6 +65,27 @@ class MockSqlDWBaseRelation extends BaseRelation {
   }
 }
 
+class MockSpark2SqlDWBaseRelation extends BaseRelation {
+  private final String com$databricks$spark$sqldw$SqlDWRelation$$tableNameOrSubquery;
+  private final Object params;
+
+  @Override
+  public SQLContext sqlContext() {
+    return null;
+  }
+
+  @Override
+  public StructType schema() {
+    return new StructType(
+        new StructField[] {new StructField("name", StringType$.MODULE$, false, null)});
+  }
+
+  public MockSpark2SqlDWBaseRelation(String tableNameOrSubquery, String jdbcUrl) {
+    this.com$databricks$spark$sqldw$SqlDWRelation$$tableNameOrSubquery = tableNameOrSubquery;
+    this.params = new SqlDwRelationParams(jdbcUrl);
+  }
+}
+
 class TestSqlDWDatabricksVisitor extends SqlDWDatabricksVisitor {
   public TestSqlDWDatabricksVisitor(OpenLineageContext context, DatasetFactory factory) {
     super(context, factory);
@@ -97,6 +118,45 @@ class SQLDWDatabricksVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+            Seq$.MODULE$
+                .<AttributeReference>newBuilder()
+                .$plus$eq(
+                    new AttributeReference(
+                        "name",
+                        StringType$.MODULE$,
+                        false,
+                        null,
+                        ExprId.apply(1L),
+                        Seq$.MODULE$.<String>empty()))
+                .result(),
+            Option.empty(),
+            false);
+
+    TestSqlDWDatabricksVisitor visitor =
+        new TestSqlDWDatabricksVisitor(
+            SparkAgentTestExtension.newContext(session),
+            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+    List<OpenLineage.Dataset> datasets = visitor.apply(lr);
+
+    assertEquals(1, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals(expectedNamespace, ds.getNamespace());
+    assertEquals(expectedName, ds.getName());
+  }
+
+  @Test
+  void testSpark2SQLDWRelation() {
+    String inputName = "\"dbo\".\"table1\"";
+    String inputJdbcUrl =
+        "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB";
+    String expectedName = "dbo.table1";
+    String expectedNamespace =
+        "sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB;";
+
+    // Instantiate a MockSQLDWRelation
+    LogicalRelation lr =
+        new LogicalRelation(
+            new MockSpark2SqlDWBaseRelation(inputName, inputJdbcUrl),
             Seq$.MODULE$
                 .<AttributeReference>newBuilder()
                 .$plus$eq(


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Databricks runtimes earlier than 7.1 (Spark 2.x) have a SQL DW Connector that defines their internal methods differently than Spark 3.

As a result, OpenLineage does not return lineage because the internal field name is different.

Closes: #629 

### Solution

Instead of looking for just `tableNameOrSubquery` (which works for Spark3) I now look for the field `com$databricks$spark$sqldw$SqlDWRelation$$tableNameOrSubquery` (which works for Spark2).  This all has to be done via reflection and I now more gracefully check for these fields.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)