### PR TITLE
[INTEGRATION][AIRFLOW] Add MySQL support

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -117,6 +117,7 @@ suited to extract metadata from particular operator (or operators).
 `openlineage-airflow` provides extractors for
 
 * `PostgresOperator`
+* `MySqlOperator`
 * `BigQueryOperator`
 * `SnowflakeOperator`
 * `GreatExpectationsOperator`

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -15,6 +15,9 @@ _extractors = list(
                 'openlineage.airflow.extractors.postgres_extractor.PostgresExtractor'
             ),
             try_import_from_string(
+                'openlineage.airflow.extractors.mysql_extractor.MySqlExtractor'
+            ),
+            try_import_from_string(
                 'openlineage.airflow.extractors.bigquery_extractor.BigQueryExtractor'
             ),
             try_import_from_string(

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0.
+import logging
+from contextlib import closing
+from typing import Optional, List
+from urllib.parse import urlparse
+
+from openlineage.airflow.utils import (
+    get_connection_uri,
+    get_connection, safe_import_airflow
+)
+from openlineage.airflow.extractors.base import (
+    BaseExtractor,
+    TaskMetadata
+)
+from openlineage.client.facet import SqlJobFacet
+from openlineage.common.models import (
+    DbTableSchema,
+    DbColumn
+)
+from openlineage.common.sql import SqlMeta, parse, DbTableMeta
+from openlineage.common.dataset import Source, Dataset
+
+_TABLE_SCHEMA = 0
+_TABLE_NAME = 1
+_COLUMN_NAME = 2
+_ORDINAL_POSITION = 3
+_COLUMN_TYPE = 4
+
+logger = logging.getLogger(__name__)
+
+
+class MySqlExtractor(BaseExtractor):
+    default_schema = None
+
+    def __init__(self, operator):
+        super().__init__(operator)
+        self.conn = None
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['MySqlOperator']
+
+    def extract(self) -> TaskMetadata:
+        # (1) Parse sql statement to obtain input / output tables.
+        sql_meta: SqlMeta = parse(self.operator.sql, self.default_schema)
+
+        # (2) Get database connection
+        self.conn = get_connection(self._conn_id())
+
+        # (3) Default all inputs / outputs to current connection.
+        # NOTE: We'll want to look into adding support for the `database`
+        # property that is used to override the one defined in the connection.
+        source = Source(
+            scheme=self._get_scheme(),
+            authority=self._get_authority(),
+            connection_url=self._get_connection_uri()
+        )
+
+        database = self.operator.database
+        if not database:
+            database = self._get_database()
+
+        # (4) Map input / output tables to dataset objects with source set
+        # as the current connection. We need to also fetch the schema for the
+        # input tables to format the dataset name as:
+        # {schema_name}.{table_name}
+        inputs = [
+            Dataset.from_table(
+                source=source,
+                table_name=in_table_schema.table_name.name,
+                schema_name=in_table_schema.schema_name,
+                database_name=database
+            ) for in_table_schema in self._get_table_schemas(
+                sql_meta.in_tables
+            )
+        ]
+        outputs = [
+            Dataset.from_table_schema(
+                source=source,
+                table_schema=out_table_schema,
+                database_name=database
+            ) for out_table_schema in self._get_table_schemas(
+                sql_meta.out_tables
+            )
+        ]
+
+        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
+        run_facets = {}
+        job_facets = {
+            'sql': SqlJobFacet(self.operator.sql)
+        }
+
+        return TaskMetadata(
+            name=task_name,
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in outputs],
+            run_facets=run_facets,
+            job_facets=job_facets
+        )
+
+    def _get_connection_uri(self):
+        return get_connection_uri(self.conn)
+
+    def _get_scheme(self):
+        return 'mysql'
+
+    def _get_database(self) -> str:
+        if self.conn.schema:
+            return self.conn.schema
+        else:
+            parsed = urlparse(self.conn.get_uri())
+            return f'{parsed.path}'
+
+    def _get_authority(self) -> str:
+        if self.conn.host and self.conn.port:
+            return f'{self.conn.host}:{self.conn.port}'
+        else:
+            parsed = urlparse(self.conn.get_uri())
+            return f'{parsed.hostname}:{parsed.port}'
+
+    def _conn_id(self):
+        return self.operator.mysql_conn_id
+
+    def _information_schema_query(self, table_names: str) -> str:
+        return f"""
+        SELECT table_schema,
+        table_name,
+        column_name,
+        ordinal_position,
+        column_type
+        FROM information_schema.columns
+        WHERE table_name IN ({table_names});
+        """
+
+    def _get_hook(self):
+        MySqlHook = safe_import_airflow(
+            airflow_1_path="airflow.hooks.mysql_hook.MySqlHook",
+            airflow_2_path="airflow.providers.mysql.hooks.mysql.MySqlHook"
+        )
+        return MySqlHook(
+            mysql_conn_id=self.operator.mysql_conn_id,
+            schema=self.operator.database
+        )
+
+    def _get_table_schemas(
+            self, table_names: [DbTableMeta]
+    ) -> [DbTableSchema]:
+        # Avoid querying mysql by returning an empty array
+        # if no table names have been provided.
+        if not table_names:
+            return []
+
+        # Keeps tack of the schema by table.
+        schemas_by_table = {}
+
+        hook = self._get_hook()
+        with closing(hook.get_conn()) as conn:
+            with closing(conn.cursor()) as cursor:
+                table_names_as_str = ",".join(map(
+                    lambda name: f"'{name.name}'", table_names
+                ))
+                cursor.execute(
+                    self._information_schema_query(table_names_as_str)
+                )
+                for row in cursor.fetchall():
+                    table_schema_name: str = row[_TABLE_SCHEMA]
+                    table_name: DbTableMeta = DbTableMeta(row[_TABLE_NAME])
+                    table_column: DbColumn = DbColumn(
+                        name=row[_COLUMN_NAME],
+                        type=row[_COLUMN_TYPE],
+                        ordinal_position=row[_ORDINAL_POSITION]
+                    )
+
+                    # Attempt to get table schema
+                    table_key: str = f"{table_schema_name}.{table_name}"
+                    table_schema: Optional[DbTableSchema] = schemas_by_table.get(table_key)
+
+                    if table_schema:
+                        # Add column to existing table schema.
+                        schemas_by_table[table_key].columns.append(table_column)
+                    else:
+                        # Create new table schema with column.
+                        schemas_by_table[table_key] = DbTableSchema(
+                            schema_name=table_schema_name,
+                            table_name=table_name,
+                            columns=[table_column]
+                        )
+
+        return list(schemas_by_table.values())

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -31,12 +31,13 @@ extras_require = {
         "snowflake-connector-python"
     ],
     "airflow-1": [
-        "apache-airflow[gcp_api,google,postgres]==1.10.15",
+        "apache-airflow[gcp_api,google,postgres,mysql]==1.10.15",
         "airflow-provider-great-expectations==0.0.8",
     ],
     "airflow-2": [
         "apache-airflow==2.1.4",
         "apache-airflow-providers-postgres>=2.0.0",
+        "apache-airflow-providers-mysql>=2.0.0",
         "apache-airflow-providers-snowflake>=2.1.0",
         "apache-airflow-providers-google>=5.0.0",
         "airflow-provider-great-expectations>=0.0.8",

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -24,12 +24,12 @@ def test_basic_extractor():
 
 
 def test_env_extractors():
-    assert len(Extractors().extractors) == 7
+    assert len(Extractors().extractors) == 8
 
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
         'tests.extractors.test_extractors.FakeExtractor'
 
-    assert len(Extractors().extractors) == 8
+    assert len(Extractors().extractors) == 9
     del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']
 
 

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0.
+
+import os
+from unittest import mock
+
+import pytest
+from airflow.models import Connection
+from airflow.utils.dates import days_ago
+from airflow import DAG
+
+from openlineage.airflow.utils import safe_import_airflow, get_connection
+from openlineage.common.models import (
+    DbTableSchema,
+    DbColumn
+)
+from openlineage.common.sql import DbTableMeta
+from openlineage.common.dataset import Source, Dataset
+from openlineage.airflow.extractors.mysql_extractor import MySqlExtractor
+
+MySqlOperator = safe_import_airflow(
+    airflow_1_path="airflow.operators.mysql_operator.MySqlOperator",
+    airflow_2_path="airflow.providers.mysql.operators.mysql.MySqlOperator"
+)
+
+MySqlHook = safe_import_airflow(
+    airflow_1_path="airflow.hooks.mysql_hook.MySqlHook",
+    airflow_2_path="airflow.providers.mysql.hooks.mysql.MySqlHook"
+)
+
+CONN_ID = 'food_delivery_db'
+CONN_URI = 'mysql://user:pass@localhost:3306/food_delivery'
+CONN_URI_WITHOUT_USERPASS = 'mysql://localhost:3306/food_delivery'
+
+DB_NAME = 'food_delivery'
+DB_SCHEMA_NAME = None
+DB_TABLE_NAME = DbTableMeta('discounts')
+DB_TABLE_COLUMNS = [
+    DbColumn(
+        name='id',
+        type='integer',
+        ordinal_position=1
+    ),
+    DbColumn(
+        name='amount_off',
+        type='integer',
+        ordinal_position=2
+    ),
+    DbColumn(
+        name='customer_email',
+        type='text',
+        ordinal_position=3
+    ),
+    DbColumn(
+        name='starts_on',
+        type='timestamp',
+        ordinal_position=4
+    ),
+    DbColumn(
+        name='ends_on',
+        type='timestamp',
+        ordinal_position=5
+    )
+]
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME,
+    table_name=DB_TABLE_NAME,
+    columns=DB_TABLE_COLUMNS
+)
+NO_DB_TABLE_SCHEMA = []
+
+SQL = f"SELECT * FROM {DB_TABLE_NAME.name};"
+
+DAG_ID = 'email_discounts'
+DAG_OWNER = 'datascience'
+DAG_DEFAULT_ARGS = {
+    'owner': DAG_OWNER,
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+DAG_DESCRIPTION = \
+    'Email discounts to customers that have experienced order delays daily'
+
+DAG = dag = DAG(
+    DAG_ID,
+    schedule_interval='@weekly',
+    default_args=DAG_DEFAULT_ARGS,
+    description=DAG_DESCRIPTION
+)
+
+TASK_ID = 'select'
+TASK = MySqlOperator(
+    task_id=TASK_ID,
+    mysql_conn_id=CONN_ID,
+    sql=SQL,
+    dag=DAG,
+    database=DB_NAME
+)
+
+
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.MySqlExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.get_connection')
+def test_extract(get_connection, mock_get_table_schemas):
+    mock_get_table_schemas.side_effect = \
+        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+
+    conn = Connection(
+        conn_id=CONN_ID,
+        conn_type='mysql',
+        host='localhost',
+        port='3306',
+        schema='food_delivery'
+    )
+
+    get_connection.return_value = conn
+
+    expected_inputs = [
+        Dataset(
+            name=f"{DB_NAME}.{DB_TABLE_NAME.name}",
+            source=Source(
+                scheme='mysql',
+                authority='localhost:3306',
+                connection_url=CONN_URI_WITHOUT_USERPASS
+            ),
+            fields=[]
+        ).to_openlineage_dataset()]
+
+    # Set the environment variable for the connection
+    os.environ[f"AIRFLOW_CONN_{CONN_ID.upper()}"] = CONN_URI
+
+    task_metadata = MySqlExtractor(TASK).extract()
+
+    assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
+    assert task_metadata.inputs == expected_inputs
+    assert task_metadata.outputs == []
+
+
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.MySqlExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.get_connection')
+def test_extract_authority_uri(get_connection, mock_get_table_schemas):
+
+    mock_get_table_schemas.side_effect = \
+        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI)
+    get_connection.return_value = conn
+
+    expected_inputs = [
+        Dataset(
+            name=f"{DB_NAME}.{DB_TABLE_NAME.name}",
+            source=Source(
+                scheme='mysql',
+                authority='localhost:3306',
+                connection_url=CONN_URI_WITHOUT_USERPASS
+            ),
+            fields=[]
+        ).to_openlineage_dataset()]
+
+    task_metadata = MySqlExtractor(TASK).extract()
+
+    assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
+    assert task_metadata.inputs == expected_inputs
+    assert task_metadata.outputs == []
+
+
+@mock.patch('MySQLdb.connect')
+def test_get_table_schemas(mock_conn):
+    # (1) Define a simple hook class for testing
+    class TestMySqlHook(MySqlHook):
+        conn_name_attr = 'test_conn_id'
+
+        def __init__(self, *args, **kwargs):
+            super(TestMySqlHook, self).__init__(*args, **kwargs)
+            self.schema = ''
+
+    # (2) Mock calls to mysql
+    rows = [
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'id', 1, 'integer'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'amount_off', 2, 'integer'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'customer_email', 3, 'text'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'starts_on', 4, 'timestamp'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ends_on', 5, 'timestamp')
+    ]
+
+    mock_conn.return_value \
+        .cursor.return_value \
+        .fetchall.return_value = rows
+
+    # (3) Mock conn for hook
+    hook = TestMySqlHook()
+    hook.conn = mock_conn
+
+    # (4) Extract table schemas for task
+    extractor = MySqlExtractor(TASK)
+    table_schemas = extractor._get_table_schemas(table_names=[DB_TABLE_NAME])
+
+    assert table_schemas == [DB_TABLE_SCHEMA]
+
+
+def test_get_connection_import_returns_none_if_not_exists():
+    assert get_connection("does_not_exist") is None
+    assert get_connection("does_exist") is None
+
+
+@pytest.fixture
+def create_connection():
+    create_session = safe_import_airflow(
+        airflow_1_path="airflow.utils.db.create_session",
+        airflow_2_path="airflow.utils.session.create_session",
+    )
+
+    conn = Connection("does_exist", conn_type="mysql")
+    with create_session() as session:
+        session.add(conn)
+        session.commit()
+
+    yield conn
+
+    with create_session() as session:
+        session.delete(conn)
+        session.commit()
+
+
+def test_get_connection_returns_one_if_exists(create_connection):
+    conn = Connection("does_exist")
+    assert get_connection("does_exist").conn_id == conn.conn_id

