### PR TITLE
Support the new Databricks Unity V2 Proxy

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
@@ -1,0 +1,101 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import scala.Option;
+
+/**
+ * The AbstractDatabricksHandler is intended to support Databricks' custom proxies which supersede
+ * the open source Delta Catalog. The proprietary class name of
+ * com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog is used by Databricks instead of the
+ * open source class name of org.apache.spark.sql.delta.catalog.DeltaCatalog. It is used in the same
+ * way as the {@link DeltaHandler}.
+ */
+@Slf4j
+public abstract class AbstractDatabricksHandler implements CatalogHandler {
+  final String DATABRICKS_CLASS_NAME_STRING;
+
+  protected final OpenLineageContext context;
+
+  public AbstractDatabricksHandler(OpenLineageContext context) {
+    this(context, "com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog");
+  }
+
+  protected AbstractDatabricksHandler(OpenLineageContext context, String databricksClassName) {
+    this.context = context;
+    this.DATABRICKS_CLASS_NAME_STRING = databricksClassName;
+  }
+
+  @Override
+  public boolean hasClasses() {
+    try {
+      DeltaHandler.class.getClassLoader().loadClass(DATABRICKS_CLASS_NAME_STRING);
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isClass(TableCatalog tableCatalog) {
+    return DATABRICKS_CLASS_NAME_STRING.equals(tableCatalog.getClass().getCanonicalName());
+  }
+
+  @Override
+  public DatasetIdentifier getDatasetIdentifier(
+      SparkSession session,
+      TableCatalog tableCatalog,
+      Identifier identifier,
+      Map<String, String> properties) {
+
+    Optional<String> location;
+    boolean isPathIdentifier = false;
+    try {
+      isPathIdentifier =
+          (boolean) MethodUtils.invokeMethod(tableCatalog, true, "isPathIdentifier", identifier);
+    } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+      // DO Nothing
+    }
+
+    if (isPathIdentifier) {
+      location = Optional.of(identifier.name());
+    } else {
+      location = Optional.ofNullable(properties.get("location"));
+    }
+    // Delta uses spark2 catalog when location isn't specified.
+    Path path =
+        new Path(
+            location.orElse(
+                session
+                    .sessionState()
+                    .catalog()
+                    .defaultTablePath(
+                        TableIdentifier.apply(
+                            identifier.name(),
+                            Option.apply(
+                                Arrays.stream(identifier.namespace())
+                                    .reduce((x, y) -> y)
+                                    .orElse(null))))
+                    .toString()));
+    log.info(path.toString());
+    return PathUtils.fromPath(path, "file");
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
@@ -30,7 +30,7 @@ import scala.Option;
  */
 @Slf4j
 public abstract class AbstractDatabricksHandler implements CatalogHandler {
-  final String DATABRICKS_CLASS_NAME_STRING;
+  final String databricksClassNameString;
 
   protected final OpenLineageContext context;
 
@@ -40,13 +40,13 @@ public abstract class AbstractDatabricksHandler implements CatalogHandler {
 
   protected AbstractDatabricksHandler(OpenLineageContext context, String databricksClassName) {
     this.context = context;
-    this.DATABRICKS_CLASS_NAME_STRING = databricksClassName;
+    this.databricksClassNameString = databricksClassName;
   }
 
   @Override
   public boolean hasClasses() {
     try {
-      DeltaHandler.class.getClassLoader().loadClass(DATABRICKS_CLASS_NAME_STRING);
+      DeltaHandler.class.getClassLoader().loadClass(databricksClassNameString);
       return true;
     } catch (Exception e) {
       // swallow- we don't care
@@ -56,7 +56,7 @@ public abstract class AbstractDatabricksHandler implements CatalogHandler {
 
   @Override
   public boolean isClass(TableCatalog tableCatalog) {
-    return DATABRICKS_CLASS_NAME_STRING.equals(tableCatalog.getClass().getCanonicalName());
+    return databricksClassNameString.equals(tableCatalog.getClass().getCanonicalName());
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -24,6 +24,7 @@ public class CatalogUtils3 {
             new IcebergHandler(context),
             new DeltaHandler(context),
             new DatabricksDeltaHandler(context),
+            new DatabricksUnityV2Handler(context),
             new JdbcHandler(),
             new V2SessionCatalogHandler());
     return handlers.stream().filter(CatalogHandler::hasClasses).collect(Collectors.toList());

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
@@ -12,16 +12,16 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The DatabricksDeltaHandler is intended to support Databricks' custom DeltaCatalog which has the
- * class name of com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog rather than the open
+ * The DatabricksUnityV2Handler is intended to support Databricks' custom Unity Catalog which has
+ * the class name of com.databricks.sql.managedcatalog.UnityCatalogV2Proxy rather than the open
  * source class name of org.apache.spark.sql.delta.catalog.DeltaCatalog. It is used in the same way
  * as the {@link DeltaHandler}.
  */
 @Slf4j
-public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
+public class DatabricksUnityV2Handler extends AbstractDatabricksHandler {
 
-  public DatabricksDeltaHandler(OpenLineageContext context) {
-    super(context, "com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog");
+  public DatabricksUnityV2Handler(OpenLineageContext context) {
+    super(context, "com.databricks.sql.managedcatalog.UnityCatalogV2Proxy");
   }
 
   @Override
@@ -30,11 +30,11 @@ public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
     return Optional.of(
         context
             .getOpenLineage()
-            .newStorageDatasetFacet("delta", "parquet")); // Delta is always parquet
+            .newStorageDatasetFacet("unity", "parquet")); // The default is parquet / delta
   }
 
   @Override
   public String getName() {
-    return "delta";
+    return "unity";
   }
 }


### PR DESCRIPTION
The Databricks Unity V2 Handler is a copy paste of the DatabricksDeltaHandler but uses the unity class name.

I believe it's worth separating out because we have no idea what Unity will turn into and it should be handled independently from Delta.

Signed-off-by: Will Johnson <will@willj.co>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Starting with Databricks Runtime 10.4, Databricks introduced a UnityV2Proxy class that sits in front of the normal hive metastore. We now have to handle this new catalog layer.

Closes: #964 

### Solution

The Databricks Unity V2 Handler is a copy paste of the DatabricksDeltaHandler but uses the unity class name.

I believe it's worth separating out because we have no idea what Unity will turn into and it should be handled independently from Delta.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)