### PR TITLE
airflow: revert queue-based thread mechanism

### DIFF
--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -1,9 +1,6 @@
 import logging
 import threading
 import uuid
-from queue import Queue, Empty
-
-import atexit
 
 import attr
 
@@ -51,66 +48,28 @@ class ActiveRunManager:
 log = logging.getLogger('airflow')
 
 
-class TaskRunner:
-    """
-    Run extractors in a separate thread. We do this because sometimes extractors execute
-    long-running tasks, such as a network call to another service (e.g., BigQuery) or execute
-    sometimes long-running database queries. The task runner starts a daemon thread and manages a
-    queue for tasks to be executed. While the queue is non-empty, the thread will pull tasks and
-    execute them. A `running` state flag tells the thread whether to keep reading from the queue
-    even if it's empty.
-    An `atexit` hook is registered to set the `running` flag to false, wait until the queue is
-    empty, and then wait for the thread to complete any tasks
-    """
+def execute_in_thread(target: Callable, kwargs=None):
+    if kwargs is None:
+        kwargs = {}
+    thread = threading.Thread(
+        target=target,
+        kwargs=kwargs,
+        daemon=True
+    )
+    thread.start()
 
-    def __init__(self):
-        self.queue = Queue(maxsize=0)
-        self.thread = threading.Thread(
-            target=self.run,
-            daemon=True
-        )
-        self.running = True
-        self.thread.start()
-        log.info("Started OpenLineage event listener thread")
+    # Join, but ignore checking if thread stopped. If it did, then we shoudn't do anything.
+    # This basically gives this thread 5 seconds to complete work, then it can be killed,
+    # as daemon=True. We don't want to deadlock Airflow if our code hangs.
 
-    def push(self, item: Callable):
-        self.queue.put(item, False)
-
-    def run(self):
-        while self.running:
-            try:
-                item: Callable = self.queue.get(True, 5)
-                item()
-            except Empty:
-                log.debug("Nothing in the queue")
-
-    def terminate(self):
-        """
-        Terminate the running thread
-        :return:
-        """
-        log.info("Tearing down OpenLineage thread - waiting for active tasks")
-        self.running = False
-
-        # don't wait for the queue to be empty - a task may be hanging, meaning tasks at the end
-        # of the queue may never be handled, so we'd wait forever.
-        # leaving this here in case someone else thinks to add this line in the future :)
-        # self.queue.join()
-
-        self.thread.join(timeout=2)
-        log.info("OpenLineage thread torn down")
+    # This will hang if this timeouts, and extractor is running non-daemon thread inside,
+    # since it will never be cleaned up. Ex. SnowflakeOperator
+    thread.join(timeout=10)
 
 
 run_data_holder = ActiveRunManager()
 extractor_manager = ExtractorManager()
 adapter = OpenLineageAdapter()
-runner = TaskRunner()
-
-atexit.register(runner.terminate)
-
-
-def execute_in_thread(target: Callable, kwargs=None):
-    runner.push(target)
 
 
 @hookimpl
@@ -120,6 +79,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
             f"No task set for TI object task_id: {task_instance.task_id} - dag_id: {task_instance.dag_id} - run_id {task_instance.run_id}")  # noqa
         return
 
+    log.debug("OpenLineage listener got notification about task instance start")
     dagrun = task_instance.dag_run
     task = task_instance.task
     dag = task_instance.task.dag
@@ -153,6 +113,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
 
 @hookimpl
 def on_task_instance_success(previous_state, task_instance: "TaskInstance", session):
+    log.debug("OpenLineage listener got notification about task instance success")
     run_data = run_data_holder.get_active_run(task_instance)
 
     dagrun = task_instance.dag_run
@@ -174,6 +135,7 @@ def on_task_instance_success(previous_state, task_instance: "TaskInstance", sess
 
 @hookimpl
 def on_task_instance_failed(previous_state, task_instance: "TaskInstance", session):
+    log.debug("OpenLineage listener got notification about task instance failure")
     run_data = run_data_holder.get_active_run(task_instance)
 
     dagrun = task_instance.dag_run


### PR DESCRIPTION
Nonblocking single-thread mechanism causes https://github.com/OpenLineage/OpenLineage/issues/827
Revert to blocking mechanism with longer timeout to counteract hang tasks from https://github.com/OpenLineage/OpenLineage/issues/807.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>