### PR TITLE
Set log to `debug` on unknown facet entry

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -72,7 +72,7 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
     List<UnknownEntryFacet.AttributeField> output = attributeFields(x.outputSet());
     List<UnknownEntryFacet.AttributeField> input = attributeFields(x.inputSet());
     String serializedNode = planSerializer.serialize(x);
-    log.info("Adding serialized node for unknown facet entry {}", serializedNode);
+    log.debug("Adding serialized node for unknown facet entry {}", serializedNode);
     return Optional.of(new UnknownEntryFacet.FacetEntry(serializedNode, input, output));
   }
 


### PR DESCRIPTION
### Problem

The `unknown_facet` was added to help in the early stages of our spark integration, but the facet is also logged which can pollute logs.

### Solution

Set log to `debug` on unknown facet entry.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)