### PR TITLE
remove module metadata file from published artifacts

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -130,6 +130,10 @@ jacocoTestReport {
     }
 }
 
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {


### PR DESCRIPTION
Signed-off-by: tomasznazarewicz <t.nazarewicz94@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

gradle module metadata file has our submodules as dependencies which causes problems when spark integration is used as dependency. 

Closes: #934

### Solution

For now we should be ok relying only on pom file so .module can be removed from published artifacts