### PR TITLE
Airflow: use databases & schemas in SQL Extractors.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
 _TABLE_SCHEMA = 0
 _TABLE_NAME = 1
 _COLUMN_NAME = 2
@@ -21,6 +20,10 @@ _ORDINAL_POSITION = 3
 # Use 'udt_name' which is the underlying type of column
 # (ex: int4, timestamp, varchar, etc)
 _UDT_NAME = 4
+# Database is optional as 5th column
+_TABLE_DATABASE = 5
+
+TablesHierarchy = Dict[str, Dict[str, List[str]]]
 
 
 def get_table_schemas(
@@ -49,42 +52,96 @@ def get_table_schemas(
                     query_schemas.append(parse_query_result(cursor))
                 else:
                     query_schemas.append([])
-    return tuple([
+    return tuple(
         [
-            Dataset.from_table_schema(
-                source=source,
-                table_schema=schema,
-                database_name=database
-            ) for schema in schemas
-        ] for schemas in query_schemas
-    ])
+            [
+                Dataset.from_table_schema(
+                    source=source, table_schema=schema, database_name=db or database
+                )
+                for schema, db in schemas
+            ]
+            for schemas in query_schemas
+        ]
+    )
 
 
-def parse_query_result(cursor) -> List[DbTableSchema]:
+def parse_query_result(cursor) -> List[Tuple[DbTableSchema, str]]:
     schemas: Dict = {}
     for row in cursor.fetchall():
         table_schema_name: str = row[_TABLE_SCHEMA]
-        table_name: DbTableMeta = DbTableMeta(
-            row[_TABLE_NAME]
-        )
+        table_name: DbTableMeta = DbTableMeta(row[_TABLE_NAME])
         table_column: DbColumn = DbColumn(
             name=row[_COLUMN_NAME],
             type=row[_UDT_NAME],
-            ordinal_position=row[_ORDINAL_POSITION]
+            ordinal_position=row[_ORDINAL_POSITION],
         )
+        try:
+            table_database = row[_TABLE_DATABASE]
+        except IndexError:
+            table_database = None
 
         # Attempt to get table schema
-        table_key: str = f"{table_schema_name}.{table_name}"
-        table_schema: Optional[DbTableSchema] = schemas.get(table_key)
+        table_key = ".".join(
+            filter(None, [table_database, table_schema_name, table_name.name])
+        )
+        # table_key: str = f"{table_schema_name}.{table_name}"
+        table_schema: Optional[DbTableSchema]
+        table_schema, _ = schemas.get(table_key) or (None, None)
 
         if table_schema:
             # Add column to existing table schema.
-            schemas[table_key].columns.append(table_column)
+            schemas[table_key][0].columns.append(table_column)
         else:
             # Create new table schema with column.
-            schemas[table_key] = DbTableSchema(
-                schema_name=table_schema_name,
-                table_name=table_name,
-                columns=[table_column]
+            schemas[table_key] = (
+                DbTableSchema(
+                    schema_name=table_schema_name,
+                    table_name=table_name,
+                    columns=[table_column],
+                ),
+                table_database,
             )
     return list(schemas.values())
+
+
+def create_information_schema_query(
+    columns: List[str],
+    information_schema_table_name: str,
+    tables_hierarchy: TablesHierarchy,
+    case_sensitive: bool = False,
+) -> str:
+    """
+    This function creates query for getting table schemas from information schema.
+    """
+    sqls = []
+    for db, schema_mapping in tables_hierarchy.items():
+        filter_clauses = create_filter_clauses(schema_mapping, case_sensitive)
+        source = information_schema_table_name
+        if db:
+            source = f"{db.upper() if case_sensitive else db}." f"{source}"
+        sqls.append(
+            (
+                f"SELECT {', '.join(columns)} "
+                f"FROM {source} "
+                f"WHERE {' OR '.join(filter_clauses)}"
+            )
+        )
+    return " UNION ALL ".join(sqls) + ";"
+
+
+def create_filter_clauses(schema_mapping, case_sensitive: bool = False) -> List[str]:
+    filter_clauses = []
+    for schema, tables in schema_mapping.items():
+        table_names = ",".join(
+            map(
+                lambda name: f"'{name.upper() if case_sensitive else name}'",
+                tables,
+            )
+        )
+        if schema:
+            filter_clauses.append(
+                f"( table_schema = '{schema.upper()}' AND table_name IN ({table_names}) )"
+            )
+        else:
+            filter_clauses.append(f"( table_name IN ({table_names}) )")
+    return filter_clauses

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -3,13 +3,19 @@ import logging
 from typing import List, Optional, TYPE_CHECKING, Dict, Tuple
 from urllib.parse import urlparse
 
-from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
+from openlineage.airflow.extractors.dbapi_utils import (
+    get_table_schemas,
+    create_information_schema_query,
+    TablesHierarchy
+)
 from openlineage.airflow.utils import get_connection
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.facet import BaseFacet, SqlJobFacet
 from openlineage.common.sql import SqlMeta, parse
 from openlineage.common.dataset import Dataset, Source
 from abc import abstractmethod
+
+from openlineage.common.sql.parser import DbTableMeta
 
 if TYPE_CHECKING:
     from airflow.models import Connection, BaseHook
@@ -20,10 +26,23 @@ logger = logging.getLogger(__name__)
 class SqlExtractor(BaseExtractor):
     default_schema = "public"
 
+    _information_schema_columns = [
+        "table_schema",
+        "table_name",
+        "column_name",
+        "ordinal_position",
+        "udt_name",
+    ]
+    _information_schema_table_name = "information_schema.columns"
+    _is_information_schema_cross_db = False
+    _is_case_sensitive = False
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._conn = None
         self._hook = None
+        self._database: Optional[str] = None
+        self._scheme: Optional[str] = None
 
     def extract(self) -> TaskMetadata:
         task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
@@ -46,7 +65,7 @@ class SqlExtractor(BaseExtractor):
 
         # (2) Construct source object
         source = Source(
-            scheme=self._scheme,
+            scheme=self.scheme,
             authority=self._get_authority(),
             connection_url=self._get_connection_uri(),
         )
@@ -63,8 +82,12 @@ class SqlExtractor(BaseExtractor):
             self.hook,
             source,
             database,
-            self._get_in_query(sql_meta.in_tables) if sql_meta.in_tables else None,
-            self._get_out_query(sql_meta.out_tables) if sql_meta.out_tables else None,
+            self._information_schema_query(sql_meta.in_tables)
+            if sql_meta.in_tables
+            else None,
+            self._information_schema_query(sql_meta.out_tables)
+            if sql_meta.out_tables
+            else None,
         )
 
         for ds in inputs:
@@ -103,15 +126,23 @@ class SqlExtractor(BaseExtractor):
         return self._conn
 
     @property
-    def _scheme(self) -> str:
-        return self._get_scheme()
+    def scheme(self) -> Optional[str]:
+        if not self._scheme:
+            self._scheme = self._get_scheme()
+        return self._scheme
+
+    @property
+    def database(self) -> Optional[str]:
+        if not self._database:
+            self._database = self._get_database()
+        return self._database
 
     @abstractmethod
-    def _get_scheme(self) -> str:
+    def _get_scheme(self) -> Optional[str]:
         raise NotImplementedError
 
     @abstractmethod
-    def _get_database(self) -> str:
+    def _get_database(self) -> Optional[str]:
         raise NotImplementedError
 
     def _get_authority(self) -> str:
@@ -129,14 +160,6 @@ class SqlExtractor(BaseExtractor):
     def _get_connection_uri(self) -> str:
         raise NotImplementedError
 
-    # optional to implement
-    def _get_in_query(self, in_tables) -> str:
-        pass
-
-    # optional to implement
-    def _get_out_query(self, out_tables) -> str:
-        pass
-
     def _get_db_specific_run_facets(
         self,
         source: Source,
@@ -150,3 +173,35 @@ class SqlExtractor(BaseExtractor):
 
     def _get_output_facets(self) -> Dict[str, BaseFacet]:
         return {}
+
+    def _information_schema_query(self, tables: List[DbTableMeta]) -> str:
+        tables_hierarchy = self._get_tables_hierarchy(
+            tables,
+            database=self.database,
+            is_cross_db=self._is_information_schema_cross_db,
+        )
+        return create_information_schema_query(
+            columns=self._information_schema_columns,
+            information_schema_table_name=self._information_schema_table_name,
+            tables_hierarchy=tables_hierarchy,
+            case_sensitive=self._is_case_sensitive,
+        )
+
+    @staticmethod
+    def _get_tables_hierarchy(
+        tables: List[DbTableMeta],
+        database: Optional[str] = None,
+        is_cross_db: bool = False,
+    ) -> TablesHierarchy:
+        def normalize_name(name: Optional[str]) -> Optional[str]:
+            return name.lower() if name else name
+        hierarchy: TablesHierarchy = {}
+        for table in tables:
+            if is_cross_db:
+                db = table.database or database
+            else:
+                db = None
+            hierarchy.setdefault(normalize_name(db), {}).setdefault(
+                normalize_name(table.schema), []
+            ).append(table.name)
+        return hierarchy

--- a/integration/airflow/tests/extractors/test_dbapi_utils.py
+++ b/integration/airflow/tests/extractors/test_dbapi_utils.py
@@ -3,7 +3,10 @@
 
 from unittest.mock import MagicMock
 
-from openlineage.airflow.extractors.dbapi_utils import get_table_schemas
+from openlineage.airflow.extractors.dbapi_utils import (
+    get_table_schemas,
+    create_filter_clauses,
+)
 from openlineage.common.dataset import Source, Dataset
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
@@ -12,36 +15,14 @@ DB_NAME = 'FOOD_DELIVERY'
 DB_SCHEMA_NAME = 'PUBLIC'
 DB_TABLE_NAME = DbTableMeta('DISCOUNTS')
 DB_TABLE_COLUMNS = [
-    DbColumn(
-        name='ID',
-        type='int4',
-        ordinal_position=1
-    ),
-    DbColumn(
-        name='AMOUNT_OFF',
-        type='int4',
-        ordinal_position=2
-    ),
-    DbColumn(
-        name='CUSTOMER_EMAIL',
-        type='varchar',
-        ordinal_position=3
-    ),
-    DbColumn(
-        name='STARTS_ON',
-        type='timestamp',
-        ordinal_position=4
-    ),
-    DbColumn(
-        name='ENDS_ON',
-        type='timestamp',
-        ordinal_position=5
-    )
+    DbColumn(name="ID", type="int4", ordinal_position=1),
+    DbColumn(name="AMOUNT_OFF", type="int4", ordinal_position=2),
+    DbColumn(name="CUSTOMER_EMAIL", type="varchar", ordinal_position=3),
+    DbColumn(name="STARTS_ON", type="timestamp", ordinal_position=4),
+    DbColumn(name="ENDS_ON", type="timestamp", ordinal_position=5),
 ]
 DB_TABLE_SCHEMA = DbTableSchema(
-    schema_name=DB_SCHEMA_NAME,
-    table_name=DB_TABLE_NAME,
-    columns=DB_TABLE_COLUMNS
+    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
 )
 
 
@@ -49,33 +30,194 @@ def test_get_table_schemas():
     hook = MagicMock()
     # (2) Mock calls to database
     rows = [
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ID', 1, 'int4'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'AMOUNT_OFF', 2, 'int4'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'CUSTOMER_EMAIL', 3, 'varchar'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'STARTS_ON', 4, 'timestamp'),
-        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, 'ENDS_ON', 5, 'timestamp')
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "CUSTOMER_EMAIL", 3, "varchar"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "STARTS_ON", 4, "timestamp"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ENDS_ON", 5, "timestamp"),
     ]
 
-    hook.get_conn.return_value \
-        .cursor.return_value \
-        .fetchall.side_effect = [rows, rows]
+    hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, rows]
 
