### PR TITLE
Add RedshiftSQLExtractor & RedshiftDataExtractor.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -33,6 +33,12 @@ _extractors = list(
             try_import_from_string(
                 'openlineage.airflow.extractors.bash_extractor.BashExtractor'
             ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.redshift_sql_extractor.RedshiftSQLExtractor'
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.redshift_data_extractor.RedshiftDataExtractor'
+            )
         ],
     )
 )

--- a/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0.
+import logging
+from typing import Optional, List
+
+from openlineage.client.facet import SqlJobFacet
+from openlineage.common.provider.redshift_data import RedshiftDataDatasetsProvider
+
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.utils import get_job_name
+from openlineage.common.sql import SqlMeta, parse
+
+log = logging.getLogger(__name__)
+
+
+class RedshiftDataExtractor(BaseExtractor):
+    default_schema = "public"
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ["RedshiftDataOperator"]
+
+    def extract(self) -> Optional[TaskMetadata]:
+        return None
+
+    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
+        log.debug(f"extract_on_complete({task_instance})")
+        job_facets = {"sql": SqlJobFacet(self.operator.sql)}
+
+        log.debug(f"Sending SQL to parser: {self.operator.sql}")
+        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
+        log.debug(f"Got meta {sql_meta}")
+        try:
+            redshift_job_id = self._get_xcom_redshift_job_id(task_instance)
+            if redshift_job_id is None:
+                raise Exception(
+                    "Xcom could not resolve Redshift job id. Job may have failed."
+                )
+        except Exception as e:
+            log.error(f"Cannot retrieve job details from {e}", exc_info=True)
+            return TaskMetadata(
+                name=get_job_name(task=self.operator),
+                run_facets={},
+                job_facets=job_facets,
+            )
+
+        client = self.operator.hook.conn
+
+        redshift_details = [
+            "database",
+            "cluster_identifier",
+            "db_user",
+            "secret_arn",
+            "region",
+        ]
+
+        connection_details = {
+            detail: getattr(self.operator, detail) for detail in redshift_details
+        }
+
+        stats = RedshiftDataDatasetsProvider(
+            client=client, connection_details=connection_details
+        ).get_facets(
+            job_id=redshift_job_id,
+            inputs=sql_meta.in_tables if sql_meta else [],
+            outputs=sql_meta.out_tables if sql_meta else [],
+        )
+
+        return TaskMetadata(
+            name=get_job_name(task=self.operator),
+            inputs=[ds.to_openlineage_dataset() for ds in stats.inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in stats.output],
+            run_facets=stats.run_facets,
+            job_facets={"sql": SqlJobFacet(self.operator.sql)},
+        )
+
+    def _get_xcom_redshift_job_id(self, task_instance):
+        redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id)
+
+        log.debug(f"redshift job id: {redshift_job_id}")
+        return redshift_job_id

--- a/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0.
+from typing import List, TYPE_CHECKING
+from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+import logging
+import boto3
+
+if TYPE_CHECKING:
+    from airflow.models import BaseHook
+
+logger = logging.getLogger(__name__)
+
+
+class RedshiftSQLExtractor(PostgresExtractor):
+    default_schema = "public"
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ["RedshiftSQLOperator"]
+
+    def _get_scheme(self) -> str:
+        return "redshift"
+
+    def _get_hook(self) -> "BaseHook":
+        from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+
+        return RedshiftSQLHook(
+            redshift_conn_id=self.operator.redshift_conn_id,
+        )
+
+    def _get_authority(self) -> str:
+        # If IAM enabled disregard hostname, use info from extras
+        # Important: RedshiftSQLOperator does not handle
+        # Redshift Serverless connections yet neither Airflow AWS provider does.
+        extras = self.conn.extra_dejson
+        if extras.get("iam") is True:
+            host = extras.get("cluster_identifier")
+            region = extras.get("region")
+            if not region:
+                profile = extras.get('profile', None)
+                session = boto3.Session(profile_name=profile)
+                region = session.region_name
+            port = extras.get("port", 5439)
+            identifier = f"{host}.{region}"
+        elif not self.conn.host:
+            raise ValueError(
+                "Missing host in connection since there" "s no IAM setting"
+            )
+        else:
+            identifier = self._get_cluster_identifier_from_hostname(self.conn.host)
+            port = self.conn.port or 5439
+        return f"{identifier}:{port}"
+
+    def _get_cluster_identifier_from_hostname(self, hostname: str) -> str:
+        parts = hostname.split(".")
+        if "amazonaws.com" in hostname and len(parts) == 6:
+            return f"{parts[0]}.{parts[2]}"
+        else:
+            logger.warning(
+                """Could not parse identifier from hostname '%s'.
+            You are probably using IP to connect to Redshift cluster.
+            Expected format: 'cluster_identifier.id.region_name.redshift.amazonaws.com'
+            Falling back to whole hostname.""",
+                hostname,
+            )
+            return hostname

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -41,6 +41,7 @@ extras_require = {
         "apache-airflow-providers-mysql>=2.0.0",
         "apache-airflow-providers-snowflake>=2.1.0",
         "apache-airflow-providers-google>=5.0.0",
+        "apache-airflow-providers-amazon>=3.1.1",
         "airflow-provider-great-expectations==0.1.4",
     ],
 }

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -5,7 +5,17 @@ import logging
 import os
 
 import pytest
+
+from pkg_resources import parse_version
+from airflow.version import version as AIRFLOW_VERSION
 log = logging.getLogger(__name__)
+
+
+if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
+    collect_ignore = [
+        "extractors/test_redshift_sql_extractor.py",
+        "extractors/test_redshift_data_extractor.py",
+    ]
 
 
 @pytest.fixture(scope="function")

--- a/integration/airflow/tests/extractors/redshift_statement_details.json
+++ b/integration/airflow/tests/extractors/redshift_statement_details.json
@@ -1,0 +1,23 @@
+{
+  "ClusterIdentifier": "redshift-cluster-1",
+  "Duration": 5681587,
+  "HasResultSet": true,
+  "Id": "93022fdc-7303-4351-a8fa-1947dfd65d73",
+  "QueryString": "Select 1;",
+  "RedshiftPid": 1086520345,
+  "RedshiftQueryId": -1,
+  "ResultRows": 1,
+  "ResultSize": 11,
+  "Status": "FINISHED",
+  "ResponseMetadata": {
+    "RequestId": "30d6e60a-e1be-4eaa-a43d-1c9bf82e3896",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "30d6e60a-e1be-4eaa-a43d-1c9bf82e3896",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "305",
+      "date": "Thu, 14 Jul 2022 10:58:57 GMT"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/integration/airflow/tests/extractors/redshift_table_details.json
+++ b/integration/airflow/tests/extractors/redshift_table_details.json
@@ -1,0 +1,55 @@
+{
+  "ColumnList": [
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 10,
+      "name": "fruit_id",
+      "nullable": 1,
+      "precision": 10,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "int4"
+    },
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 256,
+      "name": "name",
+      "nullable": 0,
+      "precision": 256,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "varchar"
+    },
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 256,
+      "name": "color",
+      "nullable": 0,
+      "precision": 256,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "varchar"
+    }
+  ],
+  "TableName": "dev.public.fruit",
+  "ResponseMetadata": {
+    "RequestId": "81d95b02-fad5-46b3-9a06-1b5b6198afdc",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "81d95b02-fad5-46b3-9a06-1b5b6198afdc",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "620",
+      "date": "Thu, 14 Jul 2022 08:46:36 GMT"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -1,0 +1,228 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from unittest import mock
+from mock import PropertyMock
+
+from airflow.models import TaskInstance, DAG
+from airflow.utils.state import State
+from datetime import datetime
+import pytz
+import uuid
+import json
+import logging
+import unittest
+
+from pkg_resources import parse_version
+from airflow.utils import timezone
+from airflow.version import version as AIRFLOW_VERSION
+from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.sql import DbTableMeta
+
+from openlineage.airflow.extractors.redshift_data_extractor import RedshiftDataExtractor
+from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
+from openlineage.client.facet import ErrorMessageRunFacet, OutputStatisticsOutputDatasetFacet
+
+
+CONN_ID = "food_delivery_db"
+CONN_URI = (
+    "redshift://user:pass@redshift-cluster-name.id.region.redshift.amazonaws.com:5439"
+    "/food_delivery"
+)
+CONN_URI_WITHOUT_USERPASS = \
+    "redshift://redshift-cluster-name.id.region.redshift.amazonaws.com:5439/food_delivery"
+
+DB_NAME = "food_delivery"
+DB_SCHEMA_NAME = "public"
+DB_TABLE_NAME = DbTableMeta("discounts")
+DB_TABLE_COLUMNS = [
+    DbColumn(name="id", type="int4", ordinal_position=1),
+    DbColumn(name="amount_off", type="int4", ordinal_position=2),
+    DbColumn(name="customer_email", type="varchar", ordinal_position=3),
+    DbColumn(name="starts_on", type="timestamp", ordinal_position=4),
+    DbColumn(name="ends_on", type="timestamp", ordinal_position=5),
+]
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
+)
+NO_DB_TABLE_SCHEMA = []
+
+REDSHIFT_DATABASE = "dev"
+REDSHIFT_DATABASE_USER = "admin"
+CLUSTER_IDENTIFIER = "redshift-cluster-1"
+REGION_NAME = "eu-west-2"
+
+REDSHIFT_QUERY = """
+CREATE TABLE IF NOT EXISTS fruit (
+            fruit_id INTEGER,
+            name VARCHAR NOT NULL,
+            color VARCHAR NOT NULL
+            );
+            """
+
+log = logging.getLogger(__name__)
+
+
+class TestRedshiftDataExtractor(unittest.TestCase):
+    def setUp(self):
+        log.debug("TestRedshiftDataExtractor.setup(): ")
+        run_id = str(uuid.uuid4())
+        self.task = TestRedshiftDataExtractor._get_redshift_task(run_id)
+        self.ti = TestRedshiftDataExtractor._get_ti(task=self.task, run_id=run_id)
+        self.extractor = RedshiftDataExtractor(operator=self.task)
+
+    def test_extract(self):
+        log.info("test_extractor")
+        tasks_meta_extract = RedshiftDataExtractor(self.task).extract()
+        assert tasks_meta_extract is None
+
+    @mock.patch("airflow.models.TaskInstance.xcom_pull")
+    def test_get_xcom_redshift_job_id(self, mock_xcom_pull):
+        self.extractor._get_xcom_redshift_job_id(self.ti)
+
+        mock_xcom_pull.assert_called_once_with(task_ids=self.ti.task_id)
+
+    @staticmethod
+    def _get_ti(task, run_id):
+        kwargs = {}
+        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+            kwargs["run_id"] = run_id
+        else:
+            kwargs["execution_date"] = datetime.utcnow().replace(tzinfo=pytz.utc)
+        task_instance = TaskInstance(
+            task=task,
+            # execution_date=datetime.utcnow().replace(tzinfo=pytz.utc),
+            state=State.RUNNING,
+            **kwargs,
+        )
+        task_instance.job_id = random.randrange(10000)
+
+        return task_instance
+
+    @staticmethod
+    def _get_redshift_task(run_id):
+        dag = DAG(dag_id="TestRedshiftDataExtractor")
+        execution_date = datetime.utcnow().replace(tzinfo=pytz.utc)
+        dag.create_dagrun(
+            run_id=run_id,
+            state=State.QUEUED,
+            execution_date=execution_date,
+        )
+        task = RedshiftDataOperator(
+            task_id="task_id",
+            database=REDSHIFT_DATABASE,
+            db_user=REDSHIFT_DATABASE_USER,
+            cluster_identifier=CLUSTER_IDENTIFIER,
+            sql=REDSHIFT_QUERY,
+            region=REGION_NAME,
+            dag=dag,
+            start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
+        )
+
+        return task
+
+    @mock.patch(
+        "airflow.providers.amazon.aws.operators.redshift_data.RedshiftDataOperator.hook",
+        new_callable=PropertyMock,
+    )
+    @mock.patch("botocore.client")
+    def test_extract_e2e(self, mock_client, mock_hook):
+
+        mock_client.describe_statement.return_value = self.read_file_json(
+            "tests/extractors/redshift_statement_details.json"
+        )
+        mock_client.describe_table.return_value = self.read_file_json(
+            "tests/extractors/redshift_table_details.json"
+        )
+        job_id = "test_id"
+        mock_client.execute_statement.return_value = {"Id": job_id}
+        mock_hook.return_value.conn = mock_client
+
+        extractor = RedshiftDataExtractor(self.task)
+        task_meta_extract = extractor.extract()
+        assert task_meta_extract is None
+
+        self.ti.run()
+
+        task_meta = extractor.extract_on_complete(self.ti)
+
+        mock_client.describe_statement.assert_called_with(Id=job_id)
+
+        assert task_meta.outputs
+        assert len(task_meta.outputs) == 1
+        assert task_meta.outputs[0].name == "dev.public.fruit"
+
+        assert task_meta.outputs[0].facets["schema"].fields is not None
+        assert (
+            task_meta.outputs[0].facets["dataSource"].name
+            == f"redshift://{CLUSTER_IDENTIFIER}.{REGION_NAME}:5439"
+        )
+        assert task_meta.outputs[0].facets["dataSource"].uri is None
+        assert len(task_meta.outputs[0].facets["schema"].fields) == 3
+
+        assert (
+            OutputStatisticsOutputDatasetFacet(
+                rowCount=1,
+                size=11,
+            ) == task_meta.outputs[0].facets['stats']
+        )
+
+    @mock.patch(
+        "airflow.providers.amazon.aws.operators.redshift_data."
+        "RedshiftDataOperator.wait_for_results"
+    )
+    @mock.patch(
+        "airflow.providers.amazon.aws.operators.redshift_data.RedshiftDataOperator.hook",
+        new_callable=PropertyMock,
+    )
+    @mock.patch("botocore.client")
+    def test_extract_error(self, mock_client, mock_hook, mock_wait_for_results):
+
+        mock_client.describe_statement.side_effect = Exception("redshift error")
+        mock_client.describe_table.side_effect = Exception(
+            "redshift error on describe table"
+        )
+        mock_wait_for_results.return_value = True
+        job_id = "test_id"
+        mock_client.execute_statement.return_value = {"Id": job_id}
+        mock_hook.return_value.conn = mock_client
+
+        extractor = RedshiftDataExtractor(self.task)
+        task_meta_extract = extractor.extract()
+        assert task_meta_extract is None
+
+        self.ti.run()
+
+        task_meta = extractor.extract_on_complete(self.ti)
+
+        mock_client.describe_statement.assert_called_with(Id=job_id)
+
+        assert isinstance(task_meta.run_facets["errorMessage"], ErrorMessageRunFacet)
+        assert (
+            task_meta.run_facets["errorMessage"].message
+            == "Cannot retrieve job details from Redshift Data client. redshift error"
+        )
+        assert task_meta.run_facets["errorMessage"].programmingLanguage == "PYTHON"
+        assert task_meta.run_facets["errorMessage"].stackTrace.startswith(
+            "redshift error: Traceback (most recent call last):\n"
+        )
+        assert len(task_meta.outputs) == 1
+        assert task_meta.outputs[0].name == "fruit"
+
+        assert "schema" not in task_meta.outputs[0].facets
+        assert (
+            task_meta.outputs[0].facets["dataSource"].name
+            == f"redshift://{CLUSTER_IDENTIFIER}.{REGION_NAME}:5439"
+        )
+        assert task_meta.outputs[0].facets["dataSource"].uri is None
+
+    def read_file_json(self, file):
+        f = open(file=file, mode="r")
+        details = json.loads(f.read())
+        f.close()
+        return details
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
@@ -1,0 +1,244 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+
+import pytest
+from airflow.models import Connection
+from airflow.utils.dates import days_ago
+from airflow import DAG
+
+from openlineage.airflow.utils import safe_import_airflow, get_connection
+from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.sql import DbTableMeta
+from openlineage.common.dataset import Source, Dataset, Field
+from openlineage.airflow.extractors.redshift_sql_extractor import RedshiftSQLExtractor
+from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
+
+
+CONN_ID = "food_delivery_db"
+CONN_URI = (
+    "redshift://user:pass@redshift-cluster-name.id.region.redshift.amazonaws.com:5439"
+    "/food_delivery"
+)
+CONN_URI_WITHOUT_USERPASS = \
+    "redshift://redshift-cluster-name.id.region.redshift.amazonaws.com:5439/food_delivery"
+
+DB_NAME = "food_delivery"
+DB_SCHEMA_NAME = "public"
+DB_TABLE_NAME = DbTableMeta("discounts")
+DB_TABLE_COLUMNS = [
+    DbColumn(name="id", type="int4", ordinal_position=1),
+    DbColumn(name="amount_off", type="int4", ordinal_position=2),
+    DbColumn(name="customer_email", type="varchar", ordinal_position=3),
+    DbColumn(name="starts_on", type="timestamp", ordinal_position=4),
+    DbColumn(name="ends_on", type="timestamp", ordinal_position=5),
+]
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
+)
+NO_DB_TABLE_SCHEMA = []
+
+SQL = f"SELECT * FROM {DB_TABLE_NAME.name};"
+
+DAG_ID = "email_discounts"
+DAG_OWNER = "datascience"
+DAG_DEFAULT_ARGS = {
+    "owner": DAG_OWNER,
+    "depends_on_past": False,
+    "start_date": days_ago(7),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "email": ["datascience@example.com"],
+}
+DAG_DESCRIPTION = (
+    "Email discounts to customers that have experienced order delays daily"
+)
+
+DAG = dag = DAG(
+    DAG_ID,
+    schedule_interval="@weekly",
+    default_args=DAG_DEFAULT_ARGS,
+    description=DAG_DESCRIPTION,
+)
+
+TASK_ID = "select"
+TASK = RedshiftSQLOperator(
+    task_id=TASK_ID,
+    redshift_conn_id=CONN_ID,
+    sql=SQL,
+    dag=DAG,
+)
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_table_schemas")  # noqa
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+def test_extract(get_connection, mock_get_table_schemas):
+    source = Source(
+        scheme="redshift",
+        authority="redshift-cluster-name.id.region.redshift.amazonaws.com:5439",
+        connection_url=CONN_URI_WITHOUT_USERPASS,
+    )
+
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
+
+    conn = Connection(
+        conn_id=CONN_ID,
+        conn_type="redshift",
+        host="redshift-cluster-name.id.region.redshift.amazonaws.com",
+        port="5439",
+        schema="food_delivery",
+    )
+
+    get_connection.return_value = conn
+
+    expected_inputs = [
+        Dataset(
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS],
+        ).to_openlineage_dataset()
+    ]
+
+    task_metadata = RedshiftSQLExtractor(TASK).extract()
+
+    assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
+    assert task_metadata.inputs == expected_inputs
+    assert task_metadata.outputs == []
+
+
+def test_parsing_hostname():
+    extractor = RedshiftSQLExtractor(TASK)
+    assert extractor._get_cluster_identifier_from_hostname("1.2.3.4.5") == "1.2.3.4.5"
+    assert (
+        extractor._get_cluster_identifier_from_hostname(
+            "redshift-cluster-name.id.region.redshift.amazonaws.com"
+        )
+        == "redshift-cluster-name.region"
+    )
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+def test_authority_with_clustername_in_host(get_connection):
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI)
+    get_connection.return_value = conn
+
+    assert (
+        RedshiftSQLExtractor(TASK)._get_authority()
+        == "redshift-cluster-name.region:5439"
+    )
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+def test_authority_with_iam(get_connection):
+    conn = Connection(
+        extra={
+            "iam": True,
+            "cluster_identifier": "redshift-cluster-name",
+            "region": "region",
+        }
+    )
+    get_connection.return_value = conn
+
+    assert (
+        RedshiftSQLExtractor(TASK)._get_authority()
+        == "redshift-cluster-name.region:5439"
+    )
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+def test_authority_with_iam_and_implicit_region(get_connection):
+    import os
+    os.environ['AWS_DEFAULT_REGION'] = 'region_2'
+    conn = Connection(
+        extra={
+            "iam": True,
+            "cluster_identifier": "redshift-cluster-name",
+        }
+    )
+    get_connection.return_value = conn
+
+    assert (
+        RedshiftSQLExtractor(TASK)._get_authority()
+        == "redshift-cluster-name.region_2:5439"
+    )
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+def test_authority_without_iam_wrong_connection(get_connection):
+    conn = Connection(
+        extra={
+            "iam": False,
+            "cluster_identifier": "redshift-cluster-name",
+            "region": "region",
+        }
+    )
+    get_connection.return_value = conn
+    with pytest.raises(ValueError):
+        RedshiftSQLExtractor(TASK)._get_authority()
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_table_schemas")  # noqa
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+def test_extract_authority_uri(get_connection, mock_get_table_schemas):
+
+    source = Source(
+        scheme="redshift",
+        authority="redshift-cluster-name.id.region.redshift.amazonaws.com:5439",
+        connection_url=CONN_URI_WITHOUT_USERPASS,
+    )
+
+    mock_get_table_schemas.return_value = (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+        [],
+    )
+
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI)
+    get_connection.return_value = conn
+
+    expected_inputs = [
+        Dataset(
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS],
+        ).to_openlineage_dataset()
+    ]
+
+    task_metadata = RedshiftSQLExtractor(TASK).extract()
+
+    assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
+    assert task_metadata.inputs == expected_inputs
+    assert task_metadata.outputs == []
+
+
+def test_get_connection_import_returns_none_if_not_exists():
+    assert get_connection("does_not_exist") is None
+    assert get_connection("does_exist") is None
+
+
+@pytest.fixture
+def create_connection():
+    create_session = safe_import_airflow(
+        airflow_1_path="airflow.utils.db.create_session",
+        airflow_2_path="airflow.utils.session.create_session",
+    )
+
+    conn = Connection("does_exist", conn_type="redshift")
+    with create_session() as session:
+        session.add(conn)
+        session.commit()
+
+    yield conn
+
+    with create_session() as session:
+        session.delete(conn)
+        session.commit()
+
+
+def test_get_connection_returns_one_if_exists(create_connection):
+    conn = Connection("does_exist")
+    assert get_connection("does_exist").conn_id == conn.conn_id

