### PR TITLE
[INTEGRATION][SPARK] skip functionRegistry serialization

### DIFF
--- a/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/src/main/common/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.Partition;
 import org.apache.spark.api.python.PythonRDD;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.SQLExecutionRDD;
 import org.apache.spark.sql.sources.BaseRelation;
@@ -144,7 +145,8 @@ class LogicalPlanSerializer {
               .put(PythonRDD.class, PythonRDDMixin.class)
               .put(ClassLoader.class, IgnoredType.class)
               .put(RDD.class, RDDMixin.class)
-              .put(SQLExecutionRDD.class, SqlConfigMixin.class);
+              .put(SQLExecutionRDD.class, SqlConfigMixin.class)
+              .put(FunctionRegistry.class, IgnoredType.class);
       try {
         Class<?> c = PolymorficMixIn.class.getClassLoader().loadClass("java.lang.Module");
         builder.put(c, IgnoredType.class);


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`UnknownEntryFacet` for `CreateV2Table` serializes `functionRegsitry` member of `SessionCatalog` which contains full list of available functions with documentation included. This increases Ol event size dramatically and leads to client error: 
```
  OpenLineageHttpException(code=0, message=java.lang.RuntimeException: java.util.concurrent.ExecutionException: openlineage.hc.core5.http2.H2ConnectionException: Frame size exceeds maximum, details=java.util.concurrent.CompletionException: java.lang.RuntimeException: java.util.concurrent.ExecutionException: openlineage.hc.core5.http2.H2ConnectionException: Frame size exceeds maximum)
```

Solves experienced issues defined in: #402

### Solution

Ignore `FunctionRegistry` type when serializing plan. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)