### PR TITLE
[INTEGRATION][COMMON] Improve SqlParser to extract output table more precisely

### DIFF
--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -178,6 +178,42 @@ def test_parse_simple_insert_into_select():
     assert sql_meta.out_tables == [DbTableMeta('table1')]
 
 
+def test_parse_simple_insert():
+    sql_meta = parse(
+        '''
+        INSERT table0 (col0, col1, col2)
+        VALUES (val0, val1, val2);
+        '''
+    )
+
+    assert sql_meta.in_tables == []
+    assert sql_meta.out_tables == [DbTableMeta('table0')]
+
+
+def test_parse_simple_insert_select():
+    sql_meta = parse(
+        '''
+        INSERT table1 (col0, col1, col2)
+        SELECT col0, col1, col2
+          FROM table0;
+        '''
+    )
+
+    assert sql_meta.in_tables == [DbTableMeta('table0')]
+    assert sql_meta.out_tables == [DbTableMeta('table1')]
+
+
+def test_parse_simple_update():
+    sql_meta = parse(
+        '''
+        UPDATE table0 SET col0 = val0 WHERE col1 = val1
+        '''
+    )
+
+    assert sql_meta.in_tables == []
+    assert sql_meta.out_tables == [DbTableMeta('table0')]
+
+
 def test_parse_simple_cte():
     sql_meta = parse(
         '''


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Currently, SqlParser uses `INTO` as the only keyword to extract output table. But it can't deal with the following cases.

* For BigQuery, `INTO` after `INSERT` (and also `MERGE`) can be omitted.
  https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#insert_statement

* BigQuery and Snowflake support the `UPDATE` statement, which is not accompanied with `INTO`.

### Solution

With this PR, SqlParser can extract output tables correctly from the INSERT w/o INTO and UPDATE statements.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)