### PR TITLE
exclude integrations 2.4.6 and 3.3.0 from delta lake tests

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -56,10 +56,10 @@ ext {
     testcontainersVersion = '1.15.3'
     shortVersion = sparkVersion.substring(0,3)
     versionsMap = [
-            "3.3": ["module": "spark33",    "scala": "2.12", "delta": "1.2.0"],
-            "3.2": ["module": "spark32",    "scala": "2.12", "delta": "1.2.0"],
+            "3.3": ["module": "spark33",    "scala": "2.12", "delta": "NA"],
+            "3.2": ["module": "spark32",    "scala": "2.12", "delta": "1.1.0"],
             "3.1": ["module": "spark3",     "scala": "2.12", "delta": "1.0.0"],
-            "2.4": ["module": "spark2",     "scala": "2.11"]
+            "2.4": ["module": "spark2",     "scala": "2.11", "delta": "NA"]
     ]
     versions = versionsMap[shortVersion]
 }
@@ -98,7 +98,7 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.module'
     }
 
-    if(sparkVersion.startsWith('3')) { testFixturesApi "io.delta:delta-core_2.12:${versions.delta}" }
+    if(versions.delta != "NA") { testFixturesApi "io.delta:delta-core_2.12:${versions.delta}" }
 
     testImplementation(project(":${versions.module}"))
     testImplementation testFixtures(project(":${versions.module}")){
@@ -133,7 +133,7 @@ def commonTestConfiguration = {
 test {
     useJUnitPlatform {i ->
         excludeTags ('integration-test')
-        if(!sparkVersion.startsWith('3')) {excludeTags 'spark3'}
+        if(versions.delta == "NA") {excludeTags 'delta'}
     }
     configure commonTestConfiguration
     classpath = project.sourceSets.test.runtimeClasspath + configurations."${versions.module}"

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/DeltaDataSourceTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/DeltaDataSourceTest.java
@@ -28,7 +28,6 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,11 +36,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @ExtendWith(SparkAgentTestExtension.class)
-@Tag("spark3")
+@Tag("delta")
 class DeltaDataSourceTest {
 
   @Test
-  @Disabled
   void testInsertIntoDeltaSource(@TempDir Path tempDir, SparkSession spark)
       throws IOException, InterruptedException, TimeoutException {
     StructType tableSchema =


### PR DESCRIPTION
Signed-off-by: tomasznazarewicz <t.nazarewicz94@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`DeltaDataSourceTest.testInsertIntoDeltaSource` test is failing for version `3.3.0`, no information about official support of delta lake for Spark 3.3.0 


### Solution

Delta lake tests in `app` will not be executed for integrations `3.3.0` and `2.4.6`.