### PR TITLE
Convert task object into json encodable when creating airflow version facet

### DIFF
--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -14,7 +14,7 @@ from openlineage.client.utils import RedactMixin
 @attr.s
 class AirflowVersionRunFacet(BaseFacet):
     operator: str = attr.ib()
-    taskInfo: str = attr.ib()
+    taskInfo: Dict[str, object] = attr.ib()
     airflowVersion: str = attr.ib()
     openlineageAirflowVersion: str = attr.ib()
 
@@ -27,11 +27,11 @@ class AirflowVersionRunFacet(BaseFacet):
     @classmethod
     def from_task(cls, task):
         # task.__dict__ may contain values uncastable to str
-        from openlineage.airflow.utils import SafeStrDict, get_operator_class
+        from openlineage.airflow.utils import get_operator_class, to_json_encodable
 
         return cls(
             f"{get_operator_class(task).__module__}.{get_operator_class(task).__name__}",
-            str(SafeStrDict(task.__dict__)),
+            to_json_encodable(task),
             AIRFLOW_VERSION,
             OPENLINEAGE_AIRFLOW_VERSION,
         )


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem
Airflow integration encloses `airflow_version` custom facet, but its `taskInfo` is not in a deserializable form. In order to make the use of task information included, we want it to be json format which is deserializable.

### Solution
The task object has a circular references which blocks json encoding, as well as some not encodable objects. This PR implements `to_json_encodable` function that checks a few keys that we are interested in, and convert them into desirable format.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)