### PR TITLE
[PROXY] HttpLineageStream to forward lineage event to http endpoint

### DIFF
--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -122,9 +122,9 @@ def _handle_pipeline_event(
         timestamp: float,
         repository_name: Optional[str]
 ):
-    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE, and RUN_CANCELED.
-    Assumes event type is always in the order of RUN_START
-    followed by RUN_SUCCESS, RUN_FAILURE, or RUN_CANCELED.
+    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE, and 
+    RUN_CANCELED. Assumes event type is always in the order of RUN_START followed by 
+    RUN_SUCCESS, RUN_FAILURE, or RUN_CANCELED.
 
     :param running_pipelines: map of pipeline run ids to dynamically generated metadata
                               for pipelines that are in progress between sensor evaluations.

--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -122,8 +122,8 @@ def _handle_pipeline_event(
         timestamp: float,
         repository_name: Optional[str]
 ):
-    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE, and 
-    RUN_CANCELED. Assumes event type is always in the order of RUN_START followed by 
+    """Handles pipeline events that are of type RUN_START, RUN_SUCCESS, RUN_FAILURE, and
+    RUN_CANCELED. Assumes event type is always in the order of RUN_START followed by
     RUN_SUCCESS, RUN_FAILURE, or RUN_CANCELED.
 
     :param running_pipelines: map of pipeline run ids to dynamically generated metadata

--- a/integration/flink/.gitignore
+++ b/integration/flink/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+bin/

--- a/integration/spark/.gitignore
+++ b/integration/spark/.gitignore
@@ -1,0 +1,2 @@
+bin/
+*.class

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -2,6 +2,14 @@
 proxy.yml
 !examples/kafka/proxy.yml
 
+# Gradle
+.gradle
+.project
+.classpath
+bin
+build
+*.class
+
 # MacOS
 .DS_Store
 __MACOSX

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -26,8 +26,8 @@ $ cp proxy.example.yml proxy.yml
 
 By default, the OpenLineage proxy uses the following ports:
 
-* TCP port `8080` is available for the HTTP API server.
-* TCP port `8081` is available for the admin interface.
+* TCP port `5000` is available for the HTTP API server.
+* TCP port `5001` is available for the admin interface.
 
 > **Note:** All of the configuration settings in `proxy.yml` can be specified either in the configuration file or in an environment variable.
 

--- a/proxy/proxy.example.yml
+++ b/proxy/proxy.example.yml
@@ -57,3 +57,6 @@ proxy:
     #     value.serializer : org.apache.kafka.common.serialization.StringSerializer
     #     bring.up.retries : 10
     #     bring.up.minSleepTime : 5000
+    # Enables proxying OpenLineage events to a http backend (e.g. Marquez)
+    # - type: Http
+    #   url: http://localhost:5000/api/v1/lineage

--- a/proxy/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
+++ b/proxy/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
@@ -7,11 +7,13 @@ package io.openlineage.proxy;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.openlineage.proxy.api.models.ConsoleConfig;
+import io.openlineage.proxy.api.models.HttpConfig;
 import io.openlineage.proxy.api.models.KafkaConfig;
 
 @JsonSubTypes({
   @JsonSubTypes.Type(value = ConsoleConfig.class, name = "Console"),
-  @JsonSubTypes.Type(value = KafkaConfig.class, name = "Kafka")
+  @JsonSubTypes.Type(value = KafkaConfig.class, name = "Kafka"),
+  @JsonSubTypes.Type(value = HttpConfig.class, name = "Http")
 })
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public interface ProxyStreamConfig {}

--- a/proxy/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
+++ b/proxy/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
@@ -1,6 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0.
- */
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.proxy;
 

--- a/proxy/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
+++ b/proxy/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
@@ -8,6 +8,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.openlineage.proxy.api.models.ConsoleConfig;
 import io.openlineage.proxy.api.models.ConsoleLineageStream;
+import io.openlineage.proxy.api.models.HttpConfig;
+import io.openlineage.proxy.api.models.HttpLineageStream;
 import io.openlineage.proxy.api.models.KafkaConfig;
 import io.openlineage.proxy.api.models.KafkaLineageStream;
 import io.openlineage.proxy.api.models.LineageStream;
@@ -52,6 +54,9 @@ public final class ProxyStreamFactory {
         kafkaConfig.getProperties().put("bootstrap.servers", kafkaConfig.getBootstrapServerUrl());
         kafkaConfig.getProperties().put("server.id", kafkaConfig.getLocalServerId());
         lineageStreams.add(new KafkaLineageStream((KafkaConfig) config));
+      } else if (config instanceof HttpConfig) {
+        final HttpConfig httpConfig = (HttpConfig) config;
+        lineageStreams.add(new HttpLineageStream((HttpConfig) config));
       }
     }
     return lineageStreams.build();

--- a/proxy/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
+++ b/proxy/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
@@ -1,6 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0.
- */
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.proxy;
 

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
@@ -1,6 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0.
- */
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.proxy.api.models;
 

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
@@ -28,9 +28,6 @@ public class ConsoleLineageStream extends LineageStream {
         String prettyJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
         log.info(prettyJson);
       } catch (JsonProcessingException jpe) {
-        if (log.isErrorEnabled()) {
-          log.error("Unable to beautify given JSON string");
-        }
         log.info(eventAsString);
       }
     } else {

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/HttpConfig.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/HttpConfig.java
@@ -1,0 +1,18 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.proxy.api.models;
+
+import io.openlineage.proxy.ProxyStreamConfig;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+public final class HttpConfig implements ProxyStreamConfig {
+  @Getter @Setter private String url;
+}

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/HttpLineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/HttpLineageStream.java
@@ -1,0 +1,46 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.proxy.api.models;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/** HttpLineageStream pushes events to http endpoint */
+@Slf4j
+public class HttpLineageStream extends LineageStream {
+
+  private final String url;
+
+  public HttpLineageStream(@NonNull final HttpConfig httpConfig) {
+    super(Type.HTTP);
+    this.url = httpConfig.getUrl();
+  }
+
+  @Override
+  public void collect(@NonNull String eventAsString) {
+    eventAsString = eventAsString.trim();
+    try {
+      ClientBuilder cb = ClientBuilder.newBuilder();
+      Client client = cb.build();
+
+      Response response =
+          client
+              .target(this.url)
+              .request(MediaType.APPLICATION_JSON)
+              .post(Entity.json(eventAsString));
+      int status = response.getStatus();
+      log.debug("Received lineage event: {} \n response code: {}", eventAsString, status);
+    } catch (WebApplicationException ex) {
+      log.error("Exception occurred during HttpLineageStream's collect() call.");
+      log.error(ex.getMessage());
+    }
+  }
+}

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
@@ -1,6 +1,7 @@
 /*
- * SPDX-License-Identifier: Apache-2.0.
- */
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.proxy.api.models;
 

--- a/proxy/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
+++ b/proxy/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
@@ -17,6 +17,7 @@ public abstract class LineageStream {
    */
   enum Type {
     CONSOLE,
+    HTTP,
     KAFKA
   }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

This PR implements HttpLineageStream that can be used to forward lineage event into http endpoint. Currently API token is not supported.

Closes: #984 
### Solution
The feature will enable OL proxy to act as a proxy layer to output received OL event, as well as forward the received event to any running OL backend, via Http. A good example is when you can use the proxy to view the received event, and also forward it into Marquez backend to store it.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)