### PR TITLE
mypy: disable wrong type check

### DIFF
--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -89,7 +89,7 @@ class HttpTransport(Transport):
         log.debug(f"Constructing openlineage client to send events to {url}")
         try:
             parsed = parse_url(url)
-            if not (parsed.scheme and parsed.netloc):
+            if not (parsed.scheme and parsed.netloc):  # type: ignore
                 raise ValueError(f"Need valid url for OpenLineageClient, passed {url}")
         except Exception as e:
             raise ValueError(f"Need valid url for OpenLineageClient, passed {url}. Exception: {e}")

--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -122,8 +122,8 @@ def _handle_pipeline_event(
         timestamp: float,
         repository_name: Optional[str]
 ):
-    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE, and RUN_CANCELED.
-    Assumes event type is always in the order of RUN_START
+    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE,
+    and RUN_CANCELED. Assumes event type is always in the order of RUN_START
     followed by RUN_SUCCESS, RUN_FAILURE, or RUN_CANCELED.
 
     :param running_pipelines: map of pipeline run ids to dynamically generated metadata


### PR DESCRIPTION
Mypy wrongly decided that there's no `schema` field in `Url`, while there is: https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/url.py#L80
Disable this type check.

Also fix flake8 started acting in `dagster`