--- a/integration/airflow/tests/integration/tests/airflow/dags/redshift_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/redshift_dag.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from os import getenv
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
+from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
+
+REDSHIFT_DATABASE = getenv("REDSHIFT_DATABASE", "dev")
+REDSHIFT_DATABASE_USER = getenv("REDSHIFT_DATABASE_USER", "admin")
+
+REDSHIFT_QUERY = """
+CREATE TABLE IF NOT EXISTS fruit (
+            fruit_id INTEGER,
+            name VARCHAR NOT NULL,
+            color VARCHAR NOT NULL
+            );
+            """
+POLL_INTERVAL = 10
+
+
+@task(task_id="output_results")
+def output_query_results(statement_id):
+    hook = RedshiftDataHook(region_name="eu-west-2")
+    resp = hook.conn.get_statement_result(
+        Id=statement_id,
+    )
+
+    print(resp)
+    return resp
+
+
+with DAG(
+    dag_id="redshiftter_dag",
+    start_date=datetime(2021, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    tags=['example'],
+) as dag:
+    # [START howto_operator_redshift_data]
+    task_query = RedshiftDataOperator(
+        # aws_conn_id="redshit", 
+        task_id='redshift_query',
+        database=REDSHIFT_DATABASE,
+        db_user=REDSHIFT_DATABASE_USER,
+        cluster_identifier="redshift-cluster-1",
+        sql=REDSHIFT_QUERY,
+        poll_interval=POLL_INTERVAL,
+        await_result=True,
+        region='eu-west-2',
+    )
+    # [END howto_operator_redshift_data]
+
+    task_output = output_query_results(task_query.output)

--- a/integration/common/openlineage/common/provider/redshift_data.py
+++ b/integration/common/openlineage/common/provider/redshift_data.py
@@ -1,0 +1,150 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import attr
+
+from typing import Any, Optional, Dict, List
+import botocore
+
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.sql import DbTableMeta
+from openlineage.client.facet import (
+    BaseFacet,
+    ErrorMessageRunFacet,
+    OutputStatisticsOutputDatasetFacet,
+)
+import traceback
+
+
+@attr.s
+class RedshiftFacets:
+    run_facets: Dict[str, BaseFacet] = attr.ib()
+    inputs: List[Dataset] = attr.ib()
+    output: List[Dataset] = attr.ib()
+
+
+class RedshiftDataDatasetsProvider:
+    def __init__(
+        self,
+        client: botocore.client,
+        connection_details: Dict[str, Any],
+        logger: Optional[logging.Logger] = None,
+    ):
+        if logger is None:
+            self.logger: logging.Logger = logging.getLogger(__name__)
+        else:
+            self.logger = logger
+        self.connection_details = connection_details
+        self.client = client
+
+    def get_facets(
+        self, job_id: str, inputs: List[DbTableMeta], outputs: List[DbTableMeta]
+    ) -> RedshiftFacets:
+        ds_inputs = []
+        ds_outputs = []
+        run_facets = {}
+        dataset_stat_facet = None
+
+        source = Source(
+            scheme="redshift",
+            authority=self._get_authority(),
+        )
+        try:
+            properties = self.client.describe_statement(Id=job_id)
+            dataset_stat_facet = self._get_output_statistics(properties)
+        except Exception as e:
+            self.logger.error(
+                f"Cannot retrieve job details from Redshift Data client. {e}",
+                exc_info=True,
+            )
+            run_facets.update(
+                {
+                    "errorMessage": ErrorMessageRunFacet(
+                        message=f"Cannot retrieve job details from Redshift Data client. {e}",
+                        programmingLanguage="PYTHON",
+                        stackTrace=f"{e}: {traceback.format_exc()}",
+                    )
+                }
+            )
+
+        ds_inputs = self._get_dataset_from_tables(inputs, source)
+        ds_outputs = self._get_dataset_from_tables(outputs, source)
+
+        for ds_output in ds_outputs:
+            ds_output.custom_facets.update({
+                        "stats": dataset_stat_facet
+                    })
+
+        return RedshiftFacets(run_facets, ds_inputs, ds_outputs)
+
+    def _get_output_statistics(self, properties) -> OutputStatisticsOutputDatasetFacet:
+        return OutputStatisticsOutputDatasetFacet(
+            rowCount=properties.get("ResultRows"),
+            size=properties.get("ResultSize"),
+        )
+
+    def _get_dataset_from_tables(
+        self, tables: List[DbTableMeta], source: Source
+    ) -> Dataset:
+        try:
+            return [
+                Dataset.from_table_schema(
+                    source=source,
+                    table_schema=table_schema,
+                    database_name=self.connection_details.get("database"),
+                )
+                for table_schema in self._get_table_schemas(tables)
+            ]
+        except Exception as e:
+            self.logger.warning(f"Could not extract schema from redshift. {e}")
+            return [Dataset.from_table(source, table.name) for table in tables]
+
+    def _get_authority(self) -> str:
+        return (
+            f"{self.connection_details['cluster_identifier']}."
+            f"{self.connection_details.get('region')}:5439"
+        )
+
+    def _get_table_safely(self, output_table_name):
+        try:
+            return self._get_table(output_table_name)
+        except Exception as e:
+            self.logger.warning(f"Could not extract output schema from redshift. {e}")
+        return None
+
+    def _get_table_schemas(self, tables: List[DbTableMeta]) -> List[DbTableSchema]:
+        if not tables:
+            return []
+        return [self._get_table(table) for table in tables]
+
+    def _get_table(self, table: DbTableMeta) -> Optional[DbTableSchema]:
+        kwargs: Dict[str, Any] = {
+            "ClusterIdentifier": self.connection_details.get("cluster_identifier"),
+            "Database": table.database or self.connection_details.get("database"),
+            "Table": table.name,
+            "DbUser": self.connection_details.get("db_user"),
+            "SecretArn": self.connection_details.get("secret_arn"),
+            "Schema": table.schema,
+        }
+        filter_values = {key: val for key, val in kwargs.items() if val is not None}
+        redshift_table = self.client.describe_table(**filter_values)
+        fields = redshift_table.get("ColumnList")
+        if not fields:
+            return None
+        schema_name = fields[0]["schemaName"]
+        columns = [
+            DbColumn(
+                name=fields[i].get("name"),
+                type=fields[i].get("typeName"),
+                ordinal_position=i,
+            )
+            for i in range(len(fields))
+        ]
+
+        return DbTableSchema(
+            schema_name=schema_name,
+            table_name=DbTableMeta(redshift_table.get("TableName")),
+            columns=columns,
+        )

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -37,6 +37,9 @@ extras_require = {
         "great_expectations>=0.13.26",
         "sqlalchemy>=1.3.24"
     ],
+    "redshift": [
+        "boto3>=1.15.0"
+    ],
     "tests": [
         "pytest",
         "pytest-cov",

--- a/integration/common/tests/redshift_data/statement_details.json
+++ b/integration/common/tests/redshift_data/statement_details.json
@@ -1,0 +1,23 @@
+{
+  "ClusterIdentifier": "redshift-cluster-1",
+  "Duration": 5681587,
+  "HasResultSet": true,
+  "Id": "93022fdc-7303-4351-a8fa-1947dfd65d73",
+  "QueryString": "Select 1;",
+  "RedshiftPid": 1086520345,
+  "RedshiftQueryId": -1,
+  "ResultRows": 1,
+  "ResultSize": 11,
+  "Status": "FINISHED",
+  "ResponseMetadata": {
+    "RequestId": "30d6e60a-e1be-4eaa-a43d-1c9bf82e3896",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "30d6e60a-e1be-4eaa-a43d-1c9bf82e3896",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "305",
+      "date": "Thu, 14 Jul 2022 10:58:57 GMT"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/integration/common/tests/redshift_data/table_details.json
+++ b/integration/common/tests/redshift_data/table_details.json
@@ -1,0 +1,55 @@
+{
+  "ColumnList": [
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 10,
+      "name": "fruit_id",
+      "nullable": 1,
+      "precision": 10,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "int4"
+    },
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 256,
+      "name": "name",
+      "nullable": 0,
+      "precision": 256,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "varchar"
+    },
+    {
+      "isCaseSensitive": false,
+      "isCurrency": false,
+      "isSigned": false,
+      "length": 256,
+      "name": "color",
+      "nullable": 0,
+      "precision": 256,
+      "scale": 0,
+      "schemaName": "public",
+      "tableName": "fruit",
+      "typeName": "varchar"
+    }
+  ],
+  "TableName": "dev.public.fruit",
+  "ResponseMetadata": {
+    "RequestId": "81d95b02-fad5-46b3-9a06-1b5b6198afdc",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "81d95b02-fad5-46b3-9a06-1b5b6198afdc",
+      "content-type": "application/x-amz-json-1.1",
+      "content-length": "620",
+      "date": "Thu, 14 Jul 2022 08:46:36 GMT"
+    },
+    "RetryAttempts": 0
+  }
+}

--- a/integration/common/tests/redshift_data/test_redshift_data.py
+++ b/integration/common/tests/redshift_data/test_redshift_data.py
@@ -1,0 +1,77 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import MagicMock
+
+from openlineage.common.sql import DbTableMeta
+from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.dataset import Source, Dataset, Field
+from openlineage.common.provider.redshift_data import RedshiftDataDatasetsProvider
+
+REDSHIFT_DATABASE = "dev"
+REDSHIFT_DATABASE_USER = "admin"
+CLUSTER_IDENTIFIER = "redshift-cluster-1"
+REGION_NAME = "eu-west-2"
+
+REDSHIFT_QUERY = """
+CREATE TABLE IF NOT EXISTS fruit (
+            fruit_id INTEGER,
+            name VARCHAR NOT NULL,
+            color VARCHAR NOT NULL
+            );
+            """
+POLL_INTERVAL = 10
+
+DB_NAME = "dev"
+DB_SCHEMA_NAME = "public"
+DB_TABLE_NAME = DbTableMeta("fruit")
+DB_TABLE_COLUMNS = [
+    DbColumn(name="fruit_id", type="int4", ordinal_position=1),
+    DbColumn(name="name", type="varchar", ordinal_position=2),
+    DbColumn(name="color", type="varchar", ordinal_position=3),
+]
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
+)
+
+
+def read_file_json(file):
+    with open(file=file, mode="r") as f:
+        return json.loads(f.read())
+
+
+def test_redshift_get_facets():
+    client = MagicMock()
+    client.describe_statement.return_value = read_file_json(
+        "tests/redshift_data/statement_details.json"
+    )
+    client.describe_table.return_value = read_file_json(
+        "tests/redshift_data/table_details.json"
+    )
+    inputs = [DbTableMeta(f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}")]
+    connection_details = dict(
+        database=REDSHIFT_DATABASE,
+        db_user=REDSHIFT_DATABASE_USER,
+        cluster_identifier=CLUSTER_IDENTIFIER,
+        region=REGION_NAME,
+    )
+    provider = RedshiftDataDatasetsProvider(
+        client=client, connection_details=connection_details
+    )
+
+    facets = provider.get_facets("job_id", inputs=inputs, outputs=[])
+
+    source = Source(
+        scheme="redshift",
+        authority=f"{CLUSTER_IDENTIFIER}.{REGION_NAME}:5439",
+    )
+    expected_inputs = [
+        Dataset(
+            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
+            source=source,
+            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS],
+        )
+    ]
+
+    assert facets.inputs == expected_inputs

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -51,17 +51,25 @@ Datasource hierarchy:
  * Host: examplecluster.\<XXXXXXXXXXXX>.us-west-2.redshift.amazonaws.com
  * Port: 5439
  
+OR
+
+ * Cluster identifier
+ * Region name
+ * Port (defaults to 5439)
+ 
 Naming hierarchy:
  * Database
  * Schema
  * Table
 
+One can interact with Redshift using SQL or Data API. Combination of cluster identifier + region name is the only common unique id available to both ways of interaction.
+
 Identifier:
- * Namespace: redshift://{host}:{port} of the cluster instance.
+ * Namespace: redshift://{cluster_identifier}.{region_name}:{port} of the cluster instance.
    * Scheme = redshift
-   * Authority = {host}:{port}
+   * Authority = {cluster_identifier}:{port}
  * Unique name: {database}.{schema}.{table}
-   * URI =  redshift://{host}:{port}/{database}.{schema}.{table}
+   * URI =  redshift://{cluster_identifier}.{region_name}:{port}/{database}.{schema}.{table}
   
 #### Snowflake
 See: [Object Identifiers — Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/identifiers.html)


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Add RedshiftSQLExtractor & RedshiftDataExtractor.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

Closes: #666, #665 

### Solution

Adds two extractors. Redshift Data additionaly provides extra facet with job execution details.

Note: The PR changes Redshift facet spec so both extractors can point to the same namespace achievable with every way of connecting to Redshift cluster.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [x] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)