### PR TITLE
[Integration][Airflow] Ensure unknownSourceAttribute is not set when lineage is successfully extracted

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -53,19 +53,24 @@ class ExtractorManager:
             self.log.warning(
                 f'Unable to find an extractor. {task_info}')
 
-        return TaskMetadata(
-            name=get_job_name(task),
-            run_facets={
-                "unknownSourceAttribute": UnknownOperatorAttributeRunFacet(
-                    unknownItems=[
-                        UnknownOperatorInstance(
-                            name=task.__class__.__name__,
-                            properties={attr: value for attr, value in task.__dict__.items()}
-                        )
-                    ]
-                )
-            }
-        )
+            # Only include the unkonwnSourceAttribute facet if there is no extractor
+            return TaskMetadata(
+                name=get_job_name(task),
+                run_facets={
+                    "unknownSourceAttribute": UnknownOperatorAttributeRunFacet(
+                        unknownItems=[
+                            UnknownOperatorInstance(
+                                name=task.__class__.__name__,
+                                properties={
+                                    attr: value for attr, value in task.__dict__.items()
+                                },
+                            )
+                        ]
+                    )
+                },
+            )
+
+        return TaskMetadata(name=get_job_name(task))
 
     def _get_extractor(self, task) -> Optional[BaseExtractor]:
         if task.task_id in self.extractors:


### PR DESCRIPTION
Signed-off-by: Conor Beverland <conorbev@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

In Airflow 2.3 all jobs are getting the `unknownSourceAttribute` set on them. The intent is for this attribute to only be set when no extractor is present. 

Closes: #750

### Solution

Set the facet only in the else block of the `if extractor` check.

### Checklist

- [x ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)