### PR TITLE
[INTEGRATION][SPARK] Fix timezone inconsistency in testSerializeRunEvent

### DIFF
--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -30,7 +30,7 @@ public class OpenLineageRunEventTest {
   public void testSerializeRunEvent() throws IOException, URISyntaxException {
     ObjectMapper mapper = OpenLineageClient.createMapper();
 
-    ZonedDateTime dateTime = ZonedDateTime.parse("2021-01-01T00:00:01.000000000+02:00[UTC]");
+    ZonedDateTime dateTime = ZonedDateTime.parse("2021-01-01T00:00:01.000000000+00:00[UTC]");
     OpenLineage ol =
         new OpenLineage(
             new URI(


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

I ran the unit tests for the Spark integration and came across the following error.

```
$ cd integration/spark
$ ./gradlew test

...

io.openlineage.spark.agent.OpenLineageRunEventTest testSerializeRunEvent() FAILED (1.7s)

  java.lang.AssertionError: 
  Expecting actual:
    {"eventTime"="2020-12-31T22:00:01Z", "eventType"="START", "inputs"=[{"inputFacets"={"dataQualityMetrics"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/DataQualityMetricsInputDatasetFacet.json#/$defs/DataQualityMetricsInputDatasetFacet", "bytes"=20, "columnMetrics"={"mycol"={"count"=10.0, "distinctCount"=10, "max"=30.0, "min"=5.0, "nullCount"=1, "quantiles"={"25"=52.0}, "sum"=3000.0}}, "rowCount"=10}}, "name"="input", "namespace"="ins"}], "job"={"facets"={"documentation"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/DocumentationJobFacet.json#/$defs/DocumentationJobFacet", "description"="test documentation"}, "sourceCodeLocation"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/SourceCodeLocationJobFacet.json#/$defs/SourceCodeLocationJobFacet", "branch"="branch", "path"="/path/to/file", "repoUrl"="https://github.com/apache/spark", "tag"="v1.0.0", "type"="git", "url"="https://github.com/apache/spark", "version"="v1"}, "sql"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/SQLJobFacet.json#/$defs/SQLJobFacet", "query"="SELECT * FROM test"}}, "name"="jobName", "namespace"="namespace"}, "outputs"=[{"name"="output", "namespace"="ons", "outputFacets"={"outputStatistics"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet", "rowCount"=10, "size"=20}}}], "producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "run"={"facets"={"parent"={"_producer"="https://github.com/OpenLineage/OpenLineage/tree/0.2.3-SNAPSHOT/integration/spark", "_schemaURL"="https://openlineage.io/spec/facets/1-0-0/ParentRunFacet.json#/$defs/ParentRunFacet", "job"={"name"="jobName", "namespace"="namespace"}, "run"={"runId"="5f24c93c-2ce9-49dc-82e7-95ab4915242f"}}}, "runId"="5f24c93c-2ce9-49dc-82e7-95ab4915242f"}, "schemaURL"="https://openlineage.io/spec/1-0-2/OpenLineage.json#/$defs/RunEvent"}
  to satisfy:
    matches snapshot fields {eventType=START, eventTime=2021-01-01T00:00:01Z, run={runId=5f24c93c-2ce9-49dc-82e7-95ab4915242f, facets={parent={job={namespace=namespace, name=jobName}}}}, job={namespace=namespace, name=jobName, facets={documentation={description=test documentation}, sourceCodeLocation={type=git, url=https://github.com/apache/spark, repoUrl=https://github.com/apache/spark, path=/path/to/file, version=v1, tag=v1.0.0, branch=branch}, sql={query=SELECT * FROM test}}}, inputs=[{namespace=ins, name=input, inputFacets={dataQualityMetrics={rowCount=10, bytes=20, columnMetrics={mycol={nullCount=1, distinctCount=10, sum=3000.0, count=10.0, min=5.0, max=30.0, quantiles={25=52.0}}}}}}], outputs=[{namespace=ons, name=output, outputFacets={outputStatistics={rowCount=10, size=20}}}]}
      at io.openlineage.spark.agent.OpenLineageRunEventTest.testSerializeRunEvent(OpenLineageRunEventTest.java:117)
```

It seems to come from the inconsistency between the offset and the timezone ID. `[UTC]` indicates that the offset is `+00:00`, but `+02:00` is specified just before.
https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/src/test/common/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java#L33

### Solution

After aligning the offset and the zone ID, I ran `./gradlew test` under integration/spark and ensured it succeeded.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)