### PR TITLE
[INTEGRATION][SPARK] provide DatasetFactory class with OL context

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -58,7 +58,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
   public List<PartialFunction<LogicalPlan, List<InputDataset>>> getInputVisitors(
       OpenLineageContext context) {
     List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> inputVisitors =
-        new ArrayList<>(getCommonVisitors(context, DatasetFactory.input(context.getOpenLineage())));
+        new ArrayList<>(getCommonVisitors(context, DatasetFactory.input(context)));
     if (VisitorFactory.classPresent("org.apache.spark.sql.execution.SQLExecutionRDD")) {
       inputVisitors.add(new SqlExecutionRDDVisitor(context));
     }
@@ -68,8 +68,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
   @Override
   public List<PartialFunction<LogicalPlan, List<OpenLineage.OutputDataset>>> getOutputVisitors(
       OpenLineageContext context) {
-    DatasetFactory<OpenLineage.OutputDataset> factory =
-        DatasetFactory.output(context.getOpenLineage());
+    DatasetFactory<OpenLineage.OutputDataset> factory = DatasetFactory.output(context);
 
     List<PartialFunction<LogicalPlan, List<OpenLineage.OutputDataset>>> outputCommonVisitors =
         getCommonVisitors(context, factory);

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
@@ -17,7 +17,7 @@ import org.apache.spark.sql.execution.SQLExecutionRDD;
 public class SqlExecutionRDDVisitor extends AbstractRDDNodeVisitor<LogicalRDD, InputDataset> {
 
   public SqlExecutionRDDVisitor(@NonNull OpenLineageContext context) {
-    super(context, DatasetFactory.input(context.getOpenLineage()));
+    super(context, DatasetFactory.input(context));
   }
 
   @Override

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -44,11 +44,11 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
   }
 
   protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
-    return DatasetFactory.output(context.getOpenLineage());
+    return DatasetFactory.output(context);
   }
 
   protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
-    return DatasetFactory.input(context.getOpenLineage());
+    return DatasetFactory.input(context);
   }
 
   public abstract List<D> apply(P p);

--- a/integration/spark/src/main/common/java/io/openlineage/spark/api/QueryPlanVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/api/QueryPlanVisitor.java
@@ -62,11 +62,11 @@ public abstract class QueryPlanVisitor<T extends LogicalPlan, D extends OpenLine
   }
 
   protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
-    return DatasetFactory.output(context.getOpenLineage());
+    return DatasetFactory.output(context);
   }
 
   protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
-    return DatasetFactory.input(context.getOpenLineage());
+    return DatasetFactory.input(context);
   }
 
   private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
+++ b/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
@@ -16,9 +16,7 @@ public class Spark2DatasetBuilderFactory implements DatasetBuilderFactory {
   public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
       OpenLineageContext context) {
     return ImmutableList.<PartialFunction<Object, List<OpenLineage.InputDataset>>>builder()
-        .add(
-            new LogicalRelationDatasetBuilder(
-                context, DatasetFactory.input(context.getOpenLineage()), true))
+        .add(new LogicalRelationDatasetBuilder(context, DatasetFactory.input(context), true))
         .add(new CommandPlanVisitor(context))
         .build();
   }
