### PR TITLE
airflow: strip comma-separated extractors.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -77,7 +77,7 @@ class Extractors:
         env_extractors = os.getenv("OPENLINEAGE_EXTRACTORS")
         if env_extractors is not None:
             for extractor in env_extractors.split(';'):
-                extractor = import_from_string(extractor)
+                extractor = import_from_string(extractor.strip())
                 for operator_class in extractor.get_operator_classnames():
                     self.extractors[operator_class] = extractor
 

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -47,7 +47,7 @@ def test_env_add_extractor():
 
 def test_env_multiple_extractors():
     extractor_list_len = len(Extractors().extractors)
-    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;tests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
+    with patch.dict(os.environ, {"OPENLINEAGE_EXTRACTORS": "tests.extractors.test_extractors.FakeExtractor;\ntests.extractors.test_extractors.AnotherFakeExtractor"}):  # noqa
         assert len(Extractors().extractors) == extractor_list_len + 2
 
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Comma-separated custom extractors fail when passing newlines.

Closes: #959

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)