### PR TITLE
Add BigQuery Check Support

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -22,7 +22,7 @@ def get_check_extractors(super_):
             pass
 
         def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-            if issubclass(BaseSqlCheckExtractor, BigQueryExtractor):
+            if issubclass(BigQueryExtractor, BaseSqlCheckExtractor):
                 return super().extract_on_complete(task_instance)
             return super().extract()
 
@@ -76,7 +76,7 @@ def get_check_extractors(super_):
 
         @classmethod
         def get_operator_classnames(cls) -> List[str]:
-            return ['SQLColumnCheckOperator']
+            return ['SQLColumnCheckOperator', 'BigQueryColumnCheckOperator']
 
         def _get_input_facets(self) -> Dict[str, BaseFacet]:
             column_mapping = self.operator.column_mapping
@@ -88,7 +88,7 @@ def get_check_extractors(super_):
 
         @classmethod
         def get_operator_classnames(cls) -> List[str]:
-            return ['SQLTableCheckOperator']
+            return ['SQLTableCheckOperator', 'BigQueryTableCheckOperator']
 
         def _get_input_facets(self) -> Dict[str, BaseFacet]:
             checks = self.operator.checks

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -75,13 +75,13 @@ if parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"):     # type: ignore
         class SQLCheckOperator:
             conn_id = "postgres_default"
         extractors = Extractors()
-        sql_check_operator = SQLCheckOperator()
-        extractors.instantiate_abstract_extractors(task=sql_check_operator)
+        extractors.instantiate_abstract_extractors(task=SQLCheckOperator())
         sql_check_extractor = extractors.extractors["SQLCheckOperator"]("SQLCheckOperator")
         assert sql_check_extractor._get_scheme() == "postgres"
 
     @patch('airflow.models.connection.Connection')
-    def test_instantiate_abstract_extractors_value_error(mock_conn):
+    @patch.object(BaseHook, "get_connection", return_value=Connection(conn_id="notimplemented", conn_type="notimplementeddb"))  # noqa
+    def test_instantiate_abstract_extractors_value_error(mock_hook, mock_conn):
         class SQLCheckOperator:
             conn_id = "notimplementeddb"
         with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem
BigQuery's extractor works differently than other SQL-like extractors, so it needs some extra logic to support the as-yet-to-be-released `BigQueryColumnCheckOperator` and `BigQueryTableCheckOperator`.

Closes: #961 

### Solution

This PR adds logic and support for the operators to do proper dynamic class inheritance for BigQuery-style operators.

This PR has been tested with the relevant operators and creates a node on the lineage graph in Datakin.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)