### PR TITLE
sql: explicitely specify to build source distribution

### DIFF
--- a/integration/sql/script/build.sh
+++ b/integration/sql/script/build.sh
@@ -29,7 +29,7 @@ if [[ -z ${RUN_TESTS} ]]; then
 fi
 
 # Build release wheels
-maturin build --out target/wheels
+maturin build --sdist --out target/wheels
 
 # Verify that it imports properly
 pip install openlineage-sql --no-index --find-links target/wheels --force-reinstall


### PR DESCRIPTION
New Maturin release broke build: https://github.com/PyO3/maturin/blob/main/Changelog.md

```
Breaking Change: Don't build source distribution by default in maturin build command in https://github.com/PyO3/maturin/pull/955, --no-sdist option is replaced by --sdist
```

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
