### PR TITLE
Reduce payload size by excluding local data and including output node in start events

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -92,7 +92,7 @@ class LogicalPlanSerializer {
    * LogicalPlan} and leaf nodes don't have child nodes in {@link LogicalPlan}
    */
   @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
-  @JsonIgnoreProperties({"child", "containsChild", "canonicalized", "constraints"})
+  @JsonIgnoreProperties({"child", "containsChild", "canonicalized", "constraints", "data"})
   @SuppressWarnings("PMD")
   abstract class ChildMixIn {}
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -34,12 +34,7 @@ public class AppendDataDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(AppendData x) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, AppendData appendData) {
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, AppendData appendData) {
     LogicalPlan logicalPlan = (LogicalPlan) (appendData).table();
 
     return delegate(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.api;
 
 import io.openlineage.client.OpenLineage;
+import java.util.List;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -28,6 +29,15 @@ public abstract class AbstractQueryPlanOutputDatasetBuilder<P extends LogicalPla
 
   @Override
   public boolean isDefinedAt(SparkListenerEvent event) {
-    return event instanceof SparkListenerJobEnd || event instanceof SparkListenerSQLExecutionEnd;
+    return true;
+  }
+
+  protected boolean includeDatasetVersion(SparkListenerEvent event) {
+    return event instanceof SparkListenerSQLExecutionEnd || event instanceof SparkListenerJobEnd;
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(P logicalPlan) {
+    throw new UnsupportedOperationException("Unimplemented");
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -12,6 +12,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
@@ -37,13 +38,13 @@ public class AppendDataDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(AppendData x) {
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, AppendData x) {
     // Needs to cast to logical plan despite IntelliJ claiming otherwise.
     LogicalPlan logicalPlan = (LogicalPlan) ((AppendData) x).table();
 
     if (logicalPlan instanceof DataSourceV2Relation) {
       return new DataSourceV2RelationOutputDatasetBuilder(context, factory)
-          .apply((DataSourceV2Relation) logicalPlan);
+          .apply(event, (DataSourceV2Relation) logicalPlan);
     } else {
       return Collections.emptyList();
     }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -13,6 +13,7 @@ import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
@@ -42,11 +43,15 @@ public class DataSourceV2RelationOutputDatasetBuilder
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(DataSourceV2Relation relation) {
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, DataSourceV2Relation relation) {
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         context.getOpenLineage().newDatasetFacetsBuilder();
 
-    DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, relation);
+    if (includeDatasetVersion(event)) {
+      DatasetVersionDatasetFacetUtils.includeDatasetVersion(
+          context, datasetFacetsBuilder, relation);
+    }
     return PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder);
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.AlterTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,8 @@ public class AlterTableDatasetBuilderTest {
   @SneakyThrows
   public void testApplyWhenTableNotFound() {
     when(tableCatalog.loadTable(identifier)).thenThrow(mock(NoSuchTableException.class));
-    List<OpenLineage.OutputDataset> outputDatasets = builder.apply(alterTable);
+    List<OpenLineage.OutputDataset> outputDatasets =
+        builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), alterTable);
     assertEquals(0, outputDatasets.size());
   }
 
@@ -80,7 +82,8 @@ public class AlterTableDatasetBuilderTest {
               ScalaConversionUtils.<String, String>fromMap(tableProperties)))
           .thenReturn(Optional.empty());
 
-      List<OpenLineage.OutputDataset> outputDatasets = builder.apply(alterTable);
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), alterTable);
       assertEquals(0, outputDatasets.size());
     }
   }
@@ -97,7 +100,8 @@ public class AlterTableDatasetBuilderTest {
               ScalaConversionUtils.<String, String>fromMap(tableProperties)))
           .thenReturn(Optional.of(di));
 
-      List<OpenLineage.OutputDataset> outputDatasets = builder.apply(alterTable);
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), alterTable);
 
       assertEquals(1, outputDatasets.size());
       assertEquals("table", outputDatasets.get(0).getName());
@@ -124,7 +128,8 @@ public class AlterTableDatasetBuilderTest {
                 ScalaConversionUtils.<String, String>fromMap(tableProperties)))
             .thenReturn(Optional.of(di));
 
