### PR TITLE
snowflake: reuse connections in airflow extractors

### DIFF
--- a/.circleci/workflows/openlineage-integration-airflow.yml
+++ b/.circleci/workflows/openlineage-integration-airflow.yml
@@ -48,7 +48,7 @@ workflows:
               airflow-image: [
                 'apache/airflow:2.1.4-python3.7',
                 'apache/airflow:2.2.4-python3.7',
-                'apache/airflow:2.3.0b1-python3.7'
+                'apache/airflow:2.3.1-python3.7'
               ]
           context: integration-tests
           requires:

--- a/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
@@ -1,0 +1,90 @@
+import logging
+from contextlib import closing
+from typing import Optional, TYPE_CHECKING, List, Tuple
+
+from openlineage.common.dataset import Source, Dataset
+from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.sql import DbTableMeta
+
+
+if TYPE_CHECKING:
+    from airflow.hooks.base import BaseHook
+
+
+logger = logging.getLogger(__name__)
+
+
+_TABLE_SCHEMA = 0
+_TABLE_NAME = 1
+_COLUMN_NAME = 2
+_ORDINAL_POSITION = 3
+# Use 'udt_name' which is the underlying type of column
+# (ex: int4, timestamp, varchar, etc)
+_UDT_NAME = 4
+
+
+def get_table_schemas(
+    hook: "BaseHook",
+    source: Source,
+    database: str,
+    in_query: Optional[str],
+    out_query: Optional[str],
+) -> Tuple[List[Dataset], ...]:
+    """
+    This function queries database for table schemas using provided hook.
+    Responsibility to provide queries for this function is on particular extractors.
+    If query for input or output table isn't provided, the query is skipped.
+    """
+    query_schemas = []
+
+    # Do not query if we did not get both queries
+    if not in_query and not out_query:
+        return [], []
+
+    with closing(hook.get_conn()) as conn:
+        with closing(conn.cursor()) as cursor:
+            for query in [in_query, out_query]:
+                if query:
+                    cursor.execute(query)
+                    query_schemas.append(parse_query_result(cursor))
+                else:
+                    query_schemas.append([])
+    return tuple([
+        [
+            Dataset.from_table_schema(
+                source=source,
+                table_schema=schema,
+                database_name=database
+            ) for schema in schemas
+        ] for schemas in query_schemas
+    ])
+
+
+def parse_query_result(cursor) -> List[DbTableSchema]:
+    schemas = {}
+    for row in cursor.fetchall():
+        table_schema_name: str = row[_TABLE_SCHEMA]
+        table_name: DbTableMeta = DbTableMeta(
+            row[_TABLE_NAME]
+        )
+        table_column: DbColumn = DbColumn(
+            name=row[_COLUMN_NAME],
+            type=row[_UDT_NAME],
+            ordinal_position=row[_ORDINAL_POSITION]
+        )
+
+        # Attempt to get table schema
+        table_key: str = f"{table_schema_name}.{table_name}"
+        table_schema: Optional[DbTableSchema] = schemas.get(table_key)
+
+        if table_schema:
+            # Add column to existing table schema.
+            schemas[table_key].columns.append(table_column)
+        else:
+            # Create new table schema with column.
+            schemas[table_key] = DbTableSchema(
+                schema_name=table_schema_name,
+                table_name=table_name,
+                columns=[table_column]
+            )
+    return list(schemas.values())

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 import logging
-from contextlib import closing
 from typing import Optional, List
 from urllib.parse import urlparse
 