--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -15,6 +15,8 @@ COPY requirements.txt requirements.txt
 RUN pip install --user -r requirements.txt
 
 FROM openlineage-airflow-base:latest AS integration
+RUN apt-get update && \
+    apt-get install -y python3-dev default-libmysqlclient-dev build-essential
 COPY integration-requirements.txt integration-requirements.txt
 COPY *.py ./
 COPY requests requests

--- a/integration/airflow/tests/integration/Dockerfile.2
+++ b/integration/airflow/tests/integration/Dockerfile.2
@@ -13,6 +13,8 @@ COPY requirements.txt requirements.txt
 RUN pip install --user -r requirements.txt
 
 FROM openlineage-airflow-base:latest AS integration
+RUN apt-get update && \
+    apt-get install -y python3-dev default-libmysqlclient-dev build-essential
 COPY integration-requirements.txt integration-requirements.txt
 COPY *.py ./
 COPY requests requests

--- a/integration/airflow/tests/integration/docker/init-db-mysql.sh
+++ b/integration/airflow/tests/integration/docker/init-db-mysql.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: Apache-2.0.
+#
+# Usage: $ ./init-db-mysql.sh
+
+set -eu
+
+mysql --user="${MYSQL_USER}" --password="${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" > /dev/null <<-EOSQL
+  CREATE TABLE IF NOT EXISTS top_delivery_times (
+      order_id            INTEGER,
+      order_placed_on     TIMESTAMP NOT NULL,
+      order_dispatched_on TIMESTAMP NOT NULL,
+      order_delivered_on  TIMESTAMP NOT NULL,
+      order_delivery_time DOUBLE PRECISION NOT NULL,
+      customer_email      VARCHAR(64) NOT NULL,
+      restaurant_id       INTEGER,
+      driver_id           INTEGER
+    );
+EOSQL