-    source = Source(
-        scheme="bigquery",
-        authority=None,
-        connection_url=None,
-        name=None
-    )
+    source = Source(scheme="bigquery", authority=None, connection_url=None, name=None)
 
     table_schemas = get_table_schemas(
         hook=hook,
         source=source,
         database=DB_NAME,
         in_query="fake_sql",
-        out_query="another_fake_sql"
+        out_query="another_fake_sql",
     )
 
     assert table_schemas == (
         [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
-        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)]
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
     )
+
+
+def test_get_table_schemas_with_mixed_databases():
+    hook = MagicMock()
+    ANOTHER_DB_NAME = "ANOTHER_DB"
+
+    rows = [
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4", DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4", DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "CUSTOMER_EMAIL", 3, "varchar", DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "STARTS_ON", 4, "timestamp", DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ENDS_ON", 5, "timestamp", DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4", ANOTHER_DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4", ANOTHER_DB_NAME),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "CUSTOMER_EMAIL",
+            3,
+            "varchar",
+            ANOTHER_DB_NAME,
+        ),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "STARTS_ON",
+            4,
+            "timestamp",
+            ANOTHER_DB_NAME,
+        ),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "ENDS_ON",
+            5,
+            "timestamp",
+            ANOTHER_DB_NAME,
+        ),
+    ]
+
+    hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
+
+    source = Source(scheme="bigquery", authority=None, connection_url=None, name=None)
+
+    table_schemas = get_table_schemas(
+        hook=hook,
+        source=source,
+        database=DB_NAME,
+        in_query="fake_sql",
+        out_query="another_fake_sql",
+    )
+
+    assert table_schemas == (
+        [
+            Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME),
+            Dataset.from_table_schema(source, DB_TABLE_SCHEMA, ANOTHER_DB_NAME),
+        ],
+        [],
+    )
+
+
+def test_get_table_schemas_with_mixed_schemas():
+    hook = MagicMock()
+    ANOTHER_DB_SCHEMA_NAME = "ANOTHER_DB_SCHEMA"
+    ANOTHER_DB_TABLE_SCHEMA = DbTableSchema(
+        schema_name=ANOTHER_DB_SCHEMA_NAME,
+        table_name=DB_TABLE_NAME,
+        columns=DB_TABLE_COLUMNS,
+    )
+
+    rows = [
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "CUSTOMER_EMAIL", 3, "varchar"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "STARTS_ON", 4, "timestamp"),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ENDS_ON", 5, "timestamp"),
+        (ANOTHER_DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4"),
+        (ANOTHER_DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4"),
+        (ANOTHER_DB_SCHEMA_NAME, DB_TABLE_NAME.name, "CUSTOMER_EMAIL", 3, "varchar"),
+        (ANOTHER_DB_SCHEMA_NAME, DB_TABLE_NAME.name, "STARTS_ON", 4, "timestamp"),
+        (ANOTHER_DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ENDS_ON", 5, "timestamp"),
+    ]
+
+    hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
+
+    source = Source(scheme="bigquery", authority=None, connection_url=None, name=None)
+
+    table_schemas = get_table_schemas(
+        hook=hook,
+        source=source,
+        database=DB_NAME,
+        in_query="fake_sql",
+        out_query="another_fake_sql",
+    )
+
+    assert table_schemas == (
+        [
+            Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME),
+            Dataset.from_table_schema(source, ANOTHER_DB_TABLE_SCHEMA, DB_NAME),
+        ],
+        [],
+    )
+
+
+def test_get_table_schemas_with_other_database():
+    hook = MagicMock()
+    ANOTHER_DB_NAME = "ANOTHER_DB"
+
+    rows = [
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "ID", 1, "int4", ANOTHER_DB_NAME),
+        (DB_SCHEMA_NAME, DB_TABLE_NAME.name, "AMOUNT_OFF", 2, "int4", ANOTHER_DB_NAME),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "CUSTOMER_EMAIL",
+            3,
+            "varchar",
+            ANOTHER_DB_NAME,
+        ),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "STARTS_ON",
+            4,
+            "timestamp",
+            ANOTHER_DB_NAME,
+        ),
+        (
+            DB_SCHEMA_NAME,
+            DB_TABLE_NAME.name,
+            "ENDS_ON",
+            5,
+            "timestamp",
+            ANOTHER_DB_NAME,
+        ),
+    ]
+
+    hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, rows]
+
+    source = Source(scheme="bigquery", authority=None, connection_url=None, name=None)
+
+    table_schemas = get_table_schemas(
+        hook=hook,
+        source=source,
+        database=DB_NAME,
+        in_query="fake_sql",
+        out_query="another_fake_sql",
+    )
+
+    assert table_schemas == (
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, ANOTHER_DB_NAME)],
+        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, ANOTHER_DB_NAME)],
+    )
+
+
+def test_create_filter_clauses():
+    assert create_filter_clauses({None: ["C1", "C2"]}) == [
+        "( table_name IN ('C1','C2') )"
+    ]
+    assert create_filter_clauses(
+        {"Schema1": ["Table1"], "Schema2": ["Table2"]}
+    ) == [
+        "( table_schema = 'SCHEMA1' AND table_name IN ('Table1') )",
+        "( table_schema = 'SCHEMA2' AND table_name IN ('Table2') )",
+    ]
+    assert create_filter_clauses(
+        {"Schema1": ["Table1", "Table2"]}
+    ) == ["( table_schema = 'SCHEMA1' AND table_name IN ('Table1','Table2') )"]

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -201,3 +201,44 @@ def create_connection():
 def test_get_connection_returns_one_if_exists(create_connection):
     conn = Connection("does_exist")
     assert get_connection("does_exist").conn_id == conn.conn_id
