### PR TITLE
flink: add failed job event

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -386,6 +386,7 @@ jobs:
             - v1-integration-flink-{{ .Branch }}-{{ .Revision }}
             - v1-integration-flink-{{ .Branch }}
       - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
+      - run: mkdir -p /tmp/warehouse/db/sink/data && cp -R data/iceberg/db /tmp/warehouse && chmod -R 777 /tmp/warehouse
       - run: ./gradlew examples:stateful:build
       - run: ./gradlew --no-daemon integrationTest --i
       - run:

--- a/client/java/README.md
+++ b/client/java/README.md
@@ -166,7 +166,7 @@ OpenLineageClient client = OpenLineageClient.builder()
 If contributing changes, additions or fixes to the Java client, please include the following header in any new `.java` files:
 
 ```
-/* 
+/*
 /* Copyright 2018-2002 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0 
 */

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'groovy'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group 'io.openlineage.flink'
-version '1.0-SNAPSHOT'
 
 repositories {
     mavenLocal()
@@ -53,6 +52,7 @@ dependencies {
 
     def flinkVersion = '1.14.4'
     def hadoopVersion = '3.3.1'
+    implementation("io.openlineage:openlineage-java:$project.version")
     implementation "org.apache.flink:flink-java:$flinkVersion"
     implementation "org.apache.flink:flink-streaming-java_2.12:$flinkVersion"
     implementation "org.apache.flink:flink-runtime-web_2.12:$flinkVersion"

--- a/integration/flink/examples/stateful/gradle.properties
+++ b/integration/flink/examples/stateful/gradle.properties
@@ -1,0 +1,1 @@
+version=0.12.0-SNAPSHOT

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/common/config/ConfigWrapper.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/common/config/ConfigWrapper.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.common.config;
 
 import com.typesafe.config.Config;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
@@ -1,0 +1,55 @@
+package io.openlineage.flink;
+
+import io.openlineage.flink.api.DatasetFactory;
+import io.openlineage.flink.api.LineageProvider;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import io.openlineage.client.OpenLineage;
+
+import java.util.List;
+
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
+
+public class FlinkCrashingLineageProviderApplication {
+
+  public static void main(String[] args) throws Exception {
+    StreamExecutionEnvironment env = setupEnv(args);
+    env.addSource(new FakeSource()).addSink(new FakeSink());
+
+    // we use this app to test open lineage flink integration so it cannot make use of OpenLineageFlinkJobListener classes
+    JobListener openlineageJobListener = (JobListener) Class.forName("io.openlineage.flink.OpenLineageFlinkJobListener")
+      .getConstructor(StreamExecutionEnvironment.class)
+      .newInstance(env);
+
+    env.registerJobListener(openlineageJobListener);
+    env.execute("flink-fake-application");
+  }
+
+  static class FakeSource implements SourceFunction<Integer> {
+    boolean isRunning = true;
+
+    @Override
+    public void run(SourceContext<Integer> ctx) throws Exception {
+      while(isRunning) {
+        synchronized (ctx.getCheckpointLock()) {
+          ctx.collect(1);
+        }
+        Thread.sleep(100);
+      }
+    }
+
+    @Override
+    public void cancel() {
+      isRunning = true;
+    }
+  }
+
+  static class FakeSink implements SinkFunction<Integer>, LineageProvider<OpenLineage.OutputDataset> {
+    @Override
+    public List<OpenLineage.OutputDataset> getDatasets(DatasetFactory<OpenLineage.OutputDataset> datasetFactory) {
+      throw new RuntimeException("fail");
+    }
+  }
+}

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import io.openlineage.flink.api.DatasetFactory;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import org.apache.flink.api.common.functions.MapFunction;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
@@ -12,20 +12,13 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.flink.source.FlinkSource;
 
-import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
+
 
 public class FlinkFailedApplication {
 
   public static void main(String[] args) throws Exception {
-    ParameterTool parameters = ParameterTool.fromArgs(args);
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
-    env.getConfig().setGlobalJobParameters(parameters);
-    env.setParallelism(parameters.getInt("parallelism", 1));
-    env.enableCheckpointing(parameters.getInt("checkpoint.interval", 1_000), CheckpointingMode.EXACTLY_ONCE);
-    env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
-    env.getCheckpointConfig().setMinPauseBetweenCheckpoints(parameters.getInt("min.pause.between.checkpoints", 1_000));
-    env.getCheckpointConfig().setCheckpointTimeout(parameters.getInt("checkpoint.timeout", 90_000));
+    StreamExecutionEnvironment env = setupEnv(args);
 
     env.setRestartStrategy(RestartStrategies.noRestart());
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
@@ -1,0 +1,48 @@
+package io.openlineage.flink;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
+
+public class FlinkFakeApplication {
+
+  public static void main(String[] args) throws Exception {
+    StreamExecutionEnvironment env = setupEnv(args);
+
+    env.addSource(new FakeSource()).addSink(new FakeSink());
+
+    // we use this app to test open lineage flink integration so it cannot make use of OpenLineageFlinkJobListener classes
+    JobListener openlineageJobListener = (JobListener) Class.forName("io.openlineage.flink.OpenLineageFlinkJobListener")
+      .getConstructor(StreamExecutionEnvironment.class)
+      .newInstance(env);
+
+    env.registerJobListener(openlineageJobListener);
+    env.execute("flink-fake-application");
+  }
+
+  static class FakeSource implements SourceFunction<Integer> {
+    boolean isRunning = true;
+
+    @Override
+    public void run(SourceContext<Integer> ctx) throws Exception {
+      while(isRunning) {
+        synchronized (ctx.getCheckpointLock()) {
+          ctx.collect(1);
+        }
+        Thread.sleep(100);
+      }
+    }
+
+    @Override
+    public void cancel() {
+      isRunning = true;
+    }
+  }
+
+  static class FakeSink implements SinkFunction<Integer> {}
+}

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import org.apache.flink.api.java.utils.ParameterTool;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import org.apache.flink.api.java.utils.ParameterTool;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
@@ -11,20 +11,13 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.flink.source.FlinkSource;
 
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
 import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
 
 public class FlinkIcebergApplication {
 
   public static void main(String[] args) throws Exception {
-    ParameterTool parameters = ParameterTool.fromArgs(args);
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
-    env.getConfig().setGlobalJobParameters(parameters);
-    env.setParallelism(parameters.getInt("parallelism", 1));
-    env.enableCheckpointing(parameters.getInt("checkpoint.interval", 1_000), CheckpointingMode.EXACTLY_ONCE);
-    env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
-    env.getCheckpointConfig().setMinPauseBetweenCheckpoints(parameters.getInt("min.pause.between.checkpoints", 1_000));
-    env.getCheckpointConfig().setCheckpointTimeout(parameters.getInt("checkpoint.timeout", 90_000));
+    StreamExecutionEnvironment env = setupEnv(args);
 
     TableLoader sourceLoader = TableLoader.fromHadoopTable("/tmp/warehouse/db/source");
     TableLoader sinkLoader = TableLoader.fromHadoopTable("/tmp/warehouse/db/sink");

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import io.openlineage.flink.avro.event.InputEvent;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
@@ -7,6 +7,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
 import static io.openlineage.kafka.KafkaClientProvider.legacyKafkaSink;
 import static io.openlineage.kafka.KafkaClientProvider.legacyKafkaSource;
 import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
@@ -17,14 +18,7 @@ public class FlinkLegacyKafkaApplication {
 
   public static void main(String[] args) throws Exception {
     ParameterTool parameters = ParameterTool.fromArgs(args);
-    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-
-    env.getConfig().setGlobalJobParameters(parameters);
-    env.setParallelism(parameters.getInt("parallelism", 1));
-    env.enableCheckpointing(parameters.getInt("checkpoint.interval", 1_000), CheckpointingMode.EXACTLY_ONCE);
-    env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
-    env.getCheckpointConfig().setMinPauseBetweenCheckpoints(parameters.getInt("min.pause.between.checkpoints", 1_000));
-    env.getCheckpointConfig().setCheckpointTimeout(parameters.getInt("checkpoint.timeout", 90_000));
+    StreamExecutionEnvironment env = setupEnv(args);
 
     SourceFunction<InputEvent> source = legacyKafkaSource(parameters.getRequired("input-topics").split(TOPIC_PARAM_SEPARATOR));
     env.addSource(source, "kafka-source")

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStatefulApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStatefulApplication.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import io.openlineage.flink.avro.event.InputEvent;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulCounter.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulCounter.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import io.openlineage.flink.avro.event.InputEvent;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
@@ -1,0 +1,25 @@
+package io.openlineage.flink;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import static org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
+
+public class StreamEnvironment {
+  public static StreamExecutionEnvironment setupEnv(String[] args) {
+    ParameterTool parameters = ParameterTool.fromArgs(args);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    env.getConfig().setGlobalJobParameters(parameters);
+    env.setParallelism(parameters.getInt("parallelism", 1));
+    env.enableCheckpointing(parameters.getInt("checkpoint.interval", 1_000), CheckpointingMode.EXACTLY_ONCE);
+    env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
+    env.getCheckpointConfig().setMinPauseBetweenCheckpoints(parameters.getInt("min.pause.between.checkpoints", 1_000));
+    env.getCheckpointConfig().setCheckpointTimeout(parameters.getInt("checkpoint.timeout", 90_000));
+
+    env.setRestartStrategy(RestartStrategies.noRestart());
+    return env;
+  }
+}

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka;
 
 import io.openlineage.flink.avro.event.InputEvent;

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/util/StateUtils.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/util/StateUtils.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.util;
 
 import org.apache.flink.api.common.state.ValueState;

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink
 
 class FlinkStatefulApplicationRunner {

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/Kafka.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/Kafka.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka
 
 class Kafka {

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/KafkaUtils.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/KafkaUtils.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka
 
 import com.google.common.primitives.Shorts

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SchemaUtils.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SchemaUtils.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SimpleKafkaConsumer.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SimpleKafkaConsumer.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializer

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SimpleKafkaProducer.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/SimpleKafkaProducer.groovy
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.kafka
 
 

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/sandbox/Sandbox.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/kafka/sandbox/Sandbox.groovy
@@ -1,4 +1,9 @@
-package io.openlineage.sandbox
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.kafka.sandbox
 
 import io.openlineage.flink.avro.event.InputEvent
 import io.openlineage.flink.avro.event.OutputEvent

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import io.openlineage.flink.agent.ArgumentParser;

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -56,6 +56,14 @@ public class OpenLineageFlinkJobListener implements JobListener {
       return;
     }
 
+    try {
+      start(jobClient);
+    } catch (Exception | NoClassDefFoundError | NoSuchFieldError e) {
+      log.error("Failed to notify OpenLineage about start", e);
+    }
+  }
+
+  void start(JobClient jobClient) {
     Field transformationsField =
         FieldUtils.getField(StreamExecutionEnvironment.class, "transformations", true);
     try {
@@ -83,6 +91,14 @@ public class OpenLineageFlinkJobListener implements JobListener {
   @Override
   public void onJobExecuted(
       @Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
+    try {
+      finish(jobExecutionResult, throwable);
+    } catch (Exception | NoClassDefFoundError | NoSuchFieldError e) {
+      log.error("Failed to notify OpenLineage about complete", e);
+    }
+  }
+
+  void finish(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
     if (jobExecutionResult instanceof DetachedJobExecutionResult) {
       jobContexts.remove(jobExecutionResult.getJobID());
       log.warn(

--- a/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import java.util.List;

--- a/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import java.util.ArrayList;

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/ArgumentParser.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/ArgumentParser.java
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.flink.agent;
 

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.agent.client;
 
 import io.openlineage.client.Clients;

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/client/EventEmitter.java
@@ -3,11 +3,14 @@ package io.openlineage.flink.agent.client;
 import io.openlineage.client.Clients;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.OpenLineageClientException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class EventEmitter {
 
   private final OpenLineageClient client;
@@ -25,7 +28,11 @@ public class EventEmitter {
   }
 
   public void emit(OpenLineage.RunEvent event) {
-    client.emit(event);
+    try {
+      client.emit(event);
+    } catch (OpenLineageClientException exception) {
+      log.error("Failed to emit OpenLineage event: ", exception);
+    }
   }
 
   private static URI getUri() {

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/facets/CheckpointFacet.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/facets/CheckpointFacet.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.agent.facets;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/ExecutionContext.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.agent.lifecycle;
 
 import io.openlineage.flink.agent.facets.CheckpointFacet;

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContext.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.agent.lifecycle;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/agent/lifecycle/FlinkExecutionContextFactory.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.agent.lifecycle;
 
 import java.util.List;

--- a/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/api/DatasetIdentifier.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/DatasetIdentifier.java
@@ -1,5 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 package io.openlineage.flink.api;
 
 import lombok.Value;

--- a/integration/flink/src/main/java/io/openlineage/flink/api/LineageProvider.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/LineageProvider.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.tracker;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerFactory.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.tracker;
 
 import java.time.Duration;

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/Checkpoints.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/Checkpoints.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.tracker.restapi;
 
 import lombok.Getter;

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/CheckpointsCounts.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/CheckpointsCounts.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.tracker.restapi;
 
 import lombok.Getter;

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.utils;
 
 import static org.apache.avro.Schema.Type.NULL;

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/FlinkOpenLineageConfigs.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/FlinkOpenLineageConfigs.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.utils;
 
 public enum FlinkOpenLineageConfigs {

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/PathUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/PathUtils.java
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.flink.utils;
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/LineageProviderVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/LineageProviderVisitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
@@ -1,0 +1,141 @@
+package io.openlineage.flink;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockserver.model.HttpRequest.request;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("integration-test")
+@Testcontainers
+@Slf4j
+public class ContainerFailureTest {
+
+  private static final String FAKE_APPLICATION = "io.openlineage.flink.FlinkFakeApplication";
+  private static final String MOCKSERVER_PARTITION_CONFIG = "/opt/flink/lib/openlineage.yml";
+  private static final String NETWORK_PARTITION_CONFIG =
+      "/opt/flink/lib/openlineage-network-partition.yml";
+
+  protected static final Network network = Network.newNetwork();
+  protected static MockServerClient mockServerClient;
+
+  @Container
+  protected static final MockServerContainer openLineageClientMockContainer =
+      FlinkContainerUtils.makeMockServerContainer(network);
+
+  protected static GenericContainer jobManager;
+
+  protected static GenericContainer taskManager;
+
+  void runUntilCheckpoint(String jobName, String configPath) {
+    jobManager =
+        FlinkContainerUtils.makeFlinkJobManagerContainer(
+            jobName, configPath, network, Collections.emptyList());
+    taskManager =
+        FlinkContainerUtils.makeFlinkTaskManagerContainer(
+            network, Collections.singletonList(jobManager));
+    taskManager.start();
+    await()
+        .atMost(Duration.ofMinutes(5))
+        .until(() -> jobManager.getLogs().contains("New checkpoint encountered"));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testEmitFailedNetworkPartitionDoesNotKillFlinkJob() {
+    jobManager =
+        FlinkContainerUtils.makeFlinkJobManagerContainer(
+            FAKE_APPLICATION, NETWORK_PARTITION_CONFIG, network, Collections.emptyList());
+    taskManager =
+        FlinkContainerUtils.makeFlinkTaskManagerContainer(
+            network, Collections.singletonList(jobManager));
+    taskManager.start();
+    await()
+        .atMost(Duration.ofMinutes(5))
+        .until(() -> jobManager.getLogs().contains("New checkpoint encountered"));
+
+    runUntilCheckpoint("io.openlineage.flink.FlinkFakeApplication", NETWORK_PARTITION_CONFIG);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testCrashingLineageProviderDoesNotKillFlinkJob() {
+    jobManager =
+        FlinkContainerUtils.makeFlinkJobManagerContainer(
+            FAKE_APPLICATION, NETWORK_PARTITION_CONFIG, network, Collections.emptyList());
+    taskManager =
+        FlinkContainerUtils.makeFlinkTaskManagerContainer(
+            network, Collections.singletonList(jobManager));
+    taskManager.start();
+    await()
+        .atMost(Duration.ofMinutes(5))
+        .until(() -> jobManager.getLogs().contains("New checkpoint encountered"));
+
+    runUntilCheckpoint("io.openlineage.flink.FlinkFakeApplication", NETWORK_PARTITION_CONFIG);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testEmitFailed500DoesNotKillFlinkJob() {
+    mockServerClient =
+        new MockServerClient(
+            openLineageClientMockContainer.getHost(),
+            openLineageClientMockContainer.getServerPort());
+    mockServerClient
+        .when(request("/api/v1/lineage"))
+        .respond(org.mockserver.model.HttpResponse.response().withStatusCode(500));
+
+    await().until(openLineageClientMockContainer::isRunning);
+
+    jobManager =
+        FlinkContainerUtils.makeFlinkJobManagerContainer(
+            FAKE_APPLICATION, NETWORK_PARTITION_CONFIG, network, Collections.emptyList());
+    taskManager =
+        FlinkContainerUtils.makeFlinkTaskManagerContainer(
+            network, Collections.singletonList(jobManager));
+    taskManager.start();
+    await()
+        .atMost(Duration.ofMinutes(5))
+        .until(() -> jobManager.getLogs().contains("New checkpoint encountered"));
+
+    runUntilCheckpoint("io.openlineage.flink.FlinkFakeApplication", NETWORK_PARTITION_CONFIG);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    if (mockServerClient != null) {
+      mockServerClient.reset();
+    }
+    try {
+      if (taskManager != null) taskManager.stop();
+    } catch (Exception e2) {
+      log.error("Unable to shut down taskmanager container", e2);
+    }
+    try {
+      if (jobManager != null) jobManager.stop();
+    } catch (Exception e2) {
+      log.error("Unable to shut down jobmanager container", e2);
+    }
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    FlinkContainerUtils.stopAll(
+        Arrays.asList(openLineageClientMockContainer, jobManager, taskManager));
+
+    network.close();
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import static org.awaitility.Awaitility.await;

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import static java.nio.file.Files.readAllBytes;

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -29,7 +29,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Tag("integration-test")
 @Testcontainers
 @Slf4j
-public class OpenLineageFlinkContainerTest {
+public class ContainerTest {
 
   private static final Network network = Network.newNetwork();
   private static MockServerClient mockServerClient;

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import com.google.common.io.Resources;

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -9,6 +9,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import lombok.SneakyThrows;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
@@ -94,16 +95,16 @@ public class FlinkContainerUtils {
   }
 
   static GenericContainer<?> makeFlinkJobManagerContainer(
-      String jobName, Network network, List<Startable> startables) {
+      String jobName, String configPath, Network network, List<Startable> startables) {
     GenericContainer<?> container =
         genericContainer(network, FLINK_IMAGE, "jobmanager")
             .withExposedPorts(8081)
             .withFileSystemBind(getOpenLineageJarPath(), "/opt/flink/lib/openlineage.jar")
             .withFileSystemBind(getExampleAppJarPath(), "/opt/flink/lib/example-app.jar")
+            .withFileSystemBind("/tmp/warehouse", "/tmp/warehouse/", BindMode.READ_WRITE)
             .withCopyFileToContainer(
                 MountableFile.forHostPath(Resources.getResource("openlineage.yml").getPath()),
-                "/opt/flink/lib/openlineage.yml")
-            .withFileSystemBind("data/iceberg", "/tmp/warehouse/")
+                configPath)
             .withCommand(
                 "standalone-job "
                     + String.format("--job-classname %s ", jobName)
@@ -111,11 +112,16 @@ public class FlinkContainerUtils {
                     + "--output-topic io.openlineage.flink.kafka.output ")
             .withEnv(
                 "FLINK_PROPERTIES", "jobmanager.rpc.address: jobmanager\nexecution.attached: true")
-            .withEnv("OPENLINEAGE_CONFIG", "/opt/flink/lib/openlineage.yml")
+            .withEnv("OPENLINEAGE_CONFIG", configPath)
             .withStartupTimeout(Duration.of(5, ChronoUnit.MINUTES))
             .dependsOn(startables);
-
     return container;
+  }
+
+  static GenericContainer<?> makeFlinkJobManagerContainer(
+      String jobName, Network network, List<Startable> startables) {
+    return makeFlinkJobManagerContainer(
+        jobName, "/opt/flink/lib/openlineage.yml", network, startables);
   }
 
   static GenericContainer<?> makeFlinkTaskManagerContainer(
@@ -123,7 +129,7 @@ public class FlinkContainerUtils {
     return genericContainer(network, FLINK_IMAGE, "taskmanager")
         .withFileSystemBind(getOpenLineageJarPath(), "/opt/flink/lib/openlineage.jar")
         .withFileSystemBind(getExampleAppJarPath(), "/opt/flink/lib/example-app.jar")
-        .withFileSystemBind("data/iceberg", "/tmp/warehouse/")
+        .withFileSystemBind("/tmp/warehouse", "/tmp/warehouse/", BindMode.READ_WRITE)
         .withEnv(
             "FLINK_PROPERTIES",
             "jobmanager.rpc.address: jobmanager"

--- a/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class OpenLineageFlinkJobListenerTest {
+public class JobListenerTest {
 
   JobClient jobClient = mock(JobClient.class);
   JobID jobId = mock(JobID.class);

--- a/integration/flink/src/test/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.tracker;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/PathUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/PathUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/ExampleLineageProvider.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/ExampleLineageProvider.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSourceVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.flink.visitor.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/integration/flink/src/test/resources/openlineage-network-partition.yml
+++ b/integration/flink/src/test/resources/openlineage-network-partition.yml
@@ -1,0 +1,3 @@
+transport:
+  type: http
+  url: http://doesnotexists:1080


### PR DESCRIPTION
Add tests that check if job execution succeeds even if `OpenLineageFlinkJobListener` fails.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