--- a/integration/airflow/tests/integration/docker/up-2.sh
+++ b/integration/airflow/tests/integration/docker/up-2.sh
@@ -44,6 +44,7 @@ EOL
 cat > integration-requirements.txt <<EOL
 requests==2.24.0
 psycopg2-binary==2.9.2
+mysqlclient>=1.3.6
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -44,6 +44,7 @@ cat > integration-requirements.txt <<EOL
 requests==2.24.0
 setuptools==34.0.0
 psycopg2-binary==2.9.2
+mysqlclient>=1.3.6
 httplib2>=0.18.1
 retrying==1.3.3
 pytest==6.2.2

--- a/integration/airflow/tests/integration/requests/mysql.json
+++ b/integration/airflow/tests/integration/requests/mysql.json
@@ -1,0 +1,116 @@
+[{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
+            }
+        },
+        "name": "mysql_orders_popular_day_of_week.mysql_if_not_exists",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+              "externalTrigger": false
+            }
+        }
+    }
+},
+{
+    "eventType": "START",
+    "inputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "mysql://mysql:3306",
+                    "uri": "mysql://mysql:3306/food_delivery"
+                }
+            },
+            "name": "food_delivery.top_delivery_times",
+            "namespace": "mysql://mysql:3306"
+        }
+    ],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT WEEKDAY(order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on;\n    "
+            }
+        },
+        "name": "mysql_orders_popular_day_of_week.mysql_insert",
+        "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            }
+        }
+    }
+},
+{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sql": {
+                "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );"
+            }
+        },
+        "name": "mysql_orders_popular_day_of_week.mysql_if_not_exists",
+        "namespace": "food_delivery"
+    },
+    "outputs": []
+},
+{
+	"eventType": "COMPLETE",
+	"inputs": [{
+		"facets": {
+			"dataSource": {
+				"name": "mysql://mysql:3306",
+				"uri": "mysql://mysql:3306/food_delivery"
+			}
+		},
+		"name": "food_delivery.top_delivery_times",
+		"namespace": "mysql://mysql:3306"
+	}],
+	"job": {
+		"facets": {
+			"sql": {
+				"query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT WEEKDAY(order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on;\n    "
+			}
+		},
+		"name": "mysql_orders_popular_day_of_week.mysql_insert",
+		"namespace": "food_delivery"
+	},
+	"outputs": [{
+		"facets": {
+			"dataSource": {
+				"name": "mysql://mysql:3306",
+				"uri": "mysql://mysql:3306/food_delivery"
+			},
+			"schema": {
+				"fields": [{
+					"name": "order_day_of_week",
+					"type": "varchar"
+				}, {
+					"name": "order_placed_on",
+					"type": "timestamp"
+				}, {
+					"name": "orders_placed",
+					"type": "int4"
+				}]
+			}
+		},
+		"name": "food_delivery.popular_orders_day_of_week",
+		"namespace": "mysql://mysql:3306"
+	}]
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -186,6 +186,7 @@ def test_integration_ordered(dag_id, request_dir: str):
 if __name__ == '__main__':
     setup_db()
     test_integration('postgres_orders_popular_day_of_week', 'requests/postgres.json')
+    test_integration('mysql_orders_popular_day_of_week', 'requests/mysql.json')
     test_integration('great_expectations_validation', 'requests/great_expectations.json')
     test_integration('bigquery_orders_popular_day_of_week', 'requests/bigquery.json')
     test_integration('dbt_bigquery', 'requests/dbt_bigquery.json')

--- a/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from airflow.operators.mysql_operator import MySqlOperator
+from airflow.utils.dates import days_ago
+
+from openlineage.client import set_producer
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+from airflow.version import version as AIRFLOW_VERSION
+from pkg_resources import parse_version
+if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
+    from openlineage.airflow import DAG
+else:
+    from airflow import DAG
+
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+dag = DAG(
+    'mysql_orders_popular_day_of_week',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Determines the popular day of week orders are placed.'
+)
+
+
+t1 = MySqlOperator(
+    task_id='mysql_if_not_exists',
+    mysql_conn_id='mysql_conn',
+    sql='''
+    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (
+      order_day_of_week VARCHAR(64) NOT NULL,
+      order_placed_on   TIMESTAMP NOT NULL,
+      orders_placed     INTEGER NOT NULL
+    );''',
+    dag=dag
+)
+
+t2 = MySqlOperator(
+    task_id='mysql_insert',
+    mysql_conn_id='mysql_conn',
+    sql='''
+    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)
+    SELECT WEEKDAY(order_placed_on) AS order_day_of_week,
+           order_placed_on,
+           COUNT(*) AS orders_placed
+      FROM top_delivery_times
+     GROUP BY order_placed_on;
+    ''',
+    dag=dag
+)
+
+t1 >> t2

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -24,6 +24,7 @@ x-airflow-base: &airflow-base
     AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     AIRFLOW_CONN_FOOD_DELIVERY_DB: postgres://food_delivery:food_delivery@postgres:5432/food_delivery
+    AIRFLOW_CONN_MYSQL_CONN: mysql://food_delivery:food_delivery@mysql:3306/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=openlineage-ci&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "False"
     BIGQUERY_PREFIX: ${BIGQUERY_PREFIX}
@@ -123,3 +124,16 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     volumes:
       - ../docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+
+  mysql:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_USER=food_delivery
+      - MYSQL_PASSWORD=food_delivery
+      - MYSQL_DATABASE=food_delivery
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+      - MYSQL_ONETIME_PASSWORD=
+    volumes:
+      - ../docker/init-db-mysql.sh:/docker-entrypoint-initdb.d/init-db-mysql.sh

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -17,6 +17,7 @@ x-airflow-base: &airflow-base
     AIRFLOW_LOAD_EXAMPLES: "no"
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     AIRFLOW_CONN_FOOD_DELIVERY_DB: postgres://food_delivery:food_delivery@postgres:5432/food_delivery
+    AIRFLOW_CONN_MYSQL_CONN: mysql://food_delivery:food_delivery@mysql:3306/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=openlineage-ci&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
     AIRFLOW__CELERY__BROKER_URL: redis://redis:6379/0
     AIRFLOW__CORE__LOGGING_CONFIG_CLASS: log_config.LOGGING_CONFIG
@@ -125,3 +126,16 @@ services:
       timeout: 30s
       retries: 50
     restart: always
+
+  mysql:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_USER=food_delivery
+      - MYSQL_PASSWORD=food_delivery
+      - MYSQL_DATABASE=food_delivery
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+      - MYSQL_ONETIME_PASSWORD=
+    volumes:
+      - ../docker/init-db-mysql.sh:/docker-entrypoint-initdb.d/init-db-mysql.sh

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -30,6 +30,22 @@ Identifier:
  * Unique name: {database}.{schema}.{table}
    * URI =  postgres://{host}:{port}/{database}.{schema}.{table}
 
+#### MySQL:
+Datasource hierarchy:
+ * Host
+ * Port
+
+Naming hierarchy:
+ * Database
+ * Table
+
+Identifier:
+ * Namespace: mysql://{host}:{port} of the service instance.
+   * Scheme = mysql
+   * Authority = {host}:{port}
+ * Unique name: {database}.{table}
+   * URI =  mysql://{host}:{port}/{database}.{table}
+
 #### Redshift:
 Datasource hierarchy:
  * Host: examplecluster.\<XXXXXXXXXXXX>.us-west-2.redshift.amazonaws.com


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

MySQL is not supported by default for now, but it should be useful for users to support it, since it's a widely adopted database just like PostgreSQL.

### Solution

This PR adds MySqlExtractor, which sends the lineage information by MySqlOperator.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)