### PR TITLE
[INTEGRATION][SPARK] limit delta events

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -201,6 +201,10 @@ class RddExecutionContext implements ExecutionContext {
 
   @Override
   public void start(SparkListenerJobStart jobStart) {
+    if (inputs.isEmpty() && outputs.isEmpty()) {
+      log.info("RDDs are empty: skipping sending OpenLineage event");
+      return;
+    }
     OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
     OpenLineage.RunEvent event =
         ol.newRunEventBuilder()
@@ -218,6 +222,10 @@ class RddExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
+    if (inputs.isEmpty() && outputs.isEmpty() && !(jobEnd.jobResult() instanceof JobFailed)) {
+      log.info("RDDs are empty: skipping sending OpenLineage event");
+      return;
+    }
     OpenLineage ol = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
     OpenLineage.RunEvent event =
         ol.newRunEventBuilder()

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -10,6 +10,7 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.Utils;
 import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.time.Instant;
@@ -60,6 +61,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
+    } else if (EventFilterUtils.isDisabled(olContext, startEvent)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionStart");
+      return;
     }
     RunEvent event =
         runEventBuilder.buildRun(
@@ -81,6 +86,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
+    } else if (EventFilterUtils.isDisabled(olContext, endEvent)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerSQLExecutionEnd");
+      return;
     }
     RunEvent event =
         runEventBuilder.buildRun(
@@ -99,6 +108,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
+    } else if (EventFilterUtils.isDisabled(olContext, stageSubmitted)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerStageSubmitted");
+      return;
     }
     RunEvent event =
         runEventBuilder.buildRun(
@@ -116,6 +129,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
   public void end(SparkListenerStageCompleted stageCompleted) {
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
+      return;
+    } else if (EventFilterUtils.isDisabled(olContext, stageCompleted)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerStageCompleted");
       return;
     }
     RunEvent event =
@@ -141,6 +158,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
+    } else if (EventFilterUtils.isDisabled(olContext, jobStart)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobStart");
+      return;
     }
     RunEvent event =
         runEventBuilder.buildRun(
@@ -163,6 +184,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
+      return;
+    } else if (EventFilterUtils.isDisabled(olContext, jobEnd)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerJobEnd");
       return;
     }
     RunEvent event =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent;
 
 import static java.nio.file.Files.readAllBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.JsonBody.json;
 
@@ -226,6 +227,23 @@ class SparkContainerIntegrationTest {
             "/opt/spark_scripts/spark_delta.py");
     pyspark.start();
     verifyEvents("pysparkDeltaCTASComplete.json");
+  }
+
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = "3.*")
+  @Test
+  void testFilteringDeltaEvents() {
+    pyspark =
+        SparkContainerUtils.makePysparkContainerWithDefaultConf(
+            network,
+            openLineageClientMockContainer,
+            "testV2Commands",
+            PACKAGES,
+            getDeltaPackageName(),
+            "/opt/spark_scripts/spark_delta_event_filter.py");
+    pyspark.start();
+    assertEquals(
+        12,
+        mockServerClient.retrieveRecordedRequests(request().withPath("/api/v1/lineage")).length);
   }
 
   @Test

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -241,7 +241,7 @@ class SparkReadWriteIntegTest {
 
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(RunEvent.class);
 
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(6))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(4))
         .emit(lineageEvent.capture());
     List<RunEvent> events = lineageEvent.getAllValues();
     ObjectAssert<RunEvent> completionEvent =

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_delta_event_filter.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_delta_event_filter.py
@@ -1,0 +1,24 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Delta") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .getOrCreate()
+
+spark.sql("CREATE TABLE t1 (a long, b long) USING delta LOCATION '/tmp/t1'")                   # 2 OL events expected
+df = spark.createDataFrame([
+    {'a': 1 },
+    {'a': 2 }
+])
+df.createOrReplaceTempView('temp')                                                            # 2 OL events expected
+spark.sql("CREATE TABLE t2 USING delta LOCATION '/tmp/t2' AS SELECT * FROM temp WHERE a > 1") # 2 OL events expected
+spark.sql("ALTER TABLE t2 ADD COLUMNS (b long)")                                              # 2 OL events expected
+spark.sql("INSERT INTO t1 VALUES (3,4)")                                                      # 2 OL events expected
+spark.sql("ALTER TABLE t1 ADD COLUMNS (c long)")                                              # 2 OL events expected

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
@@ -1,0 +1,121 @@
+package io.openlineage.spark.agent.filters;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.Filter;
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.LogicalRDD;
+import scala.collection.JavaConverters;
+
+@Slf4j
+public class DeltaEventFilter implements EventFilter {
+
+  private final OpenLineageContext context;
+
+  private static final List<String> DELTA_INTERNAL_RDD_COLUMNS =
+      Arrays.asList("txn", "add", "remove", "metaData", "cdc", "protocol", "commitInfo");
+
+  public DeltaEventFilter(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  public boolean isDisabled(SparkListenerEvent event) {
+    if (!isDelta()) {
+      return false;
+    }
+
+    return isFilterRoot()
+        || isLocalRelationOnly()
+        || isLogicalRDDWithInternalDataColumns()
+        || isOnJobStartOrEnd(event);
+  }
+
+  /**
+   * We get exact copies of OL events for org.apache.spark.scheduler.SparkListenerJobStart and
+   * org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart. The same happens for end
+   * events.
+   *
+   * @return
+   */
+  private boolean isOnJobStartOrEnd(SparkListenerEvent event) {
+    return event instanceof SparkListenerJobStart || event instanceof SparkListenerJobEnd;
+  }
+
+  /**
+   * Returns true if LocalRelation is the only element of LogicalPlan.
+   *
+   * @return
+   */
+  private boolean isLocalRelationOnly() {
+    return getLogicalPlan()
+        .filter(plan -> plan.children() != null)
+        .filter(plan -> plan.children().size() == 0)
+        .filter(plan -> plan instanceof LocalRelation)
+        .isPresent();
+  }
+
+  /**
+   * Returns true if Filter is a root node of LogicalPlan
+   *
+   * @return
+   */
+  private boolean isFilterRoot() {
+    return getLogicalPlan().filter(plan -> plan instanceof Filter).isPresent();
+  }
+
+  /**
+   * Verifies if `spark.sql.extensions` is set in Spark configuration and checks if it is a delta
+   * extension.
+   *
+   * @return
+   */
+  private boolean isDelta() {
+    return Optional.of(SparkSession.active())
+        .map(SparkSession::sparkContext)
+        .filter(context -> context != null)
+        .map(SparkContext::conf)
+        .map(conf -> conf.get("spark.sql.extensions", ""))
+        .filter(extension -> extension.equals("io.delta.sql.DeltaSparkSessionExtension"))
+        .isPresent();
+  }
+
+  /**
+   * Delta internally performs actions on 'LogicalRDD [txn#92, add#93, remove#94, metaData#95,
+   * protocol#96, cdc#97, commitInfo#98]'. If the leaf of logical plan is LogicalRDD with such
+   * columns, we disable OL event.
+   */
+  private boolean isLogicalRDDWithInternalDataColumns() {
+    return getLogicalPlan()
+        .map(
+            plan ->
+                JavaConverters.seqAsJavaListConverter(plan.collectLeaves()).asJava().stream()
+                    .filter(node -> node instanceof LogicalRDD)
+                    .map(node -> (LogicalRDD) node)
+                    .map(node -> JavaConverters.seqAsJavaListConverter(node.output()).asJava())
+                    .map(
+                        attributes ->
+                            attributes.stream().map(a -> a.name()).collect(Collectors.toList()))
+                    .filter(attrs -> attrs.containsAll(DELTA_INTERNAL_RDD_COLUMNS))
+                    .findAny()
+                    .isPresent())
+        .orElse(false);
+  }
+
+  private Optional<LogicalPlan> getLogicalPlan() {
+    return context
+        .getQueryExecution()
+        .filter(queryExecution -> queryExecution != null)
+        .map(queryExecution -> queryExecution.optimizedPlan())
+        .filter(plan -> plan != null);
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
@@ -1,0 +1,10 @@
+package io.openlineage.spark.agent.filters;
+
+import org.apache.spark.scheduler.SparkListenerEvent;
+
+public interface EventFilter {
+
+  default boolean isDisabled(SparkListenerEvent event) {
+    return false;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -1,0 +1,23 @@
+package io.openlineage.spark.agent.filters;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import org.apache.spark.scheduler.SparkListenerEvent;
+
+public class EventFilterUtils {
+
+  /**
+   * Method that verifies based on OpenLineageContext and SparkListenerEvent if OpenLineage event
+   * has to be sent.
+   *
+   * @param context
+   * @param event
+   * @return
+   */
+  public static boolean isDisabled(OpenLineageContext context, SparkListenerEvent event) {
+    return Arrays.asList(new DeltaEventFilter(context)).stream()
+        .filter(filter -> filter.isDisabled(event.getClass().cast(event)))
+        .findAny()
+        .isPresent();
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -92,7 +92,14 @@ class LogicalPlanSerializer {
    * LogicalPlan} and leaf nodes don't have child nodes in {@link LogicalPlan}
    */
   @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
-  @JsonIgnoreProperties({"child", "containsChild", "canonicalized", "constraints", "data"})
+  @JsonIgnoreProperties({
+    "child",
+    "containsChild",
+    "canonicalized",
+    "constraints",
+    "data",
+    "deltaLog"
+  })
   @SuppressWarnings("PMD")
   abstract class ChildMixIn {}
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
@@ -1,0 +1,156 @@
+package io.openlineage.spark.agent.filters;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.plans.logical.Filter;
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.LogicalRDD;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+
+public class DeltaEventFilterTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  DeltaEventFilter filter = new DeltaEventFilter(context);
+  SparkSession sparkSession = mock(SparkSession.class);
+  SparkContext sparkContext = mock(SparkContext.class);
+  SparkConf sparkConf = mock(SparkConf.class);
+  SparkListenerEvent sparkListenerEvent = mock(SparkListenerEvent.class);
+  QueryExecution queryExecution = mock(QueryExecution.class);
+
+  @BeforeEach
+  public void setup() {
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(sparkContext.conf()).thenReturn(sparkConf);
+    when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+  }
+
+  @Test
+  void testNotDeltaIsNotDisabled() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions")).thenReturn("non-delta-extension");
+
+      assertFalse(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  @Test
+  void testIsNotDisabledWhenSparkConfEntryMissing() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions"))
+          .thenThrow(new NoSuchElementException("spark.sql.extensions"));
+
+      assertFalse(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  @Test
+  void testIsDisabledWhenQueryExecutionIsNull() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions", ""))
+          .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
+      when(context.getQueryExecution()).thenReturn(Optional.empty());
+
+      assertFalse(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  @Test
+  void testDisabledForLocalRelationOnly() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      LocalRelation localRelation = mock(LocalRelation.class);
+      when(localRelation.children())
+          .thenReturn((Seq<LogicalPlan>) Seq$.MODULE$.<LogicalPlan>empty());
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions", ""))
+          .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
+      when(queryExecution.optimizedPlan()).thenReturn(localRelation);
+
+      assertTrue(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  @Test
+  void testDisabledForFilterRoot() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions", ""))
+          .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
+      when(queryExecution.optimizedPlan()).thenReturn(mock(Filter.class));
+
+      assertTrue(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  @Test
+  void testDisabledOnJobStartAndEnd() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions", ""))
+          .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
+      when(queryExecution.optimizedPlan()).thenReturn(mock(Filter.class));
+
+      assertTrue(filter.isDisabled(mock(SparkListenerJobStart.class)));
+      assertTrue(filter.isDisabled(mock(SparkListenerJobEnd.class)));
+    }
+  }
+
+  @Test
+  void testDisabledForLogicalRDDWithDeltaColumns() {
+    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
+      LogicalPlan logicalPlan = mock(LogicalPlan.class);
+      LogicalRDD logicalRDD = mock(LogicalRDD.class);
+      when(logicalPlan.collectLeaves())
+          .thenReturn(Arrays.asList(logicalRDD).stream().collect(ScalaConversionUtils.toSeq()));
+      Seq<Attribute> outputs =
+          Arrays.asList(
+                  attributeWithName("txn"),
+                  attributeWithName("add"),
+                  attributeWithName("remove"),
+                  attributeWithName("metaData"),
+                  attributeWithName("cdc"),
+                  attributeWithName("protocol"),
+                  attributeWithName("commitInfo"))
+              .stream()
+              .collect(ScalaConversionUtils.toSeq());
+      when(logicalRDD.output()).thenReturn(outputs);
+
+      when(SparkSession.active()).thenReturn(sparkSession);
+      when(sparkConf.get("spark.sql.extensions", ""))
+          .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
+      when(queryExecution.optimizedPlan()).thenReturn(logicalPlan);
+
+      assertTrue(filter.isDisabled(sparkListenerEvent));
+    }
+  }
+
+  private Attribute attributeWithName(String name) {
+    Attribute attr = mock(Attribute.class);
+    when(attr.name()).thenReturn(name);
+    return attr;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Delta extension generates a lot of unwanted OpenLineage events as a result of its internal mechanics. 

Closes: #628

### Solution

* Create a mechanism for filtering OpenLineage events. 
* Prepare rules to filter delta events.
* Prepare integration test to monitor amount of events sent (so far we did not do that) 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)