### PR TITLE
Fix Java client jar to stop bundling dependencies

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -65,8 +65,8 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.yaml:snakeyaml:1.30'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.apache.kafka:kafka-clients:3.1.0'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
@@ -132,33 +132,6 @@ compileJava.dependsOn tasks.generateCode, tasks.openApiGenerate
 
 test {
     useJUnitPlatform()
-}
-
-shadowJar {
-    minimize()
-    classifier = ''
-    relocate 'com.fasterxml.jackson', 'io.openlineage.client.shaded.com.fasterxml.jackson'
-    relocate 'org.apache.httpcomponents', 'io.openlineage.client.shaded.org.apache.httpcomponents'
-    relocate 'org.apache.http', 'io.openlineage.client.shaded.org.apache.http'
-    relocate 'org.apache.commons.codec', 'io.openlineage.client.shaded.org.apache.commons.codec'
-    relocate 'org.yaml', 'io.openlineage.client.shaded.org.yaml'
-
-    exclude 'META-INF/maven/**'
-
-    manifest {
-        attributes(
-                'Created-By': "Gradle ${gradle.gradleVersion}",
-                'Built-By': System.getProperty('user.name'),
-                'Build-Jdk': System.getProperty('java.version'),
-                'Implementation-Title': project.name,
-                'Implementation-Version': project.version
-        )
-    }
-    zip64 true
-}
-
-assemble {
-    dependsOn shadowJar
 }
 
 publishing {

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -191,6 +191,7 @@ shadowJar {
     relocate 'org.apache.commons.logging', 'io.openlineage.spark.shaded.org.apache.commons.logging'
     relocate 'org.apache.http', 'io.openlineage.spark.shaded.org.apache.http'
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
+    relocate 'com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson'
     manifest {
         attributes(
                 'Created-By': "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -11,12 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.Utils;
-import io.openlineage.client.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import io.openlineage.client.shaded.com.fasterxml.jackson.core.type.TypeReference;
-import io.openlineage.client.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import java.io.IOException;
 import java.net.URL;

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -49,6 +49,8 @@ archivesBaseName='openlineage-spark'
 ext {
     lombokVersion = '1.18.20'
     isReleaseVersion = !version.endsWith('SNAPSHOT')
+    jacksonVersion = "2.13.2"
+    jacksonDatabindVersion = "2.13.2.2"
 }
 
 dependencies {
@@ -56,6 +58,13 @@ dependencies {
     implementation(project(path: ":shared"))
     implementation(project(path: ":spark2"))
     implementation(project(path: ":spark3"))
+
+    compileOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    compileOnly "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    compileOnly "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
+    compileOnly "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
+    compileOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 }
 
 
@@ -199,7 +208,6 @@ shadowJar {
         exclude (project(":app"))
     }
     dependencies {
-        exclude(dependency('com.fasterxml.*::'))
         exclude(dependency('org.slf4j::'))
     }
     classifier = ''
@@ -212,6 +220,7 @@ shadowJar {
     relocate 'org.apache.commons.logging', 'io.openlineage.spark.shaded.org.apache.commons.logging'
     relocate 'org.apache.http', 'io.openlineage.spark.shaded.org.apache.http'
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
+    relocate 'com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson'
     manifest {
         attributes(
                 'Created-By': "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark.agent.facets;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.spark.agent.Versions;
 import java.util.Map;
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/LogicalPlanFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/LogicalPlanFacet.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark.agent.facets;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.shaded.com.fasterxml.jackson.annotation.JsonRawValue;
 import io.openlineage.spark.agent.Versions;
 import lombok.Builder;
 import lombok.ToString;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark.agent.facets;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.spark.agent.Versions;
 import lombok.Getter;
 import lombok.NonNull;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/TableProviderFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/TableProviderFacet.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark.agent.facets;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.spark.agent.Versions;
 import lombok.Getter;
 import lombok.NonNull;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/UnknownEntryFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/UnknownEntryFacet.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark.agent.facets;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.shaded.com.fasterxml.jackson.annotation.JsonRawValue;
 import io.openlineage.spark.agent.Versions;
 import java.util.List;
 import java.util.Map;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -7,10 +7,10 @@ package io.openlineage.spark.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.Utils;
-import io.openlineage.client.shaded.com.fasterxml.jackson.core.type.TypeReference;
-import io.openlineage.client.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.spark.agent.lifecycle.MatchesMapRecursively;
 import java.io.IOException;
 import java.net.URI;

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -5,11 +5,11 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacetFields;
 import io.openlineage.client.Utils;
-import io.openlineage.client.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import io.openlineage.client.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;


### PR DESCRIPTION
### Problem
A recent change made Jackson an `implementation` rather than `compileOnly` dependency. I actually think this is a good change, as I think that bundling dependencies is a strategy that should be used sparingly. I think it makes a lot of sense when deploying to a platform whose dependency versions are fixed and can't be easily upgraded (e.g., running on a Spark cluster or deploying a Spring/Dropwizard service). Outside of that, I don't think general-purpose libraries ought to bundle transitive dependencies, as it bloats jars and duplicates code on the classpath.

### Solution

Currently, the java client both includes Jackson as a transitive dependency _and_ bundles all the Jackson classes in the client jar. This change removes the bundling and solely includes Jackson as a transitive dependency. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)