### PR TITLE
airflow: install new sql parser by default

### DIFF
--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -15,14 +15,11 @@ requirements = [
     "attrs>=19.3",
     "requests>=2.20.0",
     "sqlparse>=0.3.1",
-    f"openlineage-integration-common=={__version__}",
+    f"openlineage-integration-common[sql]=={__version__}",
     f"openlineage-python=={__version__}",
 ]
 
 extras_require = {
-    "sql": [
-        f"openlineage-integration-common[sql]=={__version__}",
-    ],
     "tests": [
         "pytest",
         "pytest-cov",


### PR DESCRIPTION
Install new SQL parser by default when installing `openlineage-airflow`. It has been from 0.8, and there were no problems with installation using binary wheels.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