+from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
 from openlineage.airflow.utils import (
     get_connection_uri,
     get_connection, safe_import_airflow
@@ -13,18 +13,9 @@ from openlineage.airflow.extractors.base import (
     TaskMetadata
 )
 from openlineage.client.facet import SqlJobFacet
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
 from openlineage.common.sql import SqlMeta, parse, DbTableMeta
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Source
 
-_TABLE_SCHEMA = 0
-_TABLE_NAME = 1
-_COLUMN_NAME = 2
-_ORDINAL_POSITION = 3
-_COLUMN_TYPE = 4
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +32,23 @@ class MySqlExtractor(BaseExtractor):
         return ['MySqlOperator']
 
     def extract(self) -> TaskMetadata:
+        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
+        run_facets = {}
+        job_facets = {
+            'sql': SqlJobFacet(self.operator.sql)
+        }
+
         # (1) Parse sql statement to obtain input / output tables.
-        sql_meta: SqlMeta = parse(self.operator.sql, self.default_schema)
+        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
+
+        if not sql_meta:
+            return TaskMetadata(
+                name=task_name,
+                inputs=[],
+                outputs=[],
+                run_facets=run_facets,
+                job_facets=job_facets
+            )
 
         # (2) Get database connection
         self.conn = get_connection(self._conn_id())
@@ -64,31 +70,13 @@ class MySqlExtractor(BaseExtractor):
         # as the current connection. We need to also fetch the schema for the
         # input tables to format the dataset name as:
         # {schema_name}.{table_name}
-        inputs = [
-            Dataset.from_table(
-                source=source,
-                table_name=in_table_schema.table_name.name,
-                schema_name=in_table_schema.schema_name,
-                database_name=database
-            ) for in_table_schema in self._get_table_schemas(
-                sql_meta.in_tables
-            )
-        ]
-        outputs = [
-            Dataset.from_table_schema(
-                source=source,
-                table_schema=out_table_schema,
-                database_name=database
-            ) for out_table_schema in self._get_table_schemas(
-                sql_meta.out_tables
-            )
-        ]
-
-        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
-        run_facets = {}
-        job_facets = {
-            'sql': SqlJobFacet(self.operator.sql)
-        }
+        inputs, outputs = get_table_schemas(
+            self._get_hook(),
+            source,
+            database,
+            self._information_schema_query(sql_meta.in_tables) if sql_meta.in_tables else None,
+            self._information_schema_query(sql_meta.out_tables) if sql_meta.out_tables else None
+        )
 
         return TaskMetadata(
             name=task_name,
@@ -121,7 +109,11 @@ class MySqlExtractor(BaseExtractor):
     def _conn_id(self):
         return self.operator.mysql_conn_id
 
-    def _information_schema_query(self, table_names: str) -> str:
+    @staticmethod
+    def _information_schema_query(tables: List[DbTableMeta]) -> str:
+        table_names = ",".join(map(
+            lambda name: f"'{name.name}'", tables
+        ))
         return f"""
         SELECT table_schema,
         table_name,
@@ -141,49 +133,3 @@ class MySqlExtractor(BaseExtractor):
             mysql_conn_id=self.operator.mysql_conn_id,
             schema=self.operator.database
         )
-
-    def _get_table_schemas(
-            self, table_names: [DbTableMeta]
-    ) -> [DbTableSchema]:
-        # Avoid querying mysql by returning an empty array
-        # if no table names have been provided.
-        if not table_names:
-            return []
-
-        # Keeps tack of the schema by table.
-        schemas_by_table = {}
-
-        hook = self._get_hook()
-        with closing(hook.get_conn()) as conn:
-            with closing(conn.cursor()) as cursor:
-                table_names_as_str = ",".join(map(
-                    lambda name: f"'{name.name}'", table_names
-                ))
-                cursor.execute(
-                    self._information_schema_query(table_names_as_str)
-                )
-                for row in cursor.fetchall():
-                    table_schema_name: str = row[_TABLE_SCHEMA]
-                    table_name: DbTableMeta = DbTableMeta(row[_TABLE_NAME])
-                    table_column: DbColumn = DbColumn(
-                        name=row[_COLUMN_NAME],
-                        type=row[_COLUMN_TYPE],
-                        ordinal_position=row[_ORDINAL_POSITION]
-                    )
-
-                    # Attempt to get table schema
-                    table_key: str = f"{table_schema_name}.{table_name}"
-                    table_schema: Optional[DbTableSchema] = schemas_by_table.get(table_key)
-
-                    if table_schema:
-                        # Add column to existing table schema.
-                        schemas_by_table[table_key].columns.append(table_column)
-                    else:
-                        # Create new table schema with column.
-                        schemas_by_table[table_key] = DbTableSchema(
-                            schema_name=table_schema_name,
-                            table_name=table_name,
-                            columns=[table_column]
-                        )
-
-        return list(schemas_by_table.values())

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0.
 import logging
-from contextlib import closing
-from typing import Optional, List
+from typing import List, Optional
 from urllib.parse import urlparse
 
+from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
 from openlineage.airflow.utils import (
     get_normalized_postgres_connection_uri,
     get_connection, safe_import_airflow
@@ -12,21 +12,10 @@ from openlineage.airflow.extractors.base import (
     BaseExtractor,
     TaskMetadata
 )
-from openlineage.client.facet import SqlJobFacet, ExternalQueryRunFacet
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
+from openlineage.client.facet import SqlJobFacet
 from openlineage.common.sql import SqlMeta, parse, DbTableMeta
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Source
 
-_TABLE_SCHEMA = 0
-_TABLE_NAME = 1
-_COLUMN_NAME = 2
-_ORDINAL_POSITION = 3
-# Use 'udt_name' which is the underlying type of column
-# (ex: int4, timestamp, varchar, etc)
-_UDT_NAME = 4
 
 logger = logging.getLogger(__name__)
 
@@ -43,19 +32,31 @@ class PostgresExtractor(BaseExtractor):
         return ['PostgresOperator']
 
     def extract(self) -> TaskMetadata:
+        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
+        job_facets = {
+            'sql': SqlJobFacet(self.operator.sql)
+        }
+
         # (1) Parse sql statement to obtain input / output tables.
         logger.debug(f"Sending SQL to parser: {self.operator.sql}")
-        sql_meta: SqlMeta = parse(self.operator.sql, self.default_schema)
+        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
         logger.debug(f"Got meta {sql_meta}")
 
-        # (2) Get database connection
+        if not sql_meta:
+            return TaskMetadata(
+                name=task_name,
+                inputs=[],
+                outputs=[],
+                run_facets={},
+                job_facets=job_facets
+            )
+
+        # (2) Get Airflow connection
         self.conn = get_connection(self._conn_id())
 
-        # (3) Default all inputs / outputs to current connection.
-        # NOTE: We'll want to look into adding support for the `database`
-        # property that is used to override the one defined in the connection.
+        # (3) Construct source object
         source = Source(
-            scheme=self._get_scheme(),
+            scheme="postgres",
             authority=self._get_authority(),
             connection_url=self._get_connection_uri()
         )
@@ -68,49 +69,19 @@ class PostgresExtractor(BaseExtractor):
         # as the current connection. We need to also fetch the schema for the
         # input tables to format the dataset name as:
         # {schema_name}.{table_name}
-        inputs = [
-            Dataset.from_table(
-                source=source,
-                table_name=in_table_schema.table_name.name,
-                schema_name=in_table_schema.schema_name,
-                database_name=database
-            ) for in_table_schema in self._get_table_schemas(
-                sql_meta.in_tables
-            )
-        ]
-        outputs = [
-            Dataset.from_table_schema(
-                source=source,
-                table_schema=out_table_schema,
-                database_name=database
-            ) for out_table_schema in self._get_table_schemas(
-                sql_meta.out_tables
-            )
-        ]
-
-        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
-        run_facets = {}
-        job_facets = {
-            'sql': SqlJobFacet(self.operator.sql)
-        }
-
-        query_ids = self._get_query_ids()
-        if len(query_ids) == 1:
-            run_facets['externalQuery'] = ExternalQueryRunFacet(
-                externalQueryId=query_ids[0],
-                source=source.name
-            )
-        elif len(query_ids) > 1:
-            logger.warning(
-                f"Found more than one query id for task {task_name}: {query_ids} "
-                "This might indicate that this task might be better as multiple jobs"
-            )
+        inputs, outputs = get_table_schemas(
+            self._get_hook(),
+            source,
+            database,
+            self._information_schema_query(sql_meta.in_tables) if sql_meta.in_tables else None,
+            self._information_schema_query(sql_meta.out_tables) if sql_meta.out_tables else None
+        )
 
         return TaskMetadata(
             name=task_name,
             inputs=[ds.to_openlineage_dataset() for ds in inputs],
             outputs=[ds.to_openlineage_dataset() for ds in outputs],
-            run_facets=run_facets,
+            run_facets={},
             job_facets=job_facets
         )
 
@@ -137,21 +108,6 @@ class PostgresExtractor(BaseExtractor):
     def _conn_id(self):
         return self.operator.postgres_conn_id
 
-    def _normalize_identifiers(self, table: str):
-        # For SnowflakeExtractor
-        return table
-
-    def _information_schema_query(self, table_names: str) -> str:
-        return f"""
-        SELECT table_schema,
-        table_name,
-        column_name,
-        ordinal_position,
-        udt_name
-        FROM information_schema.columns
-        WHERE table_name IN ({table_names});
-        """
-
     def _get_hook(self):
         PostgresHook = safe_import_airflow(
             airflow_1_path="airflow.hooks.postgres_hook.PostgresHook",
@@ -162,53 +118,17 @@ class PostgresExtractor(BaseExtractor):
             schema=self.operator.database
         )
 
-    def _get_table_schemas(
-            self, table_names: [DbTableMeta]
-    ) -> [DbTableSchema]:
-        # Avoid querying postgres by returning an empty array
-        # if no table names have been provided.
-        if not table_names:
-            return []
-
-        # Keeps tack of the schema by table.
-        schemas_by_table = {}
-
-        hook = self._get_hook()
-        with closing(hook.get_conn()) as conn:
-            with closing(conn.cursor()) as cursor:
-                table_names_as_str = ",".join(map(
-                    lambda name: f"'{self._normalize_identifiers(name.name)}'", table_names
-                ))
-                cursor.execute(
-                    self._information_schema_query(table_names_as_str)
-                )
-                for row in cursor.fetchall():
-                    table_schema_name: str = self._normalize_identifiers(row[_TABLE_SCHEMA])
-                    table_name: DbTableMeta = DbTableMeta(
-                        self._normalize_identifiers(row[_TABLE_NAME])
-                    )
-                    table_column: DbColumn = DbColumn(
-                        name=row[_COLUMN_NAME],
-                        type=row[_UDT_NAME],
-                        ordinal_position=row[_ORDINAL_POSITION]
-                    )
-
-                    # Attempt to get table schema
-                    table_key: str = f"{table_schema_name}.{table_name}"
-                    table_schema: Optional[DbTableSchema] = schemas_by_table.get(table_key)
-
-                    if table_schema:
-                        # Add column to existing table schema.
-                        schemas_by_table[table_key].columns.append(table_column)
-                    else:
-                        # Create new table schema with column.
-                        schemas_by_table[table_key] = DbTableSchema(
-                            schema_name=table_schema_name,
-                            table_name=table_name,
-                            columns=[table_column]
-                        )
-
-        return list(schemas_by_table.values())
-
-    def _get_query_ids(self) -> List[str]:
-        return []
+    @staticmethod
+    def _information_schema_query(tables: List[DbTableMeta]) -> str:
+        table_names = ",".join(map(
+            lambda name: f"'{name.name}'", tables
+        ))
+        return f"""
+        SELECT table_schema,
+        table_name,
+        column_name,
+        ordinal_position,
+        udt_name
+        FROM information_schema.columns
+        WHERE table_name IN ({table_names});
+        """

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -1,29 +1,113 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import List
+from typing import List, TYPE_CHECKING, Optional
 
-from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
 from openlineage.airflow.utils import get_connection_uri, get_connection  # noqa
+from openlineage.client.facet import SqlJobFacet, ExternalQueryRunFacet
+from openlineage.common.dataset import Source
+from openlineage.common.sql import SqlMeta, parse, DbTableMeta
 
-log = logging.getLogger(__file__)
+
+if TYPE_CHECKING:
+    from airflow.models import Connection
 
 
-class SnowflakeExtractor(PostgresExtractor):
+logger = logging.getLogger(__file__)
+
+
+class SnowflakeExtractor(BaseExtractor):
     source_type = 'SNOWFLAKE'
+    default_schema = 'PUBLIC'
 
     def __init__(self, operator):
         super().__init__(operator)
+        self.conn: "Connection" = None
+        self.hook = None
 
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
         return ['SnowflakeOperator']
 
-    def _information_schema_query(self, table_names: str) -> str:
+    def extract(self) -> TaskMetadata:
+        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
+        run_facets = {}
+        job_facets = {
+            'sql': SqlJobFacet(self.operator.sql)
+        }
+
+        # (1) Parse sql statement to obtain input / output tables.
+        logger.debug(f"Sending SQL to parser: {self.operator.sql}")
+        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
+        logger.debug(f"Got meta {sql_meta}")
+
+        if not sql_meta:
+            return TaskMetadata(
+                name=task_name,
+                inputs=[],
+                outputs=[],
+                run_facets=run_facets,
+                job_facets=job_facets
+            )
+
+        # (2) Get Airflow connection
+        self.conn = get_connection(self._conn_id())
+
+        # (3) Default all inputs / outputs to current connection.
+        # NOTE: We'll want to look into adding support for the `database`
+        # property that is used to override the one defined in the connection.
+        source = Source(
+            scheme='snowflake',
+            authority=self._get_authority(),
+            connection_url=self._get_connection_uri()
+        )
+
         database = self.operator.database
         if not database:
             database = self._get_database()
-        return f"""
+
+        # (4) Map input / output tables to dataset objects with source set
+        # as the current connection. We need to also fetch the schema for the
+        # input tables to format the dataset name as:
+        # {schema_name}.{table_name}
+        inputs, outputs = get_table_schemas(
+            self._get_hook(),
+            source,
+            database,
+            self._information_schema_query(sql_meta.in_tables) if sql_meta.in_tables else None,
+            self._information_schema_query(sql_meta.out_tables) if sql_meta.out_tables else None
+        )
+
+        query_ids = self._get_query_ids()
+        if len(query_ids) == 1:
+            run_facets['externalQuery'] = ExternalQueryRunFacet(
+                externalQueryId=query_ids[0],
+                source=source.name
+            )
+        elif len(query_ids) > 1:
+            logger.warning(
+                f"Found more than one query id for task {task_name}: {query_ids} "
+                "This might indicate that this task might be better as multiple jobs"
+            )
+
+        return TaskMetadata(
+            name=task_name,
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in outputs],
+            run_facets=run_facets,
+            job_facets=job_facets
+        )
+
+    def _information_schema_query(self, tables: List[DbTableMeta]) -> str:
+        table_names = ",".join(map(
+            lambda name: f"'{self._normalize_identifiers(name.name)}'", tables
+        ))
+        database = self.operator.database
+        if not database:
+            database = self._get_database()
+        sql = f"""
         SELECT table_schema,
                table_name,
                column_name,
@@ -32,15 +116,19 @@ class SnowflakeExtractor(PostgresExtractor):
           FROM {database}.information_schema.columns
          WHERE table_name IN ({table_names});
         """
-
-    def _get_scheme(self):
-        return 'snowflake'
+        return sql
 
     def _get_database(self) -> str:
-        return self._get_hook()._get_conn_params()['database']
+        if hasattr(self.operator, 'database') and self.operator.database is not None:
+            return self.operator.database
+        return self.conn.extra_dejson.get('extra__snowflake__database', '') \
+            or self.conn.extra_dejson.get('database', '')
 
     def _get_authority(self) -> str:
-        return self._get_hook()._get_conn_params()['account']
+        if hasattr(self.operator, 'account') and self.operator.account is not None:
+            return self.operator.account
+        return self.conn.extra_dejson.get('extra__snowflake__account', '') \
+            or self.conn.extra_dejson.get('account', '')
 
     def _get_hook(self):
         if hasattr(self.operator, 'get_db_hook'):

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -59,9 +59,9 @@ def execute_in_thread(target: Callable, kwargs=None):
     )
     thread.start()
     # Join, but ignore checking if thread stopped. If it did, then we shoudn't do anything.
