### PR TITLE
CI: do not run snapshot deploy on non-main branches

### DIFF
--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -3,6 +3,9 @@ workflows:
     jobs:
       - build-client-java
       - publish-snapshot-client-java:
+          filters:
+            branches:
+              only: main
           context: release
           requires:
             - build-client-java


### PR DESCRIPTION
In addition of not being necessary, deploying this snapshot always fails on forks.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
