### PR TITLE
Fixing issue 633, with wait-for-it.sh

### DIFF
--- a/integration/spark/docker/wait-for-it.sh
+++ b/integration/spark/docker/wait-for-it.sh
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
-
 #!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 # see: https://github.com/vishnubob/wait-for-it
 


### PR DESCRIPTION
Signed-off-by: gary feng gary.feng@gmail.com

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Closes: #633 

The `marquez` docker container will exit with an error when testing the Spark integration with `docker-compose up` . Tested on MacOS. 

The apparent reason is with `wait-for-it.sh`, which starts with the following
```sh
# SPDX-License-Identifier: Apache-2.0

#!/usr/bin/env bash
#
# see: https://github.com/vishnubob/wait-for-it
```
where the shebang is not in the first line. This was introduced in 71f051f458323f6e43b47330e03bcab1c9833f6c. 

### Solution

Move the shepang to the first line. 

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modifcation(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)