-    # This basically gives this thread 2 seconds to complete work, then it can be killed,
+    # This basically gives this thread 5 seconds to complete work, then it can be killed,
     # as daemon=True. We don't want to deadlock Airflow if our code hangs.
-    thread.join(timeout=2)
+    thread.join(timeout=5)
 
 
 @hookimpl

--- a/integration/airflow/tests/extractors/test_dbapi_utils.py
+++ b/integration/airflow/tests/extractors/test_dbapi_utils.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
+from openlineage.common.dataset import Source, Dataset
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+
+DB_NAME = 'FOOD_DELIVERY'
+DB_SCHEMA_NAME = 'PUBLIC'
+DB_TABLE_NAME = DbTableMeta('DISCOUNTS')
+DB_TABLE_COLUMNS = [
+    DbColumn(
+        name='ID',
+        type='int4',
+        ordinal_position=1
+    ),
+    DbColumn(
+        name='AMOUNT_OFF',
+        type='int4',
+        ordinal_position=2
+    ),
+    DbColumn(
+        name='CUSTOMER_EMAIL',
+        type='varchar',
+        ordinal_position=3
+    ),
+    DbColumn(
+        name='STARTS_ON',
+        type='timestamp',
+        ordinal_position=4
+    ),
+    DbColumn(
+        name='ENDS_ON',
+        type='timestamp',
+        ordinal_position=5
+    )
+]
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME,
+    table_name=DB_TABLE_NAME,
+    columns=DB_TABLE_COLUMNS
+)
+
+
+def test_get_table_schemas():
+    hook = MagicMock()
+    # (2) Mock calls to database
+    rows = [
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ID', 1, 'int4'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'AMOUNT_OFF', 2, 'int4'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'CUSTOMER_EMAIL', 3, 'varchar'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'STARTS_ON', 4, 'timestamp'),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ENDS_ON', 5, 'timestamp')
+    ]
+
+    hook.get_conn.return_value \
+        .cursor.return_value \
+        .fetchall.side_effect = [rows, rows]
+
+    source = Source(
+        scheme="bigquery",
+        authority=None,
+        connection_url=None,
+        name=None
+    )
+
+    table_schemas = get_table_schemas(
+        hook=hook,
+        source=source,
+        database=DB_NAME,
+        in_query="fake_sql",
+        out_query="another_fake_sql"
+    )
+
+    assert table_schemas == (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)]
+    )

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0.
 
