### PR TITLE
sql: build only manylinux_2014 images

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -615,8 +615,6 @@ workflows:
               image: [
                 "quay.io/pypa/manylinux2014_x86_64",
                 "quay.io/pypa/manylinux2014_i686",
-                "quay.io/pypa/manylinux_2_24_x86_64",
-                "quay.io/pypa/manylinux_2_24_i686",
               ]
               resource_class: ["medium"]
               run_tests: [false]
@@ -631,7 +629,6 @@ workflows:
             parameters:
               image: [
                 "quay.io/pypa/manylinux2014_aarch64",
-                "quay.io/pypa/manylinux_2_24_aarch64",
               ]
               resource_class: [ "arm.medium" ]
               run_tests: [ false ]


### PR DESCRIPTION
For some, yet unknown reason ARM `manylinux_2_24` images produce `manylinux_2014` image that conflict with other job's image. Remove `manylinux_2_24` image to fix deploy.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
