### PR TITLE
[Integration][Airflow] Do not change task instance during on_running event.

### DIFF
--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -4,6 +4,7 @@
 import logging
 import threading
 import uuid
+import copy
 
 import attr
 
@@ -87,11 +88,12 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
     dag = task_instance.task.dag
 
     def on_running():
-        task_instance.render_templates()
-        task = task_instance.task
+        task_instance_copy = copy.deepcopy(task_instance)
+        task_instance_copy.render_templates()
+        task = task_instance_copy.task
 
         run_id = str(uuid.uuid4())
-        run_data_holder.set_active_run(task_instance, run_id)
+        run_data_holder.set_active_run(task_instance_copy, run_id)
         parent_run_id = str(uuid.uuid3(uuid.NAMESPACE_URL, f'{dag.dag_id}.{dagrun.run_id}'))
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task)
@@ -100,16 +102,16 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
             run_id=run_id,
             job_name=get_job_name(task),
             job_description=dag.description,
-            event_time=DagUtils.get_start_time(task_instance.start_date),
+            event_time=DagUtils.get_start_time(task_instance_copy.start_date),
             parent_job_name=dag.dag_id,
             parent_run_id=parent_run_id,
             code_location=get_task_location(task),
             nominal_start_time=DagUtils.get_start_time(dagrun.execution_date),
-            nominal_end_time=DagUtils.to_iso_8601(task_instance.end_date),
+            nominal_end_time=DagUtils.to_iso_8601(task_instance_copy.end_date),
             task=task_metadata,
             run_facets={
                 **task_metadata.run_facets,
-                **get_custom_facets(task, dagrun.external_trigger, task_instance)
+                **get_custom_facets(task, dagrun.external_trigger, task_instance_copy)
             }
         )
 

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -10,12 +10,17 @@ from pkg_resources import parse_version
 from airflow.version import version as AIRFLOW_VERSION
 log = logging.getLogger(__name__)
 
+collect_ignore = []
 
 if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):
-    collect_ignore = [
+    collect_ignore.extend([
         "extractors/test_redshift_sql_extractor.py",
         "extractors/test_redshift_data_extractor.py",
-    ]
+    ])
+
+
+if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
+    collect_ignore.append("test_listener.py")
 
 
 @pytest.fixture(scope="function")

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -1,0 +1,56 @@
+from airflow.models import BaseOperator
+from airflow.models import TaskInstance, DAG
+from airflow.utils.dates import days_ago
+import pandas as pd
+import uuid
+from unittest.mock import patch
+from airflow.utils.state import State
+from airflow.listeners.events import (
+    register_task_instance_state_events,
+    unregister_task_instance_state_events,
+)
+
+
+class TemplateOperator(BaseOperator):
+    template_fields = ["df"]
+
+    def __init__(self, df, *args, **kwargs):
+        self.df = df
+        super().__init__(*args, **kwargs)
+
+    def execute(self, context):
+        return self.df
+
+
+def render_df():
+    return pd.DataFrame({"col": [1, 2]})
+
+
+@patch("airflow.models.TaskInstance.xcom_push")
+@patch("airflow.models.BaseOperator.render_template")
+def test_listener_does_not_change_task_instance(render_mock, xcom_push_mock):
+    register_task_instance_state_events()
+    render_mock.return_value = render_df()
+
+    dag = DAG(
+        "test",
+        start_date=days_ago(1),
+        user_defined_macros={"render_df": render_df},
+        params={"df": render_df()},
+    )
+    t = TemplateOperator(
+        task_id="template_op", dag=dag, do_xcom_push=True, df=dag.param("df")
+    )
+    run_id = str(uuid.uuid1())
+    dag.create_dagrun(state=State.NONE, run_id=run_id)
+    ti = TaskInstance(t, run_id=run_id)
+    ti.check_and_change_state_before_execution()  # make listener hook on running event
+    ti._run_raw_task()
+    # we need to unregister hooks not to break BigQuery E2E tests
+    unregister_task_instance_state_events()
+
+    # check if task returns the same DataFrame
+    pd.testing.assert_frame_equal(xcom_push_mock.call_args[1]["value"], render_df())
+
+    # check if render_template method always get the same unrendered field
+    assert not isinstance(render_mock.call_args[0][0], pd.DataFrame)


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`on_running` hook changed `TaskInstance` object along with `task` attribute. The issue turned out when dealing with Pandas DataFrames as resolved template fields.

Closes: #1017 

### Solution

Work on copy of task instance in OL hook.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)