### PR TITLE
[PROPOSAL] Add transformation field to ColumnLineageDatasetFacet

### DIFF
--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -131,6 +131,8 @@ Example of valid name is `BigQueryStatisticsJobFacet` and it's key `bigQuery_sta
 
 - **version**: Captures the dataset version when versioning is defined by database (ex. Iceberg snapshot ID)
 
+- **columnLineage**: Captures the column-level lineage
+
 #### Input Dataset Facets
 
 - **dataQualityMetrics**: Captures dataset level and column level data quality metrics when scanning a dataset whith a DataQuality library (row count, byte size, null count, distinct count, average, min, max, quantiles).

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -38,9 +38,13 @@
                     ]
                   }
                 },
-                "transformation": {
+                "transformationDescription": {
                    "type": "string",
                    "description": "a string representation of the transformation applied"
+                },
+                "transformationType": {
+                   "type": "string",
+                   "description": "IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no original data available (like a hash of PII for example)"
                 }
               },
               "additionalProperties": true,

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -30,10 +30,6 @@
                       "field": {
                         "type": "string",
                         "description": "The input field"
-                      },
-                      "transformation": {
-                        "type": "string",
-                        "description": "a string representation of the transformation applied"
                       }
                     },
                     "additionalProperties": true,
@@ -41,8 +37,13 @@
                       "namespace", "name", "field"
                     ]
                   }
+                },
+                "transformation": {
+                   "type": "string",
+                   "description": "a string representation of the transformation applied"
                 }
               },
+              "additionalProperties": true,
               "required": ["inputFields"]
             }      
           }    

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -30,8 +30,13 @@
                       "field": {
                         "type": "string",
                         "description": "The input field"
+                      },
+                      "transformation": {
+                        "type": "string",
+                        "description": "a string representation of the transformation applied"
                       }
                     },
+                    "additionalProperties": true,
                     "required": [
                       "namespace", "name", "field"
                     ]

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/ColumnLineageDatasetFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-0-1/ColumnLineageDatasetFacet.json",
   "$defs": {
     "ColumnLineageDatasetFacet": {
       "allOf": [{


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

In column-level lineage we want to be able to capture  a string representation of what the transformation looks like for information purpose.

### Solution

This PR adds a transformation field to the column level lineage facet schema
It is a _backwards-compatible_ change.

closes #992

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)