### PR TITLE
flink: copy files in tests instead of db mount

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -429,7 +429,7 @@ jobs:
             - v1-integration-flink-{{ .Branch }}-{{ .Revision }}
             - v1-integration-flink-{{ .Branch }}
       - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
-      - run: mkdir -p /tmp/warehouse/db/sink/data && cp -R data/iceberg/db /tmp/warehouse && chmod -R 777 /tmp/warehouse
+      - run: chmod -R 777 data/iceberg/db
       - run: ./gradlew examples:stateful:build
       - run: ./gradlew --no-daemon integrationTest --i
       - run:

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -14,7 +14,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import lombok.SneakyThrows;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
@@ -106,7 +105,7 @@ public class FlinkContainerUtils {
             .withExposedPorts(8081)
             .withFileSystemBind(getOpenLineageJarPath(), "/opt/flink/lib/openlineage.jar")
             .withFileSystemBind(getExampleAppJarPath(), "/opt/flink/lib/example-app.jar")
-            .withFileSystemBind("/tmp/warehouse", "/tmp/warehouse/", BindMode.READ_WRITE)
+            .withCopyFileToContainer(MountableFile.forHostPath("data/iceberg"), "/tmp/warehouse/")
             .withCopyFileToContainer(
                 MountableFile.forHostPath(Resources.getResource("openlineage.yml").getPath()),
                 configPath)
@@ -134,7 +133,7 @@ public class FlinkContainerUtils {
     return genericContainer(network, FLINK_IMAGE, "taskmanager")
         .withFileSystemBind(getOpenLineageJarPath(), "/opt/flink/lib/openlineage.jar")
         .withFileSystemBind(getExampleAppJarPath(), "/opt/flink/lib/example-app.jar")
-        .withFileSystemBind("/tmp/warehouse", "/tmp/warehouse/", BindMode.READ_WRITE)
+        .withCopyFileToContainer(MountableFile.forHostPath("data/iceberg"), "/tmp/warehouse/")
         .withEnv(
             "FLINK_PROPERTIES",
             "jobmanager.rpc.address: jobmanager"


### PR DESCRIPTION
This allows to run the Flink integration tests locally without needing to copy files to `/tmp/warehouse` first.