### PR TITLE
Add SnowflakeOperatorAsync Extractor Support

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -29,7 +29,7 @@ class SnowflakeExtractor(BaseExtractor):
 
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
-        return ['SnowflakeOperator']
+        return ['SnowflakeOperator', 'SnowflakeOperatorAsync']
 
     def extract(self) -> TaskMetadata:
         task_name = f"{self.operator.dag_id}.{self.operator.task_id}"

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -34,24 +34,24 @@ def test_basic_extractor():
 
 
 def test_env_add_extractor():
-    assert len(Extractors().extractors) == 8
+    assert len(Extractors().extractors) == 9
     with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor"}):  # noqa
-        assert len(Extractors().extractors) == 9
-
-
-def test_env_multiple_extractors():
-    assert len(Extractors().extractors) == 8
-    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;tests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
         assert len(Extractors().extractors) == 10
 
 
+def test_env_multiple_extractors():
+    assert len(Extractors().extractors) == 9
+    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;tests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
+        assert len(Extractors().extractors) == 11
+
+
 def test_env_old_method_extractors():
-    assert len(Extractors().extractors) == 8
+    assert len(Extractors().extractors) == 9
 
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
         'tests.extractors.test_extractors.FakeExtractor'
 
-    assert len(Extractors().extractors) == 9
+    assert len(Extractors().extractors) == 10
     del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']
 
 


### PR DESCRIPTION
### Problem

Snowflake Extractor does not support Astronomer-provided Async Operator.

Closes: #860 

### Solution

Adds `SnowflakeOperatorAsync` to the `SnowflakeExtractor` operator classname list.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)