### PR TITLE
[PROXY] Proxy/console having better format for JSON messages

### DIFF
--- a/integration/flink/.gitignore
+++ b/integration/flink/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+bin/

--- a/integration/spark/.gitignore
+++ b/integration/spark/.gitignore
@@ -1,0 +1,2 @@
+bin/
+*.class

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -2,6 +2,14 @@
 proxy.yml
 !examples/kafka/proxy.yml
 
+# Gradle
+.gradle
+.project
+.classpath
+bin
+build
+*.class
+
 # MacOS
 .DS_Store
 __MACOSX

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
@@ -1,6 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0.
- */
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.proxy.api.models;
 

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
@@ -28,9 +28,6 @@ public class ConsoleLineageStream extends LineageStream {
         String prettyJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
         log.info(prettyJson);
       } catch (JsonProcessingException jpe) {
-        if (log.isErrorEnabled()) {
-          log.error("Unable to beautify given JSON string");
-        }
         log.info(eventAsString);
       }
     } else {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Currently, the console output of Proxy does NOT properly format JSON strings.

Closes: #966

### Solution

When JSON messages are detected, format the message so that it will be better human readable. Only apply the formatting to console output.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)