### PR TITLE
Airflow: Wait for postgres in all integration tests

### DIFF
--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     apt-get install -y git build-essential
 RUN mkdir -p /opt/airflow
 COPY data /opt/data
+COPY docker/wait-for-it.sh /opt/data/wait-for-it.sh
 RUN chown -R airflow:airflow /opt/airflow
 RUN chmod -R 777 /opt/data
 USER airflow

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -96,10 +96,10 @@ services:
 
   airflow_init:
     <<: *airflow-base
-    entrypoint: /bin/bash
     command: -c "airflow db init && airflow users create --username airflow --password airflow --firstname airflow --lastname airflow --email airflow@example.com --role Admin"
     depends_on:
       - postgres
+    entrypoint: ["/opt/data/wait-for-it.sh", "postgres:5432", "--", "/bin/bash"]
 
   redis:
     image: redis:latest

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -98,6 +98,9 @@ services:
   airflow_init:
     <<: *airflow-base
     command: initdb
+    depends_on:
+      - postgres
+    entrypoint: ["/opt/data/wait-for-it.sh", "postgres:5432", "--", "airflow"]
 
   postgres:
     image: bitnami/postgresql:12.1.0


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Sometimes integration tests fail because postgres is not ready yet.

### Solution

Add wait-for-it.sh script to all integration tests in `airflow_init` containers.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained