### PR TITLE
Feature/cosmosdb

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -124,6 +124,23 @@ Identifier:
  * Unique name: {schema}.{table}
    * URI = sqlserver://{host}:{port};database={database}/{schema}.{table}
 
+#### Azure Cosmos DB:
+Datasource hierarchy:
+azurecosmos://%s.documents.azure.com/dbs/%s
+ * Host: \<XXXXXXXXXXXX>.documents.azure.com
+ * Database
+ 
+Naming hierarchy:
+ * Schema
+ * Table
+
+Identifier:
+ * Namespace: azurecosmos://{host}.documents.azure.com/dbs/{database}
+   * Scheme = azurecosmos
+   * Authority = {host}
+ * Unique name: /colls/{table}
+   * URI = azurecosmos://{host}.documents.azure.com/dbs/{database}/colls/{table}
+
 ### Distributed file systems/blob stores
 #### GCS
 Datasource hierarchy: none, naming is global


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Openlineage does not support Azure Cosmos DB as an input or output. 

Closes: #449 

### Solution

Discovered that the [Cosmos DB spark connector](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3_2-12) does not have tableCatalog, identifier, tableProperties objects instantiated, but we can extract the table name and namespace from the relation's table object. Due to this, we did not implement a handler for Cosmos DB, but another method within PlanUtils3.java, fromDataSourceV2RelationWithNoIdentifier, which generates the Dataset from the relation's table object.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)