### PR TITLE
shade flink dependencies

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 plugins {
     id 'maven-publish'
     id 'signing'
+    id "com.github.johnrengelman.shadow" version "7.1.2"
 }
 
 repositories {
@@ -64,23 +65,29 @@ ext {
 
 dependencies {
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "org.apache.flink:flink-java:$flinkVersion"
+    compileOnly "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
+    compileOnly "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"
+    compileOnly "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
+    compileOnly "org.apache.flink:flink-avro:$flinkVersion"
+    compileOnly "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
+    compileOnly "org.apache.iceberg:iceberg-flink-$flinkVersionShort:0.13.1"
+    compileOnly "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:0.13.1"
+
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     implementation("io.openlineage:openlineage-java:${project.version}")
-
-    implementation "org.apache.flink:flink-java:$flinkVersion"
-    implementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
-    implementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"
-    implementation "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
-    implementation "org.apache.flink:flink-avro:$flinkVersion"
-    implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
-
     implementation 'org.javassist:javassist:3.27.0-GA'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
 
-    implementation "org.apache.iceberg:iceberg-flink-$flinkVersionShort:0.13.1"
-    implementation "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:0.13.1"
-
+    testImplementation "org.apache.flink:flink-java:$flinkVersion"
+    testImplementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
+    testImplementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"
+    testImplementation "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
+    testImplementation "org.apache.flink:flink-avro:$flinkVersion"
+    testImplementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
+    testImplementation "org.apache.iceberg:iceberg-flink-$flinkVersionShort:0.13.1"
+    testImplementation "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:0.13.1"
     testImplementation platform('org.junit:junit-bom:5.7.1')
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation "org.testcontainers:mockserver:${testcontainersVersion}"
@@ -266,14 +273,17 @@ shadowJar {
     minimize()
     classifier = ''
     // avoid conflict with any client version of that lib
-    relocate 'com.github.ok2c.hc5', 'openlineage.com.github.ok2c.hc5'
-    relocate 'org.apache.httpcomponents.client5', 'openlineage.org.apache.httpcomponents.client5'
-    relocate 'javassist', 'openlineage.javassist'
-    relocate 'org.apache.hc', 'openlineage.hc'
-    relocate 'org.apache.commons.codec', 'openlineage.commons.codec'
+    relocate 'com.github.ok2c.hc5', 'io.openlineage.flink.shaded.com.github.ok2c.hc5'
+    relocate 'org.apache.httpcomponents.client5', 'io.openlineage.flink.shaded.org.apache.httpcomponents.client5'
+    relocate 'org.apache.http', 'io.openlineage.flink.shaded.org.apache.http'
+    relocate 'javassist', 'io.openlineage.flink.shaded.javassist'
+    relocate 'org.apache.hc', 'io.openlineage.flink.shaded.org.apache.hc'
+    relocate 'org.apache.commons.codec', 'io.openlineage.flink.shaded.org.apache.commons.codec'
     dependencies {
         exclude(dependency('org.slf4j::'))
     }
+
+    exclude 'org/apache/commons/logging/**'
 
     manifest {
         attributes(

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -53,18 +53,18 @@ dependencies {
 
     def flinkVersion = '1.14.4'
     def hadoopVersion = '3.3.1'
-    compileOnly "org.apache.flink:flink-java:$flinkVersion"
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
+    implementation "org.apache.flink:flink-java:$flinkVersion"
+    implementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"
-    compileOnly "org.apache.flink:flink-core:$flinkVersion"
+    implementation "org.apache.flink:flink-core:$flinkVersion"
     implementation "org.apache.flink:flink-runtime:$flinkVersion"
-    compileOnly "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
-    compileOnly "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
-    compileOnly "org.apache.flink:flink-avro:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-api-java:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-api-java-bridge_2.12:$flinkVersion"
-    compileOnly "org.apache.flink:flink-table-common:$flinkVersion"
+    implementation "org.apache.flink:flink-connector-kafka_2.12:$flinkVersion"
+    implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
+    implementation "org.apache.flink:flink-avro:$flinkVersion"
+    implementation "org.apache.flink:flink-table:$flinkVersion"
+    implementation "org.apache.flink:flink-table-api-java:$flinkVersion"
+    implementation "org.apache.flink:flink-table-api-java-bridge_2.12:$flinkVersion"
+    implementation "org.apache.flink:flink-table-common:$flinkVersion"
     implementation "org.apache.flink:flink-table-runtime_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-table-planner_2.12:$flinkVersion"
 

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
-version=0.10.0-SNAPSHOT
+version=0.11.0-SNAPSHOT
 flink.version=1.14.2
 org.gradle.jvmargs=-Xmx1G


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Flink integration jar contains unshaded dependencies.

Closes: #729

### Solution

Make sure all the dependent libraries are shaded with `io.openlineage.flink.shaded`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)