### PR TITLE
clients: add OPENLINEAGE_DISABLED environment variable which overrides config to NoopTransport

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter:${junit5Version}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -1,5 +1,6 @@
 package io.openlineage.client;
 
+import io.openlineage.client.transports.NoopTransport;
 import io.openlineage.client.transports.Transport;
 import io.openlineage.client.transports.TransportFactory;
 
@@ -13,6 +14,10 @@ public final class Clients {
   }
 
   public static OpenLineageClient newClient(ConfigPathProvider configPathProvider) {
+    String isDisabled = Environment.getEnvironmentVariable("OPENLINEAGE_DISABLED");
+    if (Boolean.parseBoolean(isDisabled)) {
+      return OpenLineageClient.builder().transport(new NoopTransport()).build();
+    }
     final OpenLineageYaml openLineageYaml = Utils.loadOpenLineageYaml(configPathProvider);
     final TransportFactory factory = new TransportFactory(openLineageYaml.getTransportConfig());
     final Transport transport = factory.build();

--- a/client/java/src/main/java/io/openlineage/client/Environment.java
+++ b/client/java/src/main/java/io/openlineage/client/Environment.java
@@ -1,0 +1,8 @@
+package io.openlineage.client;
+
+// This class exists because it's not possible to mock System
+public class Environment {
+  public static String getEnvironmentVariable(String key) {
+    return System.getenv(key);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
@@ -1,0 +1,15 @@
+package io.openlineage.client.transports;
+
+import io.openlineage.client.OpenLineage;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NoopTransport extends Transport {
+  public NoopTransport() {
+    super(Type.NOOP);
+    log.info("OpenLineage client is disabled");
+  }
+
+  @Override
+  public void emit(OpenLineage.RunEvent runEvent) {}
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -7,7 +7,8 @@ public abstract class Transport {
   enum Type {
     CONSOLE,
     HTTP,
-    KAFKA
+    KAFKA,
+    NOOP
   };
 
   private final Type type;

--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -23,7 +23,7 @@ class Serde:
                 {k: cls.remove_nulls_and_enums(v) for k, v in obj.items()}.items()
             ))
         if isinstance(obj, List):
-            return list(filter(lambda x: x is not None and x != {}, [
+            return list(filter(lambda x: x is not None and (isinstance(x, dict) and x != {}), [
                 cls.remove_nulls_and_enums(v) for v in obj if v is not None
             ]))
 

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from typing import Type
 
+from openlineage.client.transport.noop import NoopTransport
 from openlineage.client.transport.transport import Transport, Config, TransportFactory
 from openlineage.client.transport.factory import DefaultTransportFactory
 from openlineage.client.transport.http import HttpTransport, HttpConfig
@@ -12,6 +13,7 @@ _factory = DefaultTransportFactory()
 _factory.register_transport(HttpTransport.kind, HttpTransport)
 _factory.register_transport(KafkaTransport.kind, KafkaTransport)
 _factory.register_transport(ConsoleTransport.kind, ConsoleTransport)
+_factory.register_transport(NoopTransport.kind, NoopTransport)
 
 
 def get_default_factory():

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -4,6 +4,7 @@ import os
 import logging
 from typing import Type, Union, Optional
 
+from openlineage.client.transport.noop import NoopConfig, NoopTransport
 from openlineage.client.transport.transport import Config, Transport, TransportFactory
 from openlineage.client.utils import try_import_from_string
 
@@ -25,6 +26,9 @@ class DefaultTransportFactory(TransportFactory):
         self.transports[type] = clazz
 
     def create(self) -> Transport:
+        if os.environ.get("OPENLINEAGE_DISABLED", False) in [True, "true", "True"]:
+            return NoopTransport(NoopConfig())
+
         if yaml:
             yml_config = self._try_config_from_yaml()
             if yml_config:

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0.
+import logging
+
+from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Transport, Config
+
+
+log = logging.getLogger(__name__)
+
+
+class NoopConfig(Config):
+    pass
+
+
+class NoopTransport(Transport):
+    kind = 'noop'
+    config = NoopConfig
+
+    def __init__(self, config: NoopConfig):
+        log.info("OpenLineage client is disabled. NoopTransport.")
+
+    def emit(self, event: RunEvent):
+        pass

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -6,6 +6,7 @@ from openlineage.client import OpenLineageClient
 from openlineage.client.transport import DefaultTransportFactory, \
     get_default_factory, KafkaTransport
 from openlineage.client.transport.http import HttpTransport
+from openlineage.client.transport.noop import NoopTransport
 from tests.transport import AccumulatingTransport, FakeTransport
 
 current_path = os.path.join(os.getcwd(), "tests")
@@ -87,3 +88,23 @@ def test_transport_decorator_registers(join, listdir, yaml):
 
     transport = get_default_factory().create()
     assert isinstance(transport, FakeTransport)
+
+
+@patch.dict(os.environ, {"OPENLINEAGE_DISABLED": "true"})
+def test_env_disables_client():
+    transport = get_default_factory().create()
+    assert isinstance(transport, NoopTransport)
+
+
+@patch.dict(os.environ, {
+    "OPENLINEAGE_DISABLED": "true",
+    "OPENLINEAGE_CONFIG": "tests/config/config.yml"
+})
+def test_env_disabled_ignores_config():
+    factory = DefaultTransportFactory()
+    factory.register_transport(
+        "fake",
+        clazz="tests.transport.FakeTransport"
+    )
+    transport = factory.create()
+    assert isinstance(transport, NoopTransport)

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -1,3 +1,5 @@
+import os
+
 from airflow.plugins_manager import AirflowPlugin
 from airflow.version import version as AIRFLOW_VERSION
 from pkg_resources import parse_version
@@ -6,7 +8,12 @@ from pkg_resources import parse_version
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0.dev0"):
+
+def _is_disabled():
+    return os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]
+
+
+if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0.dev0") or _is_disabled():
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
         macros = [lineage_run_id, lineage_parent_id]

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-
+import os
 import uuid
 import time
 
@@ -87,6 +87,9 @@ class OpenLineageBackend(LineageBackend):
     def send_lineage(cls, *args, **kwargs):
         # Do not use LineageBackend approach when we can use plugins
         if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
+            return
+        # Make this method a noop if OPENLINEAGE_DISABLED is set to true
+        if os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:
             return
         if not cls.backend:
             cls.backend = Backend()


### PR DESCRIPTION
Currently, configured OpenLineage integrations will always try to emit events. 
This PR adds environment variable OPENLINEAGE_DISABLE that when set to `true` overrides this - and will make integration use (added) NoopTransport when enabled. 

This does not override clients that were manually provided with other transports - just overrides the default transport factory construction.

Closes https://github.com/OpenLineage/OpenLineage/issues/726