### PR TITLE
ci: set up proper java client for Spark snapshot release

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -76,7 +76,7 @@ jobs:
   release-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:8
     steps:
       - *checkout_project_root
       - run: |
@@ -98,7 +98,7 @@ jobs:
   publish-snapshot-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:8
     steps:
       - *checkout_project_root
       - run: |
@@ -108,11 +108,15 @@ jobs:
           export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
           # Publish *.jar
           ./gradlew --no-daemon publish
+      - save_cache:
+          key: v1-release-client-java-snapshot-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/.m2
 
   release-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8
     steps:
       - *checkout_project_root
       - restore_cache:
@@ -134,14 +138,21 @@ jobs:
   publish-snapshot-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:8
     steps:
       - *checkout_project_root
+      - restore_cache:
+          keys:
+            - v1-release-client-java-snapshot-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-snapshot-{{ .Branch }}
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
           export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
           export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
+          cd ../../client/java
+          ./gradlew --no-daemon publishToMavenLocal
+          cd -
           # Publish *.jar
           ./gradlew --no-daemon publish
 


### PR DESCRIPTION
Currently, Spark snapshot release process fails because it does not use properly build Java OpenLineage client.

https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/3011/workflows/4c48c43d-f170-4af2-ac14-8a23d2d6c3ab/jobs/28281

This PR fixes that, by building snapshot in the same way as regular release. 

Additionally, it moves release process from deprecated `circleci/openjdk` images to supported `cimg/openjdk` ones.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

