### PR TITLE
flink: emit COMPLETE/FAIL events when running as attached

### DIFF
--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
@@ -1,0 +1,60 @@
+package io.openlineage.flink;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.FlinkSink;
+import org.apache.iceberg.flink.source.FlinkSource;
+
+import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
+
+public class FlinkFailedApplication {
+
+  public static void main(String[] args) throws Exception {
+    ParameterTool parameters = ParameterTool.fromArgs(args);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    env.getConfig().setGlobalJobParameters(parameters);
+    env.setParallelism(parameters.getInt("parallelism", 1));
+    env.enableCheckpointing(parameters.getInt("checkpoint.interval", 1_000), CheckpointingMode.EXACTLY_ONCE);
+    env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
+    env.getCheckpointConfig().setMinPauseBetweenCheckpoints(parameters.getInt("min.pause.between.checkpoints", 1_000));
+    env.getCheckpointConfig().setCheckpointTimeout(parameters.getInt("checkpoint.timeout", 90_000));
+
+    env.setRestartStrategy(RestartStrategies.noRestart());
+
+    TableLoader sourceLoader = TableLoader.fromHadoopTable("/tmp/warehouse/db/source");
+    TableLoader sinkLoader = TableLoader.fromHadoopTable("/tmp/warehouse/db/sink");
+
+    DataStream<RowData> stream = FlinkSource.forRowData()
+      .env(env)
+      .tableLoader(sourceLoader)
+      .streaming(true)
+      .build();
+
+    DataStream<RowData> failedTransform = stream.map(
+      row -> {
+        throw new RuntimeException("fail");
+      }
+    );
+
+    FlinkSink.forRowData(failedTransform)
+      .tableLoader(sinkLoader)
+      .overwrite(true)
+      .append();
+
+    // we use this app to test open lineage flink integration so it cannot make use of OpenLineageFlinkJobListener classes
+    JobListener openlineageJobListener = (JobListener) Class.forName("io.openlineage.flink.OpenLineageFlinkJobListener")
+      .getConstructor(StreamExecutionEnvironment.class)
+      .newInstance(env);
+
+    env.registerJobListener(openlineageJobListener);
+    env.execute("flink-failed-job");
+  }
+}

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
-version=0.10.0-SNAPSHOT
+version=0.11.0-SNAPSHOT
 flink.version=1.14.2
 org.gradle.jvmargs=-Xmx1G

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -82,7 +83,26 @@ public class OpenLineageFlinkJobListener implements JobListener {
   @Override
   public void onJobExecuted(
       @Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
-    log.debug("JobExecutionResult: {}", jobExecutionResult);
+    log.error("JobExecutionResult: {}", jobExecutionResult);
+    log.error("Throwable: {}", throwable);
+    if (jobExecutionResult instanceof DetachedJobExecutionResult) {
+      jobContexts.remove(jobExecutionResult.getJobID());
+      log.warn(
+          "Job running in detached mode. Set execution.attached to true if you want to emit completed events.");
+      return;
+    }
+
+    if (jobExecutionResult != null) {
+      jobContexts.remove(jobExecutionResult.getJobID()).onJobCompleted(jobExecutionResult);
+    } else {
+      // We don't have jobId when failed, so we need to assume that only existing context is that
+      // job
+      if (jobContexts.size() == 1) {
+        Map.Entry<JobID, FlinkExecutionContext> entry =
+            jobContexts.entrySet().stream().findFirst().get();
+        jobContexts.remove(entry.getKey()).onJobFailed(throwable);
+      }
+    }
   }
 
   private void makeTransformationsArchivedList(StreamExecutionEnvironment executionEnvironment) {

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
@@ -31,7 +31,7 @@ public class EventEmitter {
   private static URI getUri() {
     return URI.create(
         String.format(
-            "https://github.com/OpenLineage/OpenLineage/tree/%s/integration/spark", getVersion()));
+            "https://github.com/OpenLineage/OpenLineage/tree/%s/integration/flink", getVersion()));
   }
 
   private static String getVersion() {

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
@@ -9,5 +9,7 @@ public interface ExecutionContext {
 
   void onJobCheckpoint(CheckpointFacet facet);
 
-  void onJobExecuted(JobExecutionResult jobExecutionResult);
+  void onJobCompleted(JobExecutionResult jobExecutionResult);
+
+  void onJobFailed(Throwable failed);
 }

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -109,7 +109,8 @@ public class FlinkContainerUtils {
                     + String.format("--job-classname %s ", jobName)
                     + "--input-topics io.openlineage.flink.kafka.input1,io.openlineage.flink.kafka.input2 "
                     + "--output-topic io.openlineage.flink.kafka.output ")
-            .withEnv("FLINK_PROPERTIES", "jobmanager.rpc.address: jobmanager")
+            .withEnv(
+                "FLINK_PROPERTIES", "jobmanager.rpc.address: jobmanager\nexecution.attached: true")
             .withEnv("OPENLINEAGE_CONFIG", "/opt/flink/lib/openlineage.yml")
             .withStartupTimeout(Duration.of(5, ChronoUnit.MINUTES))
             .dependsOn(startables);

--- a/integration/flink/src/test/resources/events/expected_failed.json
+++ b/integration/flink/src/test/resources/events/expected_failed.json
@@ -1,0 +1,3 @@
+{
+  "eventType" : "FAIL"
+}

--- a/integration/flink/src/test/resources/io/openlineage/flink/agent/client/version.properties
+++ b/integration/flink/src/test/resources/io/openlineage/flink/agent/client/version.properties
@@ -1,1 +1,1 @@
-version 0.10.0-SNAPSHOT
+version 0.11.0-SNAPSHOT


### PR DESCRIPTION
Emit events if received event about job being completed.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes #537 