### PR TITLE
forced tests to be executed before creating shadow jar

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -181,6 +181,7 @@ assemble {
 }
 
 shadowJar {
+    dependsOn test
     minimize(){
         exclude (project(":shared"))
         exclude (project(":spark2"))

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -34,7 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -96,7 +95,6 @@ class LibraryTest {
   //  }
 
   @Test
-  @Disabled
   void testRdd(SparkSession spark) throws IOException {
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getJobNamespace())
         .thenReturn("ns_name");


### PR DESCRIPTION
Signed-off-by: tomasznazarewicz <t.nazarewicz94@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

while executing `LibraryTest.testRdd` with
`./gradlew --no-daemon --stacktrace app:build app:test -Pspark.version=3.1.3 --tests "io.openlineage.spark.agent.lifecycle.LibraryTest.testRdd"`
the test fails with following error:
```
io.openlineage.spark.agent.lifecycle.LibraryTest testRdd(SparkSession) FAILED (3.6s)
java.lang.NoSuchMethodError: io.openlineage.client.OpenLineageClientUtils.newObjectMapper()Lcom/fasterxml/jackson/databind/ObjectMapper;
at io.openlineage.spark.agent.lifecycle.LibraryTest.testRdd(LibraryTest.java:125)
```

As the method exists in OpenLineage java client so the issue has to be with managing dependencies during build.

### Solution

As it turns out, the tests are executed after creating shadow jar and are affected by the shading of packages. When tests are made to execute before, build seems to pass
