### PR TITLE
rename package to avoid camel case in package names

### DIFF
--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.OpenLineageContext;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -1,9 +1,9 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.ExpressionDependencyVisitor;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.IcebergMergeIntoDependencyVisitor;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors.UnionDependencyVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.ExpressionDependencyVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.IcebergMergeIntoDependencyVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.UnionDependencyVisitor;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.spark.agent.lifecycle.Rdds;
 import io.openlineage.spark.agent.util.DatasetIdentifier;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/ExpressionDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/ExpressionDependencyVisitor.java
@@ -1,6 +1,6 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+package io.openlineage.spark3.agent.lifecycle.plan.column.visitors;
 
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 
 /**

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java
@@ -1,9 +1,9 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+package io.openlineage.spark3.agent.lifecycle.plan.column.visitors;
 
-import static io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector.traverseExpression;
+import static io.openlineage.spark3.agent.lifecycle.plan.column.ExpressionDependencyCollector.traverseExpression;
 
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionDependencyVisitor.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionDependencyVisitor.java
@@ -1,9 +1,9 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+package io.openlineage.spark3.agent.lifecycle.plan.column.visitors;
 
-import static io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector.traverseExpression;
+import static io.openlineage.spark3.agent.lifecycle.plan.column.ExpressionDependencyCollector.traverseExpression;
 
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsNonV2CatalogTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsNonV2CatalogTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsV2CatalogTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsV2CatalogTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelUtilsTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelUtilsTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage;
+package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitorTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+package io.openlineage.spark3.agent.lifecycle.plan.column.visitors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -7,8 +7,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static scala.collection.JavaConverters.collectionAsScalaIterableConverter;
 
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ExpressionDependencyCollector;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ExpressionDependencyCollector;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
@@ -1,4 +1,4 @@
-package io.openlineage.spark3.agent.lifecycle.plan.columnLineage.customVisitors;
+package io.openlineage.spark3.agent.lifecycle.plan.column.visitors;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.openlineage.spark3.agent.lifecycle.plan.columnLineage.ColumnLevelLineageBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import java.util.Arrays;
 import java.util.Collection;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Package names in column level lineage are camel case.

Part of epic : #673

### Solution

Rename package in separate small PR.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)