### PR TITLE
include symlinks dataset facet

### DIFF
--- a/integration/spark/app/integrations/container/pysparkAlterTableAddColumnsEnd.json
+++ b/integration/spark/app/integrations/container/pysparkAlterTableAddColumnsEnd.json
@@ -27,6 +27,15 @@
           "name" : "d",
           "type" : "string"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/alter_test",
+            "name": "default.alter_table_test",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkAlterTableRenameEnd.json
+++ b/integration/spark/app/integrations/container/pysparkAlterTableRenameEnd.json
@@ -34,6 +34,15 @@
           "name" : "/tmp/alter_test/alter_table_test",
           "namespace" : "file"
         }
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/alter_test",
+            "name": "default.alter_table_test_new",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkCTASEnd.json
+++ b/integration/spark/app/integrations/container/pysparkCTASEnd.json
@@ -42,6 +42,15 @@
       },
       "lifecycleStateChange" : {
         "lifecycleStateChange" : "CREATE"
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl1",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkCTASStart.json
+++ b/integration/spark/app/integrations/container/pysparkCTASStart.json
@@ -42,6 +42,15 @@
       },
       "lifecycleStateChange" : {
         "lifecycleStateChange" : "CREATE"
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl1",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkCTASWithColumnLineageEnd.json
+++ b/integration/spark/app/integrations/container/pysparkCTASWithColumnLineageEnd.json
@@ -43,6 +43,15 @@
       "lifecycleStateChange" : {
         "lifecycleStateChange" : "CREATE"
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl1",
+            "type": "TABLE"
+          }
+        ]
+      },
       "columnLineage": {
         "fields": {
           "a": {

--- a/integration/spark/app/integrations/container/pysparkCreateTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkCreateTableCompleteEvent.json
@@ -28,6 +28,15 @@
         },
         "lifecycleStateChange" : {
           "lifecycleStateChange" : "CREATE"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/create_test",
+              "name": "default.create_table_test",
+              "type": "TABLE"
+            }
+          ]
         }
       }
     }

--- a/integration/spark/app/integrations/container/pysparkCreateTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkCreateTableStartEvent.json
@@ -28,6 +28,15 @@
         },
         "lifecycleStateChange" : {
           "lifecycleStateChange" : "CREATE"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/create_test",
+              "name": "default.create_table_test",
+              "type": "TABLE"
+            }
+          ]
         }
       }
     }

--- a/integration/spark/app/integrations/container/pysparkDeltaCTASComplete.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaCTASComplete.json
@@ -43,6 +43,15 @@
             }
           ]
         },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/delta",
+              "name": "default.tbl",
+              "type": "TABLE"
+            }
+          ]
+        },
         "lifecycleStateChange" : {
           "lifecycleStateChange" : "CREATE"
         }

--- a/integration/spark/app/integrations/container/pysparkDeltaSaveAsTableComplete.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaSaveAsTableComplete.json
@@ -32,6 +32,15 @@
             }
           ]
         },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/delta",
+              "name": "movies",
+              "type": "TABLE"
+            }
+          ]
+        },
         "lifecycleStateChange" : {
           "lifecycleStateChange" : "CREATE"
         }

--- a/integration/spark/app/integrations/container/pysparkDeltaViewComplete.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaViewComplete.json
@@ -1,7 +1,0 @@
-{
-  "eventType": "COMPLETE",
-  "job": {
-    "namespace": "testCreateAsSelectAndLoad",
-    "name": "open_lineage_integration_delta.execute_create_view_command"
-  }
-}

--- a/integration/spark/app/integrations/container/pysparkDeltaViewStart.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaViewStart.json
@@ -1,7 +1,0 @@
-{
-  "eventType": "START",
-  "job": {
-    "namespace": "testCreateAsSelectAndLoad",
-    "name": "open_lineage_integration_delta.execute_create_view_command"
-  }
-}

--- a/integration/spark/app/integrations/container/pysparkDropTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkDropTableStartEvent.json
@@ -14,6 +14,15 @@
           "name": "file",
           "uri": "file"
         },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/drop_test",