@@ -27,9 +25,7 @@ public class Spark2DatasetBuilderFactory implements DatasetBuilderFactory {
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
       OpenLineageContext context) {
     return ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
-        .add(
-            new LogicalRelationDatasetBuilder(
-                context, DatasetFactory.output(context.getOpenLineage()), false))
+        .add(new LogicalRelationDatasetBuilder(context, DatasetFactory.output(context), false))
         .add(new SaveIntoDataSourceCommandVisitor(context))
         .build();
   }

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -22,8 +22,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
   @Override
   public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
       OpenLineageContext context) {
-    DatasetFactory<OpenLineage.InputDataset> datasetFactory =
-        DatasetFactory.input(context.getOpenLineage());
+    DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     return ImmutableList.<PartialFunction<Object, List<OpenLineage.InputDataset>>>builder()
         .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
         .add(new CommandPlanVisitor(context))
@@ -35,8 +34,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
   @Override
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
       OpenLineageContext context) {
-    DatasetFactory<OpenLineage.OutputDataset> datasetFactory =
-        DatasetFactory.output(context.getOpenLineage());
+    DatasetFactory<OpenLineage.OutputDataset> datasetFactory = DatasetFactory.output(context);
     ImmutableList.Builder builder =
         ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -20,7 +20,6 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
   @Override
   public List<PartialFunction<LogicalPlan, List<OpenLineage.OutputDataset>>> getOutputVisitors(
       OpenLineageContext context) {
-    DatasetFactory<OutputDataset> outputFactory = DatasetFactory.output(context.getOpenLineage());
     return ImmutableList.<PartialFunction<LogicalPlan, List<OutputDataset>>>builder()
         .addAll(super.getOutputVisitors(context))
         .add(new CreateTableLikeCommandVisitor(context))

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitorTest.java
@@ -3,12 +3,15 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.client.OpenLineageClient;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.hadoop.io.LongWritable;
@@ -32,6 +35,7 @@ import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -41,7 +45,14 @@ import scala.collection.immutable.HashMap;
 @ExtendWith(SparkAgentTestExtension.class)
 class LogicalRDDVisitorTest {
 
-  private JobConf jobConf;
+  JobConf jobConf;
+  OpenLineageContext context = mock(OpenLineageContext.class);
+
+  @BeforeEach
+  public void setUp() {
+    when(context.getOpenLineage())
+        .thenReturn(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI));
+  }
 
   @AfterEach
   public void tearDown() {
@@ -53,8 +64,7 @@ class LogicalRDDVisitorTest {
     SparkSession session = SparkSession.builder().master("local").getOrCreate();
     LogicalRDDVisitor visitor =
         new LogicalRDDVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
     StructType schema =
         new StructType(
             new StructField[] {

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -53,13 +53,13 @@ class LogicalRelationDatasetBuilderTest {
   OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
   LogicalRelationDatasetBuilder builder =
       new LogicalRelationDatasetBuilder(
-          openLineageContext,
-          DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)),
-          false);
+          openLineageContext, DatasetFactory.output(openLineageContext), false);
 
   @BeforeEach
   public void setUp() {
     when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI));
   }
 
   @ParameterizedTest
@@ -112,7 +112,8 @@ class LogicalRelationDatasetBuilderTest {
             .queryExecution(qe)
             .build();
     LogicalRelationDatasetBuilder visitor =
-        new LogicalRelationDatasetBuilder<>(context, DatasetFactory.output(openLineage), false);
+        new LogicalRelationDatasetBuilder<>(
+            context, DatasetFactory.output(openLineageContext), false);
     List<OutputDataset> datasets =
         visitor.apply(new SparkListenerJobStart(1, 1, Seq$.MODULE$.empty(), null));
     assertEquals(1, datasets.size());
@@ -130,7 +131,6 @@ class LogicalRelationDatasetBuilderTest {
     Configuration hadoopConfig = mock(Configuration.class);
     SparkContext sparkContext = mock(SparkContext.class);
     FileIndex fileIndex = mock(FileIndex.class);
-    OpenLineage openLineage = mock(OpenLineage.class);
     SessionState sessionState = mock(SessionState.class);
     Path p1 = new Path("/tmp/path1");
     Path p2 = new Path("/tmp/path2");
@@ -138,8 +138,6 @@ class LogicalRelationDatasetBuilderTest {
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
     when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
-    when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
-    when(openLineage.newDatasetFacetsBuilder()).thenReturn(new OpenLineage.DatasetFacetsBuilder());
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);

--- a/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/src/test/common/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -99,10 +99,13 @@ class TestSqlDWDatabricksVisitor extends SqlDWDatabricksVisitor {
 
 class SQLDWDatabricksVisitorTest {
   SparkSession session = mock(SparkSession.class);
+  OpenLineageContext context = mock(OpenLineageContext.class);
 
   @BeforeEach
   public void setUp() {
     when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    when(context.getOpenLineage())
+        .thenReturn(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI));
   }
 
   @Test
@@ -134,8 +137,7 @@ class SQLDWDatabricksVisitorTest {
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
     List<OpenLineage.Dataset> datasets = visitor.apply(lr);
 
     assertEquals(1, datasets.size());
@@ -173,8 +175,7 @@ class SQLDWDatabricksVisitorTest {
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
     List<OpenLineage.Dataset> datasets = visitor.apply(lr);
 
     assertEquals(1, datasets.size());
@@ -212,8 +213,7 @@ class SQLDWDatabricksVisitorTest {
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
     List<OpenLineage.Dataset> datasets = visitor.apply(lr);
 
     assertEquals(1, datasets.size());
@@ -247,8 +247,7 @@ class SQLDWDatabricksVisitorTest {
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
-            SparkAgentTestExtension.newContext(session),
-            DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)));
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
     List<OpenLineage.Dataset> datasets = visitor.apply(lr);
 
     assertEquals(0, datasets.size());

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -33,9 +33,7 @@ public class LogicalRelationDatasetBuilderTest {
   SparkSession session = mock(SparkSession.class);
   LogicalRelationDatasetBuilder visitor =
       new LogicalRelationDatasetBuilder(
-          openLineageContext,
-          DatasetFactory.output(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI)),
-          false);
+          openLineageContext, DatasetFactory.output(openLineageContext), false);
   OpenLineage.DatasetVersionDatasetFacet facet = mock(OpenLineage.DatasetVersionDatasetFacet.class);
   OpenLineage openLineage = mock(OpenLineage.class);
 
@@ -52,6 +50,8 @@ public class LogicalRelationDatasetBuilderTest {
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
     when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI));
     when(facet.getDatasetVersion()).thenReturn(SOME_VERSION);
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
@@ -61,7 +61,6 @@ public class LogicalRelationDatasetBuilderTest {
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(Arrays.asList(path))
                 .asScala()
                 .toSeq());
-    when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(new OpenLineage.DatasetFacetsBuilder());
     when(openLineage.newDatasetVersionDatasetFacet(SOME_VERSION)).thenReturn(facet);
 


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Enabler PR for Column Level Lineage. In order to inject column level lineage code, `DatasetFactory` class should contain `context` field instead of `openlineage` field, which it currently contains. 

Part of: #673

### Solution

Modify `DatasetFactory` field and all the places where it gets instantiated. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)