### PR TITLE
[INTEGRATION][SPARK] add ability to extend column level lineage mechanism

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtils.java
@@ -1,0 +1,45 @@
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+public class CustomCollectorsUtils {
+
+  private static Stream<CustomColumnLineageVisitor> loadCustomCollectors() {
+    ServiceLoader<CustomColumnLineageVisitor> loader =
+        ServiceLoader.load(CustomColumnLineageVisitor.class);
+
+    List<CustomColumnLineageVisitor> collect =
+        StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                    loader.iterator(), Spliterator.IMMUTABLE & Spliterator.DISTINCT),
+                false)
+            .collect(Collectors.toList());
+
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(
+            loader.iterator(), Spliterator.IMMUTABLE & Spliterator.DISTINCT),
+        false);
+  }
+
+  static void collectInputs(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    CustomCollectorsUtils.loadCustomCollectors()
+        .forEach(collector -> collector.collectInputs(plan, builder));
+  }
+
+  static void collectOutputs(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    CustomCollectorsUtils.loadCustomCollectors()
+        .forEach(collector -> collector.collectOutputs(plan, builder));
+  }
+
+  static void collectExpressionDependencies(LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    CustomCollectorsUtils.loadCustomCollectors()
+        .forEach(collector -> collector.collectExpressionDependencies(plan, builder));
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomColumnLineageVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomColumnLineageVisitor.java
@@ -1,0 +1,37 @@
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/** Interface for implementing custom collectors of column level lineage. */
+interface CustomColumnLineageVisitor {
+
+  /**
+   * Collect inputs for a given {@link LogicalPlan}. Column level lineage mechanism traverses
+   * LogicalPlan on its node. This method will be called for each traversed node. Input information
+   * should be put into builder.
+   *
+   * @param node
+   * @param builder
+   */
+  void collectInputs(LogicalPlan node, ColumnLevelLineageBuilder builder);
+
+  /**
+   * Collect outputs for a given {@link LogicalPlan}. Column level lineage mechanism traverses
+   * LogicalPlan on its node. This method will be called for each traversed node. Output information
+   * should be put into builder.
+   *
+   * @param node
+   * @param builder
+   */
+  void collectOutputs(LogicalPlan node, ColumnLevelLineageBuilder builder);
+
+  /**
+   * Collect expressions for a given {@link LogicalPlan}. Column level lineage mechanism traverses
+   * LogicalPlan on its node. This method will be called for each traversed node. Expression
+   * dependency information should be put into builder.
+   *
+   * @param node
+   * @param builder
+   */
+  void collectExpressionDependencies(LogicalPlan node, ColumnLevelLineageBuilder builder);
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -38,6 +38,7 @@ public class ExpressionDependencyCollector {
               .filter(collector -> collector.isDefinedAt(node))
               .forEach(collector -> collector.apply(node, builder));
 
+          CustomCollectorsUtils.collectExpressionDependencies(node, builder);
           List<NamedExpression> expressions = new LinkedList<>();
           if (node instanceof Project) {
             expressions.addAll(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -35,6 +35,7 @@ class InputFieldsCollector {
   static void collect(
       OpenLineageContext context, LogicalPlan plan, ColumnLevelLineageBuilder builder) {
     discoverInputsFromNode(context, plan, builder);
+    CustomCollectorsUtils.collectInputs(plan, builder);
 
     // hacky way to replace `plan instanceof UnaryNode` which fails for Spark 3.2.1
     // because of java.lang.IncompatibleClassChangeError: UnaryNode, but class was expected

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
@@ -34,6 +34,8 @@ class OutputFieldsCollector {
 
     expressions.stream().forEach(expr -> builder.addOutput(expr.exprId(), expr.name()));
 
+    CustomCollectorsUtils.collectOutputs(plan, builder);
+
     if (!builder.hasOutputs()) {
       // extract outputs from the children
       ScalaConversionUtils.<LogicalPlan>fromSeq(plan.children()).stream()

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
@@ -1,0 +1,78 @@
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+
+@Slf4j
+public class CustomCollectorsUtilsTest {
+
+  static final String OUTPUT_COL_NAME = "outputCol";
+  static final String INPUT_COL_NAME = "inputCol";
+  static ExprId childExprId = mock(ExprId.class);
+  static ExprId parentExprId = mock(ExprId.class);
+  static LogicalPlan plan = mock(LogicalPlan.class);
+  static LogicalPlan child = mock(LogicalPlan.class);
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  QueryExecution queryExecution = mock(QueryExecution.class);
+
+  @Test
+  @SneakyThrows
+  public void testCustomCollectorsAreApplied() {
+    OpenLineage openLineage = new OpenLineage(new URI("some-url"));
+    when(plan.children())
+        .thenReturn(
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(Arrays.asList(child))
+                .asScala()
+                .toSeq());
+    when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(queryExecution.optimizedPlan()).thenReturn(plan);
+    when(child.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(plan.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(child.children()).thenReturn((Seq<LogicalPlan>) Seq$.MODULE$.empty());
+    when(context.getOpenLineage()).thenReturn(openLineage);
+
+    Mockito.doCallRealMethod().when(plan).foreach(any());
+    Mockito.doCallRealMethod().when(child).foreach(any());
+
+    OpenLineage.SchemaDatasetFacet outputSchema =
+        openLineage.newSchemaDatasetFacet(
+            Arrays.asList(
+                openLineage
+                    .newSchemaDatasetFacetFieldsBuilder()
+                    .name(OUTPUT_COL_NAME)
+                    .type("string")
+                    .build()));
+
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(context, outputSchema).get();
+
+    assertEquals(
+        INPUT_COL_NAME,
+        facet
+            .getFields()
+            .getAdditionalProperties()
+            .get(OUTPUT_COL_NAME)
+            .getInputFields()
+            .get(0)
+            .getField());
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomColumnLineageVisitorTestImpl.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomColumnLineageVisitorTestImpl.java
@@ -1,0 +1,35 @@
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.INPUT_COL_NAME;
+import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.OUTPUT_COL_NAME;
+import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.child;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+public class CustomColumnLineageVisitorTestImpl implements CustomColumnLineageVisitor {
+
+  @Override
+  public void collectInputs(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    if (node.equals(child)) {
+      builder.addInput(
+          CustomCollectorsUtilsTest.childExprId, mock(DatasetIdentifier.class), INPUT_COL_NAME);
+    }
+  }
+
+  @Override
+  public void collectOutputs(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    if (node.equals(child)) {
+      builder.addOutput(CustomCollectorsUtilsTest.parentExprId, OUTPUT_COL_NAME);
+    }
+  }
+
+  @Override
+  public void collectExpressionDependencies(LogicalPlan node, ColumnLevelLineageBuilder builder) {
+    if (node.equals(child)) {
+      builder.addDependency(
+          CustomCollectorsUtilsTest.parentExprId, CustomCollectorsUtilsTest.childExprId);
+    }
+  }
+}

--- a/integration/spark/spark3/src/test/resources/META-INF/services/io.openlineage.spark3.agent.lifecycle.plan.column.CustomColumnLineageVisitor
+++ b/integration/spark/spark3/src/test/resources/META-INF/services/io.openlineage.spark3.agent.lifecycle.plan.column.CustomColumnLineageVisitor
@@ -1,0 +1,1 @@
+io.openlineage.spark3.agent.lifecycle.plan.column.CustomColumnLineageVisitorTestImpl


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Column Lineage mechanism is missing the ability to write custom extensions. 

Closes: #738

### Solution

Enable adding custom extension classes to column level lineage. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)