+              "name": "default.drop_table_test",
+              "type": "TABLE"
+            }
+          ]
+        },
         "lifecycleStateChange": {
           "lifecycleStateChange": "DROP"
         }

--- a/integration/spark/app/integrations/container/pysparkHiveCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveCompleteEvent.json
@@ -23,6 +23,15 @@
                             "type": "string"
                         }
                     ]
+                },
+                "symlinks": {
+                    "identifiers": [
+                        {
+                            "namespace": "/tmp/warehouse",
+                            "name": "default.test",
+                            "type": "TABLE"
+                        }
+                    ]
                 }
             },
             "outputFacets": {

--- a/integration/spark/app/integrations/container/pysparkHiveSelectEndEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveSelectEndEvent.json
@@ -49,6 +49,15 @@
               "type": "string"
             }
           ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/warehouse",
+              "name": "default.target",
+              "type": "TABLE"
+            }
+          ]
         }
       },
       "outputFacets": {}

--- a/integration/spark/app/integrations/container/pysparkHiveSelectStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveSelectStartEvent.json
@@ -49,6 +49,15 @@
               "type": "string"
             }
           ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/warehouse",
+              "name": "default.target",
+              "type": "TABLE"
+            }
+          ]
         }
       },
       "outputFacets": {}

--- a/integration/spark/app/integrations/container/pysparkHiveStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveStartEvent.json
@@ -23,6 +23,15 @@
                             "type": "string"
                         }
                     ]
+                },
+                "symlinks": {
+                    "identifiers": [
+                        {
+                            "namespace": "/tmp/warehouse",
+                            "name": "default.test",
+                            "type": "TABLE"
+                        }
+                    ]
                 }
             },
             "name": "/tmp/warehouse/test",

--- a/integration/spark/app/integrations/container/pysparkLoadComplete.json
+++ b/integration/spark/app/integrations/container/pysparkLoadComplete.json
@@ -21,6 +21,15 @@
           "name" : "b",
           "type" : "long"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl1",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkLoadStart.json
+++ b/integration/spark/app/integrations/container/pysparkLoadStart.json
@@ -21,6 +21,15 @@
           "name" : "b",
           "type" : "long"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl1",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkOCTASEnd.json
+++ b/integration/spark/app/integrations/container/pysparkOCTASEnd.json
@@ -39,6 +39,15 @@
           "name" : "b",
           "type" : "long"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl2",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkOCTASStart.json
+++ b/integration/spark/app/integrations/container/pysparkOCTASStart.json
@@ -39,6 +39,15 @@
           "name" : "b",
           "type" : "long"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/ctas_load",
+            "name": "default.tbl2",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkSymlinksComplete.json
+++ b/integration/spark/app/integrations/container/pysparkSymlinksComplete.json
@@ -1,0 +1,39 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "symlinks"
+  },
+  "outputs" : [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "name": "default.test",
+              "namespace": "hive://metastore",
+              "type": "TABLE"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkTruncateTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkTruncateTableCompleteEvent.json
@@ -14,6 +14,15 @@
           "name": "file",
           "uri": "file"
         },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/truncate_test",
+              "name": "default.truncate_table_test",
+              "type": "TABLE"
+            }
+          ]
+        },
         "lifecycleStateChange": {
           "lifecycleStateChange": "TRUNCATE"
         }

--- a/integration/spark/app/integrations/container/pysparkTruncateTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkTruncateTableStartEvent.json
@@ -14,6 +14,15 @@
           "name": "file",
           "uri": "file"
         },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/truncate_test",
+              "name": "default.truncate_table_test",
+              "type": "TABLE"
+            }
+          ]
+        },
         "lifecycleStateChange": {
           "lifecycleStateChange": "TRUNCATE"
         }

--- a/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
@@ -36,6 +36,15 @@
             ]
           }
         }
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/append_data",
+            "name": "db.append_table",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkV2AppendDataStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AppendDataStartEvent.json
@@ -18,7 +18,16 @@
           "type" : "long"
         }]
       },