-import os
 from unittest import mock
 
 import pytest
@@ -14,7 +13,7 @@ from openlineage.common.models import (
     DbColumn
 )
 from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Source, Dataset, Field
 from openlineage.airflow.extractors.mysql_extractor import MySqlExtractor
 
 MySqlOperator = safe_import_airflow(
@@ -100,11 +99,19 @@ TASK = MySqlOperator(
 )
 
 
-@mock.patch('openlineage.airflow.extractors.mysql_extractor.MySqlExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.mysql_extractor.get_connection')
 def test_extract(get_connection, mock_get_table_schemas):
-    mock_get_table_schemas.side_effect = \
-        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+    source = Source(
+        scheme='mysql',
+        authority='localhost:3306',
+        connection_url=CONN_URI_WITHOUT_USERPASS
+    )
+
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
 
     conn = Connection(
         conn_id=CONN_ID,
@@ -119,12 +126,8 @@ def test_extract(get_connection, mock_get_table_schemas):
     expected_inputs = [
         Dataset(
             name=f"{DB_NAME}.{DB_TABLE_NAME.name}",
-            source=Source(
-                scheme='mysql',
-                authority='localhost:3306',
-                connection_url=CONN_URI_WITHOUT_USERPASS
-            ),
-            fields=[]
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS]
         ).to_openlineage_dataset()]
 
     task_metadata = MySqlExtractor(TASK).extract()
@@ -134,12 +137,19 @@ def test_extract(get_connection, mock_get_table_schemas):
     assert task_metadata.outputs == []
 
 
-@mock.patch('openlineage.airflow.extractors.mysql_extractor.MySqlExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.mysql_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.mysql_extractor.get_connection')
 def test_extract_authority_uri(get_connection, mock_get_table_schemas):
+    source = Source(
+        scheme='mysql',
+        authority='localhost:3306',
+        connection_url=CONN_URI_WITHOUT_USERPASS
+    )
 
-    mock_get_table_schemas.side_effect = \
-        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
 
     conn = Connection()
     conn.parse_from_uri(uri=CONN_URI)
@@ -153,7 +163,7 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
                 authority='localhost:3306',
                 connection_url=CONN_URI_WITHOUT_USERPASS
             ),
