### PR TITLE
[INTEGRATION][SPARK] Fix spotless error in the Spark integration

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
@@ -75,8 +75,11 @@ public class CommandPlanVisitor
     PartialFunction<LogicalPlan, Collection<InputDataset>> delegateFn =
         delegate(
             context.getInputDatasetQueryPlanVisitors(), context.getInputDatasetBuilders(), event);
-    return input.map(in -> in.collect(delegateFn)).map(ScalaConversionUtils::fromSeq)
-        .orElse(Collections.emptyList()).stream()
+    return input
+        .map(in -> in.collect(delegateFn))
+        .map(ScalaConversionUtils::fromSeq)
+        .orElse(Collections.emptyList())
+        .stream()
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

I tried to build the Spark integration, but ran into the following error.

```
$ cd integration/spark
$ ./gradlew build -x test

...

> Task :spotlessJavaCheck FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spotlessJavaCheck'.
> The following files had format violations:
      src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
          @@ -75,8 +75,11 @@
           ····PartialFunction<LogicalPlan,·Collection<InputDataset>>·delegateFn·=
           ········delegate(
           ············context.getInputDatasetQueryPlanVisitors(),·context.getInputDatasetBuilders(),·event);
          -····return·input.map(in·->·in.collect(delegateFn)).map(ScalaConversionUtils::fromSeq)
          -········.orElse(Collections.emptyList()).stream()
          +····return·input
          +········.map(in·->·in.collect(delegateFn))
          +········.map(ScalaConversionUtils::fromSeq)
          +········.orElse(Collections.emptyList())
          +········.stream()
           ········.flatMap(Collection::stream)
           ········.collect(Collectors.toList());
           ··}
  Run './gradlew :spotlessApply' to fix these violations.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 7s
```

### Solution

I formatted the code in question and confirmed the build succeeded.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)