### PR TITLE
[INTEGRATION][SPARK] Update README to explain dependency installation

### DIFF
--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -81,7 +81,7 @@ spark = (SparkSession.builder.master('local').appName('rdd_to_dataframe')
 ### Spark Listener
 The SparkListener reads its configuration from SparkConf parameters. These can be specified on the
 command line (e.g., `--conf "spark.openlineage.url=http://{openlineage.client.host}/api/v1/namespaces/my_namespace/job/the_job"`)
-or from the `conf/spark-defaults.conf` file. 
+or from the `conf/spark-defaults.conf` file.
 
 The following parameters can be specified
 | Parameter | Definition | Example |
@@ -101,6 +101,15 @@ The following parameters can be specified
 Testing requires a Java 8 JVM to test the scala spark components.
 
 `export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+
+## Preparation
+
+Before testing or building jar, run the following command from the client/java directory
+to install the openlineage-java jar, on which this module depends:
+
+```sh
+$ ./gradlew publishToMavenLocal
+```
 
 ## Testing
 
@@ -125,10 +134,10 @@ To run the integration tests, from the current directory run:
 # Extending
 The Spark library is intended to support extension by supporting custom implementations of a handful
 of interfaces. Nearly every extension interface extends or mimics Scala's `PartialFunction`. The
-`isDefinedAt(Object x)` method determines whether a given input is a valid input to the function. 
-A default implementation of `isDefinedAt(Object x)` is provided, which checks the generic type 
+`isDefinedAt(Object x)` method determines whether a given input is a valid input to the function.
+A default implementation of `isDefinedAt(Object x)` is provided, which checks the generic type
 arguments of the concrete class, if concrete type arguments are given, and determines if the input
-argument matches the generic type. For example the following class is automatically defined for an 
+argument matches the generic type. For example the following class is automatically defined for an
 input argument of type `MyDataset`
 
 ```
@@ -142,14 +151,14 @@ The following APIs are still evolving and may change over time, based on user fe
 ###[`OpenLineageEventHandlerFactory`](src/main/common/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java)
 This interface defines the main entrypoint to the extension codebase. Custom implementations
 are registered by following Java's [`ServiceLoader` conventions](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
-A file called `io.openlineage.spark.api.OpenLineageEventHandlerFactory` must exist in the 
-application or jar's `META-INF/service` directory. Each line of that file must be the fully 
+A file called `io.openlineage.spark.api.OpenLineageEventHandlerFactory` must exist in the
+application or jar's `META-INF/service` directory. Each line of that file must be the fully
 qualified class name of a concrete implementation of `OpenLineageEventHandlerFactory`. More than one
-implementation can be present in a single file. This might be useful to separate extensions that 
+implementation can be present in a single file. This might be useful to separate extensions that
 are targeted toward different environments - e.g., one factory may contain Azure-specific extensions,
-while another factory may contain GCP extensions. 
+while another factory may contain GCP extensions.
 
-The `OpenLineageEventHandlerFactory` interface makes heavy use of default methods. Implementations 
+The `OpenLineageEventHandlerFactory` interface makes heavy use of default methods. Implementations
 may override any or all of the following methods
 ```java
 /**
@@ -163,43 +172,43 @@ Collection<PartialFunction<LogicalPlan, List<InputDataset>>> createInputDatasetQ
 Collection<PartialFunction<LogicalPlan, List<OutputDataset>>> createOutputDatasetQueryPlanVisitors(OpenLineageContext context);
 
 /**
- * Return a collection of PartialFunctions that can generate InputDatasets from one of the 
+ * Return a collection of PartialFunctions that can generate InputDatasets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<PartialFunction<Object, List<InputDataset>>> createInputDatasetBuilder(OpenLineageContext context);
 
 /**
- * Return a collection of PartialFunctions that can generate OutputDatasets from one of the 
+ * Return a collection of PartialFunctions that can generate OutputDatasets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<PartialFunction<Object, List<OutputDataset>>> createOutputDatasetBuilder(OpenLineageContext context);
 
 /**
- * Return a collection of CustomFacetBuilders that can generate InputDatasetFacets from one of the 
+ * Return a collection of CustomFacetBuilders that can generate InputDatasetFacets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
- */ 
+ */
 Collection<CustomFacetBuilder<?, ? extends InputDatasetFacet>> createInputDatasetFacetBuilders(OpenLineageContext context);
 
 /**
- * Return a collection of CustomFacetBuilders that can generate OutputDatasetFacets from one of the 
+ * Return a collection of CustomFacetBuilders that can generate OutputDatasetFacets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>createOutputDatasetFacetBuilders(OpenLineageContext context);
 
 /**
- * Return a collection of CustomFacetBuilders that can generate DatasetFacets from one of the 
+ * Return a collection of CustomFacetBuilders that can generate DatasetFacets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<CustomFacetBuilder<?, ? extends DatasetFacet>> createDatasetFacetBuilders(OpenLineageContext context);
 
 /**
- * Return a collection of CustomFacetBuilders that can generate RunFacets from one of the 
+ * Return a collection of CustomFacetBuilders that can generate RunFacets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<CustomFacetBuilder<?, ? extends RunFacet>> createRunFacetBuilders(OpenLineageContext context);
 
 /**
- * Return a collection of CustomFacetBuilders that can generate JobFacets from one of the 
+ * Return a collection of CustomFacetBuilders that can generate JobFacets from one of the
  * pre-defined Spark types accessible from SparkListenerEvents (see below)
  */
 Collection<CustomFacetBuilder<?, ? extends JobFacet>> createJobFacetBuilders(OpenLineageContext context);
@@ -211,46 +220,46 @@ for specifics on each method.
 
 ### [`QueryPlanVisitor`](src/main/common/java/io/openlineage/spark/api/QueryPlanVisitor.java)
 QueryPlanVisitors evaluate nodes of a Spark `LogicalPlan` and attempt to generate `InputDataset`s or
-`OutputDataset`s from the information found in the `LogicalPlan` nodes. This is the most common 
-abstraction present in the OpenLineage Spark library and many examples can be found in the 
-`io.openlineage.spark.agent.lifecycle.plan` package - examples include the 
+`OutputDataset`s from the information found in the `LogicalPlan` nodes. This is the most common
+abstraction present in the OpenLineage Spark library and many examples can be found in the
+`io.openlineage.spark.agent.lifecycle.plan` package - examples include the
 [`BigQueryNodeVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeVisitor.java),
 the [`KafkaRelationVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java)
 and the [`InsertIntoHiveTableVisitor`](src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java).
 
 `QueryPlanVisitor`s implement Scala's `PartialFunction` interface and are tested against every node
-of a Spark query's optimized `LogicalPlan`. Each invocation will expect either an `InputDataset` 
-or an `OutputDataset`. If a node can be either an `InputDataset` or an `OutputDataset`, the 
-constructor should accept a `DatasetFactory` so that the correct dataset type is generated at 
-runtime. 
+of a Spark query's optimized `LogicalPlan`. Each invocation will expect either an `InputDataset`
+or an `OutputDataset`. If a node can be either an `InputDataset` or an `OutputDataset`, the
+constructor should accept a `DatasetFactory` so that the correct dataset type is generated at
+runtime.
 
 `QueryPlanVisitor`s can attach facets to the Datasets created, e.g., `SchemaDatasetFacet` and
 `DatasourceDatasetFacet` are typically attached to the dataset when it is created. Custom facets
-can also be attached, though `CustomFacetBuilder`s _may_ override facets attached directly to the 
+can also be attached, though `CustomFacetBuilder`s _may_ override facets attached directly to the
 dataset.
 
 ### [`InputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java) and [`OutputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java)
-Similar to the `QueryPlanVisitor`s, `InputDatasetBuilder`s and `OutputDatasetBuilder`s are 
+Similar to the `QueryPlanVisitor`s, `InputDatasetBuilder`s and `OutputDatasetBuilder`s are
 `PartialFunction`s defined for a specific input (see below for the list of Spark listener events and
-scheduler objects that can be passed to a builder) that can generate either an `InputDataset` or an 
+scheduler objects that can be passed to a builder) that can generate either an `InputDataset` or an
 `OutputDataset`. Though not strictly necessary, the abstract base classes
-[`AbstractInputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java) 
+[`AbstractInputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java)
 and [`AbstractOutputDatasetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java)
 are available for builders to extend.
 
 ### [`CustomFacetBuilder`](src/main/common/java/io/openlineage/spark/api/CustomFacetBuilder.java)
 CustomFacetBuilders evaluate Spark event types and scheduler objects (see below) to construct custom
 facets. CustomFacetBuilders are used to create `InputDatsetFacet`s, `OutputDatsetFacet`s,
-`DatsetFacet`s, `RunFacet`s, and `JobFacet`s. A few examples can be found in the 
+`DatsetFacet`s, `RunFacet`s, and `JobFacet`s. A few examples can be found in the
 [`io.openlineage.spark.agent.facets.builder`](src/main/common/java/io/openlineage/spark/agent/facets/builder)
 package, including the [`ErrorFacetBuilder`](src/main/common/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilder.java)
 and the [`LogicalPlanRunFacetBuilder`](src/main/common/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java).
 `CustomFacetBuilder`s are not `PartialFunction` implementations, but do define the `isDefinedAt(Object)`
 method to determine whether a given input is valid for the function. They implement the `BiConsumer`
-interface, accepting the valid input argument, and a `BiConsumer<String, Facet>` consumer, which 
+interface, accepting the valid input argument, and a `BiConsumer<String, Facet>` consumer, which
 accepts the name and value of any custom facet that should be attached to the OpenLineage run.
-There is no limit to the number of facets that can be reported by a given `CustomFacetBuilder`. 
-Facet names that conflict will overwrite previously reported facets if they are reported for the 
+There is no limit to the number of facets that can be reported by a given `CustomFacetBuilder`.
+Facet names that conflict will overwrite previously reported facets if they are reported for the
 same Spark event.
 Though not strictly necessary, the following abstract base classes are available for extension:
 * [`AbstractJobFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java)
@@ -259,20 +268,20 @@ Though not strictly necessary, the following abstract base classes are available
 * [`AbstractOutputDatasetFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java)
 * [`AbstractDatasetFacetBuilder`s](integration/spark/src/main/common/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java)
 
-Input/Output/Dataset facets returned are attached to _any_ Input/Output Dataset found for a given 
-Spark event. Typically, a Spark job only has one `OutputDataset`, so any `OutputDatasetFacet` 
+Input/Output/Dataset facets returned are attached to _any_ Input/Output Dataset found for a given
+Spark event. Typically, a Spark job only has one `OutputDataset`, so any `OutputDatasetFacet`
 generated will be attached to that `OutputDataset`. However, Spark jobs often have multiple
 `InputDataset`s. Typically, an `InputDataset` is read within a single Spark `Stage`, and any metrics
-pertaining to that dataset may be present in the `StageInfo#taskMetrics()` for that `Stage`. 
+pertaining to that dataset may be present in the `StageInfo#taskMetrics()` for that `Stage`.
 Accumulators pertaining to a dataset should be reported in the task metrics for a stage so that the
 `CustomFacetBuilder` can match against the `StageInfo` and retrieve the task metrics for that stage
 when generating the `InputDatasetFacet`. Other facet information is often found by analyzing the
 `RDD` that reads the raw data for a dataset. `CustomFacetBuilder`s that generate these facets should
-be defined for the specific subclass of `RDD` that is used to read the target dataset - e.g., 
-`HadoopRDD`, `BigQueryRDD`, or `JdbcRDD`. 
+be defined for the specific subclass of `RDD` that is used to read the target dataset - e.g.,
+`HadoopRDD`, `BigQueryRDD`, or `JdbcRDD`.
 
 ### Function Argument Types
-`CustomFacetBuilder`s and dataset builders can be defined for the following set of Spark listener 
+`CustomFacetBuilder`s and dataset builders can be defined for the following set of Spark listener
 event types and scheduler types:
 
 * `org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart`
@@ -284,8 +293,8 @@ event types and scheduler types:
 * `org.apache.spark.scheduler.StageInfo`
 * `org.apache.spark.scheduler.ActiveJob`
 
-Note that `RDD`s are "unwrapped" prior to being evaluated by builders, so there's no need to, e.g., 
+Note that `RDD`s are "unwrapped" prior to being evaluated by builders, so there's no need to, e.g.,
 check a `MapPartitionsRDD`'s dependencies. The `RDD` for each `Stage` can be evaluated when a
