### PR TITLE
[INTEGRATION][AIRFLOW] Fix wrong source path for copying integration/sql

### DIFF
--- a/integration/airflow/Dockerfile.tests
+++ b/integration/airflow/Dockerfile.tests
@@ -5,7 +5,7 @@ ADD airflow/README.md /app
 COPY python /tmp/openlineage-client-python
 COPY common /tmp/openlineage-integration-common
 COPY dbt /tmp/openlineage-integration-dbt
-COPY target/wheels /app/wheel
+COPY sql/target/wheels/*.whl /app/wheel/
 RUN cd /tmp/openlineage-client-python && pip wheel --no-deps --wheel-dir=/tmp/openlineage-client-python/wheel .
 RUN cd /tmp/openlineage-integration-common && pip wheel --no-deps --wheel-dir=/tmp/openlineage-integration-common/wheel .
 RUN cd /tmp/openlineage-integration-dbt && pip wheel --no-deps --wheel-dir=/tmp/openlineage-integration-dbt/wheel .


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

I tried to run the integration test locally on the main branch, but during its preparation, I came across the following error.

```
$ cd integration
$ docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .

...

Step 8/19 : COPY target/wheels /app/wheel
COPY failed: file not found in build context or excluded by .dockerignore: stat target/wheels: file does not exist
```

### Solution

The source path for copying integration/sql seems to be wrong, so this PR fixes it.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)