### PR TITLE
[Integration][Common][GE] Limit upper GreatExpectations version.

### DIFF
--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -34,7 +34,7 @@ extras_require = {
         "pyyaml>=5.3.1"
     ],
     "great_expectations": [
-        "great_expectations>=0.13.26",
+        "great_expectations>=0.13.26,<=0.15.19",
         "sqlalchemy>=1.3.24"
     ],
     "redshift": [


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

The issue introduced with `0.15.19` version update of Great Expectations has been fixed by a noble PR #1025 (thanks @collado-mike!). This PR is only to limit GE version.

PS. I could post a separate issue to run tests in some way to test against most recent versions of OL integrations.