### PR TITLE
airflow: redact secrets

### DIFF
--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -8,6 +8,7 @@ import uuid
 import attr
 
 from openlineage.client.facet import NominalTimeRunFacet, ParentRunFacet
+from openlineage.client.utils import RedactMixin
 
 
 class RunState(Enum):
@@ -25,9 +26,11 @@ _RUN_FACETS = [
 
 
 @attr.s
-class Run:
+class Run(RedactMixin):
     runId: str = attr.ib()
     facets: Dict = attr.ib(factory=dict)
+
+    _skip_redact: List[str] = ['runId']
 
     @runId.validator
     def check(self, attribute, value):
@@ -35,17 +38,21 @@ class Run:
 
 
 @attr.s
-class Job:
+class Job(RedactMixin):
     namespace: str = attr.ib()
     name: str = attr.ib()
     facets: Dict = attr.ib(factory=dict)
+
+    _skip_redact: List[str] = ['namespace', 'name']
 
 
 @attr.s
-class Dataset:
+class Dataset(RedactMixin):
     namespace: str = attr.ib()
     name: str = attr.ib()
     facets: Dict = attr.ib(factory=dict)
+
+    _skip_redact: List[str] = ['namespace', 'name']
 
 
 @attr.s
@@ -59,7 +66,7 @@ class OutputDataset(Dataset):
 
 
 @attr.s
-class RunEvent:
+class RunEvent(RedactMixin):
     eventType: RunState = attr.ib(validator=attr.validators.in_(RunState))
     eventTime: str = attr.ib()  # TODO: validate dates
     run: Run = attr.ib()
@@ -67,3 +74,5 @@ class RunEvent:
     producer: str = attr.ib()
     inputs: Optional[List[Dataset]] = attr.ib(factory=list)     # type: ignore
     outputs: Optional[List[Dataset]] = attr.ib(factory=list)    # type: ignore
+
+    _skip_redact: List[str] = ['eventType', 'eventTime', 'producer']

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
-from typing import Type
+from typing import Type, List
 
 import attr
 import importlib
 from warnings import warn
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def import_from_string(path: str):
@@ -42,3 +45,11 @@ def get_only_specified_fields(clazz, params: dict) -> dict:
     return {
         key: value for key, value in params.items() if key in field_keys
     }
+
+
+class RedactMixin:
+    _skip_redact: List[str] = []
+
+    @property
+    def skip_redact(self) -> List[str]:
+        return self._skip_redact

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -221,6 +221,13 @@ t1 = DataProcPySparkOperator(
         dag=dag)
 ```
 
+## Secrets redaction
+Integration uses Airflow SecretsMasker to hide secrets from produced metadata events. As not all fields in the metadata should be redacted `RedactMixin` is used to pass information which fields should be skipped from the process. 
+
+Typically you should subclass `RedactMixin` and use attribute `_skip_redact` as a list of names of fields to be skipped.
+
+However, all facets inheriting from `BaseFacet` should use `_additional_skip_redact` attribute as addition to common list of `['_producer', '_schemaURL']`.
+
 ## Development
 
 To install all dependencies for _local_ development:

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -11,6 +11,7 @@ from openlineage.airflow.extractors import TaskMetadata
 from openlineage.client import OpenLineageClient, OpenLineageClientOptions, set_producer
 from openlineage.client.facet import DocumentationJobFacet, SourceCodeLocationJobFacet, \
     NominalTimeRunFacet, ParentRunFacet, BaseFacet
+from openlineage.airflow.utils import redact_with_exclusions
 from openlineage.client.run import RunEvent, RunState, Run, Job
 import requests.exceptions
 
@@ -56,6 +57,7 @@ class OpenLineageAdapter:
         return self._client
 
     def emit(self, event: RunEvent):
+        event = redact_with_exclusions(event)
         try:
             return self.get_or_create_openlineage_client().emit(event)
         except requests.exceptions.RequestException:

--- a/integration/airflow/tests/integration/data/secrets/variables.json
+++ b/integration/airflow/tests/integration/data/secrets/variables.json
@@ -1,0 +1,3 @@
+{
+  "secrets_password": "1500100900"
+}

--- a/integration/airflow/tests/integration/requests/postgres.json
+++ b/integration/airflow/tests/integration/requests/postgres.json
@@ -88,7 +88,7 @@
 	"job": {
 		"facets": {
 			"sql": {
-				"query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on;\n    "
+                "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on;\n    "
 			}
 		},
 		"name": "postgres_orders_popular_day_of_week.postgres_insert",

--- a/integration/airflow/tests/integration/requests/secrets.json
+++ b/integration/airflow/tests/integration/requests/secrets.json
@@ -1,0 +1,44 @@
+[{
+    "eventType": "START",
+    "job": {
+        "name": "secrets.secrets",
+        "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "airflow_version": {
+                "taskInfo": "{{ not_match(result, '1500100900') }}"
+            },
+            "unknownSourceAttribute": {
+                "unknownItems": [
+                    {
+                        "name": "SecretsOperator",
+                        "properties": {
+                            "password": "***"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "job": {
+        "name": "secrets.secrets",
+        "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "unknownSourceAttribute": {
+                "unknownItems": [
+                    {
+                        "name": "SecretsOperator",
+                        "properties": {
+                            "password": "***"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -55,6 +55,14 @@ params = [
     ("custom_extractor", "requests/custom_extractor.json"),
     ("unknown_operator_dag", "requests/unknown_operator.json"),
     pytest.param(
+        "secrets",
+        "requests/secrets.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.1.0"),
+            reason="Airflow < 2.1.0"
+        )
+    ),
+    pytest.param(
         "mysql_orders_popular_day_of_week",
         "requests/mysql.json",
         marks=pytest.mark.skipif(

--- a/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from airflow.models import BaseOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.log.secrets_masker import mask_secret
+
+from openlineage.client import set_producer
+
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+from airflow.version import version as AIRFLOW_VERSION
+from pkg_resources import parse_version
+if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
+    from openlineage.airflow import DAG
+else:
+    from airflow import DAG
+
+
+class SecretsOperator(BaseOperator):
+    """This shouldn't have extractor - we're testing if we'll see password in UnknownSourceAttribute"""
+    template_fields = ['password']
+
+    def __init__(self, password, **kwargs):
+        super().__init__(**kwargs)
+        self.password = password
+
+    def execute(self, context):
+        mask_secret(self.password)
+        logging.getLogger(__name__).warning(f"Password! {self.password}")
+
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+
+dag = DAG(
+    'secrets',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Secrets test'
+)
+
+
+t1 = SecretsOperator(
+    task_id='secrets',
+    password="{{ var.value.secrets_password }}",
+    dag=dag,
+)

--- a/integration/airflow/tests/integration/tests/docker-compose-2.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-2.yml
@@ -36,7 +36,7 @@ x-airflow-base: &airflow-base
     SNOWFLAKE_USER: ${SNOWFLAKE_USER}
     SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD}
     AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
-    AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json" }'
+    AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json", "variables_file_path": "/opt/data/secrets/variables.json" }'
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=ROBOTS&role=OPENLINEAGE"
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -5,9 +5,11 @@ import os
 from urllib.parse import parse_qs, urlparse
 
 import pendulum
+import pytest
 import datetime
 from airflow.models import Connection
 from pkg_resources import parse_version
+from airflow.version import version as AIRFLOW_VERSION
 
 from openlineage.airflow.utils import (
     url_to_https,
@@ -18,10 +20,15 @@ from openlineage.airflow.utils import (
     DagUtils,
     SafeStrDict,
     build_table_check_facets,
-    build_column_check_facets
+    build_column_check_facets,
+    _is_name_redactable,
+    redact_with_exclusions,
 )
+from openlineage.client.utils import RedactMixin
+import attr
+from json import JSONEncoder
 
-AIRFLOW_VERSION = '1.10.12'
+
 AIRFLOW_CONN_ID = 'test_db'
 AIRFLOW_CONN_URI = 'postgres://localhost:5432/testdb'
 SNOWFLAKE_CONN_URI = 'snowflake://12345.us-east-1.snowflakecomputing.com/MyTestRole?extra__snowflake__account=12345&extra__snowflake__database=TEST_DB&extra__snowflake__insecure_mode=false&extra__snowflake__region=us-east-1&extra__snowflake__role=MyTestRole&extra__snowflake__warehouse=TEST_WH&extra__snowflake__aws_access_key_id=123456&extra__snowflake__aws_secret_access_key=abcdefg'  # NOQA
@@ -173,3 +180,92 @@ def test_build_column_check_facets():
     assert assertions_facet.assertions[1].assertion == "distinct_check"
     assert not assertions_facet.assertions[1].success
     assert assertions_facet.assertions[1].column == "X"
+
+
+def test_is_name_redactable():
+    class NotMixin:
+        def __init__(self):
+            self.password = "passwd"
+
+    class Mixined(RedactMixin):
+        _skip_redact = ["password"]
+
+        def __init__(self):
+            self.password = "passwd"
+            self.transparent = "123"
+
+    assert _is_name_redactable("password", NotMixin())
+    assert not _is_name_redactable("password", Mixined())
+    assert _is_name_redactable("transparent", Mixined())
+
+
+@pytest.mark.skipif(
+    parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"),
+    reason="requires AIRFLOW_VERSION to be higher than 2.0",
+)
+def test_redact_with_exclusions(monkeypatch):
+    class NotMixin:
+        def __init__(self):
+            self.password = "passwd"
+
+    def default(self, o):
+        if isinstance(o, NotMixin):
+            return o.__dict__
+        raise TypeError
+
+    assert redact_with_exclusions(NotMixin()).password == "passwd"
+    monkeypatch.setattr(JSONEncoder, "default", default)
+    assert redact_with_exclusions(NotMixin()).password == "***"
+
+    class Mixined(RedactMixin):
+        _skip_redact = ["password"]
+
+        def __init__(self):
+            self.password = "passwd"
+            self.transparent = "123"
+
+    @attr.s
+    class NestedMixined(RedactMixin):
+        _skip_redact = ["nested_field"]
+        password: str = attr.ib()
+        nested_field = attr.ib()
+
+    assert redact_with_exclusions(Mixined()).password == "passwd"
+    assert redact_with_exclusions(Mixined()).transparent == "123"
+    assert redact_with_exclusions({"password": "passwd"}) == {"password": "***"}
+    redacted_nested = redact_with_exclusions(
+        NestedMixined("passwd", NestedMixined("passwd", None))
+    )
+    assert redacted_nested == NestedMixined("***", NestedMixined("passwd", None))
+
+
+@pytest.mark.skipif(
+    parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"),
+    reason="test for Airflow 1.x only",
+)
+def test_if_stays_unredacted_without_airflow_1():
+    class NotMixin:
+        def __init__(self):
+            self.password = "passwd"
+
+    class Mixined(RedactMixin):
+        _skip_redact = ["password"]
+
+        def __init__(self):
+            self.password = "passwd"
+            self.transparent = "123"
+
+    @attr.s
+    class NestedMixined(RedactMixin):
+        _skip_redact = ["nested_field"]
+        password: str = attr.ib()
+        nested_field = attr.ib()
+
+    assert redact_with_exclusions(NotMixin()).password == "passwd"
+    assert redact_with_exclusions(Mixined()).password == "passwd"
+    assert redact_with_exclusions(Mixined()).transparent == "123"
+    assert redact_with_exclusions({"password": "passwd"}) == {"password": "passwd"}
+    redacted_nested = redact_with_exclusions(
+        NestedMixined("passwd", NestedMixined("passwd", None))
+    )
+    assert redacted_nested == NestedMixined("passwd", NestedMixined("passwd", None))

--- a/integration/common/openlineage/common/dataset.py
+++ b/integration/common/openlineage/common/dataset.py
@@ -7,9 +7,12 @@ from openlineage.common.models import DbTableSchema, DbColumn
 from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, \
     DocumentationDatasetFacet, SchemaDatasetFacet, SchemaField
 from openlineage.client.run import Dataset as OpenLineageDataset, InputDataset, OutputDataset
+from openlineage.client.utils import RedactMixin
 
 
-class Source:
+class Source(RedactMixin):
+    _skip_redact: List[str] = ['scheme', 'name']
+
     def __init__(
             self,
             scheme: Optional[str] = None,
@@ -42,7 +45,9 @@ class Source:
         return f'{self.scheme}'
 
 
-class Field:
+class Field(RedactMixin):
+    _skip_redact: List[str] = ['name', 'type', 'tags']
+
     def __init__(self, name: str, type: str,
                  tags: List[str] = None, description: str = None):
         self.name = name
@@ -72,7 +77,9 @@ class Field:
                        {self.tags!r},{self.description!r})"
 
 
-class Dataset:
+class Dataset(RedactMixin):
+    _skip_redact: List[str] = ['name']
+
     def __init__(
             self,
             source: Source,

--- a/integration/common/openlineage/common/models.py
+++ b/integration/common/openlineage/common/models.py
@@ -3,9 +3,12 @@
 
 from typing import List
 from openlineage.common.sql import DbTableMeta
+from openlineage.client.utils import RedactMixin
 
 
-class DbColumn:
+class DbColumn(RedactMixin):
+    _skip_redact: List[str] = ['name', 'type', 'ordinal_position']
+
     def __init__(self, name: str, type: str,
                  description: str = None, ordinal_position: int = None):
         self.name = name
@@ -24,7 +27,9 @@ class DbColumn:
                           {self.description!r},{self.ordinal_position!r})"
 
 
-class DbTableSchema:
+class DbTableSchema(RedactMixin):
+    _skip_redact: List[str] = ['schema_name', 'table_name']
+
     def __init__(
         self,
         schema_name: str,

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -38,11 +38,18 @@ def env_var(var: str, default: Optional[str] = None) -> str:
         raise Exception(msg)
 
 
+def not_match(result, pattern) -> str:
+    if pattern in result:
+        raise Exception(f"Found {pattern} in {result}")
+    return "true"
+
+
 def setup_jinja() -> Environment:
     env = Environment()
     env.globals['any'] = any
     env.globals['is_datetime'] = is_datetime
     env.globals['env_var'] = env_var
+    env.globals['not_match'] = not_match
     return env
 
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Add secrets DAG in integration tests.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Look at JSON serializability.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

OpenLineage produces lots of information in which some may be sensitive (such as passwords / secret variables from SecretBackend).

Closes: #921 

### Solution

Added `RedactMixin` and `redact_with_exclusions` that enable control of what fields should be excluded from redaction. The method uses Airflow's SecretsMasker.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)