### PR TITLE
airflow: import extractors based on operator classnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.6.2...HEAD)
 ### Added
 * Python implements Transport interface - HTTP and Kafka transports are available [@mobuchowski](https://github.com/mobuchowski)
+* Airflow: custom extractors lookup uses only get_operator_classnames method [@mobuchowski](https://github.com/mobuchowski)
 
 ## [0.6.2](https://github.com/OpenLineage/OpenLineage/compare/0.6.1...0.6.2)
 ### Added

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -131,12 +131,12 @@ There are two ways to register them for use in `openlineage-airflow`.
 
 First one, is to provide environment variable in pattern of 
 ```
-OPENLINEAGE_EXTRACTOR_<operator>=full.path.to.ExtractorClass
+OPENLINEAGE_EXTRACTOR_<name>=full.path.to.ExtractorClass
 ```
 
 For example: 
 ```
-OPENLINEAGE_EXTRACTOR_PostgresOperator=openlineage.airflow.extractors.postgres_extractor.PostgresExtractor
+OPENLINEAGE_EXTRACTOR_POSTGRES_OPERATOR=openlineage.airflow.extractors.postgres_extractor.PostgresExtractor
 ```
 
 Second one - working in Airflow 1.10.x only - is to register all additional operator-extractor pairings by 

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -72,8 +72,9 @@ class Extractors:
         # We import the module provided and get type using importlib then.
         for key, value in os.environ.items():
             if key.startswith("OPENLINEAGE_EXTRACTOR_"):
-                operator = key[22:]
-                self.extractors[operator] = import_from_string(value)
+                extractor = import_from_string(value)
+                for operator_class in extractor.get_operator_classnames():
+                    self.extractors[operator_class] = extractor
 
     def add_extractor(self, operator: str, extractor: Type):
         self.extractors[operator] = extractor

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -1,10 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from typing import List, Optional
 
-
-from openlineage.airflow.extractors import Extractors
+from openlineage.airflow.extractors import Extractors, BaseExtractor, TaskMetadata
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+
+
+class FakeExtractor(BaseExtractor):
+    def extract(self) -> Optional[TaskMetadata]:
+        return None
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['TestOperator']
 
 
 def test_basic_extractor():
@@ -15,8 +24,10 @@ def test_basic_extractor():
 
 
 def test_env_extractors():
+    assert len(Extractors().extractors) == 7
+
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
-        'openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'
+        'tests.extractors.test_extractors.FakeExtractor'
 
     assert len(Extractors().extractors) == 8
     del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']


### PR DESCRIPTION
Some environments restrict case-sensitive environment variable names, like Astronomer.
To solve this, make extractor loading use only operator classnames that are provided by external extractors. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
