### PR TITLE
[INTEGRATION][SPARK] column lineage: make collectors static

### DIFF
--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -24,9 +24,9 @@ public class ColumnLevelLineageUtils {
     ColumnLevelLineageBuilder builder = new ColumnLevelLineageBuilder(outputSchema, context);
     LogicalPlan plan = context.getQueryExecution().get().optimizedPlan();
 
-    new ExpressionDependencyCollector(plan).collect(builder);
-    new OutputFieldsCollector(plan).collect(builder);
-    new InputFieldsCollector(plan, context).collect(builder);
+    ExpressionDependencyCollector.collect(plan, builder);
+    OutputFieldsCollector.collect(plan, builder);
+    InputFieldsCollector.collect(context, plan, builder);
 
     OpenLineage.ColumnLineageDatasetFacetBuilder facetBuilder =
         context.getOpenLineage().newColumnLineageDatasetFacetBuilder();

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -23,15 +23,10 @@ import org.apache.spark.sql.catalyst.plans.logical.Project;
 @Slf4j
 public class ExpressionDependencyCollector {
 
-  private final LogicalPlan plan;
-  private final List<ExpressionDependencyVisitor> expressionDependencyVisitors =
+  private static final List<ExpressionDependencyVisitor> expressionDependencyVisitors =
       Arrays.asList(new UnionDependencyVisitor(), new IcebergMergeIntoDependencyVisitor());
 
-  ExpressionDependencyCollector(LogicalPlan plan) {
-    this.plan = plan;
-  }
-
-  void collect(ColumnLevelLineageBuilder builder) {
+  static void collect(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
     plan.foreach(
         node -> {
           expressionDependencyVisitors.stream()

--- a/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
+++ b/integration/spark/src/main/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
@@ -12,17 +12,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Project;
 /** Class created to collect output fields with the corresponding ExprId from LogicalPlan. */
 class OutputFieldsCollector {
 
-  private final LogicalPlan plan;
-
-  OutputFieldsCollector(LogicalPlan plan) {
-    this.plan = plan;
-  }
-
-  void collect(ColumnLevelLineageBuilder builder) {
-    collect(plan, builder);
-  }
-
-  private void collect(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+  static void collect(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
     List<NamedExpression> expressions =
         ScalaConversionUtils.fromSeq(plan.output()).stream()
             .filter(attr -> attr instanceof Attribute)

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -68,8 +68,7 @@ public class ExpressionDependencyCollectorTest {
             mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
 
-    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
-    collector.collect(builder);
+    ExpressionDependencyCollector.collect(plan, builder);
 
     verify(builder, times(1)).addDependency(aliasExprId1, exprId1);
     verify(builder, times(1)).addDependency(aliasExprId2, exprId2);
@@ -84,8 +83,7 @@ public class ExpressionDependencyCollectorTest {
             mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, aggregate, null, null, false);
 
-    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
-    collector.collect(builder);
+    ExpressionDependencyCollector.collect(plan, builder);
 
     verify(builder, times(1)).addDependency(aliasExprId1, exprId1);
   }
@@ -121,8 +119,7 @@ public class ExpressionDependencyCollectorTest {
     Project project = new Project(toScalaSeq(Arrays.asList(rootAlias)), mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
 
-    ExpressionDependencyCollector collector = new ExpressionDependencyCollector(plan);
-    collector.collect(builder);
+    ExpressionDependencyCollector.collect(plan, builder);
 
     verify(builder, times(1)).addDependency(rootAliasExprId, exprId1);
     verify(builder, times(1)).addDependency(rootAliasExprId, exprId2);

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -59,7 +59,6 @@ public class InputFieldsCollectorTest {
   public void collectWhenGrandChildNodeIsDataSourceV2Relation() {
     DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -70,7 +69,7 @@ public class InputFieldsCollectorTest {
 
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(context, relation)).thenReturn(Optional.of(di));
-      collector.collect(builder);
+      InputFieldsCollector.collect(context, plan, builder);
     }
     verify(builder, times(1)).addInput(exprId, di, "some-name");
   }
@@ -82,7 +81,6 @@ public class InputFieldsCollectorTest {
     when(scanRelation.relation()).thenReturn(relation);
 
     LogicalPlan plan = createPlanWithGrandChild(scanRelation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(scanRelation.output())
         .thenReturn(
@@ -93,7 +91,7 @@ public class InputFieldsCollectorTest {
 
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(context, relation)).thenReturn(Optional.of(di));
-      collector.collect(builder);
+      InputFieldsCollector.collect(context, plan, builder);
     }
     verify(builder, times(1)).addInput(exprId, di, "some-name");
   }
@@ -108,7 +106,6 @@ public class InputFieldsCollectorTest {
     when(catalogTable.location()).thenReturn(uri);
 
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -117,7 +114,7 @@ public class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    collector.collect(builder);
+    InputFieldsCollector.collect(context, plan, builder);
     verify(builder, times(1)).addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
   }
 
@@ -132,7 +129,6 @@ public class InputFieldsCollectorTest {
     when(relation.rdd()).thenReturn(rdd);
 
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -147,7 +143,7 @@ public class InputFieldsCollectorTest {
         when(PlanUtils.findRDDPaths(listRDD)).thenReturn(Collections.singletonList(path));
         when(PlanUtils.namespaceUri(path.toUri())).thenReturn("file");
 
-        collector.collect(builder);
+        InputFieldsCollector.collect(context, plan, builder);
         verify(builder, times(1))
             .addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
       }
@@ -164,7 +160,6 @@ public class InputFieldsCollectorTest {
     when(catalogTable.location()).thenReturn(uri);
 
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -173,7 +168,7 @@ public class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    collector.collect(builder);
+    InputFieldsCollector.collect(context, plan, builder);
     verify(builder, times(1)).addInput(exprId, new DatasetIdentifier("/tmp", "file"), "some-name");
   }
 
@@ -184,7 +179,6 @@ public class InputFieldsCollectorTest {
     when(relation.catalogTable()).thenReturn(Option.empty());
 
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -193,7 +187,7 @@ public class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    collector.collect(builder);
+    InputFieldsCollector.collect(context, plan, builder);
     verify(builder, times(0)).addInput(any(), any(), any());
   }
 
@@ -206,7 +200,6 @@ public class InputFieldsCollectorTest {
     when(catalogTable.location()).thenReturn(null);
 
     LogicalPlan plan = createPlanWithGrandChild(relation);
-    InputFieldsCollector collector = new InputFieldsCollector(plan, context);
 
     when(relation.output())
         .thenReturn(
@@ -215,7 +208,7 @@ public class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    collector.collect(builder);
+    InputFieldsCollector.collect(context, plan, builder);
     verify(builder, times(0)).addInput(any(), any(), any());
   }
 

--- a/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
+++ b/integration/spark/src/test/spark3/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
@@ -20,7 +20,6 @@ import scala.collection.Seq$;
 public class OutputFieldsCollectorTest {
 
   LogicalPlan plan = mock(LogicalPlan.class);
-  OutputFieldsCollector collector = new OutputFieldsCollector(plan);
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
 
   Attribute attr1 = mock(Attribute.class);
@@ -50,7 +49,7 @@ public class OutputFieldsCollectorTest {
   public void verifyOutputAttributeIsCollected() {
     when(plan.output()).thenReturn(attrs);
 
-    collector.collect(builder);
+    OutputFieldsCollector.collect(plan, builder);
 
     Mockito.verify(builder, times(1)).addOutput(exprId1, "name1");
     Mockito.verify(builder, times(1)).addOutput(exprId2, "name2");
@@ -73,7 +72,7 @@ public class OutputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    new OutputFieldsCollector(aggregate).collect(builder);
+    OutputFieldsCollector.collect(aggregate, builder);
 
     Mockito.verify(builder, times(1)).addOutput(exprId, "some-name");
   }
@@ -95,7 +94,7 @@ public class OutputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    new OutputFieldsCollector(project).collect(builder);
+    OutputFieldsCollector.collect(project, builder);
 
     Mockito.verify(builder, times(1)).addOutput(exprId, "some-name");
   }
@@ -114,7 +113,7 @@ public class OutputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    new OutputFieldsCollector(plan).collect(builder);
+    OutputFieldsCollector.collect(plan, builder);
 
     Mockito.verify(builder, times(1)).addOutput(exprId1, "name1");
     Mockito.verify(builder, times(1)).addOutput(exprId2, "name2");


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Column lineage collector classes contain stateless non-static methods. 

Part of epic : #673

### Solution

Make collectors contain static method.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)