-      "version" : {}
+      "version" : {},
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/append_data",
+            "name": "db.source1",
+            "type": "TABLE"
+          }
+        ]
+      }
     }
   }, {
     "namespace" : "file",
@@ -34,7 +43,16 @@
           "type" : "long"
         }]
       },
-      "version" : {}
+      "version" : {},
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/append_data",
+            "name": "db.source2",
+            "type": "TABLE"
+          }
+        ]
+      }
     }
   } ]
 }

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2",
+            "name": "db.target",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {},
       "columnLineage": {
         "fields": {

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
@@ -23,6 +23,15 @@
             "type": "long"
           }
         ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2",
+            "name": "db.source1",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   }, {
@@ -42,6 +51,15 @@
           {
             "name": "b",
             "type": "long"
+          }
+        ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2",
+            "name": "db.source2",
+            "type": "TABLE"
           }
         ]
       }

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
@@ -21,6 +21,15 @@
           "name" : "b",
           "type" : "string"
         } ]
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_create",
+            "name": "db.create_table_test",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkV2DeleteCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_delete",
+            "name": "db.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {}
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
@@ -16,6 +16,15 @@
         },
         "lifecycleStateChange": {
           "lifecycleStateChange": "DROP"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/v2_drop",
+              "name": "db.drop_table_test",
+              "type": "TABLE"
+            }
+          ]
         }
       }
     }

--- a/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
@@ -16,6 +16,15 @@
         },
         "lifecycleStateChange": {
           "lifecycleStateChange": "DROP"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "/tmp/v2_drop",
+              "name": "db.drop_table_test",
+              "type": "TABLE"
+            }
+          ]
         }
       }
     }

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
@@ -54,6 +54,15 @@
             ]
           }
         }
+      },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_merge",
+            "name": "db.events",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableStartEvent.json
@@ -21,7 +21,16 @@
           "type" : "long"
         } ]
       },
-      "version" : {}
+      "version" : {},
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_merge",
+            "name": "db.updates",
+            "type": "TABLE"
+          }
+        ]
+      }
     }
   } ],
   "outputs" : [ ]

--- a/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_overwrite",
+            "name": "db.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {},
       "lifecycleStateChange": {
         "lifecycleStateChange": "OVERWRITE"

--- a/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
@@ -25,6 +25,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_overwrite",
+            "name": "db.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "lifecycleStateChange": {
         "lifecycleStateChange": "OVERWRITE"
       },

--- a/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
@@ -24,6 +24,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_overwrite",
+            "name": "db.source",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {}
     }
   } ],

--- a/integration/spark/app/integrations/container/pysparkV2ReplaceTableAsSelectCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2ReplaceTableAsSelectCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_replace_table_as_select",
+            "name": "db.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {},
       "lifecycleStateChange": {
         "lifecycleStateChange": "OVERWRITE"

--- a/integration/spark/app/integrations/container/pysparkV2ReplaceTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2ReplaceTableCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "string"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp",
+            "name": "default.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {},
       "lifecycleStateChange": {
         "lifecycleStateChange": "OVERWRITE"

--- a/integration/spark/app/integrations/container/pysparkV2UpdateCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateCompleteEvent.json
@@ -22,6 +22,15 @@
           "type" : "long"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/v2_update_table",
+            "name": "db.tbl",
+            "type": "TABLE"
+          }
+        ]
+      },
       "version" : {}
     }
   } ]

--- a/integration/spark/app/integrations/container/pysparkWriteDeltaTableVersionEnd.json
+++ b/integration/spark/app/integrations/container/pysparkWriteDeltaTableVersionEnd.json
@@ -26,6 +26,15 @@
           }
         ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp",
+            "name": "default.versioned_table",
+            "type": "TABLE"
+          }
+        ]
+      },
       "storage" : {
         "storageLayer" : "delta",
         "fileFormat" : "parquet"

--- a/integration/spark/app/integrations/container/pysparkWriteDeltaTableVersionStart.json
+++ b/integration/spark/app/integrations/container/pysparkWriteDeltaTableVersionStart.json
@@ -12,6 +12,9 @@
         "name": "file",
         "uri": "file"
       },
+      "version" : {
+        "datasetVersion" : "3"
+      },
       "schema": {
         "fields": [
           {
@@ -28,8 +31,14 @@
           }
         ]
       },
-      "version" : {
-        "datasetVersion" : "3"
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp",
+            "name": "default.versioned_input_table",
+            "type": "TABLE"
+          }
+        ]
       }
     }
   }

--- a/integration/spark/app/integrations/container/pysparkWriteIcebergTableVersionEnd.json
+++ b/integration/spark/app/integrations/container/pysparkWriteIcebergTableVersionEnd.json
@@ -17,6 +17,15 @@
           "type" : "integer"
         } ]
       },
+      "symlinks": {
+        "identifiers": [
+          {
+            "namespace": "/tmp/write_iceberg_table_version",
+            "name": "db.table",
+            "type": "TABLE"
+          }
+        ]
+      },
       "storage" : {
         "storageLayer" : "iceberg",
         "fileFormat" : "parquet"

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -212,6 +212,14 @@ class SparkContainerIntegrationTest {
   }
 
   @Test
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3) // Spark version >= 3.*
+  void testSymlinksFacetForHiveCatalog() {
+    SparkContainerUtils.runPysparkContainerWithDefaultConf(
+        network, openLineageClientMockContainer, "symlinks", "spark_hive_catalog.py");
+    verifyEvents("pysparkSymlinksComplete.json");
+  }
+
+  @Test
   @EnabledIf("isDeltaTestEnabled")
   void testCTASDelta() {
     pyspark =

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hive_catalog.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hive_catalog.py
@@ -1,0 +1,20 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os, time
+
+os.makedirs("/tmp/warehouse", exist_ok=True)
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration Hive") \
+    .config("spark.sql.catalogImplementation", "hive") \
+    .config("spark.sql.hive.metastore.uris", "http://metastore") \
+    .enableHiveSupport() \
+    .getOrCreate()
+spark.sparkContext.setLogLevel('info')
+
+spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive")
+time.sleep(1)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -68,7 +68,6 @@ public class AlterTableRenameCommandVisitor
             new OpenLineage.DatasetFacetsBuilder()
                 .schema(PlanUtils.schemaFacet(context.getOpenLineage(), table.schema()))
                 .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
-                .lifecycleStateChange(lifecycleStateChangeDatasetFacet)
-                .build()));
+                .lifecycleStateChange(lifecycleStateChangeDatasetFacet)));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
@@ -54,8 +54,7 @@ public class DropTableCommandVisitor
                           .newLifecycleStateChangeDatasetFacet(
                               OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
                                   .DROP,
-                              null))
-                  .build()));
+                              null))));
 
     } else {
       // already deleted, do nothing

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -57,8 +57,7 @@ public class TruncateTableCommandVisitor
                           .newLifecycleStateChangeDatasetFacet(
                               OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
                                   .TRUNCATE,
-                              null))
-                  .build()));
+                              null))));
 
     } else {
       // table does not exist, cannot prepare an event

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
@@ -5,10 +5,40 @@
 
 package io.openlineage.spark.agent.util;
 
+import java.util.LinkedList;
+import java.util.List;
 import lombok.Value;
 
 @Value
 public class DatasetIdentifier {
   String name;
   String namespace;
+  List<Symlink> symlinks;
+
+  public enum SymlinkType {
+    TABLE
+  };
+
+  public DatasetIdentifier(String name, String namespace) {
+    this.name = name;
+    this.namespace = namespace;
+    this.symlinks = new LinkedList<>();
+  }
+
+  public DatasetIdentifier withSymlink(String name, String namespace, SymlinkType type) {
+    symlinks.add(new Symlink(name, namespace, type));
+    return this;
+  }
+
+  public DatasetIdentifier withSymlink(Symlink symlink) {
+    symlinks.add(symlink);
+    return this;
+  }
+
+  @Value
+  public static class Symlink {
+    String name;
+    String namespace;
+    SymlinkType type;
+  }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -5,10 +5,12 @@
 
 package io.openlineage.spark.agent.util;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
@@ -55,23 +57,31 @@ public class PathUtils {
   public static DatasetIdentifier fromCatalogTable(
       CatalogTable catalogTable, Optional<SparkConf> sparkConf) {
     Optional<URI> metastoreUri = extractMetastoreUri(sparkConf);
-    if (metastoreUri.isPresent() && metastoreUri.get() != null) {
-      // dealing with Hive tables
-      return prepareHiveDatasetIdentifier(catalogTable, metastoreUri.get());
-    } else {
-      if (catalogTable.storage() != null && catalogTable.storage().locationUri().isDefined()) {
-        // location is present -> use it for dataset identifier with `file:/` scheme
-        return PathUtils.fromURI(catalogTable.storage().locationUri().get(), DEFAULT_SCHEME);
-      }
 
+    DatasetIdentifier di;
+    if (catalogTable.storage() != null && catalogTable.storage().locationUri().isDefined()) {
+      di = PathUtils.fromURI(catalogTable.storage().locationUri().get(), DEFAULT_SCHEME);
+    } else {
+      // try to obtain location
       try {
-        // read it from default table path
-        return prepareDatasetIdentifierFromDefaultTablePath(catalogTable);
+        di = prepareDatasetIdentifierFromDefaultTablePath(catalogTable);
       } catch (IllegalStateException e) {
         // session inactive - no way to find DatasetProvider
         throw new IllegalArgumentException(
             "Unable to extract DatasetIdentifier from a CatalogTable", e);
       }
+    }
+
+    if (metastoreUri.isPresent() && metastoreUri.get() != null) {
+      // dealing with Hive tables
+      DatasetIdentifier symlink = prepareHiveDatasetIdentifier(catalogTable, metastoreUri.get());
+      return di.withSymlink(
+          symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.TABLE);
+    } else {
+      return di.withSymlink(
+          catalogTable.identifier().unquotedString(),
+          StringUtils.substringBeforeLast(di.getName(), File.separator),
+          DatasetIdentifier.SymlinkType.TABLE);
     }
   }
 
@@ -110,8 +120,8 @@ public class PathUtils {
    * good to have it set in case of SPARK-29046
    */
   private static Optional<SparkConf> loadSparkConf() {
-    if (!sparkConf.isPresent() && SparkSession.getActiveSession().isDefined()) {
-      sparkConf = Optional.of(SparkSession.getActiveSession().get().sparkContext().getConf());
+    if (!sparkConf.isPresent() && SparkSession.getDefaultSession().isDefined()) {
+      sparkConf = Optional.of(SparkSession.getDefaultSession().get().sparkContext().getConf());
     }
     return sparkConf;
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -8,7 +8,6 @@ package io.openlineage.spark.agent.util;
 import static io.openlineage.spark.agent.util.PathUtils.enrichHiveMetastoreURIWithTableName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -21,10 +20,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
-import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
-import org.apache.spark.sql.internal.SessionState;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
@@ -36,6 +34,12 @@ class PathUtilsTest {
   private static final String SCHEME = "scheme";
   private static final String FILE = "file";
   private static final String TABLE = "table";
+
+  SparkSession sparkSession = mock(SparkSession.class);
+  SparkContext sparkContext = mock(SparkContext.class);
+  SparkConf sparkConf = new SparkConf();
+  CatalogTable catalogTable = mock(CatalogTable.class);
+  CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
 
   @Test
   void testPathSeparation() {
@@ -109,56 +113,59 @@ class PathUtilsTest {
   }
 
   @Test
-  void testFromCatalogTableWithHiveTables() throws URISyntaxException {
-    SparkSession sparkSession = mock(SparkSession.class);
-    SparkContext sparkContext = mock(SparkContext.class);
-    SparkConf sparkConf = new SparkConf();
+  void testFromCatalogTableWithStorage() throws URISyntaxException {
     sparkConf.set("spark.sql.catalogImplementation", "hive");
     sparkConf.set("spark.sql.hive.metastore.uris", "thrift://10.1.0.1:9083");
     when(sparkContext.getConf()).thenReturn(sparkConf);
     when(sparkSession.sparkContext()).thenReturn(sparkContext);
 
-    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
     when(catalogTable.qualifiedName()).thenReturn(TABLE);
+    when(catalogStorageFormat.locationUri()).thenReturn(Option.apply(new URI("/tmp/warehouse")));
 
     DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, Optional.of(sparkConf));
-    assertThat(di.getName()).isEqualTo(TABLE);
-    assertThat(di.getNamespace()).isEqualTo("hive://10.1.0.1:9083");
+    assertThat(di.getName()).isEqualTo("/tmp/warehouse");
+    assertThat(di.getNamespace()).isEqualTo("file");
+    assertThat(di.getSymlinks().size()).isEqualTo(1);
+    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
+    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://10.1.0.1:9083");
 
     sparkConf.set(
         "spark.sql.hive.metastore.uris", "anotherprotocol://127.0.0.1:1010,yetanother://something");
     di = PathUtils.fromCatalogTable(catalogTable, Optional.of(sparkConf));
-    assertThat(di.getName()).isEqualTo(TABLE);
-    assertThat(di.getNamespace()).isEqualTo("hive://127.0.0.1:1010");
+    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
+    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://127.0.0.1:1010");
 
     sparkConf.remove("spark.sql.hive.metastore.uris");
     sparkConf.set("spark.hadoop.hive.metastore.uris", "thrift://10.1.0.1:9083");
     di = PathUtils.fromCatalogTable(catalogTable, Optional.of(sparkConf));
-    assertThat(di.getName()).isEqualTo(TABLE);
-    assertThat(di.getNamespace()).isEqualTo("hive://10.1.0.1:9083");
+    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
+    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://10.1.0.1:9083");
   }
 
   @Test
-  void testFromCatalogWithNoHiveMetastoreAndHdfsLocation() throws URISyntaxException {
-    CatalogTable catalogTable = mock(CatalogTable.class);
-    CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
-    SparkConf sparkConf = new SparkConf();
-
+  void testFromCatalogWithDefaultStorage() throws URISyntaxException {
     sparkConf.remove("spark.hadoop.hive.metastore.uris");
     when(catalogTable.storage()).thenReturn(catalogStorageFormat);
     when(catalogStorageFormat.locationUri())
         .thenReturn(Option.apply(new URI("hdfs://namenode:8020/warehouse/table")));
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.unquotedString()).thenReturn("db.table");
+
     DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, Optional.of(sparkConf));
     assertThat(di.getName()).isEqualTo("/warehouse/table");
     assertThat(di.getNamespace()).isEqualTo("hdfs://namenode:8020");
+    assertThat(di.getSymlinks().size()).isEqualTo(1);
+    assertThat(di.getSymlinks().get(0).getName()).isEqualTo("db.table");
+    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("/warehouse");
   }
 
   @Test
   void testFromCatalogExceptionIsThrownWhenUnableToExtractDatasetIdentifier() {
-    CatalogTable catalogTable = mock(CatalogTable.class);
     try (MockedStatic mocked = mockStatic(SparkSession.class)) {
       mocked.when(SparkSession::active).thenThrow(new IllegalStateException("some message"));
-      mocked.when(SparkSession::getActiveSession).thenReturn(Option.empty());
+      mocked.when(SparkSession::getDefaultSession).thenReturn(Option.empty());
       assertThrows(IllegalArgumentException.class, () -> PathUtils.fromCatalogTable(catalogTable));
     }
   }
@@ -167,25 +174,5 @@ class PathUtilsTest {
   void testEnrichMetastoreUriWithTableName() throws URISyntaxException {
     assertThat(enrichHiveMetastoreURIWithTableName(new URI("thrift://10.1.0.1:9083"), "/db/table"))
         .isEqualTo(new URI("hive://10.1.0.1:9083/db/table"));
-  }
-
-  @Test
-  void testFromCatalogFromDefaultTablePath() throws URISyntaxException {
-    SparkSession sparkSession = mock(SparkSession.class);
-    SessionState sessionState = mock(SessionState.class);
-    SessionCatalog sessionCatalog = mock(SessionCatalog.class);
-
-    when(sparkSession.sessionState()).thenReturn(sessionState);
-    when(sessionState.catalog()).thenReturn(sessionCatalog);
-    when(sessionCatalog.defaultTablePath(any())).thenReturn(new URI("/warehouse/table"));
-
-    try (MockedStatic mocked = mockStatic(SparkSession.class)) {
-      mocked.when(SparkSession::active).thenReturn(sparkSession);
-      DatasetIdentifier di =
-          PathUtils.fromCatalogTable(mock(CatalogTable.class), Optional.of(new SparkConf()));
-
-      assertThat(di.getName()).isEqualTo("/warehouse/table");
-      assertThat(di.getNamespace()).isEqualTo(FILE);
-    }
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilder.java
@@ -61,8 +61,7 @@ public class AlterTableDatasetBuilder extends AbstractQueryPlanOutputDatasetBuil
             version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
       }
 
-      return Collections.singletonList(
-          outputDataset().getDataset(di.get().getName(), di.get().getNamespace(), builder.build()));
+      return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
     } else {
       return Collections.emptyList();
     }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -121,7 +121,6 @@ public class CreateReplaceDatasetBuilder
 
     CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
         .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
-    return Collections.singletonList(
-        outputDataset().getDataset(di.get().getName(), di.get().getNamespace(), builder.build()));
+    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
@@ -8,11 +8,13 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
@@ -96,6 +98,11 @@ public abstract class AbstractDatabricksHandler implements CatalogHandler {
                                     .orElse(null))))
                     .toString()));
     log.info(path.toString());
-    return PathUtils.fromPath(path, "file");
+    DatasetIdentifier di = PathUtils.fromPath(path, "file");
+    return di.withSymlink(
+        identifier.toString(),
+        StringUtils.substringBeforeLast(
+            di.getName(), File.separator), // parent location from a name becomes a namespace
+        DatasetIdentifier.SymlinkType.TABLE);
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -9,11 +9,13 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.io.File;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -81,7 +83,12 @@ public class DeltaHandler implements CatalogHandler {
                                     .orElse(null))))
                     .toString()));
     log.info(path.toString());