+
+
+@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+def test_information_schema_query(get_connection):
+    extractor = MySqlExtractor(TASK)
+
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI)
+    get_connection.return_value = conn
+
+    same_schema_explicit = [
+        DbTableMeta("SCHEMA.TABLE_A"),
+        DbTableMeta("SCHEMA.TABLE_B"),
+    ]
+
+    same_schema_explicit_sql = (
+            "SELECT table_schema, table_name, column_name, ordinal_position, column_type "
+            "FROM information_schema.columns "
+            "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A','TABLE_B') );"
+    )
+
+    different_schema_implicit = [
+        DbTableMeta("SCHEMA.TABLE_A"),
+        DbTableMeta("ANOTHER_SCHEMA.TABLE_B"),
+    ]
+
+    different_schema_implicit_sql = (
+        "SELECT table_schema, table_name, column_name, ordinal_position, column_type "
+        "FROM information_schema.columns "
+        "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A') ) "
+        "OR ( table_schema = 'ANOTHER_SCHEMA' AND table_name IN ('TABLE_B') );"
+    )
+
+    assert (
+        extractor._information_schema_query(same_schema_explicit)
+        == same_schema_explicit_sql
+    )
+    assert (
+        extractor._information_schema_query(different_schema_implicit)
+        == different_schema_implicit_sql
+    )

--- a/integration/airflow/tests/extractors/test_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_sql_extractor.py
@@ -1,0 +1,42 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from openlineage.common.sql import DbTableMeta
+from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+
+
+def test_get_tables_hierarchy():
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Table1"), DbTableMeta("Table2")]
+    ) == {None: {None: ["Table1", "Table2"]}}
+
+    # base check with db, no cross db
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")]
+    ) == {None: {"schema1": ["Table1"], "schema2": ["Table2"]}}
+
+    # same, with cross db
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")],
+        is_cross_db=True,
+    ) == {"db": {"schema1": ["Table1"], "schema2": ["Table2"]}}
+
+    # explicit db, no cross db
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        database="Db",
+    ) == {None: {"schema1": ["Table1", "Table2"]}}
+
+    # explicit db, with cross db
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        database="Db",
+        is_cross_db=True,
+    ) == {"db": {"schema1": ["Table1", "Table2"]}}
+
+    # mixed db, with cross db
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Db2.Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        database="Db",
+        is_cross_db=True,
+    ) == {"db": {"schema1": ["Table2"]}, "db2": {"schema1": ["Table1"]}}

--- a/integration/airflow/tests/integration/requests/mysql.json
+++ b/integration/airflow/tests/integration/requests/mysql.json
@@ -62,13 +62,13 @@
 			"schema": {
 				"fields": [{
 					"name": "order_day_of_week",
-					"type": "varchar"
+					"type": "varchar(64)"
 				}, {
 					"name": "order_placed_on",
 					"type": "timestamp"
 				}, {
 					"name": "orders_placed",
-					"type": "int4"
+					"type": "int"
 				}]
 			}
 		},
@@ -106,13 +106,13 @@
 			"schema": {
 				"fields": [{
 					"name": "order_day_of_week",
-					"type": "varchar"
+					"type": "varchar(64)"
 				}, {
 					"name": "order_placed_on",
 					"type": "timestamp"
 				}, {
 					"name": "orders_placed",
-					"type": "int4"
+					"type": "int"
 				}]
 			}
 		},


### PR DESCRIPTION
…to differentiate databases and schemas.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Snowflake upper cases fix.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

There was no notion of database & schemas when querying and parsing results from `information_schema` tables. Additionally, `MySqlExtractor` should have follow naming convention defined in [spec](https://github.com/OpenLineage/OpenLineage/blob/42177fd1066ce911babfec59a4ba85bdc2dfbff6/spec/Naming.md?plain=1#L46).

Closes: #916 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained