### PR TITLE
[INTEGRATION][AIRFLOW] Add SafeStrDict to skip failing attibutes

### DIFF
--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -17,11 +17,13 @@ class AirflowVersionRunFacet(BaseFacet):
 
     @classmethod
     def from_task(cls, task):
+        # task.__dict__ may contain values uncastable to str
+        from openlineage.airflow.utils import SafeStrDict
         return cls(
-            f'{task.__class__.__module__}.{task.__class__.__name__}',
-            str(task.__dict__),
+            f"{task.__class__.__module__}.{task.__class__.__name__}",
+            str(SafeStrDict(task.__dict__)),
             AIRFLOW_VERSION,
-            OPENLINEAGE_AIRFLOW_VERSION
+            OPENLINEAGE_AIRFLOW_VERSION,
         )
 
 
@@ -33,8 +35,10 @@ class AirflowRunArgsRunFacet(BaseFacet):
 @attr.s
 class UnknownOperatorInstance:
     """
-    Describes an unknown operator - specifies the (class) name of the operator and its properties
+    Describes an unknown operator - specifies the (class) name of the operator
+    and its properties
     """
+
     name: str = attr.ib()
     properties: Dict[str, object] = attr.ib()
     type: str = attr.ib(default="operator")
@@ -45,4 +49,5 @@ class UnknownOperatorAttributeRunFacet(BaseFacet):
     """
     RunFacet that describes unknown operators in an Airflow DAG
     """
+
     unknownItems: List[UnknownOperatorInstance] = attr.ib()

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -58,6 +58,18 @@ class JobIdMapping:
         return "openlineage_id_mapping-{}-{}".format(job_name, run_id)
 
 
+class SafeStrDict(dict):
+    def __str__(self):
+        castable = list()
+        for attr, val in self.items():
+            try:
+                str(attr), str(val)
+                castable.append((attr, val))
+            except (TypeError, NotImplementedError):
+                continue
+        return str(dict(castable))
+
+
 def url_to_https(url) -> str:
     # Ensure URL exists
     if not url:

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -13,7 +13,8 @@ from openlineage.airflow.utils import (
     get_connection_uri,
     get_normalized_postgres_connection_uri,
     get_connection,
-    DagUtils
+    DagUtils,
+    SafeStrDict,
 )
 
 AIRFLOW_VERSION = '1.10.12'
@@ -110,3 +111,12 @@ def test_parse_version():
     assert parse_version("2.2.4") < parse_version("2.3.0.dev0")
     assert parse_version("1.10.15") < parse_version("2.3.0.dev0")
     assert parse_version("2.2.4.dev0") < parse_version("2.3.0.dev0")
+
+
+def test_safe_dict():
+    assert str(SafeStrDict({'a': 1})) == str({'a': 1})
+
+    class NotImplemented():
+        def __str__(self):
+            raise NotImplementedError
+    assert str(SafeStrDict({'a': NotImplemented()})) == str({})


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`AirflowVersionRunFacet.from_task` method fails when `__dict__` contains attributes not castable to str.

### Solution

Get rid of all failing to cast attributes when casting.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)