### PR TITLE
airflow: support getting credentials from secrets backend

### DIFF
--- a/integration/airflow/tests/integration/data/secrets/connections.json
+++ b/integration/airflow/tests/integration/data/secrets/connections.json
@@ -1,0 +1,3 @@
+{
+    "food_delivery_db": "postgres://food_delivery:food_delivery@postgres:5432/food_delivery"
+}

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -23,7 +23,6 @@ x-airflow-base: &airflow-base
     AIRFLOW__CORE__LOAD_EXAMPLES: "False"
     AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
-    AIRFLOW_CONN_FOOD_DELIVERY_DB: postgres://food_delivery:food_delivery@postgres:5432/food_delivery
     AIRFLOW_CONN_MYSQL_CONN: mysql://food_delivery:food_delivery@mysql:3306/food_delivery
     AIRFLOW_CONN_BQ_CONN: google-cloud-platform://?extra__google_cloud_platform__project=openlineage-ci&extra__google_cloud_platform__key_path=%2Fopt%2Fconfig%2Fgcloud%2Fgcloud-service-key.json
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "False"
@@ -36,6 +35,8 @@ x-airflow-base: &airflow-base
     SNOWFLAKE_ACCOUNT_ID: ${SNOWFLAKE_ACCOUNT_ID}
     SNOWFLAKE_USER: ${SNOWFLAKE_USER}
     SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD}
+    AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
+    AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json" }'
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=DEMO&role=OPENLINEAGE"
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py


### PR DESCRIPTION
If Airflow > 2 is used, try to get connection from Secrets Backend, before falling back to querying database. 

Add test that utilizes LocalFilesystemBackend to make sure that getting connection from it works.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: https://github.com/OpenLineage/OpenLineage/issues/672
