### PR TITLE
[INTEGRATION][Common][GE] Add checkpoint_name as optional per GE update to 0.15.13.

### DIFF
--- a/integration/common/openlineage/common/provider/great_expectations/facets.py
+++ b/integration/common/openlineage/common/provider/great_expectations/facets.py
@@ -27,6 +27,7 @@ class GreatExpectationsRunFacet(BaseFacet):
     batch_kwargs: Optional[BatchKwargs] = attr.ib(default=None)
     active_batch_definition: Union[None, IDDict, BatchDefinition] = attr.ib(default=None)
     batch_parameters = attr.ib(default=None)
+    checkpoint_name: Optional[str] = attr.ib(default=None)
 
     @staticmethod
     def _get_schema() -> str:


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

0.15.13 `great-expectations` update adds `checkpoint_name` to validation results.

### Solution

Adding `checkpoint_name` as optional in  `GreatExpectationsRunFacet`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained