### PR TITLE
Fix CircleCI to generate config for release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,3 +106,10 @@ workflows:
   schedule_workflow:
     jobs:
       - determine_changed_modules
+      - continuation/continue:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+          configuration_path: .circleci/continue_config.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -468,25 +468,66 @@ jobs:
 workflows:
   release:
     # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
-    when:
-      matches:
-        value: << pipeline.git.tag >>
-        pattern: ^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$
     jobs:
       - release-client-java:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
           context: release
       - release-integration-spark:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
           context: release
           requires:
             - release-client-java
       - release-proxy-backend:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
           context: release
-      - build-client-python
-      - build-integration-common
-      - build-integration-airflow
-      - build-integration-dbt
-      - build-integration-dagster
+      - build-client-python:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-common:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-airflow:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-dbt:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-dagster:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
       - release-python:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
           context: release
           requires:
             - build-client-python


### PR DESCRIPTION
### Problem
As called out in https://discuss.circleci.com/t/dynamic-config-git-tag-not-running-workflow/40475 , workflows don't trigger for tags unless the jobs include the tag filter. This includes the setup workflow used for dynamic configs. I added a release step that uses the raw `continue_config.yml` config unmodified and added the required filter for each job. (note, we can't use the anchor syntax because `yq` chokes on it - it's a small amount of copy/paste and I actually find it more readable anyway)

See the workflow generated at https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/2974 (I temporarily pushed a `0.7.0` tag to this branch for testing).

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)