### PR TITLE
ci: non-snapshot relase should release sql; airflow release does not require runtime sql dependency

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -11,9 +11,6 @@ checkout_project_root: &checkout_project_root
 install_python_client: &install_python_client
   run: (cd ~/openlineage/client/python && pip install . --user)
 
-install_integration_common: &install_integration_common
-  run: (cd ~/openlineage/integration/common && pip install . --user)
-
 param_build_tag: &param_build_tag
   parameters:
     build_tag:
@@ -368,7 +365,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - install_integration_common:
-          install_parser: true
+          install_parser: false
       - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
@@ -600,6 +597,24 @@ workflows:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
+      - build-integration-sql:
+          name: build-integration-sql-x86
+          image: "quay.io/pypa/manylinux2014_x86_64"
+          resource_class: "medium"
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-sql:
+          name: build-integration-sql-arm
+          image: "quay.io/pypa/manylinux2014_aarch64"
+          resource_class: "arm.medium"
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
       - release-python:
           filters:
             tags:
@@ -613,3 +628,5 @@ workflows:
             - build-integration-airflow
             - build-integration-dbt
             - build-integration-dagster
+            - build-integration-sql-x86
+            - build-integration-sql-arm


### PR DESCRIPTION

Release 0.8.0 failed because `release-python`, in comparison to snapshot release, did not provide SQL dependency. 
Instead of providing it, stop requiring dependency that is used only at runtime.

https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/3164/workflows/5c9350ae-fe06-455b-abba-2a792093ccbc/jobs/30183

Also, build SQL parser on release. Even if we did not fail on ⬆️ , we'd have to release again with SQL. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>