### PR TITLE
Spark: add Kusto relation visitor

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -1,0 +1,171 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.sources.BaseRelation;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scala.Option;
+import scala.collection.Seq$;
+
+/**
+ * This unit test tests the apply method of KustoRelationVisitor. Therefore it only tests Kusto read
+ * operations. It does not cover Kusto writes, as those are routed to the visitor from the
+ * SaveIntoDataSourceCommandVisitor
+ */
+@Slf4j
+class kustoCoordinates {
+  @SuppressWarnings("PMD") // used by reflection
+  private String clusterUrl; // field read from kustoCoordinates by reflection in getNamespace
+
+  @SuppressWarnings("PMD") // used by reflection
+  private String database; // field read from kustoCoordinates in by reflection in getNamespace
+
+  @SuppressWarnings("PMD") // used by reflection
+  private String getClusterUrl() {
+    return clusterUrl;
+  }
+
+  @SuppressWarnings("PMD") // used by reflection
+  private String getDatabase() {
+    return database;
+  }
+
+  public kustoCoordinates(String clusterUrl, String database) {
+    this.clusterUrl = clusterUrl;
+    this.database = database;
+  }
+}
+
+class MockKustoRelation extends BaseRelation {
+
+  @SuppressWarnings("PMD") // used by reflection
+  private final String query; // field read from relation by reflection in getName
+
+  @SuppressWarnings("PMD")
+  private final Object kustoCoordinates; // field read from relation by reflection in getNamespace
+
+  @Override
+  public SQLContext sqlContext() {
+    return null;
+  }
+
+  @Override
+  public StructType schema() {
+    return new StructType(
+        new StructField[] {new StructField("name", StringType$.MODULE$, false, null)});
+  }
+
+  public MockKustoRelation(String query, String clusterUrl, String database) {
+    this.query = query;
+    this.kustoCoordinates = new kustoCoordinates(clusterUrl, database);
+  }
+}
+
+class TestKustoRelationVisitor extends KustoRelationVisitor {
+  public TestKustoRelationVisitor(OpenLineageContext context, DatasetFactory factory) {
+    super(context, factory);
+  }
+
+  @Override
+  protected boolean isKustoClass(LogicalPlan plan) {
+    return true;
+  }
+}
+
+class KustoRelationVisitorTest {
+  private static final String FIELD_NAME = "name";
+  SparkSession session = mock(SparkSession.class);
+  OpenLineageContext context = mock(OpenLineageContext.class);
+
+  @BeforeEach
+  public void setUp() {
+    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInputsForTestKustoRelation")
+  void testKustoRelationMain(
+      String inputQuery,
+      String url,
+      String database,
+      String expectedName,
+      String expectedNamespace,
+      int expectedNumOfDatasets) {
+
+    // Instantiate a MockKustoRelation
+    LogicalRelation lr =
+        new LogicalRelation(
+            new MockKustoRelation(inputQuery, url, database),
+            Seq$.MODULE$
+                .<AttributeReference>newBuilder()
+                .$plus$eq(
+                    new AttributeReference(
+                        FIELD_NAME,
+                        StringType$.MODULE$,
+                        false,
+                        null,
+                        ExprId.apply(1L),
+                        Seq$.MODULE$.<String>empty()))
+                .result(),
+            Option.empty(),
+            false);
+
+    TestKustoRelationVisitor visitor =
+        new TestKustoRelationVisitor(
+            SparkAgentTestExtension.newContext(session), DatasetFactory.output(context));
+
+    List<OpenLineage.Dataset> datasets = visitor.apply(lr);
+
+    assertEquals(expectedNumOfDatasets, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals(expectedNamespace, ds.getNamespace());
+    assertEquals(expectedName, ds.getName());
+  }
+
+  private static Stream<Arguments> provideInputsForTestKustoRelation() {
+    return Stream.of(
+        Arguments.of(
+            "table01",
+            "https://CLUSTERNAME.REGION.kusto.windows.net",
+            "DATABASE",
+            "table01",
+            "azurekusto://CLUSTERNAME.REGION.kusto.windows.net/DATABASE",
+            1),
+        Arguments.of(
+            "table01 | where MinTemp > 19",
+            "https://CLUSTERNAME.REGION.kusto.windows.net",
+            "DATABASE",
+            "COMPLEX",
+            "azurekusto://CLUSTERNAME.REGION.kusto.windows.net/DATABASE",
+            1));
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -41,7 +41,7 @@ import scala.collection.Seq$;
  * SaveIntoDataSourceCommandVisitor
  */
 @Slf4j
-class kustoCoordinates {
+class KustoCoordinates {
   @SuppressWarnings("PMD") // used by reflection
   private String clusterUrl; // field read from kustoCoordinates by reflection in getNamespace
 
@@ -58,7 +58,7 @@ class kustoCoordinates {
     return database;
   }
 
-  public kustoCoordinates(String clusterUrl, String database) {
+  public KustoCoordinates(String clusterUrl, String database) {
     this.clusterUrl = clusterUrl;
     this.database = database;
   }
@@ -85,7 +85,7 @@ class MockKustoRelation extends BaseRelation {
 
   public MockKustoRelation(String query, String clusterUrl, String database) {
     this.query = query;
-    this.kustoCoordinates = new kustoCoordinates(clusterUrl, database);
+    this.kustoCoordinates = new KustoCoordinates(clusterUrl, database);
   }
 }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -25,6 +25,7 @@ import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHadoopFsRelationVisit
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveDirVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHiveTableVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.KafkaRelationVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.KustoRelationVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LoadDataCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelectCommandVisitor;
@@ -55,6 +56,9 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     }
     if (InsertIntoHiveTableVisitor.hasHiveClasses()) {
       list.add(new HiveTableRelationVisitor<>(context, factory));
+    }
+    if (KustoRelationVisitor.hasKustoClasses()) {
+      list.add(new KustoRelationVisitor(context, factory));
     }
     return list;
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -1,0 +1,181 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.spark.api.java.Optional;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.sources.BaseRelation;
+import org.apache.spark.sql.sources.CreatableRelationProvider;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * {@link LogicalPlan} visitor that matches the KustoRelation that comes from the Azure Kusto (Azure
+ * Data Factory). The KustoRelation is used to extract the table name and database name to populate
+ * the {@link OpenLineage.Dataset} during Kusto read operations.
+ */
+@Slf4j
+public class KustoRelationVisitor<D extends OpenLineage.Dataset>
+    extends QueryPlanVisitor<LogicalRelation, D> {
+
+  private final DatasetFactory<D> factory;
+  private static final String KUSTO_CLASS_NAME =
+      "com.microsoft.kusto.spark.datasource.KustoRelation";
+
+  private static final String KUSTO_PROVIDER_CLASS_NAME =
+      "com.microsoft.kusto.spark.datasource.DefaultSource";
+
+  private static final String KUSTO_URL_SUFFIX = ".kusto.windows.net";
+
+  private static final String KUSTO_PREFIX = "azurekusto://";
+
+  public KustoRelationVisitor(OpenLineageContext context, DatasetFactory<D> factory) {
+    super(context);
+    this.factory = factory;
+  }
+
+  protected boolean isKustoClass(LogicalPlan plan) {
+    try {
+      Class c = Thread.currentThread().getContextClassLoader().loadClass(KUSTO_CLASS_NAME);
+      return (plan instanceof LogicalRelation
+          && c.isAssignableFrom(((LogicalRelation) plan).relation().getClass()));
+    } catch (Exception e) {
+      // swallow - not a kusto class
+    }
+    return false;
+  }
+
+  public static boolean isKustoSource(CreatableRelationProvider provider) {
+    try {
+      Class c = Thread.currentThread().getContextClassLoader().loadClass(KUSTO_PROVIDER_CLASS_NAME);
+      return c.isAssignableFrom(provider.getClass());
+    } catch (Exception e) {
+      // swallow - not a kusto source
+    }
+    return false;
+  }
+
+  public static boolean hasKustoClasses() {
+    /**
+     * Checking the Kusto class with both KustoRelationVisitor.class.getClassLoader.loadClass and
+     * Thread.currentThread().getContextClassLoader().loadClass. The first checks if the class is
+     * present on the classpath, and the second one is a catchall which captures if the class has
+     * been installed. This is relevant for Azure Databricks where jars can be installed and
+     * accessible to the user, even if they are not present on the classpath.
+     */
+    try {
+      KustoRelationVisitor.class.getClassLoader().loadClass(KUSTO_PROVIDER_CLASS_NAME);
+      return true;
+    } catch (Exception e) {
+      // swallow - we don't care
+    }
+    try {
+      Thread.currentThread().getContextClassLoader().loadClass(KUSTO_PROVIDER_CLASS_NAME);
+      return true;
+    } catch (Exception e) {
+      // swallow - we don't care
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan plan) {
+    return isKustoClass(plan);
+  }
+
+  private static Optional<String> getName(BaseRelation relation) {
+    String tableName = "";
+    try {
+      Object query = FieldUtils.readField(relation, "query", true);
+      tableName = (String) query;
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      log.warn("Unable to discover Kusto table property");
+      return Optional.empty();
+    }
+
+    if ("".equals(tableName)) {
+      log.warn("Unable to discover Kusto table property");
+      return Optional.empty();
+    }
+    // Check if the query is complex
+    if (StringUtils.countMatches(tableName, "|") > 0) {
+      tableName = "COMPLEX";
+    }
+
+    return Optional.of(tableName);
+  } // end of getName
+
+  private static Optional<String> getNamespace(BaseRelation relation) {
+    String url;
+    String databaseName;
+    String kustoUrl;
+    try {
+      Object kustoCoords = FieldUtils.readField(relation, "kustoCoordinates", true);
+      Object clusterUrl = FieldUtils.readField(kustoCoords, "clusterUrl", true);
+      Object database = FieldUtils.readField(kustoCoords, "database", true);
+
+      kustoUrl = (String) clusterUrl;
+      kustoUrl = kustoUrl.replace("https://", "");
+      databaseName = (String) database;
+      url = String.format("%s%s/%s", KUSTO_PREFIX, kustoUrl, databaseName);
+    } catch (IllegalAccessException | IllegalArgumentException e) {
+      log.warn("Unable to discover clusterUrl or database property");
+      return Optional.empty();
+    }
+    if ("".equals(url)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(url);
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> createKustoDatasets(
+      DatasetFactory<D> datasetFactory,
+      scala.collection.immutable.Map<String, String> options,
+      StructType schema) {
+    // Called from SaveIntoDataSourceCommandVisitor on Kusto write operations.
+    List<D> output;
+
+    Map<String, String> javaOptions =
+        io.openlineage.spark.agent.util.ScalaConversionUtils.fromMap(options);
+
+    String name = javaOptions.get("kustotable");
+    String database = javaOptions.get("kustodatabase");
+    String kustoCluster = javaOptions.get("kustocluster");
+
+    String namespace =
+        String.format("%s%s%s/%s", KUSTO_PREFIX, kustoCluster, KUSTO_URL_SUFFIX, database);
+    output = Collections.singletonList(datasetFactory.getDataset(name, namespace, schema));
+    return output;
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan x) {
+    BaseRelation relation = ((LogicalRelation) x).relation();
+    List<D> output;
+    Optional<String> name = getName(relation);
+    Optional<String> namespace = getNamespace(relation);
+    if (name.isPresent() && namespace.isPresent()) {
+      output =
+          Collections.singletonList(
+              factory.getDataset(name.get(), namespace.get(), relation.schema()));
+    } else {
+      output = Collections.emptyList();
+    }
+    return output;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -106,7 +106,7 @@ public class KustoRelationVisitor<D extends OpenLineage.Dataset>
       log.warn("Unable to discover Kusto table property");
       return Optional.empty();
     }
-    
+
     if (StringUtils.isBlank(tableName)) {
       log.warn("Unable to discover Kusto table property");
       return Optional.empty();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -106,8 +106,8 @@ public class KustoRelationVisitor<D extends OpenLineage.Dataset>
       log.warn("Unable to discover Kusto table property");
       return Optional.empty();
     }
-
-    if ("".equals(tableName)) {
+    
+    if (StringUtils.isBlank(tableName)) {
       log.warn("Unable to discover Kusto table property");
       return Optional.empty();
     }
@@ -117,7 +117,7 @@ public class KustoRelationVisitor<D extends OpenLineage.Dataset>
     }
 
     return Optional.of(tableName);
-  } // end of getName
+  }
 
   private static Optional<String> getNamespace(BaseRelation relation) {
     String url;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -97,8 +97,8 @@ public class SaveIntoDataSourceCommandVisitor
           command.schema());
     }
 
-    // Similar to Kafka, Azure Kusto also has some special handling, so we use the below method
-    // for extracting the dataset from Kusto write operations.
+    // Similar to Kafka, Azure Kusto also has some special handling. So we use the method
+    // below for extracting the dataset from Kusto write operations.
     if (KustoRelationVisitor.isKustoSource(command.dataSource())) {
       return KustoRelationVisitor.createKustoDatasets(
           outputDataset(), command.options(), command.schema());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -97,6 +97,13 @@ public class SaveIntoDataSourceCommandVisitor
           command.schema());
     }
 
+    // Similar to Kafka, Azure Kusto also has some special handling, so we use the below method
+    // for extracting the dataset from Kusto write operations.
+    if (KustoRelationVisitor.isKustoSource(command.dataSource())) {
+      return KustoRelationVisitor.createKustoDatasets(
+          outputDataset(), command.options(), command.schema());
+    }
+
     StructType schema = getSchema(command);
     LifecycleStateChange lifecycleStateChange =
         (SaveMode.Overwrite == command.mode()) ? OVERWRITE : CREATE;

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -148,6 +148,21 @@ Identifier:
    * Authority = {host}
  * Unique name: /colls/{table}
    * URI = azurecosmos://{host}.documents.azure.com/dbs/{database}/colls/{table}
+#### Azure Data Explorer:
+Datasource hierarchy:
+ * Host: \<clustername>.\<clusterlocation> 
+ * Database
+ * Table
+ 
+Naming hierarchy:
+ * Database
+ * Table
+
+Identifier:
+ * Namespace: azurekusto://{host}.kusto.windows.net/{database}
+   * Scheme = azurekusto
+ * Unique name: {database}/{table}
+   * URI = azurekusto://{host}.kusto.windows.net/{database}/{table}
 
 ### Distributed file systems/blob stores
 #### GCS


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Openlineage does not support Azure Kusto (aka Azure Data Explorer) as an input or output.

### Solution

Implemented the KustoRelationVisitor to support lineage for [Azure Kusto's spark connector](https://github.com/Azure/azure-kusto-spark). In the process of implementing the class, we found the following: 

1. There are two paths in OpenLineage to the KustoRelationVisitor:
    * Write events reach the SaveIntoDataSourceCommandVisitor, so we included a condition to route to the KustoRelationVisitor's `createKustoDatasets` function. 
    * Read events trigger KustoRelationVisitor's `getNameSpace` function via the list of visitors instantiated in BaseVisitorFactory. 
2. When developing the `hasKustoClasses` method, we discovered that the function used by the other relation visitors to load the class - [`class.getClassLoader()`](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getClassLoader--) did not work as expected in all scenarios. It gives the expected result if the connector jar and its dependencies are added to the classpath, but this does not automatically happen when a library is installed on Spark, and requires an additional step from the user. For example, a user can install the Kusto Spark connector, and successfully interact with their Kusto data source, but would not see any lineage unless they had updated the classpath or copied the jars to a location already on the classpath. This behaviour is not specific to the Kusto connector - we also observed it with other connectors e.g. Apache Iceberg. We addressed this issue in `hasKustoClasses` by using [`Thread.currentThread().getContextClassLoader`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#getContextClassLoader--) in addition to [`class.getClassLoader()`](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getClassLoader--). The former allows us to load all installed classes, regardless of whether or not they are on the classpath. [Apache Spark](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/util/Utils.scala#L208-L237) also uses the same approach.


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)