### PR TITLE
airflow: add script for easier creation of local development environment

### DIFF
--- a/.circleci/get-docker-compose.sh
+++ b/.circleci/get-docker-compose.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-curl -L https://github.com/docker/compose/releases/download/1.25.3/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
 chmod +x ~/docker-compose
 sudo mv ~/docker-compose /usr/local/bin/docker-compose
 docker-compose --version

--- a/integration/airflow/.gitignore
+++ b/integration/airflow/.gitignore
@@ -3,3 +3,6 @@ requirements.txt
 /tests/integration/tests/events
 /tests/integration/integration-requirements.txt
 /test-results
+/scripts/airflow/logs
+/scripts/events
+/scripts/*requirements.txt

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -236,6 +236,13 @@ Airflow 2.0+:
 ```bash
 $ pip install -r dev-requirements-2.x.txt
 ```
+
+There is also bash script that can run arbitrary Airflow image with OpenLineage integration build from current branch.
+Run it as
+```bash
+$ AIRFLOW_IMAGE=<airflow_image_with_tag> ./scripts/run-dev-airflow.sh [--rebuild]
+```
+Rebuild option forces docker images to be rebuilt.
 ### Unit tests
 To run the entire unit test suite use below command:
 ```bash

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -39,7 +39,7 @@ deps = -r dev-requirements-2.x.txt
 	airflow-2.1.4: apache-airflow==2.1.4
 	airflow-2.3.1: apache-airflow==2.3.1
 whitelist_externals = bash
-commands = flake8 --extend-exclude 'tests/integration'
+commands = flake8 --extend-exclude tests/integration,scripts/
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}
 	pytest --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml
@@ -49,7 +49,7 @@ setenv =
 
 [testenv:py3-airflow-1.10.15]
 install_command = python -m pip install {opts} --find-links target/wheels/ --find-links ../sql/target/wheels --use-deprecated=legacy-resolver {packages}
-commands = flake8 --extend-exclude 'tests/integration'
+commands = flake8 --extend-exclude tests/integration,scripts/
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow resetdb -y; fi" {envdir}
 	pytest --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -25,7 +25,7 @@ x-airflow-base: &airflow-base
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     AIRFLOW_CONN_MYSQL_CONN: mysql://food_delivery:food_delivery@mysql:3306/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=openlineage-ci&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
-    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "False"
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: ${DAGS_ARE_PAUSED_AT_CREATION:-False}
     BIGQUERY_PREFIX: ${BIGQUERY_PREFIX}
     DBT_DATASET_PREFIX: ${DBT_DATASET_PREFIX}_dbt
     GOOGLE_APPLICATION_CREDENTIALS: /opt/config/gcloud/gcloud-service-key.json
@@ -40,7 +40,7 @@ x-airflow-base: &airflow-base
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=ROBOTS&role=OPENLINEAGE"
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
-      - ./airflow/logs:/opt/airflow/logs
+      - $PWD/airflow/logs:/opt/airflow/logs
       - ./airflow/dags:/opt/airflow/dags
       - ../gcloud:/opt/config/gcloud
 
@@ -84,6 +84,20 @@ services:
       timeout: 10s
       retries: 5
 
+  airflow:
+    profiles:
+      - dev
+    <<: *airflow-base
+    command: webserver
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+
   backend:
     build:
       context: ../server
@@ -92,7 +106,7 @@ services:
       - FLASK_RUN_PORT=5000
       - SERVER_EVENTS=/opt/airflow/events
     volumes:
-      - ./events:/opt/airflow/events
+      - $PWD/events:/opt/airflow/events
 
   airflow_init:
     <<: *airflow-base


### PR DESCRIPTION
This script adds possibility to run any Airflow image with OpenLineage integrations build from current branch.

To do that, run it from airflow integration directory as 

```bash
AIRFLOW_IMAGE=<airflow_image_with_tag> ./scripts/run-airflow.sh
```

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>