-`org.apache.spark.scheduler.SparkListenerStageCompleted` event occurs. When a 
+`org.apache.spark.scheduler.SparkListenerStageCompleted` event occurs. When a
 `org.apache.spark.scheduler.SparkListenerJobEnd` event is encountered, the last `Stage` for the
-`ActiveJob` can be evaluated. 
+`ActiveJob` can be evaluated.


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Currently, building the Spark integration on the main branch fails with the following error.

```
$ cd integration/spark
$ ./gradlew clean compileJava

...

> Task :compileJava FAILED
/home/sekikn/repos/OpenLineage/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java:142: error: method newDatasetFacets in class OpenLineage cannot be applied to given types;
                        .newDatasetFacets(
                        ^
  required: DocumentationDatasetFacet,DatasourceDatasetFacet,DatasetVersionDatasetFacet,SchemaDatasetFacet,StorageDatasetFacet,ColumnLineageDatasetFacet,LifecycleStateChangeDatasetFacet
  found: DocumentationDatasetFacet,DatasourceDatasetFacet,DatasetVersionDatasetFacet,SchemaDatasetFacet,<null>,LifecycleStateChangeDatasetFacet
  reason: actual and formal argument lists differ in length
/home/sekikn/repos/OpenLineage/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java:48: error: method newDatasetFacets in class OpenLineage cannot be applied to given types;
                        .newDatasetFacets(
                        ^
  required: DocumentationDatasetFacet,DatasourceDatasetFacet,DatasetVersionDatasetFacet,SchemaDatasetFacet,StorageDatasetFacet,ColumnLineageDatasetFacet,LifecycleStateChangeDatasetFacet
  found: DocumentationDatasetFacet,DatasourceDatasetFacet,DatasetVersionDatasetFacet,SchemaDatasetFacet,<null>,LifecycleStateChangeDatasetFacet
  reason: actual and formal argument lists differ in length
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 2s
3 actionable tasks: 3 executed
```

But the ColumnLineageDatasetFacet class in question is not defined anywhere. I guess it's included in a jar file which is implicitly downloaded from datakin.jfrog.io.

### Solution

To avoid this problem, developers can install openlineage-java into the local maven repository in advance.

```
$ cd ../../client/java
$ ./gradlew publishToMavenLocal

...

> Task :generateCode
[main] INFO io.openlineage.client.Generator - Generating code for schemas:
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/OpenLineage.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/StorageDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DatasetVersionDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DocumentationDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/SchemaDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/LifecycleStateChangeDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DatasourceDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DataQualityAssertionsDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/OutputStatisticsOutputDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/SQLJobFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DataQualityMetricsInputDatasetFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/SourceCodeJobFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/SourceCodeLocationJobFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/ParentRunFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/DocumentationJobFacet.json
file:/home/sekikn/repos/OpenLineage/client/java/../../spec/facets/NominalTimeRunFacet.json
[main] WARN io.openlineage.client.Generator - This version of the spec is not published yet: https://openlineage.io/spec/facets/1-0-0/LifecycleStateChangeDatasetFacet.json
[main] WARN io.openlineage.client.Generator - This version of the spec is not published yet: https://openlineage.io/spec/facets/1-0-0/SourceCodeJobFacet.json

BUILD SUCCESSFUL in 2s
12 actionable tasks: 4 executed, 8 up-to-date
$ ls ~/.m2/repository/io/openlineage/openlineage-java/0.8.0-SNAPSHOT
maven-metadata-local.xml             openlineage-java-0.8.0-SNAPSHOT-javadoc.jar  openlineage-java-0.8.0-SNAPSHOT.pom
openlineage-java-0.8.0-SNAPSHOT.jar  openlineage-java-0.8.0-SNAPSHOT.module       openlineage-java-0.8.0-SNAPSHOT-sources.jar
$ cd -
/home/sekikn/repos/OpenLineage/integration/spark
$ ./gradlew clean compileJava

> Task :compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :compileSpark3Java
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :compileSpark2Java
Note: /home/sekikn/repos/OpenLineage/integration/spark/src/main/spark2/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4s
5 actionable tasks: 5 executed
```

But this workaround is not mentioned in integration/spark/README.md, so I'd like to add it so that other developers can avoid the same problem.
In addition, that file has many CR+LF newline characters, so CRs should be removed.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)