### PR TITLE
bigquery: use client from Airflow hook when possible

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -89,6 +89,10 @@ class BigQueryExtractor(BaseExtractor):
         # Get client using Airflow hook - this way we use the same credentials as Airflow
         if hasattr(self.operator, 'hook') and self.operator.hook:
             hook = self.operator.hook
+            return hook.get_client(
+                project_id=hook.project_id,
+                location=hook.location
+            )
         elif parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"):
             BigQueryHook = try_import_from_string(
                 'airflow.providers.google.cloud.operators.bigquery.BigQueryHook'


### PR DESCRIPTION
This PR makes bigquery integration for Airflow reuse hook code that provides BigQuery client.

By doing that, we use "proven" connection instead of relying on `GOOGLE_APPLICATION_CREDENTIALS` which are one of the few different methods of specifying BigQuery connection in Airflow - for example, providing keyfile json in UI.

Additionally, this solves issue of using proper query location that @collado-mike raised.

Closes: https://github.com/OpenLineage/OpenLineage/issues/649

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>