-            fields=[]
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS]
         ).to_openlineage_dataset()]
 
     task_metadata = MySqlExtractor(TASK).extract()
@@ -161,31 +171,6 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
     assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
     assert task_metadata.inputs == expected_inputs
     assert task_metadata.outputs == []
-
-
-@mock.patch('MySQLdb.connect')
-def test_get_table_schemas(mock_conn):
-    # (1) Mock calls to mysql
-    rows = [
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'id', 1, 'integer'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'amount_off', 2, 'integer'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'customer_email', 3, 'text'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'starts_on', 4, 'timestamp'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ends_on', 5, 'timestamp')
-    ]
-
-    mock_conn.return_value \
-        .cursor.return_value \
-        .fetchall.return_value = rows
-
-    # (2) Set the environment variable for the connection
-    os.environ[f"AIRFLOW_CONN_{CONN_ID.upper()}"] = CONN_URI
-
-    # (3) Extract table schemas for task
-    extractor = MySqlExtractor(TASK)
-    table_schemas = extractor._get_table_schemas(table_names=[DB_TABLE_NAME])
-
-    assert table_schemas == [DB_TABLE_SCHEMA]
 
 
 def test_get_connection_import_returns_none_if_not_exists():

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0.
 
-import os
 from unittest import mock
 
 import pytest
