### PR TITLE
shade 3rd party libs in openlineage-java

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -122,12 +122,13 @@ shadowJar {
     minimize()
     classifier = ''
     relocate 'com.fasterxml.jackson', 'io.openlineage.client.shaded.com.fasterxml.jackson'
-    relocate 'org.apache.httpcomponents', 'io.openlineage.client.shaded.org.apache.httpcomponents'
-    relocate 'org.apache.http', 'io.openlineage.client.shaded.org.apache.http'
-    relocate 'org.apache.commons.codec', 'io.openlineage.client.shaded.org.apache.commons.codec'
+    relocate('org.apache', 'io.openlineage.client.shaded.org.apache') {
+        exclude  '%regex[org/apache/commons/logging/.*]' // we want to relocate all apache jars except logging which we exclude later
+    }
     relocate 'org.yaml', 'io.openlineage.client.shaded.org.yaml'
 
     exclude 'META-INF/maven/**'
+    exclude 'org/apache/commons/logging/**'
 
     manifest {
         attributes(


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

The problem of unshaded jackson libraries in openlineage-spark got solved within PR #834.
This PR removes remaining unshaded dependencies from `openlineage-java`

Closes: #852

### Solution

* relocate client dependencies.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)