### PR TITLE
airflow: remove redundant logging from GE import

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -14,7 +14,6 @@ try:
 except Exception:
     # Create placeholder for GreatExpectationsOperator
     GreatExpectationsOperator = None
-    log.info('Did not find great_expectations_provider library or failed to import it')
     _has_great_expectations = False
 
 


### PR DESCRIPTION
Remove redundant logging that GE library was not imported. Since we're using slightly different mechanism to register extractors, the logging does not give anything useful.

Closes: https://github.com/OpenLineage/OpenLineage/issues/648 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
