### PR TITLE
[INTEGRATION][SPARK] include InMemoryRelation dataset builder

### DIFF
--- a/integration/spark/app/integrations/container/pysparkCachedDatasetComplete.json
+++ b/integration/spark/app/integrations/container/pysparkCachedDatasetComplete.json
@@ -1,0 +1,30 @@
+{
+  "eventType" : "START",
+  "job" : {
+    "namespace" : "cachedDataset"
+  },
+  "inputs" : [
+    {
+      "namespace": "file",
+      "name": "/tmp/caching/temp",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -199,6 +199,14 @@ public class SparkContainerIntegrationTest {
   }
 
   @Test
+  @EnabledIfSystemProperty(named = "spark.version", matches = SPARK_3) // Spark version >= 3.*
+  public void testCachedDataset() {
+    SparkContainerUtils.runPysparkContainerWithDefaultConf(
+        network, openLineageClientMockContainer, "cachedDataset", "spark_cached.py");
+    verifyEvents("pysparkCachedDatasetComplete.json");
+  }
+
+  @Test
   @EnabledIfSystemProperty(
       named = "spark.version",
       matches = SPARK_ABOVE_EQUAL_2_4_8) // Spark version >= 2.4.8

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_cached.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_cached.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+
+os.makedirs("/tmp/caching", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage In Memory Relation") \
+    .config("spark.sql.warehouse.dir", "/tmp/caching") \
+    .enableHiveSupport() \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+spark.createDataFrame([
+    {'a': 1, 'b': 2},
+    {'a': 3, 'b': 4}
+]).write.saveAsTable('temp')
+
+cached = spark.read.table("temp").cache()       # create cached dataset
+cached.count()                                  # call an action on cached dataset
+cached.select('a').write.saveAsTable('target')  # target table lineage should be aware of temp table

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -12,6 +12,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import java.util.Collection;
@@ -25,6 +26,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
     DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     return ImmutableList.<PartialFunction<Object, List<OpenLineage.InputDataset>>>builder()
         .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
+        .add(new InMemoryRelationInputDatasetBuilder(context))
         .add(new CommandPlanVisitor(context))
         .add(new DataSourceV2ScanRelationInputDatasetBuilder(context, datasetFactory))
         .add(new DataSourceV2RelationInputDatasetBuilder(context, datasetFactory))

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilder.java
@@ -1,0 +1,84 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.CacheManager;
+import org.apache.spark.sql.execution.CachedData;
+import org.apache.spark.sql.execution.columnar.InMemoryRelation;
+import org.apache.spark.sql.internal.SharedState;
+import scala.collection.IndexedSeq;
+
+@Slf4j
+public class InMemoryRelationInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<InMemoryRelation> {
+
+  public InMemoryRelationInputDatasetBuilder(OpenLineageContext context) {
+    super(context, true);
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    return true;
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(InMemoryRelation x) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(
+      SparkListenerEvent event, InMemoryRelation inMemoryRelation) {
+    try {
+      SharedState sharedState = context.getSparkSession().get().sharedState();
+      CacheManager cacheManager =
+          (CacheManager)
+              FieldUtils.getField(SharedState.class, "cacheManager", true).get(sharedState);
+      IndexedSeq<CachedData> cachedDataIndexedSeq =
+          (IndexedSeq<CachedData>)
+              FieldUtils.getField(CacheManager.class, "cachedData", true).get(cacheManager);
+
+      return ScalaConversionUtils.<CachedData>fromSeq(cachedDataIndexedSeq).stream()
+          .filter(
+              cachedData ->
+                  cachedData
+                      .cachedRepresentation()
+                      .cacheBuilder()
+                      .cachedName()
+                      .equals(inMemoryRelation.cacheBuilder().cachedName()))
+          .map(cachedData -> (LogicalPlan) cachedData.plan())
+          .findAny()
+          .map(
+              plan ->
+                  ScalaConversionUtils.fromSeq(
+                          plan.collect(
+                              delegate(
+                                  context.getInputDatasetQueryPlanVisitors(),
+                                  context.getInputDatasetBuilders(),
+                                  event)))
+                      .stream()
+                      .flatMap(Collection::stream)
+                      .collect(Collectors.toList()))
+          .orElse(Collections.<OpenLineage.InputDataset>emptyList());
+    } catch (Exception e) {
+      log.warn("cannot extract logical plan", e);
+      // do nothing
+    }
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return x instanceof InMemoryRelation;
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilderTest.java
@@ -1,0 +1,167 @@
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static scala.collection.JavaConverters.collectionAsScalaIterableConverter;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.CacheManager;
+import org.apache.spark.sql.execution.CachedData;
+import org.apache.spark.sql.execution.columnar.CachedRDDBuilder;
+import org.apache.spark.sql.execution.columnar.InMemoryRelation;
+import org.apache.spark.sql.internal.SharedState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.collection.IndexedSeq;
+
+public class InMemoryRelationInputDatasetBuilderTest {
+
+  String CACHED_NAME = "some-table";
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  SparkSession sparkSession = mock(SparkSession.class);
+  SharedState sharedState = mock(SharedState.class);
+  CacheManager cacheManager = mock(CacheManager.class);
+  CachedData cachedData = mock(CachedData.class);
+  LogicalPlan logicalPlan = mock(LogicalPlan.class);
+  InMemoryRelationInputDatasetBuilder builder = new InMemoryRelationInputDatasetBuilder(context);
+
+  InMemoryRelation inMemoryRelation = mock(InMemoryRelation.class);
+  InMemoryRelation inMemoryRelationFromCacheManager = mock(InMemoryRelation.class);
+
+  CachedRDDBuilder cacheBuilder1 = mock(CachedRDDBuilder.class);
+  CachedRDDBuilder cacheBuilder2 = mock(CachedRDDBuilder.class);
+
+  OpenLineage.InputDataset inputDataset = mock(OpenLineage.InputDataset.class);
+
+  @BeforeEach
+  public void setup() {
+    when(context.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(context.getInputDatasetBuilders()).thenReturn(Collections.emptyList());
+    when(context.getInputDatasetQueryPlanVisitors()).thenReturn(Collections.emptyList());
+
+    when(sparkSession.sharedState()).thenReturn(sharedState);
+    when(sharedState.cacheManager()).thenReturn(cacheManager);
+    when(cachedData.plan()).thenReturn(logicalPlan);
+    when(cachedData.cachedRepresentation()).thenReturn(inMemoryRelationFromCacheManager);
+
+    when(inMemoryRelation.cacheBuilder()).thenReturn(cacheBuilder1);
+    when(inMemoryRelationFromCacheManager.cacheBuilder()).thenReturn(cacheBuilder2);
+
+    when(logicalPlan.collect(any()))
+        .thenReturn(
+            collectionAsScalaIterableConverter(
+                    Arrays.asList((Object) Collections.singletonList(inputDataset)))
+                .asScala()
+                .toSeq());
+
+    when(cacheBuilder1.cachedName()).thenReturn(CACHED_NAME);
+    when(cacheBuilder2.cachedName()).thenReturn(CACHED_NAME);
+  }
+
+  @SneakyThrows
+  @Test
+  public void testApply() {
+    IndexedSeq<CachedData> cachedItems =
+        collectionAsScalaIterableConverter(Arrays.asList(cachedData)).asScala().toIndexedSeq();
+
+    try (MockedStatic mocked = mockStatic(FieldUtils.class)) {
+      Field cacheManagerField = mock(Field.class);
+      when(FieldUtils.getField(SharedState.class, "cacheManager", true))
+          .thenReturn(cacheManagerField);
+      when(cacheManagerField.get(sharedState)).thenReturn(cacheManager);
+
+      Field cachedDataField = mock(Field.class);
+      when(FieldUtils.getField(CacheManager.class, "cachedData", true)).thenReturn(cachedDataField);
+      when(cachedDataField.get(cacheManager)).thenReturn(cachedItems);
+
+      List<OpenLineage.InputDataset> inputDatasets =
+          builder.apply(mock(SparkListenerEvent.class), inMemoryRelation);
+      assertEquals(1, inputDatasets.size());
+      assertEquals(inputDataset, inputDatasets.get(0));
+    }
+  }
+
+  @SneakyThrows
+  @Test
+  public void testApplyWithMultipleCachedPlans() {
+    CachedRDDBuilder anotherCacheBuilder = mock(CachedRDDBuilder.class);
+    CachedData anotherCachedData = mock(CachedData.class);
+    InMemoryRelation anotherInMemoryRelation = mock(InMemoryRelation.class);
+
+    when(anotherCachedData.cachedRepresentation()).thenReturn(anotherInMemoryRelation);
+    when(anotherInMemoryRelation.cacheBuilder()).thenReturn(anotherCacheBuilder);
+    when(anotherCacheBuilder.cachedName()).thenReturn("another-name");
+
+    IndexedSeq<CachedData> cachedItems =
+        collectionAsScalaIterableConverter(Arrays.asList(anotherCachedData, cachedData))
+            .asScala()
+            .toIndexedSeq();
+
+    try (MockedStatic mocked = mockStatic(FieldUtils.class)) {
+      Field cacheManagerField = mock(Field.class);
+      when(FieldUtils.getField(SharedState.class, "cacheManager", true))
+          .thenReturn(cacheManagerField);
+      when(cacheManagerField.get(sharedState)).thenReturn(cacheManager);
+
+      Field cachedDataField = mock(Field.class);
+      when(FieldUtils.getField(CacheManager.class, "cachedData", true)).thenReturn(cachedDataField);
+      when(cachedDataField.get(cacheManager)).thenReturn(cachedItems);
+
+      List<OpenLineage.InputDataset> inputDatasets =
+          builder.apply(mock(SparkListenerEvent.class), inMemoryRelation);
+      assertEquals(1, inputDatasets.size());
+      assertEquals(inputDataset, inputDatasets.get(0));
+    }
+  }
+
+  @SneakyThrows
+  @Test
+  public void testApplyWhenNoCachedPlan() {
+    IndexedSeq<CachedData> cachedItems =
+        collectionAsScalaIterableConverter(Collections.<CachedData>emptyList())
+            .asScala()
+            .toIndexedSeq();
+
+    try (MockedStatic mocked = mockStatic(FieldUtils.class)) {
+      Field cacheManagerField = mock(Field.class);
+      when(FieldUtils.getField(SharedState.class, "cacheManager", true))
+          .thenReturn(cacheManagerField);
+      when(cacheManagerField.get(sharedState)).thenReturn(cacheManager);
+
+      Field cachedDataField = mock(Field.class);
+      when(FieldUtils.getField(CacheManager.class, "cachedData", true)).thenReturn(cachedDataField);
+      when(cachedDataField.get(cacheManager)).thenReturn(cachedItems);
+
+      assertEquals(0, builder.apply(mock(SparkListenerEvent.class), inMemoryRelation).size());
+    }
+  }
+
+  @SneakyThrows
+  @Test
+  public void testApplyWhenExceptionThrown() {
+    try (MockedStatic mocked = mockStatic(FieldUtils.class)) {
+      Field cacheManagerField = mock(Field.class);
+      when(FieldUtils.getField(SharedState.class, "cacheManager", true))
+          .thenReturn(cacheManagerField);
+      when(cacheManagerField.get(sharedState)).thenThrow(new RuntimeException("message"));
+
+      assertEquals(0, builder.apply(mock(SparkListenerEvent.class), inMemoryRelation).size());
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

When a  Spark dataset is cached, its lineage is lost. 

Closes: [#610](https://github.com/OpenLineage/OpenLineage/issues/610)

### Solution

 * Get access to `CacheManager` by using reflection. List cached data and find the logical plan of the `InMemoryRelation`.
 * Provide `InMemoryRelationDatasetBuilder` that makes use of it. 
 * Prepare integration test to verify the behavior. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)