### PR TITLE
Made listener thread use a queue rather than spinning up many new thr…

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -436,7 +436,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: docker build -f airflow/Dockerfile.tests -t openlineage-airflow-base .
-      - run: ./airflow/tests/integration/docker/up-failure.sh
+      - run: AIRFLOW_IMAGE=apache/airflow:2.3.1-python3.7 ./airflow/tests/integration/docker/up-failure.sh
       - store_artifacts:
           path: airflow/tests/integration/failures/airflow/logs
           destination: airflow-logs

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+from time import sleep
+from typing import Union, Optional, List
+
+from openlineage.airflow.extractors import TaskMetadata
+from openlineage.airflow.extractors.base import BaseExtractor
+from openlineage.client.run import Dataset
+
+
+class HangingExtractor(BaseExtractor):
+    """
+    Custom extractor that hangs for 30 seconds. The listener module should terminate the thread that executes
+    this extractor after waiting for the timeout to complete.
+    """
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['CustomOperator']
+
+    def extract(self) -> Union[Optional[TaskMetadata], List[TaskMetadata]]:
+        sleep(30)
+        return TaskMetadata(
+            "test",
+            inputs=[
+                Dataset(
+                    namespace="test",
+                    name="dataset",
+                    facets={}
+                )
+            ]
+        )

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import Any
+
+from airflow.models import BaseOperator
+from airflow.utils.dates import days_ago
+from openlineage.client import set_producer
+
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+from airflow.version import version as AIRFLOW_VERSION
+from pkg_resources import parse_version
+if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
+    from openlineage.airflow import DAG
+else:
+    from airflow import DAG
+
+# Exercise the extractor only for Airflow 2.3.0+
+# This is to test the thread handling in the Airflow listener. The thread should be shutdown after 2 seconds, even
+# if the extractor is hanging
+if parse_version(AIRFLOW_VERSION) > parse_version("2.3.0"):
+    os.environ["OPENLINEAGE_EXTRACTOR_CustomOperator"] = 'hanging_extractor.HangingExtractor'
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+
+dag = DAG(
+    'hanging_extractor_dag',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Test dag.'
+)
+
+
+class CustomOperator(BaseOperator):
+    def execute(self, context: Any):
+        for i in range(10):
+            print(i)
+
+
+t1 = CustomOperator(
+    task_id='hanging_extractor',
+    dag=dag
+)

--- a/integration/airflow/tests/integration/failures/docker-compose.yml
+++ b/integration/airflow/tests/integration/failures/docker-compose.yml
@@ -5,6 +5,8 @@ x-airflow-common: &airflow-common
     context: ../
     target: airflow
     dockerfile: Dockerfile.2
+    args:
+      AIRFLOW_IMAGE: ${AIRFLOW_IMAGE}
   environment: &airflow-common-env
     DB_BACKEND: postgresql+psycopg2
     DB_HOST: postgres
@@ -41,6 +43,8 @@ services:
       context: ../
       target: integration
       dockerfile: Dockerfile.2
+      args:
+        AIRFLOW_IMAGE: ${AIRFLOW_IMAGE}
     volumes:
       - ./docker/wait-for-it.sh:/wait-for-it.sh
     depends_on:

--- a/integration/airflow/tests/integration/test_failure.py
+++ b/integration/airflow/tests/integration/test_failure.py
@@ -76,3 +76,6 @@ if __name__ == '__main__':
     trigger_dag("test_dag")
     if not wait_for_dag("test_dag"):
         sys.exit(1)
+    trigger_dag("hanging_extractor_dag")
+    if not wait_for_dag("hanging_extractor_dag"):
+        sys.exit(1)


### PR DESCRIPTION
### Problem

The Airflow task listener collects and emits lineage information in a separate thread that's spun up on each state change event. The thread is terminated after a couple of seconds so that a) the thread doesn't prevent the process from terminating and b) we try to give the thread a chance to actually emit the lineage information.

Unfortunately, as described in #807, the extra thread introduces the possibility of deadlock, especially since we terminate the thread manually without the opportunity to release any locks held.

Closes: #807

### Solution

This change alters the way we manage the lineage thread, starting a single thread at the beginning of the process and using a `Queue` to manage tasks that need to be executed in that thread. It also adds an exit hook that waits for the queue to be empty and then terminates the thread (with a short timeout). Since it's an exit hook, we can be sure that the Airflow task itself has completed before we attempt to terminate the thread. This should completely eliminate the possibility of deadlock.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)