### PR TITLE
airflow: Manual inlets/outlets issue#384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,27 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.9.0...HEAD)
-* CI: added static code anlalysis tool mypy to python source codes ([#802](https://github.com/openlineage/openlineage/issues/802)) [@howardyoo](https://github.com/howardyoo)
+
+### Added
+
+* Add static code anlalysis tool [mypy](http://mypy-lang.org) to run in CI for against all python modules ([`#802`](https://github.com/openlineage/openlineage/issues/802)) [@howardyoo](https://github.com/howardyoo)
+* Extend `SaveIntoDataSourceCommandVisitor` to extract schema from `LocalRelaiton` and `LogicalRdd` in spark integration ([`#794`](https://github.com/OpenLineage/OpenLineage/pull/794)) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Add `InMemoryRelationInputDatasetBuilder` for `InMemory` datasets to Spark integration ([`#818`](https://github.com/OpenLineage/OpenLineage/pull/818)) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Add copyright to source files [`#755`](https://github.com/OpenLineage/OpenLineage/pull/755) [@merobi-hub](https://github.com/merobi-hub)
+* Add `SnowflakeOperatorAsync` extractor support to Airflow integration [`#869`](https://github.com/OpenLineage/OpenLineage/pull/869) [@merobi-hub](https://github.com/merobi-hub)
+
+### Changed
+
+* Skip `FunctionRegistry.class` serialization in Spark integration ([`#828`](https://github.com/OpenLineage/OpenLineage/pull/828)) [@mobuchowski](https://github.com/mobuchowski)
+* Install new `rust`-based SQL parser by default in Airflow integration ([`#835`](https://github.com/OpenLineage/OpenLineage/pull/835)) [@mobuchowski](https://github.com/mobuchowski)
+* Improve overall `pytest` and integration tests for Airflow integration ([`#851`](https://github.com/OpenLineage/OpenLineage/pull/851),[`#858`](https://github.com/OpenLineage/OpenLineage/pull/858)) [@denimalpaca](https://github.com/denimalpaca)
+* Reduce OL event payload size by excluding local data and including output node in start events ([`#881`](https://github.com/OpenLineage/OpenLineage/pull/881)) [@collado-mike](https://github.com/collado-mike)
+
+### Fixed
+
+* Conditionally import `sqlalchemy` lib for Great Expectations integration ([`#826`](https://github.com/OpenLineage/OpenLineage/pull/826)) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Add check for missing **class** `org.apache.spark.sql.catalyst.plans.logical.CreateV2Table` in Spark integration ([`#866`](https://github.com/OpenLineage/OpenLineage/pull/866)) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+* Fix static code analysis issues ([`#867`](https://github.com/OpenLineage/OpenLineage/pull/867),[`#874`](https://github.com/OpenLineage/OpenLineage/pull/874)) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 
 ## [0.9.0](https://github.com/OpenLineage/OpenLineage/compare/0.8.2...0.9.0)
 ### Added

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -1,13 +1,23 @@
 import logging
-from typing import Optional, Type
+import os
+from typing import Optional, Type, List
 
-from openlineage.airflow.extractors import TaskMetadata, BaseExtractor, Extractors
-from openlineage.airflow.facets import UnknownOperatorAttributeRunFacet, UnknownOperatorInstance
+from openlineage.airflow.extractors import (
+    TaskMetadata,
+    BaseExtractor,
+    Extractors,
+)
+from openlineage.airflow.facets import (
+    UnknownOperatorAttributeRunFacet,
+    UnknownOperatorInstance,
+)
 from openlineage.airflow.utils import get_job_name
+from openlineage.client.run import Dataset
 
 
 class ExtractorManager:
     """Class abstracting management of custom extractors."""
+
     def __init__(self):
         self.extractors = {}
         self.task_to_extractor = Extractors()
@@ -17,23 +27,37 @@ class ExtractorManager:
         self.task_to_extractor.add_extractor(operator, extractor)
 
     def extract_metadata(
-        self,
-        dagrun,
-        task,
-        complete: bool = False,
-        task_instance=None
+        self, dagrun, task, complete: bool = False, task_instance=None
     ) -> TaskMetadata:
         extractor = self._get_extractor(task)
-        task_info = f'task_type={task.__class__.__name__} ' \
-            f'airflow_dag_id={task.dag_id} ' \
-            f'task_id={task.task_id} ' \
-            f'airflow_run_id={dagrun.run_id} '
+        task_info = (
+            f"task_type={task.__class__.__name__} "
+            f"airflow_dag_id={task.dag_id} "
+            f"task_id={task.task_id} "
+            f"airflow_run_id={dagrun.run_id} "
+        )
+        collect_manual_lineage = False
+        if os.environ.get(
+            "OPENLINEAGE_EXPERIMENTAL_COLLECT_MANUAL_LINEAGE", "False"
+        ).lower() in ("true", "1", "t"):
+            self.log.warning("COLLECT_MANUAL_LINEAGE is experimental")
+            collect_manual_lineage = True
+
         if extractor:
             # Extracting advanced metadata is only possible when extractor for particular operator
             # is defined. Without it, we can't extract any input or output data.
             try:
                 self.log.debug(
-                    f'Using extractor {extractor.__class__.__name__} {task_info}')
+                    f"Using extractor {extractor.__class__.__name__} {task_info}"
+                )
+                if (
+                    len(task.get_inlet_defs())
+                    or len(task.get_outlet_defs())
+                    and collect_manual_lineage
+                ):
+                    self.log.exception(
+                        f"Inputs/outputs were defined but {extractor.__class__.__name__} extractor's lineage metadata is being used. Extractor metadata is prioritized over manually defined lineage."
+                    )
                 if complete:
                     task_metadata = extractor.extract_on_complete(task_instance)
                 else:
@@ -47,11 +71,34 @@ class ExtractorManager:
 
             except Exception as e:
                 self.log.exception(
-                    f'Failed to extract metadata {e} {task_info}',
+                    f"Failed to extract metadata {e} {task_info}",
                 )
         else:
-            self.log.warning(
-                f'Unable to find an extractor. {task_info}')
+            self.log.warning(f"Unable to find an extractor. {task_info}")
+            _inputs: List = []
+            _outputs: List = []
+
+            if collect_manual_lineage:
+                self.log.warning(
+                    "Inputs/outputs were defined manually and no extractor was found that excepts the given operator. Collecting manual lineage from the provided input and/or output definitions."
+                )
+
+                if len(task.get_inlet_defs()):
+                    _inputs = list(
+                        map(
+                            self.extract_inlets_and_outlets,
+                            task.get_inlet_defs(),
+                        )
+                    )
+                    self.log.info(f"manual inputs: {_inputs}")
+                if len(task.get_outlet_defs()):
+                    _outputs = list(
+                        map(
+                            self.extract_inlets_and_outlets,
+                            task.get_outlet_defs(),
+                        )
+                    )
+                    self.log.info(f"manual outputs: {_outputs}")
 
             # Only include the unkonwnSourceAttribute facet if there is no extractor
             return TaskMetadata(
@@ -62,12 +109,15 @@ class ExtractorManager:
                             UnknownOperatorInstance(
                                 name=task.__class__.__name__,
                                 properties={
-                                    attr: value for attr, value in task.__dict__.items()
+                                    attr: value
+                                    for attr, value in task.__dict__.items()
                                 },
                             )
                         ]
                     )
                 },
+                inputs=_inputs,
+                outputs=_outputs,
             )
 
         return TaskMetadata(name=get_job_name(task))
@@ -76,8 +126,15 @@ class ExtractorManager:
         if task.task_id in self.extractors:
             return self.extractors[task.task_id]
         extractor = self.task_to_extractor.get_extractor_class(task.__class__)
-        self.log.debug(f'extractor for {task.__class__} is {extractor}')
+        self.log.debug(f"extractor for {task.__class__} is {extractor}")
         if extractor:
             self.extractors[task.task_id] = extractor(task)
             return self.extractors[task.task_id]
         return None
+
+    def extract_inlets_and_outlets(self, properties):
+        return Dataset(
+            namespace=properties["database"],
+            name=properties["name"],
+            facets=properties,
+        )

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -56,7 +56,8 @@ class ExtractorManager:
                     and collect_manual_lineage
                 ):
                     self.log.exception(
-                        f"Inputs/outputs were defined but {extractor.__class__.__name__} extractor's lineage metadata is being used. Extractor metadata is prioritized over manually defined lineage."
+                        f"""Inputs/outputs were defined but {extractor.__class__.__name__} extractor's lineage metadata is being used.
+                            Extractor metadata is prioritized over manually defined lineage."""
                     )
                 if complete:
                     task_metadata = extractor.extract_on_complete(task_instance)
@@ -80,7 +81,8 @@ class ExtractorManager:
 
             if collect_manual_lineage:
                 self.log.warning(
-                    "Inputs/outputs were defined manually and no extractor was found that excepts the given operator. Collecting manual lineage from the provided input and/or output definitions."
+                    """Inputs/outputs were defined manually and no extractor was found that excepts the given operator.
+                        Collecting manual lineage from the provided input and/or output definitions."""
                 )
 
                 if len(task.get_inlet_defs()):

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -44,9 +44,9 @@ class PythonExtractor(BaseExtractor):
                 )
             }
         """
-        This allows for the collection of manual lineage data. When OPENLINEAGE_COLLECT_MANUALLY 
-        is set to true, PythonExtractor will extract Datasets, when set to false, 
-        inputs and outputs are set to empty Lists. 
+        This allows for the collection of manual lineage data. When OPENLINEAGE_COLLECT_MANUALLY
+        is set to true, PythonExtractor will extract Datasets, when set to false,
+        inputs and outputs are set to empty Lists.
         """
         collect_manual_lineage = False
         if os.environ.get("OPENLINEAGE_COLLECT_MANUALLY", "False").lower() in (

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -109,7 +109,7 @@ class PythonExtractor(BaseExtractor):
             )
         return None
 
-    def extract_inlets_and_outlets(self, properties):
+    def extract_inlets_and_outlets_to_dataset(self, properties):
         return Dataset(
             namespace=properties["database"],
             name=properties["name"],


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Addressing issue #384.

- We want the ability to set inlets and outlets manually 

### Solution

- expand the `postgres_extractor` to except `_PythonDecoratedOperator`.
- add env check to attach `inputs` and `outputs` to  `TaskMetadata` when `OPENLINEAGE_COLLECT_MANUALLY` is set to `true`.
- added `extract_inlets_and_outlets_to_dataset` function. 

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)