### PR TITLE
Rename all parentRun occurrences to parent from airflow integration.

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -194,11 +194,15 @@ class OpenLineageAdapter:
                 "nominalTime": NominalTimeRunFacet(nominal_start_time, nominal_end_time)
             })
         if parent_run_id:
-            facets.update({"parentRun": ParentRunFacet.create(
+            parent_run_facet = ParentRunFacet.create(
                 parent_run_id,
                 _DAG_NAMESPACE,
                 parent_job_name or job_name
-            )})
+            )
+            facets.update({
+                "parent": parent_run_facet,
+                "parentRun": parent_run_facet  # Keep sending this for the backward compatibility
+            })
 
         if run_facets:
             facets.update(run_facets)

--- a/integration/airflow/tests/integration/requests/custom_extractor.json
+++ b/integration/airflow/tests/integration/requests/custom_extractor.json
@@ -19,7 +19,7 @@
  				"airflow_runArgs": {
  					"externalTrigger": false
  				},
- 				"parentRun": {
+ 				"parent": {
  					"job": {
  						"name": "custom_extractor",
  						"namespace": "food_delivery"

--- a/integration/airflow/tests/integration/requests/mapped_dag.json
+++ b/integration/airflow/tests/integration/requests/mapped_dag.json
@@ -16,7 +16,7 @@
         "airflow_runArgs": {
           "externalTrigger": false
         },
-        "parentRun": {
+        "parent": {
           "job": {
             "name": "mapped_dag",
             "namespace": "food_delivery"
@@ -50,7 +50,7 @@
         "airflow_runArgs": {
           "externalTrigger": false
         },
-        "parentRun": {
+        "parent": {
           "job": {
             "name": "mapped_dag",
             "namespace": "food_delivery"
@@ -81,7 +81,7 @@
         "airflow_runArgs": {
           "externalTrigger": false
         },
-        "parentRun": {
+        "parent": {
           "job": {
             "name": "mapped_dag",
             "namespace": "food_delivery"
@@ -107,7 +107,7 @@
         "airflow_runArgs": {
           "externalTrigger": false
         },
-        "parentRun": {
+        "parent": {
           "job": {
             "name": "mapped_dag",
             "namespace": "food_delivery"

--- a/integration/airflow/tests/integration/requests/snowflake.json
+++ b/integration/airflow/tests/integration/requests/snowflake.json
@@ -37,7 +37,7 @@
 			"nominalTime": {
 				"nominalStartTime": "{{ any(result) }}"
 			},
-			"parentRun": {
+			"parent": {
 				"job": {
 					"name": "snowflake",
 					"namespace": "food_delivery"

--- a/integration/airflow/tests/integration/requests/unknown_operator.json
+++ b/integration/airflow/tests/integration/requests/unknown_operator.json
@@ -15,7 +15,7 @@
  				"airflow_runArgs": {
  					"externalTrigger": false
  				},
- 				"parentRun": {
+ 				"parent": {
  					"job": {
  						"name": "unknown_operator_dag",
  						"namespace": "food_delivery"

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -160,6 +160,11 @@ def test_openlineage_dag(
             eventTime=mock.ANY,
             run=Run(run_id_completed, {
                 "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parent": ParentRunFacet.create(
+                    runId=parent_run_id,
+                    namespace=DAG_NAMESPACE,
+                    name=DAG_ID
+                ),
                 "parentRun": ParentRunFacet.create(
                     runId=parent_run_id,
                     namespace=DAG_NAMESPACE,
@@ -182,6 +187,11 @@ def test_openlineage_dag(
             eventTime=mock.ANY,
             run=Run(run_id_failed, {
                 "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parent": ParentRunFacet.create(
+                    runId=parent_run_id,
+                    namespace=DAG_NAMESPACE,
+                    name=DAG_ID
+                ),
                 "parentRun": ParentRunFacet.create(
                     runId=parent_run_id,
                     namespace=DAG_NAMESPACE,
@@ -479,6 +489,11 @@ def test_openlineage_dag_with_extractor(
             mock.ANY,
             Run(run_id, {
                 "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parent": ParentRunFacet.create(
+                    runId=parent_run_id,
+                    namespace=DAG_NAMESPACE,
+                    name=dag_id
+                ),
                 "parentRun": ParentRunFacet.create(
                     runId=parent_run_id,
                     namespace=DAG_NAMESPACE,
@@ -590,6 +605,11 @@ def test_openlineage_dag_with_extract_on_complete(
             eventTime=mock.ANY,
             run=Run(run_id, {
                 "nominalTime": NominalTimeRunFacet(start_time, end_time),
+                "parent": ParentRunFacet.create(
+                    runId=parent_run_id,
+                    namespace=DAG_NAMESPACE,
+                    name=dag_id
+                ),
                 "parentRun": ParentRunFacet.create(
                     runId=parent_run_id,
                     namespace=DAG_NAMESPACE,
@@ -701,6 +721,11 @@ def test_openlineage_dag_adds_custom_facets(
         eventTime=mock.ANY,
         run=Run(run_id, {
             "nominalTime": NominalTimeRunFacet(start_time, end_time),
+            "parent": ParentRunFacet.create(
+                runId=parent_run_id,
+                namespace=DAG_NAMESPACE,
+                name=DAG_ID
+            ),
             "parentRun": ParentRunFacet.create(
                 runId=parent_run_id,
                 namespace=DAG_NAMESPACE,


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem
OpenLineage spec defines the ParentRunFacet with the property name `parent` but airflow integration creates a lineage event with `parentRun`.

Closes: #1036 

### Solution
Change the `parentRun` property name to `parent` from airflow integration.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)