### PR TITLE
great expectations: do not always require sqlalchemy

### DIFF
--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -36,8 +36,18 @@ from openlineage.common.provider.great_expectations.results import \
     COLUMN_EXPECTATIONS_PARSER, \
     GreatExpectationsAssertion
 from openlineage.common.sql import parse
-from sqlalchemy import MetaData, Table
-from sqlalchemy.engine import Connection
+
+# There is no guarantee that SqlAlchemy is available with Great Expectations.
+# Especially, it could be used only with Pandas datasets, in which case
+# we shouldn't try to import it.
+# Great Expectations itself tries hard to not import SqlAlchemy if not needed.
+try:
+    from sqlalchemy import MetaData, Table
+    from sqlalchemy.engine import Connection
+except ImportError:
+    MetaData = None
+    Table = None
+    Connection = None
 
 
 class OpenLineageValidationAction(ValidationAction):


### PR DESCRIPTION
We always try to top-level import SqlAlchemy, even if it's used with Pandas datasets. 
Treat the import [as GreatExpectations does](https://github.com/great-expectations/great_expectations/blob/74f7f2aa7b51144f34156ed49490dae4edaa5cb7/great_expectations/dataset/sqlalchemy_dataset.py#L35) and only try to import the dependencies.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: #733
