### PR TITLE
[INTEGRATION][Airflow] Add dynamic mapped tasks support.

### DIFF
--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -20,9 +20,9 @@ class AirflowVersionRunFacet(BaseFacet):
     @classmethod
     def from_task(cls, task):
         # task.__dict__ may contain values uncastable to str
-        from openlineage.airflow.utils import SafeStrDict
+        from openlineage.airflow.utils import SafeStrDict, get_operator_class
         return cls(
-            f"{task.__class__.__module__}.{task.__class__.__name__}",
+            f"{get_operator_class(task).__module__}.{get_operator_class(task).__name__}",
             str(SafeStrDict(task.__dict__)),
             AIRFLOW_VERSION,
             OPENLINEAGE_AIRFLOW_VERSION,
@@ -32,6 +32,22 @@ class AirflowVersionRunFacet(BaseFacet):
 @attr.s
 class AirflowRunArgsRunFacet(BaseFacet):
     externalTrigger: bool = attr.ib(default=False)
+
+
+@attr.s
+class AirflowMappedTaskRunFacet(BaseFacet):
+    mapIndex: int = attr.ib()
+    operatorClass: str = attr.ib()
+
+    @classmethod
+    def from_task_instance(cls, task_instance):
+        task = task_instance.task
+        from openlineage.airflow.utils import get_operator_class
+
+        return cls(
+            task_instance.map_index,
+            f"{get_operator_class(task).__module__}.{get_operator_class(task).__name__}",
+        )
 
 
 @attr.s

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type, Dict, Any
 from uuid import uuid4
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from typing import Optional
@@ -15,12 +15,16 @@ from airflow.version import version as AIRFLOW_VERSION
 
 from pkg_resources import parse_version
 
-from openlineage.airflow.facets import AirflowVersionRunFacet, AirflowRunArgsRunFacet
+from openlineage.airflow.facets import (
+    AirflowMappedTaskRunFacet,
+    AirflowVersionRunFacet,
+    AirflowRunArgsRunFacet
+)
 from pendulum import from_timestamp
 
 
 if TYPE_CHECKING:
-    from airflow.models import Connection
+    from airflow.models import Connection, BaseOperator, TaskInstance
 
 
 log = logging.getLogger(__name__)
@@ -29,6 +33,12 @@ _NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 def openlineage_job_name(dag_id: str, task_id: str) -> str:
     return f'{dag_id}.{task_id}'
+
+
+def get_operator_class(task: "BaseOperator") -> Type:
+    if task.__class__.__name__ in ('DecoratedMappedOperator', 'MappedOperator'):
+        return task.operator_class
+    return task.__class__
 
 
 class JobIdMapping:
@@ -223,11 +233,20 @@ def get_job_name(task):
     return f'{task.dag_id}.{task.task_id}'
 
 
-def get_custom_facets(task, is_external_trigger: bool):
-    return {
+def get_custom_facets(
+    task, is_external_trigger: bool, task_instance: "TaskInstance" = None
+) -> Dict[str, Any]:
+    custom_facets = {
         "airflow_runArgs": AirflowRunArgsRunFacet(is_external_trigger),
-        "airflow_version": AirflowVersionRunFacet.from_task(task)
+        "airflow_version": AirflowVersionRunFacet.from_task(task),
     }
+    # check for -1 comes from SmartSensor compatibility with dynamic task mapping
+    # this comes from Airflow code
+    if hasattr(task_instance, "map_index") and getattr(task_instance, "map_index") != -1:
+        custom_facets["airflow_mappedTask"] = AirflowMappedTaskRunFacet.from_task_instance(
+            task_instance
+        )
+    return custom_facets
 
 
 def new_lineage_run_id(dag_run_id: str, task_id: str) -> str:

--- a/integration/airflow/tests/integration/requests/mapped_dag.json
+++ b/integration/airflow/tests/integration/requests/mapped_dag.json
@@ -1,0 +1,185 @@
+[
+  {
+    "eventType": "START",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "python",
+          "source": "        python_callable=lambda: list(map(lambda x: \"echo \" + str(x), [1, 2, 3])),\n"
+        }
+      },
+      "name": "mapped_dag.get_input",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "parentRun": {
+          "job": {
+            "name": "mapped_dag",
+            "namespace": "food_delivery"
+          }
+        },
+        "unknownSourceAttribute": {
+          "unknownItems": [
+            {
+              "type": "operator",
+              "name": "PythonOperator",
+              "properties": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "eventType": "START",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "bash"
+        }
+      },
+      "name": "mapped_dag.multiply",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "parentRun": {
+          "job": {
+            "name": "mapped_dag",
+            "namespace": "food_delivery"
+          }
+        },
+        "airflow_mappedTask": {
+          "operatorClass": "airflow.operators.bash.BashOperator"
+        },
+        "unknownSourceAttribute": {
+          "unknownItems": [
+            {
+              "type": "operator",
+              "name": "BashOperator"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "eventType": "START",
+    "job": {
+      "name": "mapped_dag.total",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "parentRun": {
+          "job": {
+            "name": "mapped_dag",
+            "namespace": "food_delivery"
+          }
+        }
+      }
+    }
+  },
+  {
+    "eventType": "START",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "python",
+          "source": "        python_callable=lambda: list(map(lambda x: \"echo \" + str(x), [1, 2, 3])),\n"
+        }
+      },
+      "name": "mapped_dag.get_input",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "parentRun": {
+          "job": {
+            "name": "mapped_dag",
+            "namespace": "food_delivery"
+          }
+        },
+        "unknownSourceAttribute": {
+          "unknownItems": [
+            {
+              "type": "operator",
+              "name": "PythonOperator",
+              "properties": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "eventType": "COMPLETE",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "python",
+          "source": "        python_callable=lambda: list(map(lambda x: \"echo \" + str(x), [1, 2, 3])),\n"
+        }
+      },
+      "name": "mapped_dag.get_input",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "unknownSourceAttribute": {
+          "unknownItems": [
+            {
+              "type": "operator",
+              "name": "PythonOperator",
+              "properties": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "eventType": "COMPLETE",
+    "job": {
+      "facets": {
+        "sourceCode": {
+          "language": "bash"
+        }
+      },
+      "name": "mapped_dag.multiply",
+      "namespace": "food_delivery"
+    },
+    "run": {
+      "facets": {
+        "unknownSourceAttribute": {
+          "unknownItems": [
+            {
+              "type": "operator",
+              "name": "BashOperator"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "eventType": "COMPLETE",
+    "job": {
+      "name": "mapped_dag.total",
+      "namespace": "food_delivery"
+    }
+  }
+]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -33,9 +33,10 @@ try:
 except:  # noqa
     pass
 
-IS_AIRFLOW_VERSION_ENOUGH = os.environ.get("AIRFLOW_VERSION", None) or parse_version(
+IS_AIRFLOW_VERSION_ENOUGH = lambda x: parse_version(
     os.environ.get("AIRFLOW_VERSION", "0.0.0")
-) >= parse_version("2.2.4")
+) >= parse_version(x)
+
 
 params = [
     ("postgres_orders_popular_day_of_week", "requests/postgres.json"),
@@ -57,7 +58,7 @@ params = [
         "mysql_orders_popular_day_of_week",
         "requests/mysql.json",
         marks=pytest.mark.skipif(
-            not IS_AIRFLOW_VERSION_ENOUGH, reason="Airflow < 2.2.4"
+            not IS_AIRFLOW_VERSION_ENOUGH("2.2.4"), reason="Airflow < 2.2.4"
         ),
     ),
     pytest.param(
@@ -65,11 +66,11 @@ params = [
         "requests/dbt_snowflake.json",
         marks=[
             pytest.mark.skipif(
-                not IS_AIRFLOW_VERSION_ENOUGH,
+                not IS_AIRFLOW_VERSION_ENOUGH("2.2.4"),
                 reason="Airflow < 2.2.4",
             ),
             pytest.mark.skipif(
-                os.environ.get("SNOWFLAKE_PASSWORD", '') == '',
+                os.environ.get("SNOWFLAKE_PASSWORD", "") == "",
                 reason="no snowflake credentials",
             ),
         ],
@@ -79,14 +80,21 @@ params = [
         "requests/snowflake.json",
         marks=[
             pytest.mark.skipif(
-                not IS_AIRFLOW_VERSION_ENOUGH,
+                not IS_AIRFLOW_VERSION_ENOUGH("2.2.4"),
                 reason="Airflow < 2.2.4",
             ),
             pytest.mark.skipif(
-                os.environ.get("SNOWFLAKE_ACCOUNT_ID", '') == '',
+                os.environ.get("SNOWFLAKE_ACCOUNT_ID", "") == "",
                 reason="no snowflake credentials",
             ),
         ],
+    ),
+    pytest.param(
+        "mapped_dag",
+        "requests/mapped_dag.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"
+        ),
     ),
 ]
 
@@ -246,14 +254,18 @@ def test_integration_ordered(dag_id, request_dir: str, airflow_db_conn):
     log.info(f"Events for dag {dag_id} verified!")
 
 
-@pytest.mark.parametrize("dag_id, request_path", [
-    pytest.param(
-        "mysql_orders_popular_day_of_week",
-        "requests/airflow_run_facet/mysql.json",
-        marks=pytest.mark.skipif(
-            not IS_AIRFLOW_VERSION_ENOUGH, reason="Airflow < 2.2.4"
-        ),
-    )])
+@pytest.mark.parametrize(
+    "dag_id, request_path",
+    [
+        pytest.param(
+            "mysql_orders_popular_day_of_week",
+            "requests/airflow_run_facet/mysql.json",
+            marks=pytest.mark.skipif(
+                not IS_AIRFLOW_VERSION_ENOUGH("2.2.4"), reason="Airflow < 2.2.4"
+            ),
+        )
+    ],
+)
 def test_airflow_run_facet(dag_id, request_path, airflow_db_conn):
     log.info(f"Checking dag {dag_id} for AirflowRunFacet")
     result = wait_for_dag(dag_id, airflow_db_conn)
@@ -264,6 +276,47 @@ def test_airflow_run_facet(dag_id, request_path, airflow_db_conn):
 
     actual_events = get_events()
     assert check_matches(expected_events, actual_events) is True
+
+
+@pytest.mark.skipif(not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0")
+def test_airflow_mapped_task_facet(airflow_db_conn):
+    dag_id = "mapped_dag"
+    task_id = "multiply"
+    log.info(f"Checking dag {dag_id} for AirflowMappedTaskRunFacet")
+    result = wait_for_dag(dag_id, airflow_db_conn)
+    assert result is True
+
+    actual_events = get_events(dag_id)
+    mapped_events = [
+        event
+        for event in actual_events
+        if event["job"]["name"] == f"{dag_id}.{task_id}"
+    ]
+
+    started_events = [event for event in mapped_events if event["eventType"] == "START"]
+    assert len(started_events) == 3
+    assert started_events[0]["job"]["name"] == f"{dag_id}.{task_id}"
+    assert set(
+        [event["job"]["facets"]["sourceCode"]["source"] for event in started_events]
+    ) == set(["echo 1", "echo 2", "echo 3"])
+    assert sorted(
+        [
+            event["run"]["facets"]["airflow_mappedTask"]["mapIndex"]
+            for event in started_events
+        ]
+    ) == [0, 1, 2]
+    assert set(
+        [
+            event["run"]["facets"]["airflow_mappedTask"]["operatorClass"]
+            for event in started_events
+        ]
+    ) == set(["airflow.operators.bash.BashOperator"])
+    assert set(
+        [
+            event["run"]["facets"]["unknownSourceAttribute"]["unknownItems"][0]["name"]
+            for event in mapped_events
+        ]
+    ) == set(["BashOperator"])
 
 
 if __name__ == "__main__":

--- a/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from airflow import DAG, XComArg
+from airflow.decorators import task
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash_operator import BashOperator
+
+
+with DAG(
+    dag_id="mapped_dag", start_date=datetime(2020, 4, 7), schedule_interval="@once"
+) as dag:
+    input = PythonOperator(
+        task_id="get_input",
+        python_callable=lambda: list(map(lambda x: "echo " + str(x), [1, 2, 3])),
+    )
+
+    counts = BashOperator.partial(task_id="multiply", do_xcom_push=True).expand(
+        bash_command=XComArg(input),
+    )
+
+    @task
+    def total(numbers):
+        return sum((int(x) for x in numbers))
+
+    total(numbers=XComArg(counts))


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Airflow 2.3.0 introduced dynamic task mapping. Tasks created using this way have wrong information contained in OL events.

Closes: #894

### Solution

Added support for `DynamicMappedOperator` and `MappedOperator`.

It also introduces new kind of run facet `airflow_mappedTask` that should help in differing between mapped tasks and possibly grouping them on the UI-side - with attribute `mapIndex`. If event contains the facet one should be able to group tasks in similar way Airflow does in the UI. Example [here](https://output.circle-artifacts.com/output/job/bc4b2dd5-7f40-4f32-a68a-e4fa900f5dbd/artifacts/0/events/2022-06-30-mapped_dag.multiply.json).
### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)