### PR TITLE
[INTEGRATION][SPARK] column lineage core mechanism

### DIFF
--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageBuilder.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageBuilder.java
@@ -1,0 +1,200 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacetFields;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Builder class used to store information required to build {@link
+ * ColumnLineageDatasetFacetFields}. Single instance of the class is passed when traversing logical
+ * plan. It stores input fields, output fields and dependencies between the expressions in {@link
+ * LogicalPlan}. Dependency between expressions are used to identify inputs used to evaluate
+ * specific output field.
+ */
+@Slf4j
+public class ColumnLevelLineageBuilder {
+
+  private Map<ExprId, Set<ExprId>> exprDependencies = new HashMap<>();
+  private Map<ExprId, List<Pair<DatasetIdentifier, String>>> inputs = new HashMap<>();
+  private Map<StructField, ExprId> outputs = new HashMap<>();
+  private final StructType schema;
+  private final OpenLineageContext context;
+
+  ColumnLevelLineageBuilder(StructType schema, OpenLineageContext context) {
+    this.schema = schema;
+    this.context = context;
+  }
+
+  /**
+   * Adds input field.
+   *
+   * @param exprId
+   * @param datasetIdentifier
+   * @param attributeName
+   */
+  public void addInput(ExprId exprId, DatasetIdentifier datasetIdentifier, String attributeName) {
+    if (!inputs.containsKey(exprId)) {
+      inputs.put(exprId, new LinkedList<>());
+    }
+    inputs.get(exprId).add(Pair.of(datasetIdentifier, attributeName));
+  }
+
+  /**
+   * Adds output field.
+   *
+   * @param exprId
+   * @param attributeName
+   */
+  public void addOutput(ExprId exprId, String attributeName) {
+    Arrays.stream(schema.fields())
+        .filter(field -> field.name().equals(attributeName))
+        .findAny()
+        .ifPresent(field -> outputs.put(field, exprId));
+  }
+
+  /**
+   * Add dependency between parent expression and child expression. Evaluation of parent requires
+   * child.
+   *
+   * @param parent
+   * @param child
+   */
+  public void addDependency(ExprId parent, ExprId child) {
+    if (!exprDependencies.containsKey(parent)) {
+      exprDependencies.put(parent, new HashSet<>());
+    }
+    exprDependencies.get(parent).add(child);
+  }
+
+  public boolean hasOutputs() {
+    return !outputs.isEmpty();
+  }
+
+  @SneakyThrows
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    ObjectMapper mapper = new ObjectMapper();
+    sb.append("Inputs: ").append(mapper.writeValueAsString(inputs)).append(System.lineSeparator());
+    sb.append("Dependencies: ")
+        .append(
+            mapper.writeValueAsString(
+                exprDependencies.entrySet().stream()
+                    .collect(
+                        Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.toString())) // need to call toString method explicitly
+                ))
+        .append(System.lineSeparator());
+
+    sb.append("Outputs: ")
+        .append(
+            mapper.writeValueAsString(
+                outputs.entrySet().stream()
+                    .collect(
+                        Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> e.toString())) // need to call toString method explicitly
+                ))
+        .append(System.lineSeparator());
+
+    return sb.toString();
+  }
+
+  /**
+   * Builds {@link ColumnLineageDatasetFacetFields} to be included in dataset facet.
+   *
+   * @return
+   */
+  public ColumnLineageDatasetFacetFields build() {
+    OpenLineage.ColumnLineageDatasetFacetFieldsBuilder fieldsBuilder =
+        context.getOpenLineage().newColumnLineageDatasetFacetFieldsBuilder();
+
+    Arrays.stream(schema.fields())
+        .map(field -> Pair.of(field, getInputsUsedFor(field.name())))
+        .filter(pair -> !pair.getRight().isEmpty())
+        .map(pair -> Pair.of(pair.getLeft(), facetInputFields(pair.getRight())))
+        .forEach(
+            pair ->
+                fieldsBuilder.put(
+                    pair.getLeft().name(),
+                    context
+                        .getOpenLineage()
+                        .newColumnLineageDatasetFacetFieldsAdditionalBuilder()
+                        .inputFields(pair.getRight())
+                        .build()));
+
+    return fieldsBuilder.build();
+  }
+
+  private List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetInputFields(
+      List<Pair<DatasetIdentifier, String>> inputFields) {
+    return inputFields.stream()
+        .map(
+            field ->
+                new OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFieldsBuilder()
+                    .namespace(field.getLeft().getNamespace())
+                    .name(field.getLeft().getName())
+                    .field(field.getRight())
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  List<Pair<DatasetIdentifier, String>> getInputsUsedFor(String outputName) {
+    Optional<StructField> outputField =
+        Arrays.stream(schema.fields())
+            .filter(field -> field.name().equalsIgnoreCase(outputName))
+            .findAny();
+
+    if (!outputField.isPresent() || !outputs.containsKey(outputField.get())) {
+      return Collections.emptyList();
+    }
+
+    return findDependentInputs(outputs.get(outputField.get())).stream()
+        .filter(inputExprId -> inputs.containsKey(inputExprId))
+        .flatMap(inputExprId -> inputs.get(inputExprId).stream())
+        .filter(Objects::nonNull)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  private List<ExprId> findDependentInputs(ExprId outputExprId) {
+    List<ExprId> dependentInputs = new LinkedList<>();
+    dependentInputs.add(outputExprId);
+    boolean continueSearch = true;
+
+    while (continueSearch) {
+      Set<ExprId> newDependentInputs =
+          dependentInputs.stream()
+              .filter(exprId -> exprDependencies.containsKey(exprId))
+              .flatMap(exprId -> exprDependencies.get(exprId).stream())
+              .filter(exprId -> !dependentInputs.contains(exprId)) // filter already added
+              .collect(Collectors.toSet());
+
+      dependentInputs.addAll(newDependentInputs);
+      continueSearch = !newDependentInputs.isEmpty();
+    }
+
+    return dependentInputs;
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtils.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtils.java
@@ -1,0 +1,69 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Utility functions for detecting column level lineage within {@link
+ * org.apache.spark.sql.catalyst.plans.logical.LogicalPlan}.
+ */
+@Slf4j
+public class ColumnLevelLineageUtils {
+
+  public static Optional<OpenLineage.ColumnLineageDatasetFacet> buildColumnLineageDatasetFacet(
+      OpenLineageContext context, StructType outputSchema) {
+    if (!context.getQueryExecution().isPresent()
+        || context.getQueryExecution().get().optimizedPlan() == null) {
+      return Optional.empty();
+    }
+
+    ColumnLevelLineageBuilder builder = new ColumnLevelLineageBuilder(outputSchema, context);
+    LogicalPlan plan = context.getQueryExecution().get().optimizedPlan();
+
+    new ExpressionDependencyCollector(plan).collect(builder);
+    new OutputFieldsCollector(plan).collect(builder);
+    new InputFieldsCollector(plan, context).collect(builder);
+
+    OpenLineage.ColumnLineageDatasetFacetBuilder facetBuilder =
+        context.getOpenLineage().newColumnLineageDatasetFacetBuilder();
+
+    facetBuilder.fields(builder.build());
+    OpenLineage.ColumnLineageDatasetFacet facet = facetBuilder.build();
+
+    if (facet.getFields().getAdditionalProperties().isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.of(facetBuilder.build());
+    }
+  }
+
+  public static OpenLineage.OutputDataset rewriteOutputDataset(
+      OpenLineage.OutputDataset outputDataset,
+      OpenLineage.ColumnLineageDatasetFacet columnLineageDatasetFacet) {
+    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
+        new OpenLineage.DatasetFacetsBuilder()
+            .documentation(outputDataset.getFacets().getDocumentation())
+            .version(outputDataset.getFacets().getVersion())
+            .schema(outputDataset.getFacets().getSchema())
+            .dataSource(outputDataset.getFacets().getDataSource())
+            .lifecycleStateChange(outputDataset.getFacets().getLifecycleStateChange())
+            .storage(outputDataset.getFacets().getStorage())
+            .columnLineage(columnLineageDatasetFacet);
+
+    outputDataset
+        .getFacets()
+        .getAdditionalProperties()
+        .forEach((key, value) -> datasetFacetsBuilder.put(key, value));
+
+    return new OpenLineage.OutputDatasetBuilder()
+        .name(outputDataset.getName())
+        .namespace(outputDataset.getNamespace())
+        .outputFacets(outputDataset.getOutputFacets())
+        .facets(datasetFacetsBuilder.build())
+        .build();
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ExpressionDependencyCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ExpressionDependencyCollector.java
@@ -1,0 +1,73 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.ExpressionDependencyVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.IcebergMergeIntoDependencyVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.UnionDependencyVisitor;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression;
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+
+/**
+ * Traverses LogicalPlan and collects dependencies between the expressions and operations used
+ * within the plan.
+ */
+@Slf4j
+public class ExpressionDependencyCollector {
+
+  private final LogicalPlan plan;
+  private final List<ExpressionDependencyVisitor> expressionDependencyVisitors =
+      Arrays.asList(new UnionDependencyVisitor(), new IcebergMergeIntoDependencyVisitor());
+
+  ExpressionDependencyCollector(LogicalPlan plan) {
+    this.plan = plan;
+  }
+
+  void collect(ColumnLevelLineageBuilder builder) {
+    plan.foreach(
+        node -> {
+          expressionDependencyVisitors.stream()
+              .filter(collector -> collector.isDefinedAt(node))
+              .forEach(collector -> collector.apply(node, builder));
+
+          List<NamedExpression> expressions = new LinkedList<>();
+          if (node instanceof Project) {
+            expressions.addAll(
+                ScalaConversionUtils.<NamedExpression>fromSeq(((Project) node).projectList()));
+          } else if (node instanceof Aggregate) {
+            expressions.addAll(
+                ScalaConversionUtils.<NamedExpression>fromSeq(
+                    ((Aggregate) node).aggregateExpressions()));
+          }
+          expressions.stream()
+              .forEach(expr -> traverseExpression((Expression) expr, expr.exprId(), builder));
+          return scala.runtime.BoxedUnit.UNIT;
+        });
+  }
+
+  public static void traverseExpression(
+      Expression expr, ExprId ancestorId, ColumnLevelLineageBuilder builder) {
+    if (expr instanceof NamedExpression && !((NamedExpression) expr).exprId().equals(ancestorId)) {
+      builder.addDependency(ancestorId, ((NamedExpression) expr).exprId());
+    }
+
+    // discover children expression -> handles UnaryExpressions like Alias
+    if (expr.children() != null) {
+      ScalaConversionUtils.<Expression>fromSeq(expr.children()).stream()
+          .forEach(child -> traverseExpression(child, ancestorId, builder));
+    }
+
+    if (expr instanceof AggregateExpression) {
+      AggregateExpression aggr = (AggregateExpression) expr;
+      builder.addDependency(ancestorId, aggr.resultId());
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/InputFieldsCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/InputFieldsCollector.java
@@ -1,0 +1,109 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import io.openlineage.spark.agent.lifecycle.Rdds;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.plans.logical.LeafNode;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.UnaryNode;
+import org.apache.spark.sql.execution.LogicalRDD;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
+
+/** Traverses LogicalPlan and collect input fields with the corresponding ExprId. */
+@Slf4j
+class InputFieldsCollector {
+
+  private final LogicalPlan plan;
+  private final OpenLineageContext context;
+
+  InputFieldsCollector(LogicalPlan plan, OpenLineageContext context) {
+    this.plan = plan;
+    this.context = context;
+  }
+
+  void collect(ColumnLevelLineageBuilder builder) {
+    collect(plan, builder);
+  }
+
+  void collect(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    discoverInputsFromNode(node, builder);
+
+    // hacky way to replace `node instanceof UnaryNode` which fails for Spark 3.2.1
+    // because of java.lang.IncompatibleClassChangeError: UnaryNode, but class was expected
+    // probably related to single code base for different Spark versions
+    if ((node.getClass()).isAssignableFrom(UnaryNode.class)) {
+      collect(((UnaryNode) node).child(), builder);
+    } else if (node.children() != null) {
+      ScalaConversionUtils.<LogicalPlan>fromSeq(node.children()).stream()
+          .forEach(child -> collect(child, builder));
+    }
+  }
+
+  private void discoverInputsFromNode(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    extractDatasetIdentifier(node).stream()
+        .forEach(
+            di ->
+                ScalaConversionUtils.fromSeq(node.output()).stream()
+                    .filter(attr -> attr instanceof AttributeReference)
+                    .map(attr -> (AttributeReference) attr)
+                    .forEach(attr -> builder.addInput(attr.exprId(), di, attr.name())));
+  }
+
+  private List<DatasetIdentifier> extractDatasetIdentifier(LogicalPlan node) {
+    if (node instanceof DataSourceV2Relation) {
+      return extractDatasetIdentifier((DataSourceV2Relation) node);
+    } else if (node instanceof DataSourceV2ScanRelation) {
+      return extractDatasetIdentifier(((DataSourceV2ScanRelation) node).relation());
+    } else if (node instanceof HiveTableRelation) {
+      return extractDatasetIdentifier(((HiveTableRelation) node).tableMeta());
+    } else if (node instanceof LogicalRelation
+        && ((LogicalRelation) node).catalogTable().isDefined()) {
+      return extractDatasetIdentifier(((LogicalRelation) node).catalogTable().get());
+    } else if (node instanceof LogicalRDD) {
+      return extractDatasetIdentifier((LogicalRDD) node);
+    } else if (node instanceof LeafNode) {
+      log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());
+    }
+    return Collections.emptyList();
+  }
+
+  private List<DatasetIdentifier> extractDatasetIdentifier(LogicalRDD logicalRDD) {
+    List<RDD<?>> fileLikeRdds = Rdds.findFileLikeRdds(logicalRDD.rdd());
+    return PlanUtils.findRDDPaths(fileLikeRdds).stream()
+        .map(
+            path ->
+                new DatasetIdentifier(path.toUri().getPath(), PlanUtils.namespaceUri(path.toUri())))
+        .collect(Collectors.toList());
+  }
+
+  private List<DatasetIdentifier> extractDatasetIdentifier(DataSourceV2Relation relation) {
+    return PlanUtils3.getDatasetIdentifier(context, relation)
+        .map(Collections::singletonList)
+        .orElse(Collections.emptyList());
+  }
+
+  private List<DatasetIdentifier> extractDatasetIdentifier(CatalogTable catalogTable) {
+    URI location = catalogTable.location();
+    if (location == null) {
+      return Collections.emptyList();
+    } else {
+      return Collections.singletonList(
+          new DatasetIdentifier(
+              catalogTable.location().getPath(), PlanUtils.namespaceUri(catalogTable.location())));
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/OutputFieldsCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/OutputFieldsCollector.java
@@ -1,0 +1,48 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+
+/** Class created to collect output fields with the corresponding ExprId from LogicalPlan. */
+class OutputFieldsCollector {
+
+  private final LogicalPlan plan;
+
+  OutputFieldsCollector(LogicalPlan plan) {
+    this.plan = plan;
+  }
+
+  void collect(ColumnLevelLineageBuilder builder) {
+    collect(plan, builder);
+  }
+
+  private void collect(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    List<NamedExpression> expressions =
+        ScalaConversionUtils.fromSeq(plan.output()).stream()
+            .filter(attr -> attr instanceof Attribute)
+            .map(attr -> (Attribute) attr)
+            .collect(Collectors.toList());
+
+    if (plan instanceof Aggregate) {
+      expressions.addAll(
+          ScalaConversionUtils.<NamedExpression>fromSeq(((Aggregate) plan).aggregateExpressions()));
+    } else if (plan instanceof Project) {
+      expressions.addAll(
+          ScalaConversionUtils.<NamedExpression>fromSeq(((Project) plan).projectList()));
+    }
+
+    expressions.stream().forEach(expr -> builder.addOutput(expr.exprId(), expr.name()));
+
+    if (!builder.hasOutputs()) {
+      // extract outputs from the children
+      ScalaConversionUtils.<LogicalPlan>fromSeq(plan.children()).stream()
+          .forEach(childPlan -> collect(childPlan, builder));
+    }
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/ExpressionDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/ExpressionDependencyVisitor.java
@@ -1,0 +1,27 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Interface to visit custom {@link LogicalPlan} nodes to collect expression dependencies within the
+ * plan.
+ */
+public interface ExpressionDependencyVisitor {
+
+  /**
+   * Verifies if the visitor should be applied on the plan
+   *
+   * @param plan
+   * @return
+   */
+  boolean isDefinedAt(LogicalPlan plan);
+
+  /**
+   * Applies the visitor and adds extracted dependencies to {@link ColumnLevelLineageBuilder}
+   *
+   * @param plan
+   * @param builder
+   */
+  void apply(LogicalPlan plan, ColumnLevelLineageBuilder builder);
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/IcebergMergeIntoDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/IcebergMergeIntoDependencyVisitor.java
@@ -1,0 +1,109 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+
+import static io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector.traverseExpression;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import scala.Option;
+import scala.collection.Seq;
+
+/** Custom visitor for `MERGE INTO TABLE` implementation of Iceberg provider. */
+@Slf4j
+public class IcebergMergeIntoDependencyVisitor implements ExpressionDependencyVisitor {
+
+  // https://github.com/apache/iceberg/blob/apache-iceberg-0.13.1/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeRows.scala
+  private static final String MERGE_ROWS_CLASS_NAME =
+      "org.apache.spark.sql.catalyst.plans.logical.MergeRows";
+
+  // https://github.com/apache/iceberg/blob/0.13.x/spark/v3.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeInto.scala
+  private static final String MERGE_INTO_CLASS_NAME =
+      "org.apache.spark.sql.catalyst.plans.logical.MergeInto";
+
+  public boolean isDefinedAt(LogicalPlan plan) {
+    return Arrays.asList(MERGE_INTO_CLASS_NAME, MERGE_ROWS_CLASS_NAME)
+        .contains(plan.getClass().getCanonicalName());
+  }
+
+  public void apply(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    try {
+      String nodeClass = node.getClass().getCanonicalName();
+
+      if (nodeClass.equals(MERGE_ROWS_CLASS_NAME)) {
+        Class mergeRows = Class.forName(MERGE_ROWS_CLASS_NAME);
+        Seq<Seq<Expression>> matched =
+            (Seq<Seq<Expression>>) mergeRows.getMethod("matchedOutputs").invoke(node);
+        Seq<Seq<Expression>> notMatched =
+            (Seq<Seq<Expression>>) mergeRows.getMethod("notMatchedOutputs").invoke(node);
+        collect(
+            node.output(),
+            ScalaConversionUtils.<Seq<Expression>>fromSeq(matched).stream()
+                .map(e -> Option.apply(e))
+                .collect(Collectors.toList()),
+            ScalaConversionUtils.<Seq<Expression>>fromSeq(notMatched).stream()
+                .map(e -> Option.apply(e))
+                .collect(Collectors.toList()),
+            builder);
+      } else if (nodeClass.equals(MERGE_INTO_CLASS_NAME)) {
+        Class mergeInto = Class.forName("org.apache.spark.sql.catalyst.plans.logical.MergeInto");
+        Class mergeIntoParamsClass =
+            Class.forName("org.apache.spark.sql.catalyst.plans.logical.MergeIntoParams");
+        Object mergeIntoParams = mergeInto.getMethod("mergeIntoProcessor").invoke(node);
+
+        Seq<Option<Seq<Expression>>> matched =
+            (Seq<Option<Seq<Expression>>>)
+                mergeIntoParamsClass.getMethod("matchedOutputs").invoke(mergeIntoParams);
+        Seq<Option<Seq<Expression>>> notMatched =
+            (Seq<Option<Seq<Expression>>>)
+                mergeIntoParamsClass.getMethod("notMatchedOutputs").invoke(mergeIntoParams);
+
+        collect(
+            node.output(),
+            ScalaConversionUtils.<Option<Seq<Expression>>>fromSeq(matched),
+            ScalaConversionUtils.<Option<Seq<Expression>>>fromSeq(notMatched),
+            builder);
+      }
+
+    } catch (Exception e) {
+      // do nothing
+      log.error("Collecting dependencies for Iceberg MergeInto failed", e);
+    }
+  }
+
+  void collect(
+      Seq<Attribute> outputSeq,
+      List<Option<Seq<Expression>>> matched,
+      List<Option<Seq<Expression>>> notMatched,
+      ColumnLevelLineageBuilder builder) {
+    Attribute[] output =
+        ScalaConversionUtils.<Attribute>fromSeq(outputSeq).toArray(new Attribute[0]);
+
+    IntStream.range(0, output.length)
+        .forEach(
+            position -> {
+              matched.stream()
+                  .filter(Option::isDefined)
+                  .map(opt -> opt.get())
+                  .filter(exprs -> exprs.size() > position)
+                  .map(exprs -> ScalaConversionUtils.<Expression>fromSeq(exprs).get(position))
+                  .filter(expr -> expr instanceof NamedExpression)
+                  .forEach(expr -> traverseExpression(expr, output[position].exprId(), builder));
+
+              notMatched.stream()
+                  .filter(Option::isDefined)
+                  .map(opt -> opt.get())
+                  .filter(exprs -> exprs.size() > position)
+                  .map(exprs -> ScalaConversionUtils.<Expression>fromSeq(exprs).get(position))
+                  .filter(expr -> expr instanceof NamedExpression)
+                  .forEach(expr -> traverseExpression(expr, output[position].exprId(), builder));
+            });
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/UnionDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/UnionDependencyVisitor.java
@@ -1,0 +1,56 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+
+import static io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector.traverseExpression;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Union;
+
+/**
+ * Extracts expression dependencies from UNION node in {@link LogicalPlan}. Example query 'SELECT *
+ * FROM local.db.t1 UNION SELECT * FROM local.db.t2'. Custom visitor is required because of
+ * transpose operation on unioned datasets within Spark's plan:
+ *
+ * @see <a
+ *     href="https://github.com/apache/spark/blob/v3.2.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala#L306">Spark
+ *     code</a>
+ */
+@Slf4j
+public class UnionDependencyVisitor implements ExpressionDependencyVisitor {
+
+  public boolean isDefinedAt(LogicalPlan plan) {
+    return plan instanceof Union;
+  }
+
+  public void apply(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    Union union = (Union) plan;
+
+    // implement in Java code equivalent to Scala 'children.map(_.output).transpose.map { attrs =>'
+    List<LogicalPlan> children = ScalaConversionUtils.<LogicalPlan>fromSeq(union.children());
+    List<ArrayList<Attribute>> childrenAttributes = new LinkedList<>();
+    children.stream()
+        .map(child -> ScalaConversionUtils.<Attribute>fromSeq(child.output()))
+        .forEach(list -> childrenAttributes.add(new ArrayList<>(list)));
+
+    // max attributes size
+    int maxAttributeSize =
+        childrenAttributes.stream().map(list -> list.size()).max(Integer::compare).get();
+
+    IntStream.range(0, maxAttributeSize)
+        .forEach(
+            position -> {
+              ExprId firstExpr = childrenAttributes.get(0).get(position).exprId();
+              IntStream.range(1, children.size())
+                  .mapToObj(childIndex -> childrenAttributes.get(childIndex).get(position))
+                  .forEach(attr -> traverseExpression(attr, firstExpr, builder));
+            });
+  }
+}

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -35,6 +35,23 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 public class PlanUtils3 {
 
   public static Optional<DatasetIdentifier> getDatasetIdentifier(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    return Optional.of(relation)
+        .filter(r -> r.identifier() != null)
+        .filter(r -> r.identifier().isDefined())
+        .filter(r -> r.catalog() != null)
+        .filter(r -> r.catalog().isDefined())
+        .filter(r -> r.catalog().get() instanceof TableCatalog)
+        .flatMap(
+            r ->
+                PlanUtils3.getDatasetIdentifier(
+                    context,
+                    (TableCatalog) r.catalog().get(),
+                    r.identifier().get(),
+                    r.table().properties()));
+  }
+
+  public static Optional<DatasetIdentifier> getDatasetIdentifier(
       OpenLineageContext context,
       TableCatalog catalog,
       Identifier identifier,

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageBuilderTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageBuilderTest.java
@@ -1,0 +1,153 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.HashMap;
+
+class ColumnLevelLineageBuilderTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+  StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("a", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            new StructField("b", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+          });
+  ColumnLevelLineageBuilder builder = new ColumnLevelLineageBuilder(schema, context);
+
+  ExprId rootExprId = mock(ExprId.class);
+  ExprId childExprId = mock(ExprId.class);
+  ExprId grandChildExprId1 = mock(ExprId.class);
+  ExprId grandChildExprId2 = mock(ExprId.class);
+
+  @BeforeEach
+  public void setup() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+  }
+
+  @Test
+  public void testEmptyOutput() {
+    assertTrue(builder.getInputsUsedFor("non-existing-output").isEmpty());
+  }
+
+  @Test
+  public void testSingleInputSingleOutput() {
+    DatasetIdentifier di = new DatasetIdentifier("t", "db");
+    builder.addOutput(rootExprId, "a");
+    builder.addInput(rootExprId, di, "inputA");
+
+    List<Pair<DatasetIdentifier, String>> inputs = builder.getInputsUsedFor("a");
+
+    assertTrue(builder.hasOutputs());
+    assertEquals(1, inputs.size());
+    assertEquals("inputA", inputs.get(0).getRight());
+    assertEquals(di, inputs.get(0).getLeft());
+  }
+
+  @Test
+  public void testMultipleOutputs() {
+    DatasetIdentifier di = new DatasetIdentifier("t", "db");
+    builder.addOutput(rootExprId, "a");
+    builder.addOutput(rootExprId, "b");
+    builder.addInput(rootExprId, di, "inputA");
+
+    assertEquals(1, builder.getInputsUsedFor("a").size());
+    assertEquals(1, builder.getInputsUsedFor("b").size());
+  }
+
+  @Test
+  public void testMultipleInputsAndSingleOutputWithNestedExpressions() {
+    DatasetIdentifier di1 = new DatasetIdentifier("t1", "db");
+    DatasetIdentifier di2 = new DatasetIdentifier("t2", "db");
+
+    builder.addOutput(rootExprId, "a");
+    builder.addDependency(rootExprId, childExprId);
+    builder.addDependency(childExprId, grandChildExprId1);
+    builder.addDependency(childExprId, grandChildExprId2);
+    builder.addInput(grandChildExprId1, di1, "input1");
+    builder.addInput(grandChildExprId1, di2, "input2");
+
+    List<Pair<DatasetIdentifier, String>> inputs = builder.getInputsUsedFor("a");
+
+    assertTrue(builder.hasOutputs());
+    assertEquals(2, inputs.size());
+    assertEquals("input1", inputs.get(0).getRight());
+    assertEquals("input2", inputs.get(1).getRight());
+    assertEquals(di1, inputs.get(0).getLeft());
+    assertEquals(di2, inputs.get(1).getLeft());
+  }
+
+  @Test
+  public void testCycledExpressionDependency() {
+    builder.addOutput(rootExprId, "a");
+    builder.addDependency(rootExprId, childExprId);
+    builder.addDependency(childExprId, rootExprId); // cycle that should not happen
+
+    List<Pair<DatasetIdentifier, String>> inputs = builder.getInputsUsedFor("a");
+    assertEquals(0, inputs.size());
+  }
+
+  @Test
+  public void testBuild() {
+    DatasetIdentifier diA = new DatasetIdentifier("tableA", "db");
+    DatasetIdentifier diB = new DatasetIdentifier("tableB", "db");
+
+    builder.addOutput(rootExprId, "a");
+    builder.addInput(rootExprId, diA, "inputA");
+    builder.addInput(rootExprId, diB, "inputB");
+
+    List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetFields =
+        builder.build().getAdditionalProperties().get("a").getInputFields();
+
+    assertEquals(2, facetFields.size());
+
+    assertEquals("db", facetFields.get(0).getNamespace());
+    assertEquals("tableA", facetFields.get(0).getName());
+    assertEquals("inputA", facetFields.get(0).getField());
+
+    assertEquals("db", facetFields.get(0).getNamespace());
+    assertEquals("tableA", facetFields.get(0).getName());
+    assertEquals("inputA", facetFields.get(0).getField());
+  }
+
+  @Test
+  public void testBuildWithEmptyInputs() {
+    builder.addOutput(rootExprId, "a");
+    builder.addDependency(rootExprId, childExprId);
+
+    // no inputs
+    assertEquals(0, builder.build().getAdditionalProperties().size());
+  }
+
+  @Test
+  public void testBuildWithDuplicatedInputs() {
+    DatasetIdentifier di = new DatasetIdentifier("tableA", "db");
+
+    builder.addOutput(rootExprId, "a");
+    builder.addInput(rootExprId, di, "inputA");
+    builder.addInput(childExprId, di, "inputA"); // the same input with different exprId
+    builder.addDependency(rootExprId, childExprId);
+
+    List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetFields =
+        builder.build().getAdditionalProperties().get("a").getInputFields();
+
+    assertEquals(1, facetFields.size());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtilsNonV2CatalogTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtilsNonV2CatalogTest.java
@@ -1,0 +1,131 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.LastQueryExecutionSparkEventListener;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SparkSession$;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.HashMap;
+
+@Slf4j
+public class ColumnLevelLineageUtilsNonV2CatalogTest {
+
+  SparkSession spark;
+  OpenLineageContext context;
+  QueryExecution queryExecution = mock(QueryExecution.class);
+
+  StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("a", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            new StructField("b", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+          });
+
+  @BeforeAll
+  @SneakyThrows
+  public static void beforeAll() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
+  @AfterAll
+  @SneakyThrows
+  public static void afterAll() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
+  @BeforeEach
+  @SneakyThrows
+  public void beforeEach() {
+    spark =
+        SparkSession.builder()
+            .master("local[*]")
+            .appName("ColumnLevelLineage")
+            .config("spark.extraListeners", LastQueryExecutionSparkEventListener.class.getName())
+            .config("spark.driver.host", "127.0.0.1")
+            .config("spark.driver.bindAddress", "127.0.0.1")
+            .config("spark.driver.extraJavaOptions", "-Dderby.system.home=/tmp/derby")
+            .enableHiveSupport()
+            .getOrCreate();
+
+    context =
+        OpenLineageContext.builder()
+            .sparkSession(Optional.of(spark))
+            .sparkContext(spark.sparkContext())
+            .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+            .queryExecution(queryExecution)
+            .build();
+
+    FileSystem.get(spark.sparkContext().hadoopConfiguration())
+        .delete(new Path("/tmp/column_non_v2/"), true);
+
+    spark.sql("DROP TABLE IF EXISTS t1");
+    spark.sql("DROP TABLE IF EXISTS t2");
+    spark.sql("DROP TABLE IF EXISTS t");
+  }
+
+  @Test
+  public void testNonV2CreateTableAsSelect() {
+    spark.sql("CREATE TABLE t1 (a int, b int) LOCATION '/tmp/column_non_v2/t1'");
+    spark.sql("INSERT INTO t1 VALUES (1,2)");
+    spark.sql("CREATE TABLE t2 LOCATION '/tmp/column_non_v2/t2' AS SELECT * FROM t1");
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema).get();
+
+    assertColumnDependsOn(facet, "a", "file", "column_non_v2/t1", "a");
+    assertColumnDependsOn(facet, "b", "file", "column_non_v2/t1", "b");
+  }
+
+  @Test
+  public void testNonV2CatalogInsertIntoTable() {
+    spark.sql("CREATE TABLE t1 (a int, b int) LOCATION '/tmp/column_non_v2/t1'");
+    spark.sql("INSERT INTO t1 VALUES (1,2)");
+    spark.sql("CREATE TABLE t2 (a int, b int) LOCATION '/tmp/column_non_v2/t2'");
+    spark.sql("INSERT INTO t2 SELECT * FROM t1");
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema).get();
+
+    assertColumnDependsOn(facet, "a", "file", "column_non_v2/t1", "a");
+    assertColumnDependsOn(facet, "b", "file", "column_non_v2/t1", "b");
+  }
+
+  private void assertColumnDependsOn(
+      OpenLineage.ColumnLineageDatasetFacet facet,
+      String outputColumn,
+      String expectedNamespace,
+      String expectedName,
+      String expectedInputField) {
+    assertTrue(
+        facet.getFields().getAdditionalProperties().get(outputColumn).getInputFields().stream()
+            .filter(f -> f.getNamespace().equalsIgnoreCase(expectedNamespace))
+            .filter(f -> f.getName().endsWith(expectedName))
+            .filter(f -> f.getField().equalsIgnoreCase(expectedInputField))
+            .findAny()
+            .isPresent());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtilsV2CatalogTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelLineageUtilsV2CatalogTest.java
@@ -1,0 +1,320 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.client.OpenLineageClient;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.LastQueryExecutionSparkEventListener;
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SparkSession$;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.collection.immutable.HashMap;
+
+@Slf4j
+public class ColumnLevelLineageUtilsV2CatalogTest {
+
+  SparkSession spark;
+  QueryExecution queryExecution = mock(QueryExecution.class);
+
+  OpenLineageContext context;
+  StructType schema =
+      new StructType(
+          new StructField[] {
+            new StructField("a", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            new StructField("b", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+          });
+
+  @BeforeAll
+  @SneakyThrows
+  public static void beforeAll() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
+  @AfterAll
+  @SneakyThrows
+  public static void afterAll() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
+  @BeforeEach
+  @SneakyThrows
+  public void beforeEach() {
+    spark =
+        SparkSession.builder()
+            .master("local[*]")
+            .appName("ColumnLevelLineage")
+            .config("spark.extraListeners", LastQueryExecutionSparkEventListener.class.getName())
+            .config("spark.driver.host", "127.0.0.1")
+            .config("spark.driver.bindAddress", "127.0.0.1")
+            .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.spark_catalog.type", "hive")
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.warehouse", "/tmp/column_level_lineage/")
+            .config("spark.sql.catalog.local.type", "hadoop")
+            .config(
+                "spark.sql.extensions",
+                "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+            .config("spark.driver.extraJavaOptions", "-Dderby.system.home=/tmp/derby")
+            .getOrCreate();
+
+    context =
+        OpenLineageContext.builder()
+            .sparkSession(Optional.of(spark))
+            .sparkContext(spark.sparkContext())
+            .openLineage(new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI))
+            .queryExecution(queryExecution)
+            .build();
+
+    FileSystem.get(spark.sparkContext().hadoopConfiguration())
+        .delete(new Path("/tmp/column_level_lineage/"), true);
+
+    spark.sql("DROP TABLE IF EXISTS local.db.t1");
+    spark.sql("DROP TABLE IF EXISTS local.db.t2");
+    spark.sql("DROP TABLE IF EXISTS local.db.t");
+
+    spark
+        .createDataFrame(Arrays.asList(new GenericRow(new Object[] {1, 2})), schema)
+        .createOrReplaceTempView("temp");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testCreateTableAsSelectWithUnion() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("CREATE TABLE local.db.t2 USING iceberg AS SELECT * FROM temp");
+    spark.sql(
+        "CREATE TABLE local.db.t USING iceberg AS (SELECT * FROM local.db.t1 UNION SELECT * FROM local.db.t2)");
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema).get();
+
+    assertColumnDependsOn(facet, "a", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "a", "file", "/tmp/column_level_lineage/db.t2", "a");
+    assertColumnDependsOn(facet, "b", "file", "/tmp/column_level_lineage/db.t2", "b");
+    assertColumnDependsOn(facet, "b", "file", "/tmp/column_level_lineage/db.t1", "b");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testInsertIntoTableWithAlias() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("CREATE TABLE local.db.t2 USING iceberg AS SELECT * FROM temp");
+    spark.sql("INSERT INTO local.db.t2 SELECT * FROM local.db.t1");
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema).get();
+
+    assertColumnDependsOn(facet, "a", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "b", "file", "/tmp/column_level_lineage/db.t1", "b");
+  }
+
+  @Test
+  public void testUnaryExpression() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("INSERT INTO local.db.t1 VALUES (1,2),(3,4),(5,6)");
+    spark.sql(
+        "CREATE TABLE local.db.t2 USING iceberg AS (SELECT a, b, ceil(a) as `c`, abs(b) as `d` FROM local.db.t1)");
+
+    StructType outputSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("c", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("d", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "d", "file", "/tmp/column_level_lineage/db.t1", "b");
+  }
+
+  @Test
+  public void testEmptyColumnLineageFacet() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("INSERT INTO local.db.t1 VALUES (1,2),(3,4),(5,6)");
+    spark.sql("CREATE TABLE local.db.t2 USING iceberg AS (SELECT * FROM local.db.t1)");
+
+    StructType wrongSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("x", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("y", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    Optional<OpenLineage.ColumnLineageDatasetFacet> facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, wrongSchema);
+
+    assertFalse(facet.isPresent());
+  }
+
+  @Test
+  public void testLogicalPlanUnavailable() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    when(context.getQueryExecution()).thenReturn(Optional.empty());
+    assertEquals(
+        Optional.empty(), ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema));
+  }
+
+  @Test
+  public void testLogicalPlanWhenOptimizedPlanIsNull() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    QueryExecution queryExecution = mock(QueryExecution.class);
+    when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(queryExecution.optimizedPlan()).thenReturn(null);
+    assertEquals(
+        Optional.empty(), ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, schema));
+  }
+
+  @Test
+  public void testBinaryAndComplexExpression() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("INSERT INTO local.db.t1 VALUES (1,2),(3,4),(5,6)");
+    spark.sql(
+        "CREATE TABLE local.db.t2 AS SELECT CONCAT(CAST(a AS STRING), CAST(b AS STRING)) as `c`, a+b as `d` FROM local.db.t1");
+
+    StructType outputSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("c", StringType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("d", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t1", "b");
+    assertColumnDependsOn(facet, "d", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "d", "file", "/tmp/column_level_lineage/db.t1", "b");
+    assertColumnDependsOnInputs(facet, "c", 2);
+    assertColumnDependsOnInputs(facet, "d", 2);
+  }
+
+  @Test
+  public void testJoinQuery() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("CREATE TABLE local.db.t2 USING iceberg AS SELECT * FROM temp");
+
+    spark.sql(
+        "CREATE TABLE local.db.t AS (SELECT (local.db.t1.a + local.db.t2.a) as c FROM local.db.t1 JOIN local.db.t2 ON local.db.t1.a = local.db.t2.a)");
+
+    StructType outputSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("c", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t2", "a");
+    assertColumnDependsOnInputs(facet, "c", 2);
+  }
+
+  @Test
+  public void testAggregateQuery() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark.sql("CREATE TABLE local.db.t2 AS (SELECT max(a) as a FROM local.db.t1 GROUP BY a)");
+
+    StructType outputSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("a", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertColumnDependsOn(facet, "a", "file", "/tmp/column_level_lineage/db.t1", "a");
+  }
+
+  @Test
+  public void testCTEQuery() {
+    spark.sql("CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp");
+    spark
+        .sql(
+            "WITH t2(a,b) AS (SELECT * FROM local.db.t1) SELECT a AS c, b AS d FROM t2 WHERE t2.a = 1")
+        .collect();
+
+    StructType outputSchema =
+        new StructType(
+            new StructField[] {
+              new StructField("c", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("d", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    LogicalPlan plan = LastQueryExecutionSparkEventListener.getLastExecutedLogicalPlan().get();
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertColumnDependsOn(facet, "c", "file", "/tmp/column_level_lineage/db.t1", "a");
+    assertColumnDependsOn(facet, "d", "file", "/tmp/column_level_lineage/db.t1", "b");
+    assertColumnDependsOnInputs(facet, "c", 1);
+    assertColumnDependsOnInputs(facet, "d", 1);
+  }
+
+  private void assertColumnDependsOn(
+      OpenLineage.ColumnLineageDatasetFacet facet,
+      String outputColumn,
+      String expectedNamespace,
+      String expectedName,
+      String expectedInputField) {
+
+    assertTrue(
+        facet.getFields().getAdditionalProperties().get(outputColumn).getInputFields().stream()
+            .filter(f -> f.getNamespace().equalsIgnoreCase(expectedNamespace))
+            .filter(f -> f.getName().equals(expectedName))
+            .filter(f -> f.getField().equalsIgnoreCase(expectedInputField))
+            .findAny()
+            .isPresent());
+  }
+
+  private void assertColumnDependsOnInputs(
+      OpenLineage.ColumnLineageDatasetFacet facet,
+      String outputColumn,
+      int expectedAmountOfInputs) {
+
+    assertEquals(
+        expectedAmountOfInputs,
+        facet.getFields().getAdditionalProperties().get(outputColumn).getInputFields().size());
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelUtilsTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ColumnLevelUtilsTest.java
@@ -1,0 +1,70 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ColumnLevelUtilsTest {
+
+  @Test
+  public void testRewriteOutputDataset() {
+    OpenLineage.OutputDataset outputDataset = mock(OpenLineage.OutputDataset.class);
+    OpenLineage.OutputDatasetOutputFacets datasetOutputFacets =
+        mock(OpenLineage.OutputDatasetOutputFacets.class);
+    OpenLineage.ColumnLineageDatasetFacet columnLineageDatasetFacet =
+        mock(OpenLineage.ColumnLineageDatasetFacet.class);
+    OpenLineage.DatasetFacets datasetFacets = mock(OpenLineage.DatasetFacets.class);
+
+    OpenLineage.DocumentationDatasetFacet documentationDatasetFacet =
+        mock(OpenLineage.DocumentationDatasetFacet.class);
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet = mock(OpenLineage.SchemaDatasetFacet.class);
+    OpenLineage.DatasetVersionDatasetFacet datasetVersionDatasetFacet =
+        mock(OpenLineage.DatasetVersionDatasetFacet.class);
+    OpenLineage.StorageDatasetFacet storageDatasetFacet =
+        mock(OpenLineage.StorageDatasetFacet.class);
+    OpenLineage.DatasourceDatasetFacet datasourceDatasetFacet =
+        mock(OpenLineage.DatasourceDatasetFacet.class);
+    OpenLineage.LifecycleStateChangeDatasetFacet lifecycleStateChangeDatasetFacet =
+        mock(OpenLineage.LifecycleStateChangeDatasetFacet.class);
+    OpenLineage.DatasetFacet datasetFacet = mock(OpenLineage.DatasetFacet.class);
+    Map<String, OpenLineage.DatasetFacet> additionalProperties =
+        Collections.singletonMap("key", datasetFacet);
+
+    when(outputDataset.getName()).thenReturn("name");
+    when(outputDataset.getNamespace()).thenReturn("namespace");
+    when(outputDataset.getOutputFacets()).thenReturn(datasetOutputFacets);
+    when(outputDataset.getFacets()).thenReturn(datasetFacets);
+
+    when(datasetFacets.getDocumentation()).thenReturn(documentationDatasetFacet);
+    when(datasetFacets.getDataSource()).thenReturn(datasourceDatasetFacet);
+    when(datasetFacets.getSchema()).thenReturn(schemaDatasetFacet);
+    when(datasetFacets.getVersion()).thenReturn(datasetVersionDatasetFacet);
+    when(datasetFacets.getStorage()).thenReturn(storageDatasetFacet);
+    when(datasetFacets.getLifecycleStateChange()).thenReturn(lifecycleStateChangeDatasetFacet);
+    when(datasetFacets.getAdditionalProperties()).thenReturn(additionalProperties);
+
+    OpenLineage.OutputDataset rewriteOutputDataset =
+        ColumnLevelLineageUtils.rewriteOutputDataset(outputDataset, columnLineageDatasetFacet);
+
+    assertEquals("name", rewriteOutputDataset.getName());
+    assertEquals("namespace", rewriteOutputDataset.getNamespace());
+    assertEquals(datasetOutputFacets, rewriteOutputDataset.getOutputFacets());
+
+    assertEquals(documentationDatasetFacet, rewriteOutputDataset.getFacets().getDocumentation());
+    assertEquals(schemaDatasetFacet, rewriteOutputDataset.getFacets().getSchema());
+    assertEquals(datasetVersionDatasetFacet, rewriteOutputDataset.getFacets().getVersion());
+    assertEquals(storageDatasetFacet, rewriteOutputDataset.getFacets().getStorage());
+    assertEquals(datasourceDatasetFacet, rewriteOutputDataset.getFacets().getDataSource());
+    assertEquals(
+        lifecycleStateChangeDatasetFacet,
+        rewriteOutputDataset.getFacets().getLifecycleStateChange());
+    assertEquals(columnLineageDatasetFacet, rewriteOutputDataset.getFacets().getColumnLineage());
+    assertEquals(
+        datasetFacet, rewriteOutputDataset.getFacets().getAdditionalProperties().get("key"));
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/ExpressionDependencyCollectorTest.java
@@ -1,0 +1,136 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.spark.sql.catalyst.expressions.Alias;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.BinaryExpression;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression;
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata$;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+
+public class ExpressionDependencyCollectorTest {
+
+  ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+
+  ExprId exprId1 = mock(ExprId.class);
+  ExprId exprId2 = mock(ExprId.class);
+
+  ExprId aliasExprId1 = mock(ExprId.class);
+  ExprId aliasExprId2 = mock(ExprId.class);
+
+  NamedExpression expression1 =
+      new AttributeReference(
+          "name1", IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId1, null);
+  NamedExpression expression2 =
+      new AttributeReference(
+          "name2", IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId2, null);
+
+  Alias alias1 =
+      new Alias(
+          (Expression) expression1,
+          "name1",
+          aliasExprId1,
+          (Seq<String>) Seq$.MODULE$.empty(),
+          Option.empty(),
+          (Seq<String>) Seq$.MODULE$.empty());
+
+  Alias alias2 =
+      new Alias(
+          (Expression) expression2,
+          "name2",
+          aliasExprId2,
+          (Seq<String>) Seq$.MODULE$.empty(),
+          Option.empty(),
+          (Seq<String>) Seq$.MODULE$.empty());
+
+  @Test
+  public void testCollectFromProjectPlan() {
+    Project project =
+        new Project(
+            toScalaSeq(Arrays.asList((NamedExpression) alias1, (NamedExpression) alias2)),
+            mock(LogicalPlan.class));
+    LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
+
+    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
+    collector.collect(builder);
+
+    verify(builder, times(1)).addDependency(aliasExprId1, exprId1);
+    verify(builder, times(1)).addDependency(aliasExprId2, exprId2);
+  }
+
+  @Test
+  public void testCollectFromAggregatePlan() {
+    Aggregate aggregate =
+        new Aggregate(
+            (Seq<Expression>) Seq$.MODULE$.empty(),
+            toScalaSeq(Arrays.asList((NamedExpression) alias1)),
+            mock(LogicalPlan.class));
+    LogicalPlan plan = new CreateTableAsSelect(null, null, null, aggregate, null, null, false);
+
+    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
+    collector.collect(builder);
+
+    verify(builder, times(1)).addDependency(aliasExprId1, exprId1);
+  }
+
+  @Test
+  public void testCollectTraversingExpressions() {
+    // AggregateExpression
+    AggregateExpression aggr1 = mock(AggregateExpression.class);
+    AggregateExpression aggr2 = mock(AggregateExpression.class);
+
+    when(aggr1.resultId()).thenReturn(exprId1);
+    when(aggr2.resultId()).thenReturn(exprId2);
+
+    // BinaryExpression
+    Seq<Expression> children =
+        scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                Arrays.asList((Expression) aggr1, aggr2))
+            .asScala()
+            .toSeq();
+    BinaryExpression binaryExpression = mock(BinaryExpression.class);
+    when(binaryExpression.children()).thenReturn(children);
+
+    ExprId rootAliasExprId = mock(ExprId.class);
+    Alias rootAlias =
+        new Alias(
+            (Expression) binaryExpression,
+            "name2",
+            rootAliasExprId,
+            (Seq<String>) Seq$.MODULE$.empty(),
+            Option.empty(),
+            (Seq<String>) Seq$.MODULE$.empty());
+
+    Project project = new Project(toScalaSeq(Arrays.asList(rootAlias)), mock(LogicalPlan.class));
+    LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
+
+    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
+    collector.collect(builder);
+
+    verify(builder, times(1)).addDependency(rootAliasExprId, exprId1);
+    verify(builder, times(1)).addDependency(rootAliasExprId, exprId2);
+  }
+
+  private Seq<NamedExpression> toScalaSeq(Collection<NamedExpression> expressions) {
+    return scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions)
+        .asScala()
+        .toSeq();
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/InputFieldsCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/InputFieldsCollectorTest.java
@@ -1,0 +1,232 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.lifecycle.Rdds;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.execution.LogicalRDD;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+public class InputFieldsCollectorTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+
+  NamedExpression expression = mock(NamedExpression.class);
+  ExprId exprId = mock(ExprId.class);
+  DatasetIdentifier di = mock(DatasetIdentifier.class);
+  AttributeReference attributeReference = mock(AttributeReference.class);
+
+  @BeforeEach
+  public void setup() {
+    when(attributeReference.exprId()).thenReturn(exprId);
+    when(attributeReference.name()).thenReturn("some-name");
+  }
+
+  @Test
+  public void collectWhenGrandChildNodeIsDataSourceV2Relation() {
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(context, relation)).thenReturn(Optional.of(di));
+      collector.collect(builder);
+    }
+    verify(builder, times(1)).addInput(exprId, di, "some-name");
+  }
+
+  @Test
+  public void collectWhenGrandChildNodeIsDataSourceV2ScanRelation() {
+    DataSourceV2ScanRelation scanRelation = mock(DataSourceV2ScanRelation.class);
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+    when(scanRelation.relation()).thenReturn(relation);
+
+    LogicalPlan plan = createPlanWithGrandChild(scanRelation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(scanRelation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(context, relation)).thenReturn(Optional.of(di));
+      collector.collect(builder);
+    }
+    verify(builder, times(1)).addInput(exprId, di, "some-name");
+  }
+
+  @Test
+  @SneakyThrows
+  public void collectWhenGrandChildNodeIsHiveTableRelation() {
+    HiveTableRelation relation = mock(HiveTableRelation.class);
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    URI uri = new URI("file:/tmp");
+    when(relation.tableMeta()).thenReturn(catalogTable);
+    when(catalogTable.location()).thenReturn(uri);
+
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    collector.collect(builder);
+    verify(builder, times(1)).addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
+  }
+
+  @Test
+  @SneakyThrows
+  public void collectWhenGrandChildNodeIsLogicalRdd() {
+    LogicalRDD relation = mock(LogicalRDD.class);
+    RDD<InternalRow> rdd = mock(RDD.class);
+    List<RDD<?>> listRDD = Collections.singletonList(rdd);
+    Path path = new Path("file:///tmp");
+
+    when(relation.rdd()).thenReturn(rdd);
+
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList((Attribute) attributeReference))
+                .asScala()
+                .toSeq());
+
+    try (MockedStatic rdds = mockStatic(Rdds.class)) {
+      try (MockedStatic planUtils = mockStatic(PlanUtils.class)) {
+        when(Rdds.findFileLikeRdds(rdd)).thenReturn(listRDD);
+        when(PlanUtils.findRDDPaths(listRDD)).thenReturn(Collections.singletonList(path));
+        when(PlanUtils.namespaceUri(path.toUri())).thenReturn("file");
+
+        collector.collect(builder);
+        verify(builder, times(1))
+            .addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
+      }
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void collectWhenGrandChildNodeIsLogicalRelation() {
+    LogicalRelation relation = mock(LogicalRelation.class);
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    URI uri = new URI("file:/tmp");
+    when(relation.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(catalogTable.location()).thenReturn(uri);
+
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    collector.collect(builder);
+    verify(builder, times(1)).addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
+  }
+
+  @Test
+  @SneakyThrows
+  public void collectWhenGrandChildNodeIsLogicalRelationAndCatalogTableNotDefined() {
+    LogicalRelation relation = mock(LogicalRelation.class);
+    when(relation.catalogTable()).thenReturn(Option.empty());
+
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    collector.collect(builder);
+    verify(builder, times(0)).addInput(any(), any(), any());
+  }
+
+  @Test
+  @SneakyThrows
+  public void collectWhenGrandChildNodeIsLogicalRelationAndLocationIsEmpty() {
+    LogicalRelation relation = mock(LogicalRelation.class);
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(relation.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(catalogTable.location()).thenReturn(null);
+
+    LogicalPlan plan = createPlanWithGrandChild(relation);
+    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
+
+    when(relation.output())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(attributeReference))
+                .asScala()
+                .toSeq());
+
+    collector.collect(builder);
+    verify(builder, times(0)).addInput(any(), any(), any());
+  }
+
+  private LogicalPlan createPlanWithGrandChild(LogicalPlan grandChild) {
+    LogicalPlan child =
+        new Project(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(expression))
+                .asScala()
+                .toSeq(),
+            grandChild);
+    return new CreateTableAsSelect(null, null, null, child, null, null, false);
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/IcebergMergeIntoDependencyVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/IcebergMergeIntoDependencyVisitorTest.java
@@ -1,0 +1,102 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static scala.collection.JavaConverters.collectionAsScalaIterableConverter;
+
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+import scala.collection.Seq;
+
+public class IcebergMergeIntoDependencyVisitorTest {
+
+  Attribute output1 = mock(Attribute.class);
+  Attribute output2 = mock(Attribute.class);
+
+  ExprId outputExprId1 = mock(ExprId.class);
+  ExprId outputExprId2 = mock(ExprId.class);
+
+  Seq<Attribute> outputs =
+      scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+              Arrays.asList(output1, output2))
+          .asScala()
+          .toSeq();
+
+  Expression expr1 = mock(Expression.class, withSettings().extraInterfaces(NamedExpression.class));
+  Expression expr2 = mock(Expression.class, withSettings().extraInterfaces(NamedExpression.class));
+  Expression expr3 = mock(Expression.class, withSettings().extraInterfaces(NamedExpression.class));
+  Expression expr4 = mock(Expression.class, withSettings().extraInterfaces(NamedExpression.class));
+
+  Seq<Expression> seq1 =
+      collectionAsScalaIterableConverter(Arrays.asList(expr1, expr2)).asScala().toSeq();
+
+  Seq<Expression> seq2 =
+      collectionAsScalaIterableConverter(Arrays.asList(expr3, expr4)).asScala().toSeq();
+
+  IcebergMergeIntoDependencyVisitor visitor = new IcebergMergeIntoDependencyVisitor();
+  ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+
+  @Test
+  public void testCollectMatched() {
+    when(output1.exprId()).thenReturn(outputExprId1);
+    when(output2.exprId()).thenReturn(outputExprId2);
+
+    try (MockedStatic<ExpressionDependencyCollector> mockStatic =
+        mockStatic(ExpressionDependencyCollector.class)) {
+      List<Option<Seq<Expression>>> matched = Arrays.asList(Option.apply(seq1), Option.apply(seq2));
+      visitor.collect(outputs, matched, Collections.emptyList(), builder);
+
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr1, outputExprId1, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr2, outputExprId2, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr3, outputExprId1, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr4, outputExprId2, builder),
+          times(1));
+    }
+  }
+
+  @Test
+  public void testCollectNotMatched() {
+    when(output1.exprId()).thenReturn(outputExprId1);
+    when(output2.exprId()).thenReturn(outputExprId2);
+
+    try (MockedStatic<ExpressionDependencyCollector> mockStatic =
+        mockStatic(ExpressionDependencyCollector.class)) {
+      List<Option<Seq<Expression>>> notMatched =
+          Arrays.asList(Option.apply(seq1), Option.apply(seq2));
+      visitor.collect(outputs, Collections.emptyList(), notMatched, builder);
+
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr1, outputExprId1, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr2, outputExprId2, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr3, outputExprId1, builder),
+          times(1));
+      mockStatic.verify(
+          () -> ExpressionDependencyCollector.traverseExpression(expr4, outputExprId2, builder),
+          times(1));
+    }
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/UnionFieldDependencyCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/columnLineage/customVisitors/UnionFieldDependencyCollectorTest.java
@@ -1,0 +1,72 @@
+package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.catalyst.plans.logical.Union;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata$;
+import org.junit.jupiter.api.Test;
+import scala.collection.Seq;
+
+public class UnionFieldDependencyCollectorTest {
+
+  UnionDependencyVisitor visitor = new UnionDependencyVisitor();
+  ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+
+  ExprId exprId1 = mock(ExprId.class);
+  ExprId exprId2 = mock(ExprId.class);
+
+  NamedExpression expression1 =
+      new AttributeReference(
+          "name1", IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId1, null);
+  NamedExpression expression2 =
+      new AttributeReference(
+          "name2", IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId2, null);
+
+  @Test
+  public void testIsDefinedAt() {
+    assertTrue(visitor.isDefinedAt(mock(Union.class)));
+    assertFalse(visitor.isDefinedAt(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  public void testCollect() {
+    Union union =
+        new Union(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(
+                        (LogicalPlan)
+                            new Project(
+                                toScalaSeq(Arrays.asList(expression1)), mock(LogicalPlan.class)),
+                        (LogicalPlan)
+                            new Project(
+                                toScalaSeq(Arrays.asList(expression2)), mock(LogicalPlan.class))))
+                .asScala()
+                .toSeq(),
+            true,
+            true);
+
+    visitor.apply(union, builder);
+
+    // first element of a union is treated as an ancestor node
+    verify(builder, times(1)).addDependency(exprId1, exprId2);
+  }
+
+  private Seq<NamedExpression> toScalaSeq(Collection<NamedExpression> expressions) {
+    return scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions)
+        .asScala()
+        .toSeq();
+  }
+}

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/LastQueryExecutionSparkEventListener.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/utils/LastQueryExecutionSparkEventListener.java
@@ -1,0 +1,28 @@
+package io.openlineage.spark3.agent.utils;
+
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.SQLExecution;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+
+public class LastQueryExecutionSparkEventListener extends SparkListener {
+
+  private static Optional<QueryExecution> lastQueryExecution = Optional.empty();
+
+  @Override
+  public void onOtherEvent(SparkListenerEvent event) {
+    if (event instanceof SparkListenerSQLExecutionStart) {
+      lastQueryExecution =
+          Optional.ofNullable(
+              SQLExecution.getQueryExecution(
+                  ((SparkListenerSQLExecutionStart) event).executionId()));
+    }
+  }
+
+  public static Optional<LogicalPlan> getLastExecutedLogicalPlan() {
+    return lastQueryExecution.map(qe -> qe.optimizedPlan());
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Implement column level lineage for Spark integration.

Part of epic: #673

### Solution

- The solution has been implemented according to the [proposal](https://github.com/OpenLineage/OpenLineage/blob/main/proposals/148/column_level_lineage.md).
- This PR contains a part of #645 and contains a core mechanism to collect column level lineage from logical plans. 
- The PR does not include column level lineage in any OpenLineage events, so it does not affect current behavior of Spark integration. 
- Integration of the mechanism with visitors and dataset builders will be merged within other PR with the code already available in #645. 

### Short description of the PR content:

- Class `ColumnLevelLineageUtils.java` is an entry point for the whole column lineage generation and its methods will be used in further PRs. 
- Classes `ColumnLevelLineageUtilsNonV2CatalogTest` and `ColumnLevelLineageUtilsV2CatalogTest` contain real-life test cases which run Spark jobs and get an access to the last query plan executed. They evaluate column level lineage based on the plan and expected output schema. Then, they verify if this meets the requirements. This is a pretty cool way to test column level lineage behavior in real scenarios. The more tests and scenarios put here, the better. 
- Class `ColumnLevelLineageBuilder` is used when traversing logical plans to store all the information required to produce column lineage. It allows storing input/output columns. It also stores dependencies between the expressions contained in query plan. Once inputs, outputs and dependencies are filled, `build` method is used to produce output facet (`ColumnLineageDatasetFacetFields`). 

### How does the mechanism work?  

1. The mechanism gets output schema and logical plan as input. Output schemas are tightly coupled with root nodes of execution plans, however we do already have this information extracted within the other visitors and dataset input builders.  
2. `OutputFieldsCollector` class is used to traverse the plan to gather the outputs. Outputs can be extracted from `Aggregate` or `Project` and each output field has its `ExprId` (expression id) attached from the plan. 
3. `InputFieldsCollector` class is used to collect the inputs which can be extracted from `DataSourceV2Relation`, `DataSourceV2ScanRelation`, `HiveTableRelation` or `LogicalRelation`. Each input field has its `ExprId` within the plan. Each input is identified by `DatasetIdentifier`,which means it contains `name` and `namespace`, of a dataset and an input field.
4. `FieldDependenciesCollector` traverses the plan to identify dependencies between different `ExprId`. Dependencies map parent expressions to children expressions'. This is used to identify inputs used to evaluate certain output. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)