@@ -14,7 +13,7 @@ from openlineage.common.models import (
     DbColumn
 )
 from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Source, Dataset, Field
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
 PostgresOperator = safe_import_airflow(
@@ -100,11 +99,19 @@ TASK = PostgresOperator(
 )
 
 
-@mock.patch('openlineage.airflow.extractors.postgres_extractor.PostgresExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.postgres_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.postgres_extractor.get_connection')
 def test_extract(get_connection, mock_get_table_schemas):
-    mock_get_table_schemas.side_effect = \
-        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+    source = Source(
+        scheme='postgres',
+        authority='localhost:5432',
+        connection_url=CONN_URI_WITHOUT_USERPASS
+    )
+
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
 
     conn = Connection(
         conn_id=CONN_ID,
@@ -119,12 +126,8 @@ def test_extract(get_connection, mock_get_table_schemas):
     expected_inputs = [
         Dataset(
             name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
-            source=Source(
-                scheme='postgres',
-                authority='localhost:5432',
-                connection_url=CONN_URI_WITHOUT_USERPASS
-            ),
-            fields=[]
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS]
         ).to_openlineage_dataset()]
 
     task_metadata = PostgresExtractor(TASK).extract()
@@ -134,12 +137,20 @@ def test_extract(get_connection, mock_get_table_schemas):
     assert task_metadata.outputs == []
 
 
-@mock.patch('openlineage.airflow.extractors.postgres_extractor.PostgresExtractor._get_table_schemas')  # noqa
+@mock.patch('openlineage.airflow.extractors.postgres_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.postgres_extractor.get_connection')
 def test_extract_authority_uri(get_connection, mock_get_table_schemas):
 
-    mock_get_table_schemas.side_effect = \
-        [[DB_TABLE_SCHEMA], NO_DB_TABLE_SCHEMA]
+    source = Source(
+        scheme='postgres',
+        authority='localhost:5432',
+        connection_url=CONN_URI_WITHOUT_USERPASS
+    )
+
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
 
     conn = Connection()
     conn.parse_from_uri(uri=CONN_URI)
@@ -148,12 +159,8 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
     expected_inputs = [
         Dataset(
             name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
-            source=Source(
-                scheme='postgres',
-                authority='localhost:5432',
-                connection_url=CONN_URI_WITHOUT_USERPASS
-            ),
-            fields=[]
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS]
         ).to_openlineage_dataset()]
 
     task_metadata = PostgresExtractor(TASK).extract()
