### PR TITLE
[INTEGRATION][FLINK] include schema facet

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
+    implementation "org.apache.flink:flink-avro:$flinkVersion"
 
     implementation 'org.javassist:javassist:3.27.0-GA'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
@@ -90,6 +91,7 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
     testImplementation 'org.mock-server:mockserver-client-java:5.12.0'
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.1.1'
+
     testCompile "org.assertj:assertj-core:${assertjVersion}"
     testCompile "org.junit.jupiter:junit-jupiter:${junit5Version}"
     testCompile "org.junit.jupiter:junit-jupiter-params:${junit5Version}"

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
-version=0.7.0-SNAPSHOT
+version=0.9.0-SNAPSHOT
 flink.version=1.14.2
 org.gradle.jvmargs=-Xmx1G

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -1,0 +1,54 @@
+package io.openlineage.flink.utils;
+
+import static org.apache.avro.Schema.Type.NULL;
+
+import io.openlineage.client.OpenLineage;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.avro.Schema;
+
+/** Utility class for translating Avro schema into open lineage schema */
+public class AvroSchemaUtils {
+
+  /**
+   * Converts Avro {@link Schema} to {@link OpenLineage.SchemaDatasetFacet}
+   *
+   * @param avroSchema
+   * @return
+   */
+  public static OpenLineage.SchemaDatasetFacet convert(OpenLineage openLineage, Schema avroSchema) {
+    OpenLineage.SchemaDatasetFacetBuilder builder = openLineage.newSchemaDatasetFacetBuilder();
+    List<OpenLineage.SchemaDatasetFacetFields> fields = new LinkedList<>();
+
+    avroSchema.getFields().stream()
+        .forEach(
+            avroField -> {
+              fields.add(
+                  openLineage.newSchemaDatasetFacetFields(
+                      avroField.name(), getTypeName(avroField.schema()), avroField.doc()));
+            });
+
+    return builder.fields(fields).build();
+  }
+
+  private static String getTypeName(Schema fieldSchema) {
+    // In case of union type containing some type and null type, non-null type name is returned.
+    // For example, Avro type `"type": ["null", "long"]` is converted to `long`.
+    return Optional.of(fieldSchema)
+        .filter(Schema::isUnion)
+        .map(Schema::getTypes)
+        .filter(types -> types.size() == 2) // check if schema field contains two types
+        .filter(
+            types ->
+                types.get(0).getType().equals(NULL)
+                    || types.get(1).getType().equals(NULL)) // check if one of the two types is NULL
+        .stream()
+        .flatMap(Collection::stream)
+        .filter(type -> !type.getType().equals(NULL)) // if so, choose the non-null type
+        .map(type -> type.getType().getName())
+        .findAny()
+        .orElse(fieldSchema.getType().getName());
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/DatasetFactory.java
@@ -35,17 +35,24 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
     };
   }
 