-        List<OpenLineage.OutputDataset> outputDatasets = builder.apply(alterTable);
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), alterTable);
 
         assertEquals(1, outputDatasets.size());
         assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.analysis.NamedRelation;
 import org.apache.spark.sql.catalyst.plans.logical.AppendData;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -64,7 +65,8 @@ public class AppendDataDatasetBuilderTest {
         when(PlanUtils3.fromDataSourceV2Relation(eq(factory), eq(context), eq(relation), any()))
             .thenReturn(Collections.singletonList(dataset));
 
-        List<OpenLineage.OutputDataset> datasets = builder.apply(appendData);
+        List<OpenLineage.OutputDataset> datasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), appendData);
 
         assertEquals(1, datasets.size());
         assertEquals(dataset, datasets.get(0));
@@ -80,6 +82,6 @@ public class AppendDataDatasetBuilderTest {
             (NamedRelation)
                 mock(LogicalPlan.class, withSettings().extraInterfaces(NamedRelation.class)));
 
-    assertEquals(0, builder.apply(appendData).size());
+    assertEquals(0, builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), appendData).size());
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -137,7 +138,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
                 ScalaConversionUtils.<String, String>fromMap(commandProperties)))
             .thenReturn(Optional.of(di));
 
-        List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
+        List<OpenLineage.OutputDataset> outputDatasets =
+            visitor.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
         assertEquals(1, outputDatasets.size());
         assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());
@@ -169,7 +171,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
                 ScalaConversionUtils.<String, String>fromMap(commandProperties)))
             .thenReturn(Optional.of(di));
 
-        List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
+        List<OpenLineage.OutputDataset> outputDatasets =
+            visitor.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
         assertEquals(1, outputDatasets.size());
         assertEquals(null, outputDatasets.get(0).getFacets().getVersion());
@@ -190,7 +193,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
               ScalaConversionUtils.<String, String>fromMap(tableProperties)))
           .thenReturn(Optional.of(di));
 
-      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
+      List<OpenLineage.OutputDataset> outputDatasets =
+          visitor.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
       assertEquals(1, outputDatasets.size());
       assertEquals(
@@ -212,7 +216,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
               ScalaConversionUtils.<String, String>fromMap(logicalPlan.properties())))
           .thenReturn(Optional.empty());
 
-      List<OpenLineage.OutputDataset> outputDatasets = visitor.apply(logicalPlan);
+      List<OpenLineage.OutputDataset> outputDatasets =
+          visitor.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
       assertEquals(0, outputDatasets.size());
     }
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -36,6 +36,7 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -163,7 +164,8 @@ public class TableContentChangeDatasetBuilderTest {
             .thenReturn(Collections.singletonList(dataset));
         when(CatalogUtils3.getDatasetVersion(any(), any(), any())).thenReturn(Optional.of("v2"));
 
-        List<OpenLineage.OutputDataset> datasetList = builder.apply(logicalPlan);
+        List<OpenLineage.OutputDataset> datasetList =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
         assertEquals(1, datasetList.size());
         assertEquals(dataset, datasetList.get(0));


### PR DESCRIPTION
### Problem

We see consistently high payload sizes, almost always due to the `spark_unknown` facet. This tackles two of the root causes

1. The LocalRelation has a `data` field that includes the base64 encoded serialized binary of the local data sent to the executors. This can be many MBs of data.
2. The `AbstractQueryPlanOutputDatasetBuilder` is, by default, only defined for `SparkListenerSqlExecutionEnd` and `SparkListenerJobEnd` events. I believe the intention here was to only supply dataset version information _after_ the dataset has been changed. However, the result is that all nodes handled by subclasses of that builder are now serialized in the `spark_unknown` facet for start events.



### Solution
1. Filter the `data` field from LogicalPlans so we don't send unnecessary binary
2. Change `AbstractQueryPlanOutputDatasetBuilder` to be defined for all events, but override the `apply(SparkListenerEvent, LogicalPlan)` method so that implementations can selectively include dataset version information while still marking the node as _visited_.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)