### PR TITLE
Adding naming conventions around Azure services

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -91,6 +91,23 @@ Identifier :
  * Unique name: {project id}.{dataset name}.{table name}
    * URI =   bigquery:{project id}.{schema}.{table}
 
+#### Azure Synapse:
+Datasource hierarchy:
+ * Host: \<XXXXXXXXXXXX>.sql.azuresynapse.net
+ * Port: 1433
+ * Database: SQLPool1
+ 
+Naming hierarchy:
+ * Schema
+ * Table
+
+Identifier:
+ * Namespace: sqlserver://{host}:{port};database={database};
+   * Scheme = sqlserver
+   * Authority = {host}:{port}
+ * Unique name: {schema}.{table}
+   * URI = sqlserver://{host}:{port};database={database}/{schema}.{table}
+
 ### Distributed file systems/blob stores
 #### GCS
 Datasource hierarchy: none, naming is global
@@ -141,6 +158,30 @@ Identifier :
    * Authority = workspace name
  * Unique name: {path}
    * URI =   hdfs://{workspace name}{path}
+
+#### ABFSS (Azure Data Lake Gen2)
+Naming hierarchy:
+ * service name => globally unique
+ * Path
+
+Identifier :
+ * Namespace: abfss://{container name}@{service name}
+   * Scheme = abfss
+   * Authority = service name
+ * Unique name: {path}
+   * URI =   abfss://{container name}@{service name}{path}
+
+#### WASBS (Azure Blob Storage)
+Naming hierarchy:
+ * service name => globally unique
+ * Path
+
+Identifier :
+ * Namespace: wasbs://{container name}@{service name}
+   * Scheme = wasbs
+   * Authority = service name
+ * Unique name: {path}
+   * URI =   wasbs://{container name}@{service name}{path}
 
 ## Jobs
 ### Context


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

The naming conventions in the spec folder do not include recent changes to support Azure Blob, Azure Data Lake Gen2, and Azure Synapse.

Closes: N/A

### Solution

This PR documents the naming conventions that are currently implemented for Azure services that have bespoke behaviors.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)