### PR TITLE
backfill changelog for `0.8.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.8.1...HEAD)
 
+### Added
+
+* `openlineage-airflow` now supports getting credentials from [Airflows secrets backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html) [@mobuchowski](https://github.com/mobuchowski)
+* `openlineage-spark` now supports [Azure Databricks Credential Passthrough](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough) [@wjohnson](https://github.com/wjohnson)
+
+### Fixed
+
+* `PostgresOperator` fails to retrieve host and conn during extraction [@mobuchowski](https://github.com/mobuchowski)
+* SQL parser accepts lists of sql statements [@mobuchowski](https://github.com/mobuchowski)
+
 ## [0.8.1](https://github.com/OpenLineage/OpenLineage/compare/0.7.1...0.8.1)
 ### Added
 * Airflow integration uses [new TaskInstance listener API](https://github.com/apache/airflow/blob/main/docs/apache-airflow/listeners.rst) for Airflow 2.3+ ([#508](https://github.com/OpenLineage/OpenLineage/pull/508)) [@mobuchowski](https://github.com/mobuchowski)


### PR DESCRIPTION
### Problem

The changelog is not up-to-date for `0.8.2`

### Solution

Update changelog for `0.8.2`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)