### PR TITLE
sql: add support for CREATE TABLE CLONE

### DIFF
--- a/integration/sql/src/lib.rs
+++ b/integration/sql/src/lib.rs
@@ -394,7 +394,7 @@ fn parse_stmt(stmt: &Statement, context: &mut Context) -> Result<(), String> {
             Ok(())
         }
         Statement::CreateTable {
-            name, query, like, ..
+            name, query, like, clone, ..
         } => {
             if let Some(boxed_query) = query {
                 parse_query(boxed_query.as_ref(), context)?;
@@ -402,6 +402,10 @@ fn parse_stmt(stmt: &Statement, context: &mut Context) -> Result<(), String> {
             if let Some(like_table) = like {
                 context.add_input(&like_table.to_string());
             }
+            if let Some(clone) = clone {
+                context.add_input(&clone.to_string());
+            }
+
             context.add_output(&name.to_string());
             Ok(())
         }

--- a/integration/sql/tests/tests_create.rs
+++ b/integration/sql/tests/tests_create.rs
@@ -38,6 +38,18 @@ fn test_create_table_like() {
 }
 
 #[test]
+fn test_create_table_clone() {
+    assert_eq!(
+        test_sql("CREATE OR REPLACE TABLE new CLONE original"),
+        SqlMeta {
+            in_tables: table("original"),
+            out_tables: table("new")
+        }
+    )
+}
+
+
+#[test]
 fn test_create_and_insert() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
Had to add support in sqlparser-rs: https://github.com/sqlparser-rs/sqlparser-rs/pull/542

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
