### PR TITLE
Support ParentRunFacet for Databricks' Synapse DW Connector in Spark

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -48,6 +48,7 @@ public class DatabricksEnvironmentFacetBuilder
   protected void build(Object event, BiConsumer<String, ? super EnvironmentFacet> consumer) {
     if (event instanceof SparkListenerJobStart) {
       SparkListenerJobStart jobStart = (SparkListenerJobStart) event;
+      log.info(String.format("WILLJ: EnvFacet JobId:%s", Integer.toString(jobStart.jobId())));
       consumer.accept(
           "environment-properties",
           new EnvironmentFacet(getDatabricksJobStartProperties(jobStart)));
@@ -86,7 +87,7 @@ public class DatabricksEnvironmentFacetBuilder
             (p) -> {
               dbProperties.put(p, jobStart.properties().getProperty(p));
             });
-
+    dbProperties.put("willjJobId", Integer.toString(jobStart.jobId()));
     /**
      * Azure Databricks makes available a dbutils mount point to list aliased paths to cloud
      * storage. However, that dbutils object is not available inside a spark listener. We must

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import scala.collection.JavaConversions;
 
 /**
@@ -21,7 +23,7 @@ import scala.collection.JavaConversions;
  */
 @Slf4j
 public class DatabricksEnvironmentFacetBuilder
-    extends CustomFacetBuilder<SparkListenerJobStart, EnvironmentFacet> {
+    extends CustomFacetBuilder<Object, EnvironmentFacet> {
   private HashMap<String, Object> dbProperties;
   private final OpenLineageContext openLineageContext;
   private Class dbutilsClass;
@@ -31,20 +33,38 @@ public class DatabricksEnvironmentFacetBuilder
     this.openLineageContext = openLineageContext;
   }
 
+  @Override
+  public boolean isDefinedAt(Object x) {
+    return (x instanceof SparkListenerSQLExecutionEnd
+        || x instanceof SparkListenerSQLExecutionStart
+        || x instanceof SparkListenerJobStart);
+  }
+
   public static boolean isDatabricksRuntime() {
     return System.getenv().containsKey("DATABRICKS_RUNTIME_VERSION");
   }
 
   @Override
-  protected void build(
-      SparkListenerJobStart event, BiConsumer<String, ? super EnvironmentFacet> consumer) {
-    consumer.accept(
-        "environment-properties",
-        new EnvironmentFacet(getDatabricksEnvironmentalAttributes(event)));
+  protected void build(Object event, BiConsumer<String, ? super EnvironmentFacet> consumer) {
+    if (event instanceof SparkListenerJobStart) {
+      SparkListenerJobStart jobStart = (SparkListenerJobStart) event;
+      consumer.accept(
+          "environment-properties",
+          new EnvironmentFacet(getDatabricksJobStartProperties(jobStart)));
+    } else if (event instanceof SparkListenerSQLExecutionStart) {
+      SparkListenerSQLExecutionStart executionStart = (SparkListenerSQLExecutionStart) event;
+      consumer.accept(
+          "environment-properties",
+          new EnvironmentFacet(getDatabricksSqlStartProperties(executionStart)));
+    } else if (event instanceof SparkListenerSQLExecutionEnd) {
+      SparkListenerSQLExecutionEnd executionEnd = (SparkListenerSQLExecutionEnd) event;
+      consumer.accept(
+          "environment-properties",
+          new EnvironmentFacet(getDatabricksSqlEndProperties(executionEnd)));
+    }
   }
 
-  private HashMap<String, Object> getDatabricksEnvironmentalAttributes(
-      SparkListenerJobStart jobStart) {
+  private HashMap<String, Object> getDatabricksJobStartProperties(SparkListenerJobStart jobStart) {
     dbProperties = new HashMap<>();
     // These are useful properties to extract if they are available
 
@@ -59,7 +79,8 @@ public class DatabricksEnvironmentFacetBuilder
             "user",
             "userId",
             "spark.databricks.clusterUsageTags.clusterName",
-            "spark.databricks.clusterUsageTags.azureSubscriptionId");
+            "spark.databricks.clusterUsageTags.azureSubscriptionId",
+            "spark.sql.execution.parent");
     dbPropertiesKeys.stream()
         .forEach(
             (p) -> {
@@ -90,5 +111,19 @@ public class DatabricksEnvironmentFacetBuilder
       mountpoints.add(new DatabricksMountpoint(mount.mountPoint(), mount.source()));
     }
     return mountpoints;
+  }
+
+  private HashMap<String, Object> getDatabricksSqlStartProperties(
+      SparkListenerSQLExecutionStart event) {
+    dbProperties = new HashMap<>();
+    dbProperties.put("execution-id", String.valueOf(event.executionId()));
+    return dbProperties;
+  }
+
+  private HashMap<String, Object> getDatabricksSqlEndProperties(
+      SparkListenerSQLExecutionEnd event) {
+    dbProperties = new HashMap<>();
+    dbProperties.put("execution-id", String.valueOf(event.executionId()));
+    return dbProperties;
   }
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksSynapseParentRunFacetBuilder copy.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksSynapseParentRunFacetBuilder copy.java
@@ -1,0 +1,59 @@
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.ParentRunFacet;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+
+/**
+ * {@link CustomFacetBuilder} that generates a {@link ParentRunFacet} when using OpenLineage on
+ * Databricks.
+ */
+@Slf4j
+public class DatabricksSynapseParentRunFacetBuilder
+    extends CustomFacetBuilder<SparkListenerJobStart, ParentRunFacet> {
+  private final OpenLineageContext openLineageContext;
+
+  public DatabricksSynapseParentRunFacetBuilder(OpenLineageContext openLineageContext) {
+    this.openLineageContext = openLineageContext;
+  }
+
+  @Override
+  public boolean isDefinedAt(Object x) {
+    if (x instanceof SparkListenerJobStart) {
+      SparkListenerJobStart jobStart = (SparkListenerJobStart) x;
+      return jobStart.properties().contains("openlineage.databricks.parentRun");
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  protected void build(
+      SparkListenerJobStart event, BiConsumer<String, ? super ParentRunFacet> consumer) {
+    SparkListenerJobStart jobStart = (SparkListenerJobStart) event;
+    String parentRunId = event.properties().getProperty("openlineage.databricks.parentRun");
+    Optional<UUID> parentRunUuid = convertToUUID(parentRunId);
+    OpenLineage openLineage = openLineageContext.getOpenLineage();
+    consumer.accept(
+        "parent",
+        openLineage
+            .newParentRunFacetBuilder()
+            .run(openLineage.newParentRunFacetRun(parentRunUuid.get()))
+            .job(openLineage.newParentRunFacetJob("testnamespace", "testName"))
+            .build());
+  }
+
+  private static Optional<UUID> convertToUUID(String uuid) {
+    try {
+      return Optional.ofNullable(uuid).map(UUID::fromString);
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksSynapseParentRunFacetBuilder.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/facets/builder/DatabricksSynapseParentRunFacetBuilder.java
@@ -25,9 +25,13 @@ public class DatabricksSynapseParentRunFacetBuilder
 
   @Override
   public boolean isDefinedAt(Object x) {
+    log.info("WILLJ: Synapse Parent Run is being checked");
     if (x instanceof SparkListenerJobStart) {
       SparkListenerJobStart jobStart = (SparkListenerJobStart) x;
-      return jobStart.properties().contains("openlineage.databricks.parentRun");
+      String parentRun = (String) jobStart.properties().get("openlineage.databricks.parentRun");
+      boolean hasParentRun = (parentRun != null);
+      log.info(String.format("WILLJ: HasParentRun== %s", Boolean.toString(hasParentRun)));
+      return hasParentRun;
     } else {
       return false;
     }
@@ -37,6 +41,7 @@ public class DatabricksSynapseParentRunFacetBuilder
   protected void build(
       SparkListenerJobStart event, BiConsumer<String, ? super ParentRunFacet> consumer) {
     SparkListenerJobStart jobStart = (SparkListenerJobStart) event;
+    log.info("WILLJ: Parent Run Facet Builder is Building!");
     String parentRunId = event.properties().getProperty("openlineage.databricks.parentRun");
     Optional<UUID> parentRunUuid = convertToUUID(parentRunId);
     OpenLineage openLineage = openLineageContext.getOpenLineage();

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -2,6 +2,7 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import java.util.UUID;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
@@ -33,4 +34,6 @@ public interface ExecutionContext {
   void end(SparkListenerSQLExecutionEnd sqlEnd);
 
   void end(SparkListenerStageCompleted stageCompleted);
+
+  UUID getRunId();
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -12,6 +12,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.OutputDatasetFacet;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.DatabricksSynapseParentRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
@@ -181,6 +182,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new SparkVersionFacetBuilder(context));
     if (DatabricksEnvironmentFacetBuilder.isDatabricksRuntime()) {
       listBuilder.add(new DatabricksEnvironmentFacetBuilder(context));
+      listBuilder.add(new DatabricksSynapseParentRunFacetBuilder(context));
     }
     return listBuilder.build();
   }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -396,4 +396,8 @@ class RddExecutionContext implements ExecutionContext {
     }
     return OpenLineage.RunEvent.EventType.FAIL;
   }
+
+  public UUID getRunId() {
+    return runId;
+  };
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -228,4 +228,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
       return Optional.empty();
     }
   }
+
+  public UUID getRunId() {
+    return olContext.getOpenLineage().getRunId();
+  };
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -135,13 +135,14 @@ class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public void start(SparkListenerJobStart jobStart) {
     // TODO HOW DO I GET THIS TO BE THE REAL ID?
-    String x = (String) jobStart.properties().get("spark.sql.execution.parent");
-    Optional<UUID> parentExecutionId = Optional.empty();
-    if (x != null) {
-      // TODO: Fix this with a real execution id
-      parentExecutionId = convertToUUID("38400000-8cf0-11bd-b23e-10b96e4ef00d");
-    }
-    log.debug("SparkListenerJobStart - executionId: " + executionId);
+    // String x = (String) jobStart.properties().get("spark.sql.execution.parent");
+    // Optional<UUID> parentExecutionId = Optional.empty();
+    // if (x != null) {
+    //   // TODO: Fix this with a real execution id
+    //   parentExecutionId = convertToUUID("38400000-8cf0-11bd-b23e-10b96e4ef00d");
+    // }
+    log.info("WILLJ: Start occurred");
+    log.info("SparkListenerJobStart - executionId: " + executionId);
     jobId = Optional.of(jobStart.jobId());
     if (!olContext.getQueryExecution().isPresent()) {
       log.info("No execution info {}", olContext);
@@ -149,9 +150,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
     }
     RunEvent event =
         runEventBuilder.buildRun(
-            parentExecutionId.isPresent()
-                ? buildParentFacet(parentExecutionId, "test")
-                : buildParentFacet(),
+            // parentExecutionId.isPresent()
+            //     ? buildParentFacet(parentExecutionId, "test")
+            //     : buildParentFacet(),
+            buildParentFacet(),
             openLineage.newRunEventBuilder().eventTime(toZonedTime(jobStart.time())),
             buildJob(olContext.getQueryExecution().get()),
             jobStart);
@@ -230,6 +232,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
   }
 
   public UUID getRunId() {
-    return olContext.getOpenLineage().getRunId();
+    return olContext.getRunUuid();
   };
 }

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -134,15 +134,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void start(SparkListenerJobStart jobStart) {
-    // TODO HOW DO I GET THIS TO BE THE REAL ID?
-    // String x = (String) jobStart.properties().get("spark.sql.execution.parent");
-    // Optional<UUID> parentExecutionId = Optional.empty();
-    // if (x != null) {
-    //   // TODO: Fix this with a real execution id
-    //   parentExecutionId = convertToUUID("38400000-8cf0-11bd-b23e-10b96e4ef00d");
-    // }
-    log.info("WILLJ: Start occurred");
-    log.info("SparkListenerJobStart - executionId: " + executionId);
+    log.debug("SparkListenerJobStart - executionId: " + executionId);
     jobId = Optional.of(jobStart.jobId());
     if (!olContext.getQueryExecution().isPresent()) {
       log.info("No execution info {}", olContext);
@@ -150,9 +142,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
     }
     RunEvent event =
         runEventBuilder.buildRun(
-            // parentExecutionId.isPresent()
-            //     ? buildParentFacet(parentExecutionId, "test")
-            //     : buildParentFacet(),
             buildParentFacet(),
             openLineage.newRunEventBuilder().eventTime(toZonedTime(jobStart.time())),
             buildJob(olContext.getQueryExecution().get()),
@@ -195,12 +184,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     runId, eventEmitter.getParentJobName(), eventEmitter.getJobNamespace()));
   }
 
-  private Optional<OpenLineage.ParentRunFacet> buildParentFacet(
-      Optional<UUID> parentRunID, String parentJobName) {
-    return parentRunID.map(
-        runId -> PlanUtils.parentRunFacet(runId, parentJobName, eventEmitter.getJobNamespace()));
-  }
-
   protected ZonedDateTime toZonedTime(long time) {
     Instant i = Instant.ofEpochMilli(time);
     return ZonedDateTime.ofInstant(i, ZoneOffset.UTC);
@@ -221,14 +204,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
             sparkContext.appName().replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT)
                 + "."
                 + node.nodeName().replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT));
-  }
-
-  private static Optional<UUID> convertToUUID(String uuid) {
-    try {
-      return Optional.ofNullable(uuid).map(UUID::fromString);
-    } catch (Exception e) {
-      return Optional.empty();
-    }
   }
 
   public UUID getRunId() {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

The Datbaricks Synapse Data Warehouse Connector does not report lineage cleanly when Synapse is the output destination. The SparkSQLExecutionStart contains the correct output but the subsequent JobStart events contain lineage for a temporary folder. However, the JobStart event does report a `spark.sql.execution.parent` property which can be used to identify which parent execution id called this JobStart.

It doesn't close but it is a candidate for #670 for the Synapse DW Connector specifically.

### Solution

I plan to modify `SparkSQLExecutionContext.start(jobStart)` to do the following:
* Check if the Job Start event has the `spark.sql.execution.parent` property.
* If so, get the OpenLineage RunId for this execution Id. **Need help here**
* If there is a parent run, modify the call to `runEventBuilder.buildRun` and the `buildParentFacet` to accept:
  * Optional<UUID> parentRunID (this is provided by the above steps if I can figure them out)
  * String parentJobName (**Need help here**)
    * job Name seems to be buried in `SparkSqlExecutionContext.buildJob`  
    ```
    sparkContext.appName().replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT)
    + "."
    + node.nodeName().replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT));
    ```

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)