### PR TITLE
ci: add sdist sql parser distribution only once

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -268,7 +268,14 @@ jobs:
           root: .
           paths:
             - ./target/wheels/*.whl
-            - ./target/wheels/*.tar.gz
+      - when:
+          condition:
+            equal: [ "quay.io/pypa/manylinux2014_x86_64", << parameters.image >> ]
+          steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./target/wheels/*.tar.gz
       - store_artifacts:
           path: ./target/wheels
           destination: sql-artifacts


### PR DESCRIPTION
Currently [publishing snapshot fails](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/3316/workflows/936e0011-6dcc-4b1a-8877-5c463ce7129d/jobs/32060) because multiple jobs try to add source distribution of sql parser to the workspace. This PR changes it to be only one. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>