### PR TITLE
Change Env Add Extractor Tests

### DIFF
--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -34,24 +34,24 @@ def test_basic_extractor():
 
 
 def test_env_add_extractor():
-    assert len(Extractors().extractors) == 8
+    extractor_list_len = len(Extractors().extractors)
     with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor"}):  # noqa
-        assert len(Extractors().extractors) == 9
+        assert len(Extractors().extractors) == extractor_list_len + 1
 
 
 def test_env_multiple_extractors():
-    assert len(Extractors().extractors) == 8
+    extractor_list_len = len(Extractors().extractors)
     with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;tests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
-        assert len(Extractors().extractors) == 10
+        assert len(Extractors().extractors) == extractor_list_len + 2
 
 
 def test_env_old_method_extractors():
-    assert len(Extractors().extractors) == 8
+    extractor_list_len = len(Extractors().extractors)
 
     os.environ['OPENLINEAGE_EXTRACTOR_TestOperator'] = \
         'tests.extractors.test_extractors.FakeExtractor'
 
-    assert len(Extractors().extractors) == 9
+    assert len(Extractors().extractors) == extractor_list_len + 1
     del os.environ['OPENLINEAGE_EXTRACTOR_TestOperator']
 
 


### PR DESCRIPTION
### Problem

The extractor tests that add a new extractor by environment expected an initial, static extractor list length, but this means any time an extractor is added, these tests must be manually updated by bumping up some hard-coded numbers.

Signed-off-by: Benji Lampel <benjamin@astronomer.io>

Closes: #880 

### Solution

This PR changes extractor tests so the extractor list length is dynamic with the number of extractors, using that list as the ground truth, and continuing to test that one or two _more_ extractors are added.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)