### PR TITLE
fix noclassdef error

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -434,21 +434,14 @@ class OpenLineageRunEventBuilder {
     return datasets;
   }
 
-  private <T> Stream<T> buildDatasets(
+  private <T extends OpenLineage.Dataset> Stream<T> buildDatasets(
       List<Object> nodes, Collection<PartialFunction<Object, List<T>>> builders) {
     return nodes.stream()
         .flatMap(
             event ->
                 builders.stream()
-                    .filter(
-                        pfn -> {
-                          try {
-                            return pfn.isDefinedAt(event);
-                          } catch (ClassCastException e) {
-                            return false;
-                          }
-                        })
-                    .map(pfn -> pfn.apply(event))
+                    .filter(pfn -> PlanUtils.safeIsDefinedAt(pfn, event))
+                    .map(pfn -> PlanUtils.safeApply(pfn, event))
                     .flatMap(Collection::stream));
   }
 


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Databricks platform provides different Spark classes than expected within Spark version which causes whole SparkContext to fail. This PR prevents Spark context from failing but still does not fix the issue. 

Part of: #941

### Solution

Include catching `NoClassDefFoundError` and `NoSuchMethodError` whenever `isDefinedAt` or `apply` methods are called. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)