### PR TITLE
Fix test_dag_location to work with forked repository

### DIFF
--- a/integration/airflow/tests/test_location.py
+++ b/integration/airflow/tests/test_location.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import logging
+import re
 import sys
 from unittest.mock import patch
 
@@ -14,9 +15,9 @@ log = logging.getLogger(__name__)
 @patch('openlineage.airflow.utils.execute_git',
        side_effect=execute_git_mock)
 def test_dag_location(git_mock):
-    assert ('https://github.com/OpenLineage/OpenLineage/blob/'
-            'abcd1234/integration/airflow/tests/test_dags/'
-            'test_dag.py' == get_location("tests/test_dags/test_dag.py"))
+    assert re.match(r'https://github.com/[^/]+/OpenLineage/blob/'
+                    'abcd1234/integration/airflow/tests/test_dags/test_dag.py',
+                    get_location("tests/test_dags/test_dag.py"))
 
 
 @patch('openlineage.airflow.utils.execute_git',


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

While I was trying to set up the CI pipeline using my repository forked from github.com/OpenLineage/OpenLineage, I came across the following failure.

```
______________________________ test_dag_location _______________________________

git_mock = <MagicMock name='execute_git' id='140598011155664'>

    @patch('openlineage.airflow.utils.execute_git',
           side_effect=execute_git_mock)
    def test_dag_location(git_mock):
>       assert ('https://github.com/OpenLineage/OpenLineage/blob/'
                'abcd1234/integration/airflow/tests/test_dags/'
                'test_dag.py' == get_location("tests/test_dags/test_dag.py"))
E       AssertionError: assert 'https://gith...s/test_dag.py' == 'https://gith...s/test_dag.py'
E         - https://github.com/sekikn/OpenLineage/blob/abcd1234/integration/airflow/tests/test_dags/test_dag.py
E         ?                    ^ ^ -
E         + https://github.com/OpenLineage/OpenLineage/blob/abcd1234/integration/airflow/tests/test_dags/test_dag.py
E         ?                    ^^ ^^  ++++

tests/test_location.py:17: AssertionError
```

This is because the owner is changed for a forked repository.

### Solution

I'd like to propose to loosen the success condition of the test above to ignore the repository owner for the convenience of contributors, as the submitted PR.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)