+  public OpenLineage.DatasetFacetsBuilder getDatasetFacetsBuilder(String name, String namespace) {
+    return openLineage
+        .newDatasetFacetsBuilder()
+        .dataSource(
+            openLineage
+                .newDatasourceDatasetFacetBuilder()
+                .uri(URI.create(""))
+                .name(namespace)
+                .build());
+  }
+
+  public D getDataset(
+      String name, String namespace, OpenLineage.DatasetFacetsBuilder facetsBuilder) {
+    return getDataset(name, namespace, facetsBuilder.build());
+  }
+
   public D getDataset(String name, String namespace) {
-    OpenLineage.DatasetFacetsBuilder builder =
-        openLineage
-            .newDatasetFacetsBuilder()
-            .dataSource(
-                openLineage
-                    .newDatasourceDatasetFacetBuilder()
-                    .uri(URI.create(""))
-                    .name(namespace)
-                    .build());
-    return getDataset(name, namespace, builder.build());
+    return getDataset(name, namespace, getDatasetFacetsBuilder(name, namespace).build());
   }
 
   public D getDataset(String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
@@ -1,0 +1,70 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.formats.avro.AvroSerializationSchema;
+import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
+
+/**
+ * Wrapper class to extract hidden fields and call hidden methods on {@link KafkaSink} object. It
+ * encapsulates all the reflection methods used on {@link KafkaSink}.
+ */
+@Slf4j
+public class KafkaSinkWrapper {
+
+  private final KafkaSink kafkaSink;
+  private final KafkaRecordSerializationSchema serializationSchema;
+
+  private KafkaSinkWrapper(KafkaSink kafkaSink) {
+    this.kafkaSink = kafkaSink;
+    this.serializationSchema =
+        WrapperUtils.<KafkaRecordSerializationSchema>getFieldValue(
+                KafkaSink.class, kafkaSink, "recordSerializer")
+            .get();
+  }
+
+  public static KafkaSinkWrapper of(KafkaSink kafkaSink) {
+    return new KafkaSinkWrapper(kafkaSink);
+  }
+
+  public Properties getKafkaProducerConfig() {
+    return WrapperUtils.<Properties>getFieldValue(KafkaSink.class, kafkaSink, "kafkaProducerConfig")
+        .get();
+  }
+
+  public String getKafkaTopic() throws IllegalAccessException {
+    Function<?, ?> topicSelector =
+        WrapperUtils.<Function<?, ?>>getFieldValue(
+                serializationSchema.getClass(), serializationSchema, "topicSelector")
+            .get();
+
+    Function<?, ?> function =
+        (Function<?, ?>)
+            WrapperUtils.getFieldValue(topicSelector.getClass(), topicSelector, "topicSelector")
+                .get();
+
+    return (String) function.apply(null);
+  }
+
+  public Optional<Schema> getAvroSchema() {
+    return WrapperUtils.getFieldValue(
+            serializationSchema.getClass(), serializationSchema, "valueSerializationSchema")
+        .filter(schema -> schema instanceof RegistryAvroSerializationSchema)
+        .map(schema -> (RegistryAvroSerializationSchema) schema)
+        .flatMap(
+            schema -> {
+              WrapperUtils.invoke(
+                  RegistryAvroSerializationSchema.class, schema, "checkAvroInitialized");
+              return WrapperUtils.invoke(AvroSerializationSchema.class, schema, "getDatumWriter");
+            })
+        .flatMap(
+            writer -> {
+              return WrapperUtils.<Schema>getFieldValue(writer.getClass(), writer, "root");
+            });
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
@@ -1,0 +1,82 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.formats.avro.AvroDeserializationSchema;
+
+/**
+ * Wrapper class to extract hidden fields and call hidden methods on {@link KafkaSource} object. It
+ * encapsulates all the reflection methods used on {@link KafkaSource}.
+ */
+@Slf4j
+public class KafkaSourceWrapper {
+
+  private static final String DESERIALIZATION_SCHEMA_WRAPPER_CLASS =
+      "org.apache.flink.connector.kafka.source.reader.deserializer.KafkaValueOnlyDeserializationSchemaWrapper";
+  private final KafkaSource kafkaSource;
+
+  @Getter private final KafkaSubscriber kafkaSubscriber;
+
+  private KafkaSourceWrapper(KafkaSource kafkaSource, KafkaSubscriber kafkaSubscriber) {
+    this.kafkaSource = kafkaSource;
+    this.kafkaSubscriber = kafkaSubscriber;
+  }
+
+  public static KafkaSourceWrapper of(KafkaSource kafkaSource) throws IllegalAccessException {
+    Field subscriberField = FieldUtils.getField(KafkaSource.class, "subscriber", true);
+    KafkaSubscriber kafkaSubscriber = (KafkaSubscriber) subscriberField.get(kafkaSource);
+
+    return new KafkaSourceWrapper(kafkaSource, kafkaSubscriber);
+  }
+
+  public KafkaSubscriber getSubscriber() {
+    return kafkaSubscriber;
+  }
+
+  public Properties getProps() throws IllegalAccessException {
+    return WrapperUtils.<Properties>getFieldValue(KafkaSource.class, kafkaSource, "props").get();
+  }
+
+  public List<String> getTopics() throws IllegalAccessException {
+    return WrapperUtils.<List<String>>getFieldValue(
+            kafkaSubscriber.getClass(), kafkaSubscriber, "topics")
+        .get();
+  }
+
+  public KafkaRecordDeserializationSchema getDeserializationSchema() throws IllegalAccessException {
+    return WrapperUtils.<KafkaRecordDeserializationSchema>getFieldValue(
+            KafkaSource.class, kafkaSource, "deserializationSchema")
+        .get();
+  }
+
+  public Optional<Schema> getAvroSchema() {
+    try {
+      final Class deserializationSchemaWrapperClass =
+          Class.forName(DESERIALIZATION_SCHEMA_WRAPPER_CLASS);
+      return Optional.of(getDeserializationSchema())
+          .filter(el -> el.getClass().isAssignableFrom(deserializationSchemaWrapperClass))
+          .flatMap(
+              el ->
+                  WrapperUtils.<DeserializationSchema>getFieldValue(
+                      deserializationSchemaWrapperClass, el, "deserializationSchema"))
+          .filter(schema -> schema instanceof AvroDeserializationSchema)
+          .map(schema -> (AvroDeserializationSchema) schema)
+          .map(schema -> schema.getProducedType())
+          .flatMap(typeInformation -> Optional.ofNullable(typeInformation.getTypeClass()))
+          .flatMap(aClass -> WrapperUtils.<Schema>invokeStatic(aClass, "getClassSchema"));
+    } catch (ClassNotFoundException | IllegalAccessException e) {
+      log.error("Cannot extract Avro schema: ", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
@@ -1,0 +1,56 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+/**
+ * Class with utility methods related to make use of {@org.apache.commons.lang3.reflect.FieldUtils}
+ * and {@org.apache.commons.lang3.reflect.MethodUtils}
+ */
+@Slf4j
+public class WrapperUtils {
+
+  /**
+   * Gets a field of a given object
+   *
+   * @param aClass
+   * @param object
+   * @param field
+   * @param <T>
+   * @return
+   */
+  public static <T> Optional<T> getFieldValue(Class aClass, Object object, String field) {
+    try {
+      return Optional.ofNullable((T) FieldUtils.getField(aClass, field, true).get(object));
+    } catch (IllegalAccessException | ClassCastException | NullPointerException e) {
+      log.error("cannot extract field {} from {}", field, aClass.getName(), e);
+      return Optional.empty();
+    }
+  }
+
+  public static <T> Optional<T> invoke(Class aClass, Object object, String methodName) {
+    try {
+      Method method = aClass.getDeclaredMethod(methodName);
+      method.setAccessible(true);
+      return Optional.ofNullable((T) method.invoke(object));
+    } catch (NoSuchMethodException e) {
+      log.error("Method {} not found in class {}", methodName, aClass, e);
+      return Optional.empty();
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      log.error("Method {} invocation failed in class {}", methodName, aClass, e);
+      return Optional.empty();
+    }
+  }
+
+  public static <T> Optional<T> invokeStatic(Class aClass, String method) {
+    try {
+      return Optional.ofNullable((T) aClass.getMethod(method).invoke(null));
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      log.error("cannot call schema on produced class", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
@@ -1,0 +1,54 @@
+package io.openlineage.flink.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.agent.client.OpenLineageClient;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.jupiter.api.Test;
+
+public class AvroSchemaUtilsTest {
+
+  Schema schema =
+      SchemaBuilder.record("InputEvent")
+          .namespace("io.openlineage.flink.avro.event")
+          .fields()
+          .name("a")
+          .doc("some-doc")
+          .type()
+          .nullable()
+          .longType()
+          .noDefault()
+          .name("b")
+          .type()
+          .nullable()
+          .intType()
+          .noDefault()
+          .name("c")
+          .type()
+          .nullable()
+          .stringType()
+          .stringDefault("")
+          .endRecord();
+
+  OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+
+  @Test
+  public void testConvert() {
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+        AvroSchemaUtils.convert(openLineage, schema);
+
+    List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
+
+    assertEquals(3, fields.size());
+
+    assertEquals("a", fields.get(0).getName());
+    assertEquals("some-doc", fields.get(0).getDescription());
+
+    assertEquals("long", fields.get(0).getType());
+    assertEquals("int", fields.get(1).getType());
+    assertEquals("string", fields.get(2).getType());
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -1,0 +1,91 @@
+package io.openlineage.flink.visitor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.agent.client.OpenLineageClient;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.visitor.wrapper.KafkaSinkWrapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.SneakyThrows;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class KafkaSinkVisitorTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  KafkaSinkVisitor visitor = new KafkaSinkVisitor(context);
+  KafkaSink kafkaSink = mock(KafkaSink.class);
+  Properties props = new Properties();
+  KafkaSinkWrapper wrapper = mock(KafkaSinkWrapper.class);
+  OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+  Schema schema =
+      SchemaBuilder.record("OutputEvent")
+          .namespace("io.openlineage.flink.avro.event")
+          .fields()
+          .name("a")
+          .type()
+          .nullable()
+          .longType()
+          .noDefault()
+          .endRecord();
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    props.put("bootstrap.servers", "server1;server2");
+    when(context.getOpenLineage()).thenReturn(openLineage);
+  }
+
+  @Test
+  public void testIsDefined() {
+    assertEquals(false, visitor.isDefinedAt(mock(Object.class)));
+    assertEquals(true, visitor.isDefinedAt(mock(KafkaSink.class)));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApply() {
+    try (MockedStatic<KafkaSinkWrapper> mockedStatic = mockStatic(KafkaSinkWrapper.class)) {
+      when(KafkaSinkWrapper.of(kafkaSink)).thenReturn(wrapper);
+
+      when(wrapper.getKafkaTopic()).thenReturn("topic");
+      when(wrapper.getKafkaProducerConfig()).thenReturn(props);
+      when(wrapper.getAvroSchema()).thenReturn(Optional.of(schema));
+
+      OpenLineage.OutputDataset outputDataset = visitor.apply(kafkaSink).get(0);
+      List<OpenLineage.SchemaDatasetFacetFields> fields =
+          outputDataset.getFacets().getSchema().getFields();
+
+      assertEquals("topic", outputDataset.getName());
+      assertEquals("server1;server2", outputDataset.getNamespace());
+
+      assertEquals(1, fields.size());
+      assertEquals("a", fields.get(0).getName());
+      assertEquals("long", fields.get(0).getType());
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApplyWhenIllegalAccessExceptionThrown() {
+    try (MockedStatic<KafkaSinkWrapper> mockedStatic = mockStatic(KafkaSinkWrapper.class)) {
+      when(KafkaSinkWrapper.of(kafkaSink)).thenReturn(wrapper);
+
+      when(wrapper.getKafkaProducerConfig()).thenReturn(props);
+      when(wrapper.getKafkaTopic()).thenThrow(new IllegalAccessException(""));
+      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(kafkaSink);
+
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
@@ -1,0 +1,93 @@
+package io.openlineage.flink.visitor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.agent.client.OpenLineageClient;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.visitor.wrapper.KafkaSourceWrapper;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.SneakyThrows;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class KafkaSourceVisitorTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  KafkaSource kafkaSource = mock(KafkaSource.class);
+  KafkaSourceVisitor kafkaSourceVisitor = new KafkaSourceVisitor(context);
+  KafkaSourceWrapper wrapper = mock(KafkaSourceWrapper.class);
+  Properties props = new Properties();
+  OpenLineage openLineage = new OpenLineage(OpenLineageClient.OPEN_LINEAGE_CLIENT_URI);
+  Schema schema =
+      SchemaBuilder.record("InputEvent")
+          .namespace("io.openlineage.flink.avro.event")
+          .fields()
+          .name("a")
+          .type()
+          .nullable()
+          .longType()
+          .noDefault()
+          .endRecord();
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+  }
+
+  @Test
+  public void testIsDefined() {
+    assertEquals(false, kafkaSourceVisitor.isDefinedAt(mock(Object.class)));
+    assertEquals(true, kafkaSourceVisitor.isDefinedAt(mock(KafkaSource.class)));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApply() {
+    props.put("bootstrap.servers", "server1;server2");
+
+    try (MockedStatic<KafkaSourceWrapper> mockedStatic = mockStatic(KafkaSourceWrapper.class)) {
+      when(KafkaSourceWrapper.of(kafkaSource)).thenReturn(wrapper);
+
+      when(wrapper.getTopics()).thenReturn(Arrays.asList("topic1", "topic2"));
+      when(wrapper.getProps()).thenReturn(props);
+      when(wrapper.getAvroSchema()).thenReturn(Optional.of(schema));
+
+      List<OpenLineage.InputDataset> inputDatasets = kafkaSourceVisitor.apply(kafkaSource);
+      List<OpenLineage.SchemaDatasetFacetFields> fields =
+          inputDatasets.get(0).getFacets().getSchema().getFields();
+
+      assertEquals(2, inputDatasets.size());
+      assertEquals("topic1", inputDatasets.get(0).getName());
+      assertEquals("server1;server2", inputDatasets.get(0).getNamespace());
+
+      assertEquals(1, fields.size());
+      assertEquals("a", fields.get(0).getName());
+      assertEquals("long", fields.get(0).getType());
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  public void testApplyWhenIllegalAccessExceptionThrown() {
+    try (MockedStatic<KafkaSourceWrapper> mockedStatic = mockStatic(KafkaSourceWrapper.class)) {
+      when(KafkaSourceWrapper.of(kafkaSource)).thenReturn(wrapper);
+
+      when(wrapper.getTopics()).thenThrow(new IllegalAccessException(""));
+      List<OpenLineage.InputDataset> inputDatasets = kafkaSourceVisitor.apply(kafkaSource);
+
+      assertEquals(0, inputDatasets.size());
+    }
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
@@ -1,0 +1,127 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Function;
+import lombok.SneakyThrows;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.formats.avro.AvroSerializationSchema;
+import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class KafkaSinkWrapperTest {
+
+  private Properties props = mock(Properties.class);
+  private static Schema schema =
+      SchemaBuilder.record("OutputEvent")
+          .namespace("io.openlineage.flink.avro.event")
+          .fields()
+          .name("a")
+          .type()
+          .nullable()
+          .longType()
+          .noDefault()
+          .endRecord();
+
+  private KafkaSink kafkaSink;
+  private KafkaSinkWrapper wrapper;
+  private KafkaRecordSerializationSchema serializationSchema =
+      mock(KafkaRecordSerializationSchema.class);
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    props.put("bootstrap.servers", "server1;server2");
+    kafkaSink =
+        KafkaSink.builder()
+            .setBootstrapServers("server1;server2")
+            .setKafkaProducerConfig(props)
+            .setRecordSerializer(serializationSchema)
+            .build();
+
+    wrapper = KafkaSinkWrapper.of(kafkaSink);
+  }
+
+  @Test
+  public void testGetProducerConfig() {
+    assertEquals(props, wrapper.getKafkaProducerConfig());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetKafkaTopic() {
+    Function<?, ?> topicSelector = mock(Function.class);
+    Function noArgFunction = mock(Function.class);
+    try (MockedStatic<WrapperUtils> mockedStatic = mockStatic(WrapperUtils.class)) {
+      when(WrapperUtils.getFieldValue(
+              serializationSchema.getClass(), serializationSchema, "topicSelector"))
+          .thenReturn(Optional.ofNullable(topicSelector));
+      when(WrapperUtils.getFieldValue(topicSelector.getClass(), topicSelector, "topicSelector"))
+          .thenReturn(Optional.ofNullable(noArgFunction));
+      when(noArgFunction.apply(null)).thenReturn("topic");
+
+      assertEquals("topic", wrapper.getKafkaTopic());
+    }
+  }
+
+  @Test
+  public void testGetAvroSchema() {
+    try (MockedStatic<WrapperUtils> mockedStatic = mockStatic(WrapperUtils.class)) {
+      RegistryAvroSerializationSchema avroSerializationSchema =
+          mock(RegistryAvroSerializationSchema.class);
+      GenericDatumWriter genericDatumWriter = new GenericDatumWriter(schema);
+      when(WrapperUtils.getFieldValue(
+              serializationSchema.getClass(), serializationSchema, "valueSerializationSchema"))
+          .thenReturn(Optional.of(avroSerializationSchema));
+
+      when(WrapperUtils.invoke(
+              AvroSerializationSchema.class, avroSerializationSchema, "getDatumWriter"))
+          .thenReturn(Optional.of(genericDatumWriter));
+
+      when(WrapperUtils.getFieldValue(GenericDatumWriter.class, genericDatumWriter, "root"))
+          .thenReturn(Optional.of(schema));
+
+      assertEquals(schema, wrapper.getAvroSchema().get());
+    }
+  }
+
+  @Test
+  public void testGetAvroSchemaWhenNoValueSerializationSchemaPresent() {
+    try (MockedStatic<WrapperUtils> mockedStatic = mockStatic(WrapperUtils.class)) {
+      when(WrapperUtils.getFieldValue(
+              serializationSchema.getClass(), serializationSchema, "valueSerializationSchema"))
+          .thenReturn(Optional.empty());
+
+      assertFalse(wrapper.getAvroSchema().isPresent());
+    }
+  }
+
+  @Test
+  public void testGetAvroSchemaWhenNoDatumWriterPresent() {
+    try (MockedStatic<WrapperUtils> mockedStatic = mockStatic(WrapperUtils.class)) {
+      RegistryAvroSerializationSchema avroSerializationSchema =
+          mock(RegistryAvroSerializationSchema.class);
+      when(WrapperUtils.getFieldValue(
+              serializationSchema.getClass(), serializationSchema, "valueSerializationSchema"))
+          .thenReturn(Optional.of(avroSerializationSchema));
+
+      when(WrapperUtils.invoke(
+              AvroSerializationSchema.class, avroSerializationSchema, "getDatumWriter"))
+          .thenReturn(Optional.empty());
+
+      assertFalse(wrapper.getAvroSchema().isPresent());
+    }
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
@@ -1,0 +1,110 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+import java.util.Properties;
+import lombok.SneakyThrows;
+import org.apache.avro.Schema;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.formats.avro.AvroDeserializationSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang.reflect.FieldUtils;
+
+public class KafkaSourceWrapperTest {
+
+  private KafkaSubscriber kafkaSubscriber = mock(KafkaSubscriber.class);
+  private Properties props = mock(Properties.class);
+  private KafkaRecordDeserializationSchema deserializationSchema =
+      mock(KafkaRecordDeserializationSchema.class);
+  private static Schema schema = mock(Schema.class);
+
+  private KafkaSource kafkaSource;
+  private KafkaSourceWrapper wrapper;
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    Class kafkaSourceClass = Class.forName("org.apache.flink.connector.kafka.source.KafkaSource");
+    Constructor<KafkaSource> constructor = kafkaSourceClass.getDeclaredConstructors()[0];
+    constructor.setAccessible(true);
+    kafkaSource =
+        constructor.newInstance(kafkaSubscriber, null, null, null, deserializationSchema, props);
+    wrapper = KafkaSourceWrapper.of(kafkaSource);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetSubscriber() {
+    assertEquals(kafkaSubscriber, wrapper.getSubscriber());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetProps() {
+    assertEquals(props, wrapper.getProps());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetDeserializationSchema() {
+    assertEquals(deserializationSchema, wrapper.getDeserializationSchema());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetAvroSchema() {
+    KafkaRecordDeserializationSchema deserializationSchema =
+        (KafkaRecordDeserializationSchema)
+            mock(
+                Class.forName(
+                    "org.apache.flink.connector.kafka.source.reader.deserializer.KafkaValueOnlyDeserializationSchemaWrapper"));
+    AvroDeserializationSchema avroDeserializationSchema = mock(AvroDeserializationSchema.class);
+    TypeInformation typeInformation = mock(TypeInformation.class);
+
+    when(avroDeserializationSchema.getProducedType()).thenReturn(typeInformation);
+    when(typeInformation.getTypeClass())
+        .thenReturn(this.getClass()); // test class contains getClassSchema method
+
+    FieldUtils.writeField(kafkaSource, "deserializationSchema", deserializationSchema, true);
+    FieldUtils.writeField(
+        deserializationSchema, "deserializationSchema", avroDeserializationSchema, true);
+
+    assertEquals(Optional.of(schema), wrapper.getAvroSchema());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetAvroSchemaForNonAvroDeserializationSchema() {
+    KafkaRecordDeserializationSchema deserializationSchema =
+        (KafkaRecordDeserializationSchema)
+            mock(
+                Class.forName(
+                    "org.apache.flink.connector.kafka.source.reader.deserializer.KafkaValueOnlyDeserializationSchemaWrapper"));
+    AvroDeserializationSchema avroDeserializationSchema = mock(AvroDeserializationSchema.class);
+
+    FieldUtils.writeField(kafkaSource, "deserializationSchema", deserializationSchema, true);
+    FieldUtils.writeField(
+        deserializationSchema, "deserializationSchema", mock(DeserializationSchema.class), true);
+
+    assertEquals(Optional.empty(), wrapper.getAvroSchema());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetAvroSchemaForEmptyDeserializationSchema() {
+    assertEquals(Optional.empty(), wrapper.getAvroSchema());
+  }
+
+  public static Schema getClassSchema() {
+    return schema;
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
@@ -1,0 +1,62 @@
+package io.openlineage.flink.visitor.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class WrapperUtilsTest {
+
+  AccessedClass object = new AccessedClass("some-string");
+
+  @Test
+  public void testGetFieldValue() {
+    assertEquals(
+        Optional.of("some-string"), WrapperUtils.getFieldValue(object.getClass(), object, "field"));
+  }
+
+  @Test
+  public void testGetFieldValueIncorrectField() {
+    assertEquals(
+        Optional.empty(), WrapperUtils.getFieldValue(object.getClass(), object, "other-field"));
+  }
+
+  @Test
+  public void testInvoke() {
+    assertEquals(
+        Optional.of("some-string"), WrapperUtils.invoke(AccessedClass.class, object, "getField"));
+  }
+
+  @Test
+  public void testInvokeWrongMethod() {
+    assertEquals(
+        Optional.empty(), WrapperUtils.invoke(AccessedClass.class, object, "wrong-method"));
+  }
+
+  @Test
+  public void testInvokeStatic() {
+    assertEquals(
+        Optional.of("some-string"), WrapperUtils.invokeStatic(this.getClass(), "getStatic"));
+  }
+
+  @Test
+  public void testInvokeStaticWrongMethod() {
+    assertEquals(Optional.empty(), WrapperUtils.invokeStatic(this.getClass(), "wrong-method"));
+  }
+
+  class AccessedClass {
+    private final String field;
+
+    AccessedClass(String field) {
+      this.field = field;
+    }
+
+    private String getField() {
+      return field;
+    }
+  }
+
+  public static String getStatic() {
+    return "some-string";
+  }
+}

--- a/integration/flink/src/test/resources/events/expected_event.json
+++ b/integration/flink/src/test/resources/events/expected_event.json
@@ -1,14 +1,46 @@
 {
   "inputs": [
     {
-      "namespace" : "kafka:9092",
-      "name" : "io.openlineage.flink.kafka.input"
+      "namespace": "kafka:9092",
+      "name": "io.openlineage.flink.kafka.input",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "long"
+            }
+          ]
+        }
+      }
     }
   ],
   "outputs": [
     {
-      "namespace" : "kafka:9092",
-      "name" : "io.openlineage.flink.kafka.output"
+      "namespace": "kafka:9092",
+      "name": "io.openlineage.flink.kafka.output",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "long"
+            },
+            {
+              "name": "counter",
+              "type": "long"
+            }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Avro schema absent in OL event

Closes: #568

### Solution

 * Use reflection to extract input & output schema,
 * Cover the created code with unit tests,
 * Include schema in the existing integration test. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)