@@ -161,31 +168,6 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
     assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
     assert task_metadata.inputs == expected_inputs
     assert task_metadata.outputs == []
-
-
-@mock.patch('psycopg2.connect')
-def test_get_table_schemas(mock_conn):
-    # (1) Mock calls to postgres
-    rows = [
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'id', 1, 'int4'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'amount_off', 2, 'int4'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'customer_email', 3, 'varchar'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'starts_on', 4, 'timestamp'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ends_on', 5, 'timestamp')
-    ]
-
-    mock_conn.return_value \
-        .cursor.return_value \
-        .fetchall.return_value = rows
-
-    # (2) Set the environment variable for the connection
-    os.environ[f"AIRFLOW_CONN_{CONN_ID.upper()}"] = CONN_URI
-
-    # (3) Extract table schemas for task
-    extractor = PostgresExtractor(TASK)
-    table_schemas = extractor._get_table_schemas(table_names=[DB_TABLE_NAME])
-
-    assert table_schemas == [DB_TABLE_SCHEMA]
 
 
 def test_get_connection_import_returns_none_if_not_exists():

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -90,7 +90,7 @@ LOGGING_CONFIG = {
         }
     },
     'loggers': {
-        'openlineage.airflow': {
+        'openlineage': {
             'handler': ['console'],
             'level': 'DEBUG',
             'propagate': True,

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0.
+import logging
 from typing import Optional, Union, List
+
+
+log = logging.getLogger(__name__)
+
 
 try:
     from openlineage_sql import parse as parse_sql, SqlMeta, DbTableMeta, provider  # noqa: F401
@@ -11,7 +16,11 @@ def parse(
     sql: Union[List[str], str],
     dialect: Optional[str] = None,
     default_schema: Optional[str] = None
-) -> SqlMeta:
+) -> Optional[SqlMeta]:
     if isinstance(sql, str):
         sql = [sql]
-    return parse_sql(sql, dialect=dialect, default_schema=default_schema)
+    try:
+        return parse_sql(sql, dialect=dialect, default_schema=default_schema)
+    except Exception as e:
+        log.error(f"SQL parser failed: {e}")
+        return None

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -236,8 +236,7 @@ def test_parse_simple_cte():
 
 
 def test_parse_bugged_cte():
-    with pytest.raises(RuntimeError):
-        parse(
+    assert parse(
             '''
             WITH sum_trans (
                 SELECT user_id, COUNT(*) as cnt, SUM(amount) as balance
@@ -250,7 +249,7 @@ def test_parse_bugged_cte():
               FROM sum_trans
               WHERE count > 1000 OR balance > 100000;
             '''
-        )
+    ) is None
 
 
 def test_parse_recursive_cte():
@@ -397,3 +396,36 @@ def test_parse_statement_list():
         """])
     assert sql_meta.in_tables == [DbTableMeta('schema0.table0')]
     assert sql_meta.out_tables == [DbTableMeta('schema1.table1')]
+
+
+def test_parse_copy_into_snowflake_at_syntax():
+    parse(["""
+            COPY INTO SCHEMA.SOME_MONITORING_SYSTEM
+            FROM (
+                SELECT
+                t.$1:st AS st,
+                t.$1:index AS index,
+                t.$1:cid AS cid,
+                t.$1:k8s AS k8s,
+                t.$1:cn AS cn,
+                t.$1:did AS did,
+                t.$1:tid AS tid,
+                t.$1:tn AS tn,
+                t.$1:mt AS mt,
+                t.$1:op AS op,
+                t.$1:drid AS drid,
+                t.$1:mi AS mi,
+                t.$1:q3dm17 AS q3dm17,
+                t.$1:rsd AS rsd,
+                t.$1:red AS red,
+                t.$1:rd AS rd,
+                t.$1:state AS state,
+                t.$1:es AS es,
+                t.$1:pool AS pool,
+                t.$1:queue AS queue,
+                t.$1:pw AS pw,
+                metadata$fn AS load_fn,
+                metadata$frn AS load_filerow,
+                CURRENT_TIMESTAMP AS lts
+                FROM @schema.general_finished AS t
+            )"""])

--- a/integration/sql/tests/tests_copy.rs
+++ b/integration/sql/tests/tests_copy.rs
@@ -1,0 +1,51 @@
+extern crate core;
+
+use openlineage_sql::{parse_sql, SqlMeta};
+use sqlparser::dialect::SnowflakeDialect;
+use std::sync::Arc;
+
+#[macro_use]
+mod test_utils;
+use test_utils::*;
+
+#[test]
+fn parse_copy_from() {
+    assert_eq!(
+        parse_sql("
+            COPY INTO SCHEMA.SOME_MONITORING_SYSTEM
+                FROM (
+                SELECT
+                t.$1:st AS st,
+                t.$1:index AS index,
+                t.$1:cid AS cid,
+                t.$1:k8s AS k8s,
+                t.$1:cn AS cn,
+                t.$1:did AS did,
+                t.$1:tid AS tid,
+                t.$1:tn AS tn,
+                t.$1:mt AS mt,
+                t.$1:op AS op,
+                t.$1:drid AS drid,
+                t.$1:mi AS mi,
+                t.$1:q3dm17 AS q3dm17,
+                t.$1:rsd AS rsd,
+                t.$1:red AS red,
+                t.$1:rd AS rd,
+                t.$1:state AS state,
+                t.$1:es AS es,
+                t.$1:pool AS pool,
+                t.$1:queue AS queue,
+                t.$1:pw AS pw,
+                metadata$fn AS load_fn,
+                metadata$frn AS load_filerow,
+                CURRENT_TIMESTAMP AS lts
+                FROM @schema.general_finished AS t
+            )",
+            Arc::new(SnowflakeDialect {}),
+            None
+        )
+            .unwrap_err(),
+        "sql parser error: Expected FROM or TO, found: SCHEMA"
+    )
+}
+


### PR DESCRIPTION
This PR should mitigate issue where Airflow integration running SnowflakeExtractor dies when it exceeds thread timeout.

The PR makes few changes that should make this issue less prominent:

1. It makes the two table schema gathering queries to Snowflake (and other SQL databases that have extractors) inside one connection, instead of creating connection each time it wants to run the query
2. It gets Airflow Connection only once to get Snowflake database and account, instead of getting the connection each time
3. Bumps timeout to 5 seconds for whole process.

PR removes PostgresExtractor being a superclass for SnowflakeExtractor - finding out what happened was more opaque. Now, parts of it are extracted to separate function used by all Snowflake, Postgres and Mysql extractors. Still, there is future work to reduce duplication there.

Also, two minor fixes:

1. Remove not-used SQL parsing for BigQuery
2. Add (expected failing) tests for SQL query that was potentially causing problems. It didn't.  

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
