### PR TITLE
[INTEGRATION][SPARK] fix CreateV2Table issue

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import scala.PartialFunction;
@@ -30,6 +31,7 @@ import scala.PartialFunction;
  * @param <P>
  * @param <D>
  */
+@Slf4j
 public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, D extends Dataset>
     extends AbstractGenericArgPartialFunction<T, D> {
   protected final OpenLineageContext context;
@@ -58,14 +60,20 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
         .getQueryExecution()
         .map(
             qe -> {
-              QueryPlanVisitor<LogicalPlan, D> visitor = asQueryPlanVisitor(event);
-              if (searchDependencies) {
-                return ScalaConversionUtils.fromSeq(qe.optimizedPlan().collect(visitor)).stream()
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
-              } else if (visitor.isDefinedAt(qe.optimizedPlan())) {
-                return visitor.apply(qe.optimizedPlan());
-              } else {
+              try {
+                QueryPlanVisitor<LogicalPlan, D> visitor = asQueryPlanVisitor(event);
+                if (searchDependencies) {
+                  return ScalaConversionUtils.fromSeq(qe.optimizedPlan().collect(visitor)).stream()
+                      .flatMap(Collection::stream)
+                      .collect(Collectors.toList());
+                } else if (visitor.isDefinedAt(qe.optimizedPlan())) {
+                  return visitor.apply(qe.optimizedPlan());
+                } else {
+                  return Collections.<D>emptyList();
+                }
+              } catch (Exception e) {
+                // whatever happens (like missing class in new Spark version), continue
+                log.error("Apply method failed with ", e);
                 return Collections.<D>emptyList();
               }
             })

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -1,6 +1,9 @@
 package io.openlineage.spark.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
@@ -9,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -17,6 +21,7 @@ import org.apache.spark.scheduler.SparkListenerStageCompleted;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.Metadata;
@@ -110,6 +115,32 @@ class AbstractQueryPlanDatasetBuilderTest {
     // Even though our instance of builder is parameterized with SparkListenerJobEnd, it's not
     // *compiled* with that argument, so the isDefinedAt method fails to resolve the type arg
     Assertions.assertFalse(((PartialFunction) builder).isDefinedAt(jobEnd));
+  }
+
+  @Test
+  public void testApplyWhenExceptionIsThrown() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    when(context.getQueryExecution()).thenReturn(Optional.of(mock(QueryExecution.class)));
+    AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
+        new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
+            context, false) {
+
+          @Override
+          public List<InputDataset> apply(LocalRelation localRelation) {
+            return Collections.emptyList();
+          }
+
+          @Override
+          protected boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
+            throw new RuntimeException("some error");
+          }
+        };
+
+    try {
+      ((PartialFunction) builder).apply(mock(SparkListenerJobEnd.class));
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
   }
 
   static class MyGenericArgInputDatasetBuilder<E extends SparkListenerEvent>

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -41,7 +41,12 @@ public class CreateReplaceDatasetBuilder
     return (x instanceof CreateTableAsSelect)
         || (x instanceof ReplaceTable)
         || (x instanceof ReplaceTableAsSelect)
-        || (x instanceof CreateV2Table);
+        // Class CreateV2Table was removed in Spark Catalyst 3.3.0. For some reason, it is also
+        // missing on Databricks platform when Spark context is in version 3.2.1. This hacky way
+        // allows checking for the class also when it is not available on the class path
+        || x.getClass()
+            .getCanonicalName()
+            .equals("org.apache.spark.sql.catalyst.plans.logical.CreateV2Table");
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Missing class `org.apache.spark.sql.catalyst.plans.logical.CreateV2Table` causes Spark job to fail. 

Closes: #865

### Solution

 * catch exceptions for abstract dataset buidlers
 * make `CreateReplaceDatasetBuilder.isDefinedAtLogicalPlan` work, also when `CreateV2Table` class is unavailable.  

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)