### PR TITLE
Support ABFSS and Hadoop Logical Relation in Column Level Lineage

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -127,10 +127,7 @@ class InputFieldsCollector {
       String namespace = PlanUtils.namespaceUri(p.toUri());
       inputDatasets.add(new DatasetIdentifier(p.toUri().getPath(), namespace));
     }
-    if (inputDatasets.isEmpty()) {
-      return Collections.emptyList();
-    } else {
-      return inputDatasets;
-    }
+
+    return inputDatasets;
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -226,10 +226,11 @@ class InputFieldsCollectorTest {
   @SneakyThrows
   void collectWhenGrandChildNodeIsHadoopRelation() {
     LogicalRelation logicalRelation = mock(LogicalRelation.class);
+    when(logicalRelation.catalogTable()).thenReturn(Option.empty());
     HadoopFsRelation relation = mock(HadoopFsRelation.class, RETURNS_DEEP_STUBS);
     when(logicalRelation.relation()).thenReturn(relation);
 
-    Path p = new Path("/tmp/some/path/" + FILE);
+    Path p = new Path("abfss://tmp@storage.dfs.core.windows.net/path");
     Seq<Path> expected_path_seq =
         JavaConverters.asScalaBufferConverter(Collections.singletonList(p)).asScala();
 
@@ -245,8 +246,8 @@ class InputFieldsCollectorTest {
                 .toSeq());
 
     InputFieldsCollector.collect(context, plan, builder);
-    verify(builder, times(0))
-        .addInput(exprId, new DatasetIdentifier("/tmp/some/path", FILE), SOME_NAME);
+    verify(builder, times(1))
+        .addInput(exprId, new DatasetIdentifier("/path", "abfss://tmp@storage.dfs.core.windows.net"), SOME_NAME);
   }
 
   private LogicalPlan createPlanWithGrandChild(LogicalPlan grandChild) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -247,7 +247,10 @@ class InputFieldsCollectorTest {
 
     InputFieldsCollector.collect(context, plan, builder);
     verify(builder, times(1))
-        .addInput(exprId, new DatasetIdentifier("/path", "abfss://tmp@storage.dfs.core.windows.net"), SOME_NAME);
+        .addInput(
+            exprId,
+            new DatasetIdentifier("/path", "abfss://tmp@storage.dfs.core.windows.net"),
+            SOME_NAME);
   }
 
   private LogicalPlan createPlanWithGrandChild(LogicalPlan grandChild) {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Currently, the Column Lineage Input Field Collectors work mainly for Spark SQL operations and Data Source V2.

This leaves out normal dataframe operations like inserting into HDFS without the use of a Hive table.

Column Lineage should support this scenario as many users will want to see column lineage for operations outside of SQL and Hive Metastore backed tables.

Closes: #963

### Solution

I introduce a `extractDatasetIdentifier(HadoopFsRelation relation)` which uses similar logic to `InsertIntoHadoopFsRelationVisitor` to pull out the path on the HDFS compliant file system. This was tested on ABFSS and DBFS (Databricks FileSystem) to prove that lineage could be extracted using non-sql commands.


- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)