### PR TITLE
spark3: add Azure Cosmos Handler

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -15,8 +15,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 public class CatalogUtils3 {
+
+  private static List<RelationHandler> relationHandlers = getRelationHandlers();
 
   private static List<CatalogHandler> getHandlers(OpenLineageContext context) {
     List<CatalogHandler> handlers =
@@ -27,6 +30,11 @@ public class CatalogUtils3 {
             new JdbcHandler(),
             new V2SessionCatalogHandler());
     return handlers.stream().filter(CatalogHandler::hasClasses).collect(Collectors.toList());
+  }
+
+  private static List<RelationHandler> getRelationHandlers() {
+    List<RelationHandler> handlers = Arrays.asList(new CosmosHandler());
+    return handlers.stream().filter(RelationHandler::hasClasses).collect(Collectors.toList());
   }
 
   public static DatasetIdentifier getDatasetIdentifier(
@@ -58,6 +66,26 @@ public class CatalogUtils3 {
   public static Optional<CatalogHandler> getCatalogHandler(
       OpenLineageContext context, TableCatalog catalog) {
     return getHandlers(context).stream().filter(handler -> handler.isClass(catalog)).findAny();
+  }
+
+  public static DatasetIdentifier getDatasetIdentifierFromRelation(DataSourceV2Relation relation) {
+    return getDatasetIdentifierFromRelation(relation, relationHandlers);
+  }
+
+  public static DatasetIdentifier getDatasetIdentifierFromRelation(
+      DataSourceV2Relation relation, List<RelationHandler> relationHandlers) {
+    return relationHandlers.stream()
+        .filter(
+            handler -> handler.isClass(relation)) // TODO: is checking just the name in isClass ok?
+        .map(handler -> handler.getDatasetIdentifier(relation))
+        .findAny()
+        .orElseThrow(
+            () ->
+                new UnsupportedCatalogException(
+                    relation
+                        .getClass()
+                        .getCanonicalName())); // TODO: should have a diff exception here -
+    // UnsupportedRelationException
   }
 
   public static Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -75,17 +75,10 @@ public class CatalogUtils3 {
   public static DatasetIdentifier getDatasetIdentifierFromRelation(
       DataSourceV2Relation relation, List<RelationHandler> relationHandlers) {
     return relationHandlers.stream()
-        .filter(
-            handler -> handler.isClass(relation)) // TODO: is checking just the name in isClass ok?
+        .filter(handler -> handler.isClass(relation))
         .map(handler -> handler.getDatasetIdentifier(relation))
         .findAny()
-        .orElseThrow(
-            () ->
-                new UnsupportedCatalogException(
-                    relation
-                        .getClass()
-                        .getCanonicalName())); // TODO: should have a diff exception here -
-    // UnsupportedRelationException
+        .orElseThrow(() -> new UnsupportedCatalogException(relation.getClass().getCanonicalName()));
   }
 
   public static Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
@@ -49,7 +49,7 @@ public class CosmosHandler implements RelationHandler {
 
     if (tableParts.length != expectedParts) {
       name = relationName;
-      namespace = relationName;
+      namespace = "azurecosmos";
     } else {
       namespace =
           String.format(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import io.openlineage.spark.agent.util.DatasetIdentifier;
@@ -9,15 +14,22 @@ public class CosmosHandler implements RelationHandler {
 
   @Override
   public boolean hasClasses() {
+    String COSMOS_CATALOG_NAME = "com.azure.cosmos.spark.CosmosCatalog";
+
     try {
-      CosmosHandler.class.getClassLoader().loadClass("com.azure.cosmos.spark.CosmosCatalog");
+      CosmosHandler.class.getClassLoader().loadClass(COSMOS_CATALOG_NAME);
       return true;
     } catch (Exception e) {
-      log.info("Exception raised in CosmosHandler hasClasses {}", e);
       // swallow- we don't care
     }
-    return true; // TODO: figure out how to get the cosmos class - classpath issue that Kusto also
-    // has.
+    try {
+      Thread.currentThread().getContextClassLoader().loadClass(COSMOS_CATALOG_NAME);
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+
+    }
+    return false;
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
@@ -1,0 +1,54 @@
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+public class CosmosHandler implements RelationHandler {
+
+  @Override
+  public boolean hasClasses() {
+    try {
+      CosmosHandler.class.getClassLoader().loadClass("com.azure.cosmos.spark.CosmosCatalog");
+      return true;
+    } catch (Exception e) {
+      log.info("Exception raised in CosmosHandler hasClasses {}", e);
+      // swallow- we don't care
+    }
+    return true; // TODO: figure out how to get the cosmos class - classpath issue that Kusto also
+    // has.
+  }
+
+  @Override
+  public boolean isClass(DataSourceV2Relation relation) {
+    return relation.table().name().contains("com.azure.cosmos.spark.items.");
+  }
+
+  @Override
+  public DatasetIdentifier getDatasetIdentifier(DataSourceV2Relation relation) {
+
+    String name;
+    String namespace;
+
+    String relationName = relation.table().name().replace("com.azure.cosmos.spark.items.", "");
+    int expectedParts = 3;
+    String[] tableParts = relationName.split("\\.", expectedParts);
+
+    if (tableParts.length != expectedParts) {
+      name = relationName;
+      namespace = relationName;
+    } else {
+      namespace =
+          String.format(
+              "azurecosmos://%s.documents.azure.com/dbs/%s", tableParts[0], tableParts[1]);
+      name = String.format("/colls/%s", tableParts[2]);
+    }
+    return new DatasetIdentifier(name, namespace);
+  }
+
+  @Override
+  public String getName() {
+    return "cosmos";
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+// import io.openlineage.spark.agent.facets.TableProviderFacet;
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+public interface RelationHandler {
+  boolean hasClasses();
+
+  boolean isClass(DataSourceV2Relation relation);
+
+  DatasetIdentifier getDatasetIdentifier(DataSourceV2Relation relation);
+
+  // default Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
+  //   return Optional.empty();
+  // }
+
+  String getName();
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
@@ -5,10 +5,7 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
-// import io.openlineage.spark.agent.facets.TableProviderFacet;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 public interface RelationHandler {
@@ -17,10 +14,6 @@ public interface RelationHandler {
   boolean isClass(DataSourceV2Relation relation);
 
   DatasetIdentifier getDatasetIdentifier(DataSourceV2Relation relation);
-
-  // default Optional<TableProviderFacet> getTableProviderFacet(Map<String, String> properties) {
-  //   return Optional.empty();
-  // }
 
   String getName();
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -109,8 +109,7 @@ public class PlanUtils3 {
       if (!di.isPresent()) {
         return Collections.emptyList();
       }
-    }
-    else {
+    } else {
       Identifier identifier = relation.identifier().get();
 
       // Get catalog for dataset, or return empty list
@@ -128,13 +127,13 @@ public class PlanUtils3 {
       }
 
       CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-      .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
+          .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
     }
-    
+
     datasetFacetsBuilder
         .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
         .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
-    
+
     return Collections.singletonList(
         datasetFactory.getDataset(
             di.get().getName(), di.get().getNamespace(), datasetFacetsBuilder.build()));

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -30,6 +30,13 @@ public class PlanUtils3 {
 
   public static Optional<DatasetIdentifier> getDatasetIdentifier(
       OpenLineageContext context, DataSourceV2Relation relation) {
+
+    if (relation.identifier() == null) {
+      // Since identifier is null, short circuit and check if we can get the dataset identifer
+      // from the relation itself.
+      return getDatasetIdentifierFromRelation(relation);
+    }
+
     return Optional.of(relation)
         .filter(r -> r.identifier() != null)
         .filter(r -> r.identifier().isDefined())
@@ -67,7 +74,7 @@ public class PlanUtils3 {
     }
   }
 
-  public static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
+  private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
       DataSourceV2Relation relation) {
 
     try {
@@ -98,9 +105,7 @@ public class PlanUtils3 {
     // Get identifier for dataset, or return empty list
     if (relation.identifier().isEmpty()) {
       log.warn("Couldn't find identifier for dataset in plan {}", relation);
-      // Since there is no identifier, short circuit and check if this is a relationHandler instance
-      // if yes, then we get the datasetIdentifier and return the dataset list.
-      di = PlanUtils3.getDatasetIdentifierFromRelation(relation);
+      di = PlanUtils3.getDatasetIdentifier(context, relation);
       if (!di.isPresent()) {
         return Collections.emptyList();
       } else {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -31,12 +31,14 @@ public class PlanUtils3 {
   public static Optional<DatasetIdentifier> getDatasetIdentifier(
       OpenLineageContext context, DataSourceV2Relation relation) {
 
-    if (relation.identifier().isEmpty()) {
+    // if (relation.identifier() == null) {
+    //   return Optional.empty();
+    // }
+    if (relation.identifier() == null || relation.identifier().isEmpty()) {
       // Since identifier is null, short circuit and check if we can get the dataset identifer
       // from the relation itself.
       return getDatasetIdentifierFromRelation(relation);
     }
-    log.info("relation identifier is not null");
     return Optional.of(relation)
         .filter(r -> r.identifier() != null)
         .filter(r -> r.identifier().isDefined())

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -106,7 +106,6 @@ public class PlanUtils3 {
             datasetFactory.getDataset(
                 di.get().getName(), di.get().getNamespace(), datasetFacetsBuilder.build()));
       }
-      // return Collections.emptyList();
     }
     Identifier identifier = relation.identifier().get();
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -92,6 +92,8 @@ public class PlanUtils3 {
       DataSourceV2Relation relation,
       OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder) {
 
+    OpenLineage openLineage = context.getOpenLineage();
+
     Optional<DatasetIdentifier> di;
     // Get identifier for dataset, or return empty list
     if (relation.identifier().isEmpty()) {
@@ -102,6 +104,11 @@ public class PlanUtils3 {
       if (!di.isPresent()) {
         return Collections.emptyList();
       } else {
+
+        datasetFacetsBuilder
+            .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
+            .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+
         return Collections.singletonList(
             datasetFactory.getDataset(
                 di.get().getName(), di.get().getNamespace(), datasetFacetsBuilder.build()));
@@ -123,7 +130,6 @@ public class PlanUtils3 {
       return Collections.emptyList();
     }
 
-    OpenLineage openLineage = context.getOpenLineage();
     datasetFacetsBuilder
         .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
         .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -31,9 +31,6 @@ public class PlanUtils3 {
   public static Optional<DatasetIdentifier> getDatasetIdentifier(
       OpenLineageContext context, DataSourceV2Relation relation) {
 
-    // if (relation.identifier() == null) {
-    //   return Optional.empty();
-    // }
     if (relation.identifier() == null || relation.identifier().isEmpty()) {
       // Since identifier is null, short circuit and check if we can get the dataset identifer
       // from the relation itself.

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -31,12 +31,15 @@ public class PlanUtils3 {
   public static Optional<DatasetIdentifier> getDatasetIdentifier(
       OpenLineageContext context, DataSourceV2Relation relation) {
 
-    if (relation.identifier() == null) {
+    log.info("relation identifier: {}", relation.identifier());
+    log.info("relation identifier is empty? : {}", relation.identifier().isEmpty());
+    if (relation.identifier().isEmpty()) {
       // Since identifier is null, short circuit and check if we can get the dataset identifer
       // from the relation itself.
+      log.info("relation identifier is null");
       return getDatasetIdentifierFromRelation(relation);
     }
-
+    log.info("relation identifier is not null");
     return Optional.of(relation)
         .filter(r -> r.identifier() != null)
         .filter(r -> r.identifier().isDefined())
@@ -104,16 +107,18 @@ public class PlanUtils3 {
     Optional<DatasetIdentifier> di;
     // Get identifier for dataset, or return empty list
     if (relation.identifier().isEmpty()) {
+      log.info("hi -1");
       log.warn("Couldn't find identifier for dataset in plan {}", relation);
       di = PlanUtils3.getDatasetIdentifier(context, relation);
       if (!di.isPresent()) {
+        log.info("hi 0");
         return Collections.emptyList();
       } else {
-
+        log.info("hi 1");
         datasetFacetsBuilder
             .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
             .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
-
+        log.info("hi 2");
         return Collections.singletonList(
             datasetFactory.getDataset(
                 di.get().getName(), di.get().getNamespace(), datasetFacetsBuilder.build()));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
@@ -14,8 +14,6 @@ import io.openlineage.spark.agent.util.DatasetIdentifier;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.Test;
 
-// com.azure.cosmos.spark.items.openlineage-test-cosmos.exampledata.volcanoes
-
 public class CosmosHandlerTest {
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
@@ -6,12 +6,30 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.openlineage.spark.agent.util.DatasetIdentifier;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.Test;
 
+// com.azure.cosmos.spark.items.openlineage-test-cosmos.exampledata.volcanoes
+
 public class CosmosHandlerTest {
+
   @Test
   void testGetDatasetIdentifier() {
-    assertEquals("a", "a");
+    DataSourceV2Relation relation = mock(DataSourceV2Relation.class, RETURNS_DEEP_STUBS);
+    when(relation.table().name())
+        .thenReturn("com.azure.cosmos.spark.items.openlineage-test-cosmos.exampledata.volcanoes");
+
+    CosmosHandler cosmosHandler = new CosmosHandler();
+
+    DatasetIdentifier di = cosmosHandler.getDatasetIdentifier(relation);
+    assertEquals(
+        di.getNamespace(),
+        "azurecosmos://openlineage-test-cosmos.documents.azure.com/dbs/exampledata");
+    assertEquals(di.getName(), "/colls/volcanoes");
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
@@ -1,0 +1,17 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CosmosHandlerTest {
+  @Test
+  void testGetDatasetIdentifier() {
+    assertEquals("a", "a");
+  }
+}

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -132,6 +132,23 @@ Identifier:
  * Unique name: {schema}.{table}
    * URI = sqlserver://{host}:{port};database={database}/{schema}.{table}
 
+#### Azure Cosmos DB:
+Datasource hierarchy:
+azurecosmos://%s.documents.azure.com/dbs/%s
+ * Host: \<XXXXXXXXXXXX>.documents.azure.com
+ * Database
+ 
+Naming hierarchy:
+ * Schema
+ * Table
+
+Identifier:
+ * Namespace: azurecosmos://{host}/dbs/{database}
+   * Scheme = azurecosmos
+   * Authority = {host}
+ * Unique name: /colls/{table}
+   * URI = azurecosmos://{host}.documents.azure.com/dbs/{database}/colls/{table}
+
 ### Distributed file systems/blob stores
 #### GCS
 Datasource hierarchy: none, naming is global


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Openlineage does not support Azure Cosmos DB as an input or output.

Closes: #449 

### Solution

We discovered that the [Cosmos DB spark connector](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3_2-12) does not have TableCatalog, Identifier, TableProperties objects instantiated, but we can extract the table name and namespace from the relation's table object. In order to keep Cosmos specific code within a CosmosHandler, we defined a new interface - RelationHandler, the functions of which require only the DataSourceV2Relation. The CosmosHandler implements the RelationHandler interface. The RelationHandler interface can also be used to implement support for any future Spark 3 data sources which do not have TableCatalog, Identifier and TableProperties set. 

We have tested the implementation on Azure Databricks.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)