### PR TITLE
Add RUNNING eventType in specification and Python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.12.0...HEAD)
-
+* Add `RUNNING` EventType in specification and Python client [`#972`](https://github.com/OpenLineage/OpenLineage/pull/972) [@mzareba382](https://github.com/mzareba382)
 ## [0.12.0](https://github.com/OpenLineage/OpenLineage/compare/0.11.0...0.12.0) 2022-08-01
 ### Added
 

--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -13,6 +13,7 @@ from openlineage.client.utils import RedactMixin
 
 class RunState(Enum):
     START = 'START'
+    RUNNING = 'RUNNING'
     COMPLETE = 'COMPLETE'
     ABORT = 'ABORT'
     FAIL = 'FAIL'

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/1-0-2/OpenLineage.json",
+  "$id": "https://openlineage.io/spec/1-0-3/OpenLineage.json",
   "$defs": {
     "RunEvent": {
       "type": "object",
@@ -10,12 +10,13 @@
           "type": "string",
           "enum": [
             "START",
+            "RUNNING",
             "COMPLETE",
             "ABORT",
             "FAIL",
             "OTHER"
           ],
-          "example": "START|COMPLETE|ABORT|FAIL|OTHER"
+          "example": "START|RUNNING|COMPLETE|ABORT|FAIL|OTHER"
         },
         "eventTime": {
           "description": "the time the event occurred at",


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

Signed-off-by: mzareba <mzareba382@gmail.com>

### Problem
Flink integration lets end-users gather events based on Flink real-time running jobs. There are fields `EventType` in our Java API and `RunState` in Python API which indicate current event state/type. Those include:
```
"START",
"COMPLETE",
"ABORT",
"FAIL",
"OTHER"
```

Currently, running jobs send an event of type "OTHER".

It is related to #946 and after merging this PR our Flink Integration will be updated in subsequent PR

### Solution

This change introduces `"RUNNING"` event state/type in OpenLineage.json specification to help indicate a running task in a clearer way. It also directly adds `"RUNNING"` event type in Python API.


- [x] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)