### PR TITLE
Add support for HiveTableRelation in logical plan visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
+<<<<<<< HEAD
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.7.1...HEAD)
+### Added
+* Support for HiveTableRelation as input source in Spark integration [@collado-mike](https://github.com/collado-mike)
  
 ## [0.7.1](https://github.com/OpenLineage/OpenLineage/compare/0.6.2...0.7.1)
 ### Added

--- a/integration/spark/integrations/container/pysparkHiveSelectEndEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveSelectEndEvent.json
@@ -1,0 +1,57 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testPysparkSQLHiveTest",
+    "name": "open_lineage_integration_hive.execute_insert_into_hive_table"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "inputFacets": {}
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/target",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "outputFacets": {}
+    }
+  ]
+}

--- a/integration/spark/integrations/container/pysparkHiveSelectStartEvent.json
+++ b/integration/spark/integrations/container/pysparkHiveSelectStartEvent.json
@@ -1,0 +1,57 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testPysparkSQLHiveTest",
+    "name": "open_lineage_integration_hive.execute_insert_into_hive_table"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "inputFacets": {}
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/target",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "outputFacets": {}
+    }
+  ]
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -13,6 +13,7 @@ import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableCommandVis
 import io.openlineage.spark.agent.lifecycle.plan.CreateHiveTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.DropTableCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.HiveTableRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDirVisitor;
@@ -47,6 +48,9 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     }
     if (SqlDWDatabricksVisitor.hasSqlDWDatabricksClasses()) {
       list.add(new SqlDWDatabricksVisitor(context, factory));
+    }
+    if (InsertIntoHiveTableVisitor.hasHiveClasses()) {
+      list.add(new HiveTableRelationVisitor<>(context, factory));
     }
     return list;
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
@@ -1,0 +1,37 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.Dataset;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import lombok.NonNull;
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Simple visitor to support {@link HiveTableRelation}s in the plan. Both input and output {@link
+ * Dataset}s are supported.
+ *
+ * @param <D>
+ */
+public class HiveTableRelationVisitor<D extends Dataset>
+    extends QueryPlanVisitor<HiveTableRelation, D> {
+
+  private final DatasetFactory<D> factory;
+
+  public HiveTableRelationVisitor(@NonNull OpenLineageContext context, DatasetFactory<D> factory) {
+    super(context);
+    this.factory = factory;
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan x) {
+    HiveTableRelation hiveTable = (HiveTableRelation) x;
+    DatasetIdentifier datasetId = PathUtils.fromCatalogTable(hiveTable.tableMeta());
+    return Collections.singletonList(factory.getDataset(datasetId, x.schema()));
+  }
+}

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -164,7 +164,11 @@ public class SparkContainerIntegrationTest {
   public void testPysparkSQLHiveTest() {
     SparkContainerUtils.runPysparkContainerWithDefaultConf(
         network, openLineageClientMockContainer, "testPysparkSQLHiveTest", "spark_hive.py");
-    verifyEvents("pysparkHiveStartEvent.json", "pysparkHiveCompleteEvent.json");
+    verifyEvents(
+        "pysparkHiveStartEvent.json",
+        "pysparkHiveCompleteEvent.json",
+        "pysparkHiveSelectStartEvent.json",
+        "pysparkHiveSelectEndEvent.json");
   }
 
   @Test

--- a/integration/spark/src/test/resources/spark_scripts/spark_hive.py
+++ b/integration/spark/src/test/resources/spark_scripts/spark_hive.py
@@ -13,6 +13,8 @@ spark = SparkSession.builder \
     .getOrCreate()
 spark.sparkContext.setLogLevel('info')
 
-spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive");
-spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')");
-result = spark.sql("SELECT count(*) from test");
+spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive")
+spark.sql("CREATE TABLE IF NOT EXISTS target (key INT, value STRING) USING hive")
+spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+spark.sql("INSERT INTO target SELECT * from test WHERE value > 1")


### PR DESCRIPTION
### Problem
`HiveTableRelation`s as input sources aren't supported currently. We have a test to verify that we can write to a hive table, but nothing verifying we can support reading from one. This change adds a `HiveTableRelationVisitor` and updates the `testPysparkSQLHiveTest` to verify both the writes and the reads.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)