### PR TITLE
External rdd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * `openlineage-airflow` now supports getting credentials from [Airflows secrets backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) [@mobuchowski](https://github.com/mobuchowski)
 * `openlineage-spark` now supports [Azure Databricks Credential Passthrough](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough) [@wjohnson](https://github.com/wjohnson)
+* `openlineage-spark` detects datasets wrapped by `ExternalRDD`s [@collado-mike](https://github.com/collado-mike)
 
 ### Fixed
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -13,6 +13,7 @@ import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableCommandVis
 import io.openlineage.spark.agent.lifecycle.plan.CreateHiveTableAsSelectCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateTableCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.DropTableCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.ExternalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.HiveTableRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoDataSourceVisitor;
@@ -66,6 +67,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     if (VisitorFactory.classPresent("org.apache.spark.sql.execution.SQLExecutionRDD")) {
       inputVisitors.add(new SqlExecutionRDDVisitor(context));
     }
+    inputVisitors.add(new ExternalRDDVisitor(context));
     return inputVisitors;
   }
 

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -23,6 +23,7 @@ import org.apache.spark.Partition;
 import org.apache.spark.api.python.PythonRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.SQLExecutionRDD;
 import org.apache.spark.sql.sources.BaseRelation;
 import scala.PartialFunction;
 import scala.runtime.AbstractPartialFunction;
@@ -90,6 +91,9 @@ class LogicalPlanSerializer {
   @JsonIgnoreProperties({"child", "containsChild", "canonicalized", "constraints"})
   abstract class ChildMixIn {}
 
+  @JsonIgnoreProperties({"sqlConfigs", "sqlConfExecutorSide"})
+  public static class SqlConfigMixin {}
+
   @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
   public static class PythonRDDMixin {
     @JsonIgnore private PythonRDDMixin asJavaRDD;
@@ -139,7 +143,8 @@ class LogicalPlanSerializer {
           ImmutableMap.<Class, Class>builder()
               .put(PythonRDD.class, PythonRDDMixin.class)
               .put(ClassLoader.class, IgnoredType.class)
-              .put(RDD.class, RDDMixin.class);
+              .put(RDD.class, RDDMixin.class)
+              .put(SQLExecutionRDD.class, SqlConfigMixin.class);
       try {
         Class<?> c = PolymorficMixIn.class.getClassLoader().loadClass("java.lang.Module");
         builder.put(c, IgnoredType.class);

--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
@@ -1,0 +1,25 @@
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.Rdds;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.List;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.ExternalRDD;
+
+/** {@link RDD} node visitor for {@link ExternalRDD}s. */
+public class ExternalRDDVisitor extends AbstractRDDNodeVisitor<ExternalRDD<?>, InputDataset> {
+
+  public ExternalRDDVisitor(OpenLineageContext context) {
+    super(context, DatasetFactory.input(context));
+  }
+
+  @Override
+  public List<InputDataset> apply(LogicalPlan x) {
+    ExternalRDD externalRDD = (ExternalRDD) x;
+    List<RDD<?>> fileRdds = Rdds.findFileLikeRdds(externalRDD.rdd());
+    return findInputDatasets(fileRdds, externalRDD.schema());
+  }
+}


### PR DESCRIPTION
### Problem
`ExternalRDD`s are LogicalPlan nodes that currently aren't supported. They're basically the same as `LogicalRDD`s, so the code to support them is the same.

Additionally, testing shows that `SqlExecutionRDD`s (sometimes wrapped in `ExternalRDD`) get serialized with the `sqlConfigs` property - a map of every configuration key value in a Spark application. This change omits that property from the serializer

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)