### PR TITLE
[FLINK] Change EventType from OTHER to RUNNING for running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.12.0...HEAD)
 * Add `RUNNING` EventType in specification and Python client [`#972`](https://github.com/OpenLineage/OpenLineage/pull/972) [@mzareba382](https://github.com/mzareba382)
+* Use `RUNNING` EventType in Flink integration for currently running jobs [`#985`](https://github.com/OpenLineage/OpenLineage/pull/985) [@mzareba382](https://github.com/mzareba382)
 ## [0.12.0](https://github.com/OpenLineage/OpenLineage/compare/0.11.0...0.12.0) 2022-08-01
 ### Added
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
@@ -63,14 +63,13 @@ public class FlinkExecutionContext implements ExecutionContext {
   public void onJobCheckpoint(CheckpointFacet facet) {
     log.debug("JobClient - jobId: {}", jobId);
     RunEvent runEvent =
-        buildEventForEventType(EventType.OTHER)
+        buildEventForEventType(EventType.RUNNING)
             .run(
                 new OpenLineage.RunBuilder()
                     .runId(runId)
                     .facets(new OpenLineage.RunFacetsBuilder().put("checkpoints", facet).build())
                     .build())
             .build();
-    // TODO: introduce better event type than OTHER
     log.debug("Posting event for onJobCheckpoint {}: {}", jobId, runEvent);
     eventEmitter.emit(runEvent);
   }

--- a/integration/flink/src/test/resources/events/expected_kafka_checkpoints.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_checkpoints.json
@@ -1,5 +1,5 @@
 {
-  "eventType" : "OTHER",
+  "eventType" : "RUNNING",
   "run": {
     "facets" : {
       "checkpoints": {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem
Within Flink integration, running jobs are sending events of type 'OTHER'. We should have an EventType with a name that clearly suggests that the event is currently running.

### Solution

This change makes use of newly introduced 'RUNNING' EventType, which is a part of OpenLineage specification now and changes events from running Flink job to be of this type. 

Related to: #972 
Closes: #946 


- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)