### PR TITLE
dagster: pin protobuf version to 3.20 as suggested by tests

### DIFF
--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -26,6 +26,7 @@ DAGSTER_VERSION = "0.13.8"
 requirements = [
     "attrs>=19.3",
     "cattrs",
+    "protobuf<=3.20.0",
     f"dagster>={DAGSTER_VERSION},<=0.14.5",
     f"openlineage-python=={__version__}",
 ]


### PR DESCRIPTION
This fixes build error: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/3401/workflows/6aa6c3cc-1bc8-45bb-978f-ddc0eee0bee7/jobs/33482

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
