### PR TITLE
sql: change parser API for unified parser

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -9,7 +9,7 @@ import attr
 
 from openlineage.client.facet import SqlJobFacet
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider, BigQueryErrorRunFacet
-from openlineage.common.sql import SqlParser
+from openlineage.common.sql import parse
 
 from openlineage.airflow.extractors.base import (
     BaseExtractor,
@@ -89,7 +89,7 @@ class BigQueryExtractor(BaseExtractor):
 
     def parse_sql_context(self) -> SqlContext:
         try:
-            sql_meta = SqlParser.parse(self.operator.sql, None)
+            sql_meta = parse(self.operator.sql, None)
             log.debug(f"bigquery sql parsed and obtained meta: {sql_meta}")
             return SqlContext(
                 sql=self.operator.sql,

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -35,10 +35,10 @@ extras_require = {
         "airflow-provider-great-expectations==0.0.8",
     ],
     "airflow-2": [
-        "apache-airflow==2.1.3",
-        "apache-airflow-providers-postgres==2.0.0",
-        "apache-airflow-providers-snowflake==2.1.0",
-        "apache-airflow-providers-google==5.0.0",
+        "apache-airflow==2.1.4",
+        "apache-airflow-providers-postgres>=2.0.0",
+        "apache-airflow-providers-snowflake>=2.1.0",
+        "apache-airflow-providers-google>=5.0.0",
         "airflow-provider-great-expectations==0.0.8",
     ],
 }

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -10,10 +10,10 @@ from airflow import DAG
 
 from openlineage.airflow.utils import safe_import_airflow, get_connection
 from openlineage.common.models import (
-    DbTableName,
     DbTableSchema,
     DbColumn
 )
+from openlineage.common.sql import DbTableMeta
 from openlineage.common.dataset import Source, Dataset
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
@@ -33,7 +33,7 @@ CONN_URI_WITHOUT_USERPASS = 'postgres://localhost:5432/food_delivery'
 
 DB_NAME = 'food_delivery'
 DB_SCHEMA_NAME = 'public'
-DB_TABLE_NAME = DbTableName('discounts')
+DB_TABLE_NAME = DbTableMeta('discounts')
 DB_TABLE_COLUMNS = [
     DbColumn(
         name='id',

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -12,10 +12,10 @@ from airflow.version import version as AIRFLOW_VERSION
 from pkg_resources import parse_version
 
 from openlineage.common.models import (
-    DbTableName,
     DbTableSchema,
     DbColumn
 )
+from openlineage.common.sql import DbTableMeta
 from openlineage.common.dataset import Source, Dataset
 from openlineage.airflow.extractors.snowflake_extractor import SnowflakeExtractor
 
@@ -24,7 +24,7 @@ CONN_URI = 'snowflake://localhost:5432/food_delivery'
 
 DB_NAME = 'FOOD_DELIVERY'
 DB_SCHEMA_NAME = 'PUBLIC'
-DB_TABLE_NAME = DbTableName('DISCOUNTS')
+DB_TABLE_NAME = DbTableMeta('DISCOUNTS')
 DB_TABLE_COLUMNS = [
     DbColumn(
         name='ID',

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -19,10 +19,10 @@ from airflow.utils.state import State
 from airflow.version import version as AIRFLOW_VERSION
 from openlineage.common.dataset import Source, Dataset
 from openlineage.common.models import (
-    DbTableName,
     DbTableSchema,
     DbColumn
 )
+from openlineage.common.sql import DbTableMeta
 from openlineage.airflow import DAG
 from openlineage.airflow import __version__ as OPENLINEAGE_AIRFLOW_VERSION
 from openlineage.airflow.extractors import (
@@ -384,7 +384,7 @@ class TestFixtureDummyExtractorOnComplete(BaseExtractor):
         inputs = [
             Dataset.from_table_schema(self.source, DbTableSchema(
                 schema_name='schema',
-                table_name=DbTableName('extract_on_complete_input1'),
+                table_name=DbTableMeta('extract_on_complete_input1'),
                 columns=[DbColumn(
                     name='field1',
                     type='text',

--- a/integration/common/openlineage/common/models.py
+++ b/integration/common/openlineage/common/models.py
@@ -20,76 +20,13 @@ class DbColumn:
                           {self.description!r},{self.ordinal_position!r})"
 
 
-class DbTableName:
-    def __init__(self, value: str):
-        parts = value.strip().split('.')
-        if len(parts) > 3:
-            raise ValueError(
-                f"Expected 'database.schema.table', found '{value}'."
-            )
-        self.database = self._get_database(parts)
-        self.schema = self._get_schema(parts)
-        self.name = self._get_table(parts)
-        self.qualified_name = self._get_qualified_name()
-
-    def has_database(self) -> bool:
-        return self.database is not None
-
-    def has_schema(self) -> bool:
-        return self.schema is not None
-
-    def _get_database(self, parts) -> str:
-        # {database.schema.table}
-        return parts[0] if len(parts) == 3 else None
-
-    def _get_schema(self, parts) -> str:
-        # {database.schema.table) or {schema.table}
-        return parts[1] if len(parts) == 3 else (
-            parts[0] if len(parts) == 2 else None
-        )
-
-    def _get_table(self, parts) -> str:
-        # {database.schema.table} or {schema.table} or {table}
-        return parts[2] if len(parts) == 3 else (
-            parts[1] if len(parts) == 2 else parts[0]
-        )
-
-    def _get_qualified_name(self) -> str:
-        return (
-            f"{self.database}.{self.schema}.{self.name}"
-            if self.has_database() else (
-                f"{self.schema}.{self.name}" if self.has_schema() else None
-            )
-        )
-
-    def __hash__(self):
-        return hash((self.database, self.schema, self.name, self.qualified_name))
-
-    def __eq__(self, other):
-        return self.database == other.database and \
-               self.schema == other.schema and \
-               self.name == other.name and \
-               self.qualified_name == other.qualified_name
-
-    def __repr__(self):
-        # Return the string representation of the instance
-        return (
-            f"DbTableName({self.database!r},{self.schema!r},"
-            f"{self.name!r},{self.qualified_name!r})"
-        )
-
-    def __str__(self):
-        # Return the fully qualified table name as the string representation
-        # of this object, otherwise the table name only
-        return (
-            self.qualified_name
-            if (self.has_database() or self.has_schema()) else self.name
-        )
-
-
 class DbTableSchema:
-    def __init__(self, schema_name: str, table_name: DbTableName,
-                 columns: [DbColumn]):
+    def __init__(
+        self,
+        schema_name: str,
+        table_name: "DbTableMeta",  # noqa: F821
+        columns: [DbColumn]
+    ):
         self.schema_name = schema_name
         self.table_name = table_name
         self.columns = columns

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -10,8 +10,9 @@ from typing import Tuple, Optional, Dict, List
 from google.cloud.bigquery import Client
 
 from openlineage.common.dataset import Dataset, Source
-from openlineage.common.models import DbTableSchema, DbColumn, DbTableName
+from openlineage.common.models import DbTableSchema, DbColumn
 from openlineage.common.schema import GITHUB_LOCATION
+from openlineage.common.sql import DbTableMeta
 from openlineage.common.utils import get_from_nullable_chain
 from openlineage.client.facet import BaseFacet, OutputStatisticsOutputDatasetFacet, \
     ExternalQueryRunFacet
@@ -257,7 +258,7 @@ class BigQueryDatasetsProvider:
         return DbTableSchema(
             schema_name=table.get('tableReference').get('projectId') + '.' +
             table.get('tableReference').get('datasetId'),
-            table_name=DbTableName(table.get('tableReference').get('tableId')),
+            table_name=DbTableMeta(table.get('tableReference').get('tableId')),
             columns=columns
         )
 

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -29,7 +29,7 @@ from openlineage.common.provider.great_expectations.facets import \
 from openlineage.common.provider.great_expectations.results import EXPECTATIONS_PARSERS, \
     COLUMN_EXPECTATIONS_PARSER, \
     GreatExpectationsAssertion
-from openlineage.common.sql import SqlParser
+from openlineage.common.sql import parse
 
 
 class OpenLineageValidationAction(ValidationAction):
@@ -180,7 +180,7 @@ class OpenLineageValidationAction(ValidationAction):
         metadata = MetaData()
         if data_asset.generated_table_name is not None:
             custom_sql = data_asset.batch_kwargs.get('query')
-            parsed_sql = SqlParser.parse(custom_sql)
+            parsed_sql = parse(custom_sql)
             return [
                 self._get_sql_table(data_asset, metadata, t.schema, t.name,
                                     validation_result_suite) for t in

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0.
 
-from openlineage.common.sql.parser import SqlParser, SqlMeta  # noqa: F401
+from openlineage.common.sql.parser import parse, SqlMeta, DbTableMeta, provider  # noqa: F401

--- a/integration/common/openlineage/common/sql/parser.py
+++ b/integration/common/openlineage/common/sql/parser.py
@@ -7,9 +7,79 @@ import sqlparse
 from sqlparse.sql import T, TokenList, Parenthesis, Identifier, IdentifierList
 from sqlparse.tokens import Punctuation
 
-from openlineage.common.models import DbTableName
 
 log = logging.getLogger(__name__)
+
+
+def provider():
+    return "python"
+
+
+class DbTableMeta:
+    def __init__(self, value: str):
+        parts = value.strip().split('.')
+        if len(parts) > 3:
+            raise ValueError(
+                f"Expected 'database.schema.table', found '{value}'."
+            )
+        self.database = self._get_database(parts)
+        self.schema = self._get_schema(parts)
+        self.name = self._get_table(parts)
+        self.qualified_name = self._get_qualified_name()
+
+    def has_database(self) -> bool:
+        return self.database is not None
+
+    def has_schema(self) -> bool:
+        return self.schema is not None
+
+    def _get_database(self, parts) -> str:
+        # {database.schema.table}
+        return parts[0] if len(parts) == 3 else None
+
+    def _get_schema(self, parts) -> str:
+        # {database.schema.table) or {schema.table}
+        return parts[1] if len(parts) == 3 else (
+            parts[0] if len(parts) == 2 else None
+        )
+
+    def _get_table(self, parts) -> str:
+        # {database.schema.table} or {schema.table} or {table}
+        return parts[2] if len(parts) == 3 else (
+            parts[1] if len(parts) == 2 else parts[0]
+        )
+
+    def _get_qualified_name(self) -> str:
+        return (
+            f"{self.database}.{self.schema}.{self.name}"
+            if self.has_database() else (
+                f"{self.schema}.{self.name}" if self.has_schema() else self.name
+            )
+        )
+
+    def __hash__(self):
+        return hash(self.qualified_name)
+
+    def __eq__(self, other):
+        return self.database == other.database and \
+               self.schema == other.schema and \
+               self.name == other.name and \
+               self.qualified_name == other.qualified_name
+
+    def __repr__(self):
+        # Return the string representation of the instance
+        return (
+            f"DbTableMeta({self.database!r},{self.schema!r},"
+            f"{self.name!r},{self.qualified_name!r})"
+        )
+
+    def __str__(self):
+        # Return the fully qualified table name as the string representation
+        # of this object, otherwise the table name only
+        return (
+            self.qualified_name
+            if (self.has_database() or self.has_schema()) else self.name
+        )
 
 
 def _is_in_table(token):
@@ -38,7 +108,7 @@ def _get_tables(
         tokens,
         idx,
         default_schema: Optional[str] = None
-) -> Tuple[int, List[DbTableName]]:
+) -> Tuple[int, List[DbTableMeta]]:
     # Extract table identified by preceding SQL keyword at '_is_in_table'
     def parse_ident(ident: Identifier) -> str:
         # Extract table name from possible schema.table naming
@@ -84,22 +154,22 @@ def _get_tables(
     else:
         tables.append(parse_ident(token))
 
-    return idx, [DbTableName(table) for table in tables]
+    return idx, [DbTableMeta(table) for table in tables]
 
 
 class SqlMeta:
-    def __init__(self, in_tables: List[DbTableName], out_tables: List[DbTableName]):
+    def __init__(self, in_tables: List[DbTableMeta], out_tables: List[DbTableMeta]):
         self.in_tables = in_tables
         self.out_tables = out_tables
 
     def __repr__(self):
         return f"SqlMeta({self.in_tables!r},{self.out_tables!r})"
 
-    def add_in_tables(self, in_tables: List[DbTableName]):
+    def add_in_tables(self, in_tables: List[DbTableMeta]):
         for in_table in in_tables:
             self.in_tables.append(in_table)
 
-    def add_out_tables(self, out_tables: List[DbTableName]):
+    def add_out_tables(self, out_tables: List[DbTableMeta]):
         for out_table in out_tables:
             self.out_tables.append(out_table)
 
@@ -115,29 +185,6 @@ class SqlParser:
         self.ctes = set()
         self.intables = set()
         self.outtables = set()
-
-    @classmethod
-    def parse(cls, sql: str, default_schema: Optional[str] = None) -> SqlMeta:
-        if sql is None:
-            raise ValueError("A sql statement must be provided.")
-
-        # Tokenize the SQL statement
-        sql_statements = sqlparse.parse(sql)
-
-        sql_parser = cls(default_schema)
-        sql_meta = SqlMeta([], [])
-
-        for sql_statement in sql_statements:
-            tokens = TokenList(sql_statement.tokens)
-            log.debug(f"Successfully tokenized sql statement: {tokens}")
-
-            result = sql_parser.recurse(tokens)
-
-            # Add the in / out tables (if any) to the sql meta
-            sql_meta.add_in_tables(result.in_tables)
-            sql_meta.add_out_tables(result.out_tables)
-
-        return sql_meta
 
     def recurse(self, tokens: TokenList) -> SqlMeta:
         in_tables, out_tables = set(), set()
@@ -191,3 +238,30 @@ class SqlParser:
             # Parse CTE using recursion.
             return cte_name.value, self.recurse(TokenList(parens.tokens)).in_tables
         raise RuntimeError(f"Parens {parens} are not Parenthesis at index {gidx}")
+
+
+def parse(
+    sql: str,
+    dialect: Optional[str] = None,
+    default_schema: Optional[str] = None
+) -> SqlMeta:
+    if sql is None:
+        raise ValueError("A sql statement must be provided.")
+
+    # Tokenize the SQL statement
+    sql_statements = sqlparse.parse(sql)
+
+    sql_parser = SqlParser(default_schema)
+    sql_meta = SqlMeta([], [])
+
+    for sql_statement in sql_statements:
+        tokens = TokenList(sql_statement.tokens)
+        log.debug(f"Successfully tokenized sql statement: {tokens}")
+
+        result = sql_parser.recurse(tokens)
+
+        # Add the in / out tables (if any) to the sql meta
+        sql_meta.add_in_tables(result.in_tables)
+        sql_meta.add_out_tables(result.out_tables)
+
+    return sql_meta

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -3,51 +3,49 @@
 import logging
 
 import pytest
-from openlineage.common.models import DbTableName
-from openlineage.common.sql import SqlParser
+from openlineage.common.sql import parse, DbTableMeta, provider
 
 log = logging.getLogger(__name__)
 
 
 def test_parse_simple_select():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT *
           FROM table0;
         '''
     )
 
-    log.debug("sqlparser.parse() successful.")
-    assert sql_meta.in_tables == [DbTableName('table0')]
-    assert sql_meta.out_tables == []
+    log.debug("parse() successful.")
+    assert sql_meta.in_tables[0].qualified_name == DbTableMeta('table0').qualified_name
 
 
 def test_parse_simple_select_with_table_schema_prefix():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT *
           FROM schema0.table0;
         '''
     )
 
-    assert sql_meta.in_tables == [DbTableName('schema0.table0')]
+    assert sql_meta.in_tables == [DbTableMeta('schema0.table0')]
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_select_with_table_schema_prefix_and_extra_whitespace():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT *
           FROM    schema0.table0   ;
         '''
     )
 
-    assert sql_meta.in_tables == [DbTableName('schema0.table0')]
+    assert sql_meta.in_tables == [DbTableMeta('schema0.table0')]
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_select_into():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT *
           INTO table0
@@ -55,12 +53,12 @@ def test_parse_simple_select_into():
         '''
     )
 
-    assert sql_meta.in_tables == [DbTableName('table1')]
-    assert sql_meta.out_tables == [DbTableName('table0')]
+    assert sql_meta.in_tables == [DbTableMeta('table1')]
+    assert sql_meta.out_tables == [DbTableMeta('table0')]
 
 
 def test_parse_simple_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -69,12 +67,24 @@ def test_parse_simple_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
+    assert sql_meta.out_tables == []
+
+
+def test_parse_comma_join():
+    sql_meta = parse(
+        '''
+        SELECT col0, col1, col2
+          FROM table0, table1
+        '''
+    )
+
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_inner_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -83,12 +93,12 @@ def test_parse_simple_inner_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_left_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -97,12 +107,12 @@ def test_parse_simple_left_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_left_outer_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -111,12 +121,12 @@ def test_parse_simple_left_outer_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_right_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -125,12 +135,12 @@ def test_parse_simple_right_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_right_outer_join():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
@@ -139,12 +149,12 @@ def test_parse_simple_right_outer_join():
         '''
     )
 
-    assert set(sql_meta.in_tables) == {DbTableName('table0'), DbTableName('table1')}
+    assert set(sql_meta.in_tables) == {DbTableMeta('table0'), DbTableMeta('table1')}
     assert sql_meta.out_tables == []
 
 
 def test_parse_simple_insert_into():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         INSERT INTO table0 (col0, col1, col2)
         VALUES (val0, val1, val2);
@@ -152,11 +162,11 @@ def test_parse_simple_insert_into():
     )
 
     assert sql_meta.in_tables == []
-    assert sql_meta.out_tables == [DbTableName('table0')]
+    assert sql_meta.out_tables == [DbTableMeta('table0')]
 
 
 def test_parse_simple_insert_into_select():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         INSERT INTO table1 (col0, col1, col2)
         SELECT col0, col1, col2
@@ -164,12 +174,12 @@ def test_parse_simple_insert_into_select():
         '''
     )
 
-    assert sql_meta.in_tables == [DbTableName('table0')]
-    assert sql_meta.out_tables == [DbTableName('table1')]
+    assert sql_meta.in_tables == [DbTableMeta('table0')]
+    assert sql_meta.out_tables == [DbTableMeta('table1')]
 
 
 def test_parse_simple_cte():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         WITH sum_trans as (
             SELECT user_id, COUNT(*) as cnt, SUM(amount) as balance
@@ -183,13 +193,13 @@ def test_parse_simple_cte():
           WHERE count > 1000 OR balance > 100000;
         '''
     )
-    assert sql_meta.in_tables == [DbTableName('transactions')]
-    assert sql_meta.out_tables == [DbTableName('potential_fraud')]
+    assert sql_meta.in_tables == [DbTableMeta('transactions')]
+    assert sql_meta.out_tables == [DbTableMeta('potential_fraud')]
 
 
 def test_parse_bugged_cte():
     with pytest.raises(RuntimeError):
-        SqlParser.parse(
+        parse(
             '''
             WITH sum_trans (
                 SELECT user_id, COUNT(*) as cnt, SUM(amount) as balance
@@ -206,7 +216,7 @@ def test_parse_bugged_cte():
 
 
 def test_parse_recursive_cte():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         WITH RECURSIVE subordinates AS
             (SELECT employee_id,
@@ -223,13 +233,13 @@ def test_parse_recursive_cte():
         SELECT employee_id, manager_id, full_name FROM subordinates;
         '''
     )
-    assert sql_meta.in_tables == [DbTableName('employees')]
-    assert sql_meta.out_tables == [DbTableName('sub_employees')]
+    assert sql_meta.in_tables == [DbTableMeta('employees')]
+    assert sql_meta.out_tables == [DbTableMeta('sub_employees')]
 
 
-@pytest.mark.skip(reason="no support for this right now")
+@pytest.mark.skipif(provider() == "python", reason="no support for this in python parser")
 def test_multiple_ctes():
-    sql_meta = SqlParser.parse('''
+    sql_meta = parse('''
     WITH customers AS (
             SELECT * FROM DEMO_DB.public.stg_customers
         ),
@@ -242,35 +252,35 @@ def test_multiple_ctes():
     ON c.id = o.customer_id
     ''')
     assert sql_meta.in_tables == [
-        DbTableName('DEMO_DB.public.stg_customers'),
-        DbTableName('DEMO_DB.public.stg_orders')
+        DbTableMeta('DEMO_DB.public.stg_customers'),
+        DbTableMeta('DEMO_DB.public.stg_orders')
     ]
 
 
 def test_parse_default_schema():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM table0
         ''',
-        'public'
+        default_schema='public'
     )
-    assert sql_meta.in_tables == [DbTableName('public.table0')]
+    assert sql_meta.in_tables == [DbTableMeta('public.table0')]
 
 
 def test_ignores_default_schema_when_non_default_schema():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         '''
         SELECT col0, col1, col2
           FROM transactions.table0
         ''',
         'public'
     )
-    assert sql_meta.in_tables == [DbTableName('transactions.table0')]
+    assert sql_meta.in_tables == [DbTableMeta('transactions.table0')]
 
 
 def test_parser_integration():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         """
         INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)
             SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,
@@ -279,21 +289,37 @@ def test_parser_integration():
               FROM top_delivery_times
              GROUP BY order_placed_on;
         """,
-        "public"
+        default_schema="public"
     )
-    assert sql_meta.in_tables == [DbTableName('public.top_delivery_times')]
+    assert sql_meta.in_tables == [DbTableMeta('public.top_delivery_times')]
 
 
 def test_bigquery_escaping():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         "select * from `random-project`.`dbt_test1`.`source_table` where id = 1",
-        "public"
+        dialect="bigquery",
+        default_schema="public"
     )
-    assert sql_meta.in_tables == [DbTableName('random-project.dbt_test1.source_table')]
+    assert sql_meta.in_tables == [DbTableMeta('random-project.dbt_test1.source_table')]
 
 
+@pytest.mark.skipif(provider() == "python", reason="python does not understand DDL")
+def test_create_table():
+    sql_meta = parse("""
+        CREATE TABLE Persons (
+        PersonID int,
+        LastName varchar(255),
+        FirstName varchar(255),
+        Address varchar(255),
+        City varchar(255));
+        """)
+    assert sql_meta.in_tables == []
+    assert sql_meta.out_tables == [DbTableMeta("Persons")]
+
+
+@pytest.mark.skipif(provider() == "rust", reason="rust parser does not support multiple stmts")
 def test_parse_multi_statement():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         """
         DROP TABLE IF EXISTS schema1.table1;
         CREATE TABLE schema1.table1(
@@ -307,5 +333,5 @@ def test_parse_multi_statement():
             FROM schema0.table0;
         """
     )
-    assert sql_meta.in_tables == [DbTableName('schema0.table0')]
-    assert sql_meta.out_tables == [DbTableName('schema1.table1')]
+    assert sql_meta.in_tables == [DbTableMeta('schema0.table0')]
+    assert sql_meta.out_tables == [DbTableMeta('schema1.table1')]

--- a/integration/common/tests/sql/test_tpcds.py
+++ b/integration/common/tests/sql/test_tpcds.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from openlineage.common.sql import SqlParser
-from openlineage.common.models import DbTableName
+from openlineage.common.sql import parse, DbTableMeta
 
 
 def test_tpcds_cte_query():
-    sql_meta = SqlParser.parse(
+    sql_meta = parse(
         """
 WITH year_total AS
     (SELECT c_customer_id customer_id,
@@ -83,8 +82,8 @@ LIMIT 100;
 """
     )
     assert set(sql_meta.in_tables) == {
-        DbTableName("src.customer"),
-        DbTableName("store_sales"),
-        DbTableName("date_dim")
+        DbTableMeta("src.customer"),
+        DbTableMeta("store_sales"),
+        DbTableMeta("date_dim")
     }
     assert len(sql_meta.out_tables) == 0

--- a/integration/common/tests/test_dataset.py
+++ b/integration/common/tests/test_dataset.py
@@ -3,7 +3,8 @@
 import pytest
 from openlineage.client.facet import DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
 from openlineage.client.run import Dataset as OpenLineageDataset
-from openlineage.common.models import DbTableName, DbColumn, DbTableSchema
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
 from openlineage.common.dataset import Source, Dataset
 
 
@@ -19,7 +20,7 @@ def source():
 @pytest.fixture
 def table_schema(source):
     schema_name = 'public'
-    table_name = DbTableName('discounts')
+    table_name = DbTableMeta('discounts')
     columns = [
         DbColumn(
             name='id',

--- a/integration/common/tests/test_models.py
+++ b/integration/common/tests/test_models.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0.
-from openlineage.common.models import DbTableName
+from openlineage.common.sql import DbTableMeta
 
 
 def test_eq_table_name():
-    assert DbTableName('discounts') != DbTableName('public.discounts')
-    assert DbTableName('discounts').qualified_name is None
-    assert DbTableName('public.discounts').qualified_name == 'public.discounts'
+    assert DbTableMeta('public.discounts') == DbTableMeta('public.discounts')
+    assert DbTableMeta('discounts') != DbTableMeta('public.discounts')
+    assert DbTableMeta('discounts').qualified_name == "discounts"
+    assert DbTableMeta('public.discounts').qualified_name == 'public.discounts'


### PR DESCRIPTION
This PR makes python SQL parser an independent module, exposing API that does not rely on other modules. 
This allows next PR implementing rust parser to not depend on any Python internals; code does not rely on either of those implementations.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>