### PR TITLE
ci: move arm builds from cross compilation

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -603,17 +603,31 @@ workflows:
               ignore: /.*/
       - build-integration-sql:
           matrix:
+            alias: build-integration-sql-x86
             parameters:
               image: [
                 "quay.io/pypa/manylinux2014_x86_64",
                 "quay.io/pypa/manylinux2014_i686",
                 "quay.io/pypa/manylinux_2_24_x86_64",
                 "quay.io/pypa/manylinux_2_24_i686",
-                "messense/manylinux2014-cross:aarch64",
-                "messense/manylinux_2_24-cross:aarch64",
               ]
               resource_class: ["medium"]
               run_tests: [false]
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - build-integration-sql:
+          matrix:
+            alias: build-integration-sql-arm
+            parameters:
+              image: [
+                "quay.io/pypa/manylinux2014_aarch64",
+                "quay.io/pypa/manylinux_2_24_aarch64",
+              ]
+              resource_class: [ "arm.medium" ]
+              run_tests: [ false ]
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
@@ -632,4 +646,5 @@ workflows:
             - build-integration-airflow
             - build-integration-dbt
             - build-integration-dagster
-            - build-integration-sql
+            - build-integration-sql-x86
+            - build-integration-sql-arm

--- a/.circleci/workflows/openlineage-integration-airflow.yml
+++ b/.circleci/workflows/openlineage-integration-airflow.yml
@@ -2,12 +2,18 @@ workflows:
   openlineage-integration-airflow:
     jobs:
       - build-integration-sql:
+          name: "build-integration-sql-x86"
           image: "quay.io/pypa/manylinux2014_x86_64"
           resource_class: "medium"
           run_tests: true
+      - build-integration-sql:
+          name: "build-integration-sql-arm"
+          image: "quay.io/pypa/manylinux2014_aarch64"
+          resource_class: "arm.medium"
+          run_tests: true
       - unit-test-integration-common:
           requires:
-            - build-integration-sql
+            - build-integration-sql-x86
           matrix:
             parameters:
               install_parser: [true, false]
@@ -21,18 +27,18 @@ workflows:
       - unit-test-integration-airflow-1:
           install_parser: true
           requires:
-            - build-integration-sql
+            - build-integration-sql-x86
       - unit-test-integration-airflow-2:
           install_parser: true
           requires:
-            - build-integration-sql
+            - build-integration-sql-x86
       - integration-test-integration-airflow-1-10:
           context: integration-tests
           requires:
             - unit-test-integration-airflow-1
             - unit-test-integration-common
             - unit-test-client-python
-            - build-integration-sql
+            - build-integration-sql-x86
           filters:
             branches:
               ignore: /pull\/[0-9]+/
@@ -49,7 +55,7 @@ workflows:
             - unit-test-integration-airflow-2
             - unit-test-integration-common
             - unit-test-client-python
-            - build-integration-sql
+            - build-integration-sql-x86
           filters:
             branches:
               ignore: /pull\/[0-9]+/
@@ -59,7 +65,7 @@ workflows:
             - unit-test-integration-airflow-2
             - unit-test-integration-common
             - unit-test-client-python
-            - build-integration-sql
+            - build-integration-sql-x86
           filters:
             branches:
               ignore: /pull\/[0-9]+/


### PR DESCRIPTION
Fix [cross-compilation issues](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/3285/workflows/0ac94c60-1892-491e-8159-dfd79abe8eb8/jobs/31818) by moving to arm-based builders for arm images.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
