### PR TITLE
Force protobuf==3.20.* in Airflow integration.

### DIFF
--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -43,6 +43,7 @@ extras_require = {
         "apache-airflow-providers-google>=5.0.0",
         "apache-airflow-providers-amazon>=3.1.1",
         "airflow-provider-great-expectations==0.1.4",
+        "protobuf==3.20.*",
     ],
 }
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`apache-airflow-providers-google` started causing an exception in importing Google libraries.

### Solution

A quick fix described [here](https://github.com/protocolbuffers/protobuf/issues/10051) to force protobuf==3.20.*