### PR TITLE
Add endpoint option in HttpConfig Python Client.

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -16,6 +16,7 @@ import lombok.ToString;
 @ToString
 public final class HttpConfig implements TransportConfig {
   @Getter @Setter private URI url;
+  @Getter @Setter private @Nullable String endpoint;
   @Getter @Setter private @Nullable Double timeout;
   @Getter @Setter private @Nullable TokenProvider auth;
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -69,11 +69,18 @@ public final class HttpTransport extends Transport implements Closeable {
     try {
       URI configUri = httpConfig.getUrl();
       if (configUri.getPath() != null && !configUri.getPath().equals("")) {
+        if (httpConfig.getEndpoint() != null && !httpConfig.getEndpoint().equals("")) {
+          throw new OpenLineageClientException("You can't pass both uri and endpoint parameters.");
+        }
         this.uri = httpConfig.getUrl();
       } else {
+        String endpoint =
+            httpConfig.getEndpoint() != null && !httpConfig.getEndpoint().equals("")
+                ? httpConfig.getEndpoint()
+                : API_V1 + "/lineage";
         this.uri =
             new URIBuilder(httpConfig.getUrl())
-                .setPath(httpConfig.getUrl().getPath() + API_V1 + "/lineage")
+                .setPath(httpConfig.getUrl().getPath() + endpoint)
                 .build();
       }
     } catch (URISyntaxException e) {

--- a/client/java/src/test/resources/config/http.yaml
+++ b/client/java/src/test/resources/config/http.yaml
@@ -1,6 +1,7 @@
 transport:
   type: http
   url: http://localhost:5050
+  endpoint: api/v1/lineage
   auth:
     type: api_key
     apiKey: random_token

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -40,6 +40,7 @@ Specification of build-in ones are below.
 #### HTTP
 
 * `url` - required string parameter specifying
+* `endpoint` - optional string parameter specifying endpoint to which events are sent. By default `api/v1/lineage`.
 * `timeout` - optional float parameter specifying timeout when sending event. By default 5 seconds.
 * `verify` optional boolean attribute specifying if client should verify TLS certificates of backend. By default true.
 * `auth` - optional dictionary specifying authentication options. Type property is required.

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -49,6 +49,7 @@ def create_token_provider(auth: Dict) -> TokenProvider:
 @attr.s
 class HttpConfig(Config):
     url: str = attr.ib()
+    endpoint: str = attr.ib(default='api/v1/lineage')
     timeout: float = attr.ib(default=5.0)
     # check TLS certificates
     verify: bool = attr.ib(default=True)
@@ -94,6 +95,7 @@ class HttpTransport(Transport):
         except Exception as e:
             raise ValueError(f"Need valid url for OpenLineageClient, passed {url}. Exception: {e}")
         self.url = url
+        self.endpoint = config.endpoint
         self.session = config.session
         self.session.headers['Content-Type'] = 'application/json'
         self.timeout = config.timeout
@@ -111,7 +113,7 @@ class HttpTransport(Transport):
         if log.isEnabledFor(logging.DEBUG):
             log.debug(f"Sending openlineage event {event}")
         resp = self.session.post(
-            urljoin(self.url, 'api/v1/lineage'),
+            urljoin(self.url, self.endpoint),
             event,
             timeout=self.timeout,
             verify=self.verify

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -2,7 +2,6 @@
 import logging
 
 from openlineage.client.run import RunEvent
-from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Transport, Config
 
 

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -16,7 +16,8 @@ from openlineage.client.transport.http import HttpConfig, HttpTransport
 def test_http_loads_full_config():
     config = HttpConfig.from_dict({
         "type": "http",
-        "url": "http://backend:5000/api/v1/lineage",
+        "url": "http://backend:5000",
+        "endpoint": "api/v1/lineage",
         "verify": False,
         "auth": {
             "type": "api_key",
@@ -24,7 +25,8 @@ def test_http_loads_full_config():
         },
     })
 
-    assert config.url == "http://backend:5000/api/v1/lineage"
+    assert config.url == "http://backend:5000"
+    assert config.endpoint == "api/v1/lineage"
     assert config.verify is False
     assert config.auth.api_key == "1500100900"
     assert isinstance(config.session, Session)
@@ -64,6 +66,34 @@ def test_client_with_http_transport_emits(session):
     client.emit(event)
     transport.session.post.assert_called_once_with(
         "http://backend:5000/api/v1/lineage",
+        Serde.to_json(event),
+        timeout=5.0,
+        verify=True
+    )
+
+
+@patch("requests.Session")
+def test_client_with_http_transport_emits_custom_endpoint(session):
+    config = HttpConfig.from_dict({
+        "type": "http",
+        "url": "http://backend:5000",
+        "endpoint": "custom/lineage",
+        "session": session
+    })
+    transport = HttpTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(uuid.uuid4())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.session.post.assert_called_once_with(
+        "http://backend:5000/custom/lineage",
         Serde.to_json(event),
         timeout=5.0,
         verify=True


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Endpoint `api/v1/lineage` was hardcoded.

Closes: #695 

### Solution

Make endpoint parametrized in configs.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)