-    return PathUtils.fromPath(path, "file");
+    DatasetIdentifier di = PathUtils.fromPath(path, "file");
+    return di.withSymlink(
+        identifier.toString(),
+        StringUtils.substringBeforeLast(
+            di.getName(), File.separator), // parent location from a name becomes a namespace
+        DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -121,20 +121,18 @@ public class PlanUtils3 {
       Map<String, String> tableProperties = relation.table().properties();
       di = PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
-      if (!di.isPresent()) {
-        return Collections.emptyList();
-      }
-
       CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
           .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
+    }
+
+    if (!di.isPresent()) {
+      return Collections.emptyList();
     }
 
     datasetFacetsBuilder
         .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
         .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
 
-    return Collections.singletonList(
-        datasetFactory.getDataset(
-            di.get().getName(), di.get().getNamespace(), datasetFacetsBuilder.build()));
+    return Collections.singletonList(datasetFactory.getDataset(di.get(), datasetFacetsBuilder));
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -24,12 +26,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.execution.datasources.FileIndex;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.internal.SessionState;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import scala.Option;
+import scala.collection.immutable.HashMap;
 
 class LogicalRelationDatasetBuilderTest {
 
@@ -41,24 +52,27 @@ class LogicalRelationDatasetBuilderTest {
           openLineageContext, DatasetFactory.output(openLineageContext), false);
   OpenLineage.DatasetVersionDatasetFacet facet = mock(OpenLineage.DatasetVersionDatasetFacet.class);
   OpenLineage openLineage = mock(OpenLineage.class);
+  LogicalRelation logicalRelation = mock(LogicalRelation.class);
+  SparkContext sparkContext = mock(SparkContext.class);
+  SessionState sessionState = mock(SessionState.class);
+
+  @BeforeEach
+  void setup() {
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
+    when(facet.getDatasetVersion()).thenReturn(SOME_VERSION);
+    when(session.sessionState()).thenReturn(sessionState);
+  }
 
   @Test
   void testApplyForHadoopFsRelationDatasetVersionFacet() {
     HadoopFsRelation hadoopFsRelation = mock(HadoopFsRelation.class);
-    LogicalRelation logicalRelation = mock(LogicalRelation.class);
     Configuration hadoopConfig = mock(Configuration.class);
-    SparkContext sparkContext = mock(SparkContext.class);
-    SessionState sessionState = mock(SessionState.class);
     FileIndex fileIndex = mock(FileIndex.class);
     Path path = new Path("/tmp/path1");
-
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
-    when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
-    when(openLineageContext.getOpenLineage())
-        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
-    when(facet.getDatasetVersion()).thenReturn(SOME_VERSION);
-    when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
     when(fileIndex.rootPaths())
@@ -79,6 +93,35 @@ class LogicalRelationDatasetBuilderTest {
         assertEquals(1, datasets.size());
         OpenLineage.Dataset ds = datasets.get(0);
         assertEquals("/tmp", ds.getName());
+        assertEquals(SOME_VERSION, ds.getFacets().getVersion().getDatasetVersion());
+      }
+    }
+  }
+
+  @Test
+  void testApplyForCatalogTable() {
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(logicalRelation.catalogTable()).thenReturn(Option.apply(catalogTable));
+    DatasetIdentifier di = new DatasetIdentifier("/tmp", "namespace");
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("key", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+              new StructField("value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    try (MockedStatic pathUtils = mockStatic(PathUtils.class)) {
+      try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
+        when(PathUtils.fromCatalogTable(catalogTable)).thenReturn(di);
+        when(DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(logicalRelation))
+            .thenReturn(Optional.of(SOME_VERSION));
+        when(logicalRelation.schema()).thenReturn(schema);
+
+        List<OpenLineage.Dataset> datasets = visitor.apply(logicalRelation);
+        assertEquals(1, datasets.size());
+        OpenLineage.Dataset ds = datasets.get(0);
+        assertEquals("/tmp", ds.getName());
+        assertEquals(2, ds.getFacets().getSchema().getFields().size());
         assertEquals(SOME_VERSION, ds.getFacets().getVersion().getDatasetVersion());
       }
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -88,8 +88,7 @@ class PlanUtils3Test {
         when(CatalogUtils3.getDatasetIdentifier(
                 openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(di);
-        when(datasetFactory.getDataset(di.getName(), di.getNamespace(), datasetFacets))
-            .thenReturn(dataset);
+        when(datasetFactory.getDataset(di, datasetFacetsBuilder)).thenReturn(dataset);
 
         assertEquals(
             Collections.singletonList(dataset),

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -99,7 +99,6 @@ public class AlterTableCommandDatasetBuilder
       datasetVersion.ifPresent(
           version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
     }
-    return Collections.singletonList(
-        outputDataset().getDataset(di.get().getName(), di.get().getNamespace(), builder.build()));
+    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 }

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -164,7 +164,6 @@ public class CreateReplaceDatasetBuilder
 
     CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
         .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
-    return Collections.singletonList(
-        outputDataset().getDataset(di.get().getName(), di.get().getNamespace(), builder.build()));
+    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 }


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Sometimes dataset is identified by its physical location, in some cases by its logical name like database and table name. The same dataset can get different dataset identifiers. 

Closes: #435

### Solution

`SymlinkDatasetFacet` has been recently introduced to spec. Within this PR we include the facet in generated OpenLineage events. Most of the modified files are the updated integration tests, where existence of extra identified in symlink is verified. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [x] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)