### PR TITLE
fix databricks issue and support spark 3.3

### DIFF
--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -12,11 +12,11 @@ workflows:
       - build-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.6', '3.1.2', '3.2.1' ]
+              spark-version: [ '2.4.6', '3.1.2', '3.2.1', '3.3.0' ]
       - integration-test-integration-spark:
           matrix:
             parameters:
-              spark-version: [ '2.4.6', '3.1.2', '3.2.1' ]
+              spark-version: [ '2.4.6', '3.1.2', '3.2.1', '3.3.0' ]
           requires:
             - build-integration-spark
       - publish-snapshot-integration-spark:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.11.0...HEAD)
+* Spark 3.3.0 support added [`#950`](https://github.com/OpenLineage/OpenLineage/pull/950)[@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
 
 ## [0.11.0](https://github.com/OpenLineage/OpenLineage/compare/0.10.0...0.11.0) 2022-07-07
 ### Added

--- a/integration/README.md
+++ b/integration/README.md
@@ -4,5 +4,5 @@
 |Apache Airflow|1.10.12+, 2.1.*, 2.2.*, 2.3.0|https://github.com/apache/airflow/releases|[README](./airflow/README.md)|Support for Airflow 1.x is deprecated and will be discontinued after September 30th, 2022|
 |Dagster|0.13.8+|https://github.com/dagster-io/dagster/releases|[README](./dagster/README.md)| |
 |dbt|0.20+|https://github.com/dbt-labs/dbt-core/releases|[README](./dbt/README.md)| |
-|Apache Spark|2.4.6, 3.1.2, 3.2.1+|https://github.com/apache/spark/tags|[README](./spark/README.md)| |
+|Apache Spark|2.4.6, 3.1.2, 3.2.1+, 3.3.0|https://github.com/apache/spark/tags|[README](./spark/README.md)| |
 

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -42,6 +42,7 @@ configurations {
     spark2.extendsFrom testImplementation
     spark3.extendsFrom testImplementation
     spark32.extendsFrom testImplementation
+    spark33.extendsFrom testImplementation
 }
 
 archivesBaseName='openlineage-spark-app'
@@ -55,6 +56,7 @@ ext {
     testcontainersVersion = '1.15.3'
     shortVersion = sparkVersion.substring(0,3)
     versionsMap = [
+            "3.3": ["module": "spark33",    "scala": "2.12"],
             "3.2": ["module": "spark32",    "scala": "2.12"],
             "3.1": ["module": "spark3",     "scala": "2.12"],
             "2.4": ["module": "spark2",     "scala": "2.11"]
@@ -72,6 +74,7 @@ dependencies {
     implementation(project(path: ":spark2"))
     implementation(project(path: ":spark3"))
     implementation(project(path: ":spark32"))
+    implementation(project(path: ":spark33"))
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
 
 
@@ -80,6 +83,9 @@ dependencies {
     compileOnly ("com.google.cloud.spark:spark-bigquery_${versions.scala}:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
+        exclude group: 'com.sun.jmx'
+        exclude group: 'com.sun.jdmk'
+        exclude group: 'javax.jms'
     }
 
     testFixturesApi "org.apache.spark:spark-core_${versions.scala}:${sparkVersion}"
@@ -178,6 +184,7 @@ shadowJar {
         exclude (project(":spark2"))
         exclude (project(":spark3"))
         exclude (project(":spark32"))
+        exclude (project(":spark33"))
     }
     classifier = ''
     // avoid conflict with any client version of that lib

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
@@ -15,6 +15,8 @@ public class DatasetBuilderFactoryProvider {
       "io.openlineage.spark.agent.lifecycle.Spark3DatasetBuilderFactory";
   private static final String SPARK32_FACTORY_NAME =
       "io.openlineage.spark.agent.lifecycle.Spark32DatasetBuilderFactory";
+  private static final String SPARK33_FACTORY_NAME =
+      "io.openlineage.spark.agent.lifecycle.Spark33DatasetBuilderFactory";
 
   static DatasetBuilderFactory getInstance() {
     String version = package$.MODULE$.SPARK_VERSION();
@@ -32,12 +34,12 @@ public class DatasetBuilderFactoryProvider {
   static String getDatasetBuilderFactoryForVersion(String version) {
     if (version.startsWith("2.")) {
       return SPARK2_FACTORY_NAME;
+    } else if (version.startsWith("3.2")) {
+      return SPARK32_FACTORY_NAME;
+    } else if (version.startsWith("3.3")) {
+      return SPARK33_FACTORY_NAME;
     } else {
-      if (version.startsWith("3.2")) {
-        return SPARK32_FACTORY_NAME;
-      } else {
-        return SPARK3_FACTORY_NAME;
-      }
+      return SPARK3_FACTORY_NAME;
     }
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import com.google.common.collect.ImmutableList;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
+import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
+import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import java.util.Collection;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import scala.PartialFunction;
+
+@Slf4j
+public class Spark33DatasetBuilderFactory extends Spark32DatasetBuilderFactory
+    implements DatasetBuilderFactory {
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+      OpenLineageContext context) {
+    DatasetFactory<OpenLineage.OutputDataset> datasetFactory = DatasetFactory.output(context);
+    ImmutableList.Builder builder =
+        ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
+            .add(new SaveIntoDataSourceCommandVisitor(context))
+            .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
+            .add(new TableContentChangeDatasetBuilder(context))
+            .add(new CreateReplaceDatasetBuilder(context))
+            .add(new AlterTableCommandDatasetBuilder(context));
+
+    if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
+      builder.add(new ReplaceIcebergDataDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -91,17 +91,17 @@ class OpenLineageSparkListenerTest {
         new StaticExecutionContextFactory(emitter)
             .createSparkSQLExecutionContext(1L, emitter, qe, olContext);
 
-    executionContext.start(
-        new SparkListenerSQLExecutionStart(
-            1L,
-            "",
-            "",
-            "",
+    SparkListenerSQLExecutionStart event = mock(SparkListenerSQLExecutionStart.class);
+    when(event.sparkPlanInfo())
+        .thenReturn(
             new SparkPlanInfo(
-                "name", "string", Seq$.MODULE$.empty(), Map$.MODULE$.empty(), Seq$.MODULE$.empty()),
-            1L));
-    executionContext.start(
-        new SparkListenerJobStart(0, 2L, Seq$.MODULE$.<StageInfo>empty(), new Properties()));
+                "name",
+                "string",
+                Seq$.MODULE$.empty(),
+                Map$.MODULE$.empty(),
+                Seq$.MODULE$.empty()));
+    when(event.executionId()).thenReturn(1L);
+    executionContext.start(event);
 
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation(project(path: ":spark2"))
     implementation(project(path: ":spark3"))
     implementation(project(path: ":spark32"))
+    implementation(project(path: ":spark33"))
 
     compileOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compileOnly "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
@@ -211,6 +212,7 @@ shadowJar {
         exclude (project(":spark2"))
         exclude (project(":spark3"))
         exclude (project(":spark32"))
+        exclude (project(":spark33"))
         exclude (project(":app"))
     }
     dependencies {

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
 version=0.12.0-SNAPSHOT
-spark.version=3.1.2
+spark.version=3.3.0
 org.gradle.jvmargs=-Xmx1G

--- a/integration/spark/settings.gradle
+++ b/integration/spark/settings.gradle
@@ -1,6 +1,7 @@
 include 'spark2'
 include 'spark3'
 include 'spark32'
+include 'spark33'
 include 'shared'
 include 'app'
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -267,7 +267,13 @@ public class PlanUtils {
   public static boolean safeIsDefinedAt(PartialFunction pfn, Object x) {
     try {
       return pfn.isDefinedAt(x);
-    } catch (Exception | NoClassDefFoundError e) {
+    } catch (ClassCastException e) {
+      // do nothing
+      return false;
+    } catch (Exception e) {
+      log.info("isDefinedAt method failed on {}", e);
+      return false;
+    } catch (NoClassDefFoundError e) {
       log.info("isDefinedAt method failed on {}", pfn.getClass().getCanonicalName());
       return false;
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -8,7 +8,6 @@ package io.openlineage.spark.api;
 import io.openlineage.client.OpenLineage;
 import java.util.List;
 import org.apache.spark.scheduler.SparkListenerEvent;
-import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 
@@ -33,7 +32,7 @@ public abstract class AbstractQueryPlanOutputDatasetBuilder<P extends LogicalPla
   }
 
   protected boolean includeDatasetVersion(SparkListenerEvent event) {
-    return event instanceof SparkListenerSQLExecutionEnd || event instanceof SparkListenerJobEnd;
+    return event instanceof SparkListenerSQLExecutionEnd;
   }
 
   @Override

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -1,0 +1,136 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+import groovy.io.FileType
+
+import java.nio.file.Files
+
+
+plugins {
+    id 'java'
+    id 'java-library'
+    id 'java-test-fixtures'
+    id 'com.diffplug.spotless' version '5.12.1'
+    id "com.adarshr.test-logger" version "2.1.1"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "pmd"
+}
+
+pmd {
+    consoleOutput = true
+    toolVersion = "6.46.0"
+    rulesMinimumPriority = 5
+    ruleSetFiles = rootProject.files("pmd-openlineage.xml")
+    ruleSets = []
+    ignoreFailures = true
+}
+
+pmdMain {
+    reports {
+        html.required = true
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+    }
+}
+
+archivesBaseName='openlineage-spark-spark3'
+
+ext {
+    sparkVersion = '3.3.0'
+    jacksonVersion = '2.10.0'
+    lombokVersion = '1.18.20'
+}
+
+dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    implementation(project(":shared"))
+    implementation(project(":spark3"))
+
+    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
+    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
+
+    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
+    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
+    testImplementation(testFixtures(project(":shared")))
+    testImplementation(testFixtures(project(":spark3")))
+}
+
+def commonTestConfiguration = {
+    forkEvery 1
+    maxParallelForks 5
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+    }
+    systemProperties = [
+        'junit.platform.output.capture.stdout': 'true',
+        'junit.platform.output.capture.stderr': 'true',
+        'spark.version'                       : "${sparkVersion}",
+        'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
+        'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
+        'mockserver.logLevel'                 : 'ERROR'
+    ]
+
+    classpath = project.sourceSets.test.runtimeClasspath
+}
+
+
+test {
+    configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
+}
+
+task integrationTest(type: Test) {
+    configure commonTestConfiguration
+    useJUnitPlatform {
+        includeTags "integration-test"
+    }
+}
+
+assemble {
+    dependsOn shadowJar
+}
+
+
+shadowJar {
+    minimize()
+    classifier = ''
+    dependencies {
+        exclude(dependency('org.slf4j::'))
+    }
+    zip64 true
+}
+
+spotless {
+    def disallowWildcardImports = {
+        String text = it
+        def regex = ~/import .*\.\*;/
+        def m = regex.matcher(text)
+        if (m.find()) {
+            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
+        }
+    }
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+        custom 'disallowWildcardImports', disallowWildcardImports
+    }
+}

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -1,0 +1,170 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark33.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableAsSelect} and extracts the output
+ * {@link OpenLineage.Dataset} being written.
+ */
+@Slf4j
+public class CreateReplaceDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public CreateReplaceDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof CreateTableAsSelect)
+        || (x instanceof ReplaceTable)
+        || (x instanceof ReplaceTableAsSelect)
+        || (x instanceof CreateTable);
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
+    if (plan instanceof CreateTableAsSelect) {
+      return apply(event, (CreateTableAsSelect) plan);
+    } else if (plan instanceof ReplaceTableAsSelect) {
+      return apply(event, (ReplaceTableAsSelect) plan);
+    } else if (plan instanceof CreateTable) {
+      return apply(event, (CreateTable) plan);
+    } else {
+      return apply(event, (ReplaceTable) plan);
+    }
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, CreateTable plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.CREATE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, CreateTableAsSelect plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.CREATE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, ReplaceTable plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.OVERWRITE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, ReplaceTableAsSelect plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.OVERWRITE))
+        .orElse(Collections.emptyList());
+  }
+
+  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
+    try {
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", null));
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+      log.error("Could not obtain catalog plugin", e);
+      return Optional.empty();
+    }
+  }
+
+  private List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event,
+      TableCatalog catalog,
+      Map<String, String> tableProperties,
+      Identifier identifier,
+      StructType schema,
+      LifecycleStateChange lifecycleStateChange) {
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+
+    if (!di.isPresent()) {
+      return Collections.emptyList();
+    }
+
+    OpenLineage openLineage = context.getOpenLineage();
+    OpenLineage.DatasetFacetsBuilder builder =
+        openLineage
+            .newDatasetFacetsBuilder()
+            .schema(PlanUtils.schemaFacet(openLineage, schema))
+            .lifecycleStateChange(
+                openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
+            .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+
+    if (includeDatasetVersion(event)) {
+      Optional<String> datasetVersion =
+          CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties);
+      datasetVersion.ifPresent(
+          version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
+    }
+
+    CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
+        .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
+    return Collections.singletonList(
+        outputDataset().getDataset(di.get().getName(), di.get().getNamespace(), builder.build()));
+  }
+}

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
@@ -1,0 +1,70 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark33.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+public class ReplaceIcebergDataDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public ReplaceIcebergDataDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  public static boolean hasClasses() {
+    try {
+      ReplaceIcebergDataDatasetBuilder.class
+          .getClassLoader()
+          .loadClass("org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof ReplaceIcebergData);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
+    ReplaceIcebergData replace = (ReplaceIcebergData) plan;
+
+    if (!(replace.table() instanceof DataSourceV2Relation)) {
+      return Collections.emptyList();
+    }
+    DataSourceV2Relation table = (DataSourceV2Relation) replace.table();
+
+    final OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
+        context.getOpenLineage().newDatasetFacetsBuilder();
+    datasetFacetsBuilder.lifecycleStateChange(
+        context
+            .getOpenLineage()
+            .newLifecycleStateChangeDatasetFacet(
+                OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE, null));
+
+    if (includeDatasetVersion(event)) {
+      DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, table);
+    }
+
+    return PlanUtils3.fromDataSourceV2Relation(
+        outputDataset(), context, table, datasetFacetsBuilder);
+  }
+}

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -1,0 +1,246 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark33.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.ResolvedDBObjectName;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.TableSpec;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
+
+public class CreateReplaceVisitorDatasetBuilderTest {
+
+  private static final String TABLE = "table";
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+          .build();
+
+  CreateReplaceDatasetBuilder builder = new CreateReplaceDatasetBuilder(openLineageContext);
+
+  TableCatalog catalog = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Map<String, String> commandProperties = new HashMap<>();
+  Identifier tableName = Identifier.of(new String[] {"db"}, TABLE);
+
+  ResolvedDBObjectName namePlan =
+      new ResolvedDBObjectName(catalog, (Seq<String>) Seq$.MODULE$.empty());
+  TableSpec tableSpec = mock(TableSpec.class);
+
+  @BeforeEach
+  public void setup() {
+    when(tableSpec.properties()).thenReturn(commandProperties);
+  }
+
+  @Test
+  void testIsDefined() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTable.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyForCreateTableAsSelect() {
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+  }
+
+  @Test
+  void testApplyForReplaceTable() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyForReplaceTableAsSelect() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyForCreateTable() {
+    CreateTable logicalPlan = mock(CreateTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+  }
+
+  @Test
+  void testApplyDatasetVersionIncluded() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+        when(CatalogUtils3.getDatasetVersion(
+                openLineageContext,
+                catalog,
+                Identifier.of(new String[] {"db"}, TABLE),
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of("v2"));
+
+        when(PlanUtils3.getDatasetIdentifier(
+                openLineageContext,
+                catalog,
+                tableName,
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of(di));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());
+      }
+    }
+  }
+
+  @Test
+  void testApplyDatasetVersionMissing() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+        when(CatalogUtils3.getDatasetVersion(
+                openLineageContext,
+                catalog,
+                Identifier.of(new String[] {"db"}, TABLE),
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.empty());
+
+        when(PlanUtils3.getDatasetIdentifier(
+                openLineageContext,
+                catalog,
+                tableName,
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of(di));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals(null, outputDatasets.get(0).getFacets().getVersion());
+      }
+    }
+  }
+
+  private void verifyApply(
+      LogicalPlan logicalPlan,
+      Map<String, String> tableProperties,
+      OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange) {
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalog,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          lifecycleStateChange,
+          outputDatasets.get(0).getFacets().getLifecycleStateChange().getLifecycleStateChange());
+      assertEquals(TABLE, outputDatasets.get(0).getName());
+      assertEquals("db", outputDatasets.get(0).getNamespace());
+    }
+  }
+
+  @Test
+  void testApplyWhenNoDatasetIdentifierReturned() {
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(logicalPlan.name()).thenReturn(namePlan);
+      when(logicalPlan.tableName()).thenReturn(tableName);
+      when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+      when(logicalPlan.tableSchema()).thenReturn(schema);
+
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalog,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(tableSpec.properties())))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+}

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark33.agent.lifecycle.plan;
+
+import static io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class ReplaceIcebergDataDatasetBuilderTest {
+
+  OpenLineage openLineage = mock(OpenLineage.class);
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(openLineage)
+          .build();
+
+  ReplaceIcebergDataDatasetBuilder builder =
+      new ReplaceIcebergDataDatasetBuilder(openLineageContext);
+
+  ReplaceIcebergData plan = mock(ReplaceIcebergData.class);
+  SparkListenerEvent event = mock(SparkListenerSQLExecutionEnd.class);
+
+  @Test
+  void testIsDefinedAtLogicalPlan() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceIcebergData.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyWhenNoDataSourceV2RelationTable() {
+    when(plan.table()).thenReturn(mock(NamedRelation.class));
+    assertEquals(0, builder.apply(event, plan).size());
+  }
+
+  @Test
+  void testApply() {
+    DataSourceV2Relation table = mock(DataSourceV2Relation.class);
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
+        mock(OpenLineage.DatasetFacetsBuilder.class);
+    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
+
+    when(plan.table()).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
+        when(DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
+                openLineageContext, table))
+            .thenReturn(Optional.of("v2"));
+
+        when(PlanUtils3.fromDataSourceV2Relation(
+                any(DatasetFactory.class),
+                eq(openLineageContext),
+                eq(table),
+                eq(datasetFacetsBuilder)))
+            .thenReturn(Arrays.asList(expectedDataset));
+
+        List<OpenLineage.OutputDataset> datasets = builder.apply(event, plan);
+
+        assertEquals(1, datasets.size());
+        assertEquals(expectedDataset, datasets.get(0));
+
+        verify(datasetFacetsBuilder)
+            .lifecycleStateChange(openLineage.newLifecycleStateChangeDatasetFacet(OVERWRITE, null));
+
+        mockedFacetUtils.verify(
+            () ->
+                DatasetVersionDatasetFacetUtils.includeDatasetVersion(
+                    openLineageContext, datasetFacetsBuilder, table),
+            times(1));
+      }
+    }
+  }
+}

--- a/integration/spark/spark33/src/test/resources/io/openlineage/spark/agent/version.properties
+++ b/integration/spark/spark33/src/test/resources/io/openlineage/spark/agent/version.properties
@@ -1,0 +1,1 @@
+version 0.11.0-SNAPSHOT


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Creating simple table on Databricks does not collect Ol event. 

Closes: #941

### Solution

Although databricks makes use of Spark 3.2, it looks as if the used plan made use of objects and classes available in Spark 3.3 (it does not contain class fields that were removed between versions 3.2 and 3.3). As a solution to that, we implement new dataset builders that work with Spark 3.3 and decide within `Spark32DatasetBuilderFactory` which builder to choose. 

Based on that, it makes sense to deploy it together with a support for Spark 3.3. The supported version is tested with Iceberg library for Spark 3.3. However, still there is no Delta support for Spark 3.3 (26th July 2022). Integration tests using delta for Spark 3.3 are turned off. There is going to be a separate PR in the future to turn them on once Delta releases its version compatible with 3.3


> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)