### PR TITLE
airflow: adding custom extractors in one variable separated by comma

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -129,14 +129,9 @@ provide custom extractors. They should derive from `BaseExtractor`.
 
 There are two ways to register them for use in `openlineage-airflow`. 
 
-First one, is to provide environment variable in pattern of 
+First one, is to add them to `OPENLINEAGE_EXTRACTORS` environment variable, separated by comma `(;)` 
 ```
-OPENLINEAGE_EXTRACTOR_<name>=full.path.to.ExtractorClass
-```
-
-For example: 
-```
-OPENLINEAGE_EXTRACTOR_POSTGRES_OPERATOR=openlineage.airflow.extractors.postgres_extractor.PostgresExtractor
+OPENLINEAGE_EXTRACTORS=full.path.to.ExtractorClass;full.path.to.AnotherExtractorClass
 ```
 
 Second one - working in Airflow 1.10.x only - is to register all additional operator-extractor pairings by 

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -66,6 +66,16 @@ class Extractors:
             for operator_class in patcher.get_operator_classnames():
                 self.patchers[operator_class] = patcher
 
+        # Comma-separated extractors in OPENLINEAGE_EXTRACTORS variable.
+        # Extractors should
+        env_extractors = os.getenv("OPENLINEAGE_EXTRACTORS")
+        if env_extractors is not None:
+            for extractor in env_extractors.split(';'):
+                extractor = import_from_string(extractor)
+                for operator_class in extractor.get_operator_classnames():
+                    self.extractors[operator_class] = extractor
+
+        # Previous way of adding extractors
         # Adding operator: extractor pairs registered via environmental variable in pattern
         # OPENLINEAGE_EXTRACTOR_<operator>=<path.to.ExtractorClass>
         # The value in extractor map is extractor class type - it needs to be instantiated.

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -2,6 +2,7 @@
 
 import os
 from typing import List, Optional
+from unittest.mock import patch
 
 from openlineage.airflow.extractors import Extractors, BaseExtractor, TaskMetadata
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
@@ -16,6 +17,15 @@ class FakeExtractor(BaseExtractor):
         return ['TestOperator']
 
 
+class AnotherFakeExtractor(BaseExtractor):
+    def extract(self) -> Optional[TaskMetadata]:
+        return None
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['AnotherTestOperator']
+
+
 def test_basic_extractor():
     class PostgresOperator:
         pass
@@ -23,7 +33,19 @@ def test_basic_extractor():
     assert Extractors().get_extractor_class(PostgresOperator)
 
 
-def test_env_extractors():
+def test_env_add_extractor():
+    assert len(Extractors().extractors) == 7
+    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor"}):  # noqa
+        assert len(Extractors().extractors) == 8
+
+
+def test_env_multiple_extractors():
+    assert len(Extractors().extractors) == 7
+    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;tests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
+        assert len(Extractors().extractors) == 9
+
+
+def test_env_old_method_extractors():
     assert len(Extractors().extractors) == 7
 
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -31,7 +31,7 @@ x-airflow-base: &airflow-base
     GOOGLE_APPLICATION_CREDENTIALS: /opt/config/gcloud/gcloud-service-key.json
     OPENLINEAGE_URL: http://backend:5000
     OPENLINEAGE_NAMESPACE: food_delivery
-    OPENLINEAGE_EXTRACTOR_CustomOperator: custom_extractor.CustomExtractor
+    OPENLINEAGE_EXTRACTORS: custom_extractor.CustomExtractor
     SNOWFLAKE_ACCOUNT_ID: ${SNOWFLAKE_ACCOUNT_ID}
     SNOWFLAKE_USER: ${SNOWFLAKE_USER}
     SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD}


### PR DESCRIPTION
Implements adding custom extractors in one env variable, separated by comma.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/685