### PR TITLE
timeout configurable from url and spark conf

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -209,6 +209,9 @@ public final class HttpTransport extends Transport implements Closeable {
       httpConfig.setUrl(uri);
       httpConfig.setAuth(tokenProvider);
       httpConfig.setTimeout(timeout);
+      if (httpClient != null) {
+        return new HttpTransport(httpClient, httpConfig);
+      }
       return new HttpTransport(httpConfig);
     }
   }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -149,6 +149,7 @@ public final class HttpTransport extends Transport implements Closeable {
 
     private @Nullable CloseableHttpClient httpClient;
     private @Nullable TokenProvider tokenProvider;
+    private @Nullable Double timeout;
 
     private Builder() {
       this.uri = DEFAULT_OPENLINEAGE_URI;
@@ -177,6 +178,11 @@ public final class HttpTransport extends Transport implements Closeable {
       return this;
     }
 
+    public Builder timeout(@Nullable Double timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
     public Builder http(@NonNull CloseableHttpClient httpClient) {
       this.httpClient = httpClient;
       return this;
@@ -202,9 +208,7 @@ public final class HttpTransport extends Transport implements Closeable {
       final HttpConfig httpConfig = new HttpConfig();
       httpConfig.setUrl(uri);
       httpConfig.setAuth(tokenProvider);
-      if (httpClient != null) {
-        return new HttpTransport(httpClient, httpConfig);
-      }
+      httpConfig.setTimeout(timeout);
       return new HttpTransport(httpConfig);
     }
   }

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -92,6 +92,7 @@ The following parameters can be specified
 | spark.openlineage.parentJobName | The job name to be used for the parent job facet | ParentJobName |
 | spark.openlineage.parentRunId | The RunId of the parent job that initiated this Spark job | xxxx-xxxx-xxxx-xxxx |
 | spark.openlineage.apiKey | An API key to be used when sending events to the OpenLineage server | abcdefghijk |
+| spark.openlineage.timeout | Timeout for sending OpenLineage info in milliseconds | 5000 |
 | spark.openlineage.url.param.xyz | A url parameter (replace xyz) and value to be included in requests to the OpenLineage API server | abcdefghijk |
 | spark.openlineage.consoleTransport | Events will be emitted to a console, no additional backend is required | true |
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -26,6 +26,7 @@ public class EventEmitter {
   @Getter private URI lineageURI;
   @Getter private String jobNamespace;
   @Getter private String parentJobName;
+  @Getter private Double timeout;
   @Getter private Optional<UUID> parentRunId;
 
   public EventEmitter(ArgumentParser argument) throws URISyntaxException {
@@ -59,6 +60,7 @@ public class EventEmitter {
 
     HttpTransport.Builder builder = HttpTransport.builder().uri(this.lineageURI);
     argument.getApiKey().ifPresent(builder::apiKey);
+    argument.getTimeout().ifPresent(builder::timeout);
 
     this.client = OpenLineageClient.builder().transport(builder.build()).build();
     log.info(

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent;
 import static io.openlineage.spark.agent.ArgumentParser.DEFAULTS;
 import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKey;
+import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKeyDouble;
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkUrlParams;
 
 import io.openlineage.client.Environment;
@@ -63,6 +64,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   public static final String SPARK_CONF_NAMESPACE_KEY = "openlineage.namespace";
   public static final String SPARK_CONF_JOB_NAME_KEY = "openlineage.parentJobName";
   public static final String SPARK_CONF_PARENT_RUN_ID_KEY = "openlineage.parentRunId";
+  public static final String SPARK_CONF_TIMEOUT = "openlineage.timeout";
   public static final String SPARK_CONF_API_KEY = "openlineage.apiKey";
   public static final String SPARK_CONF_URL_PARAM_PREFIX = "openlineage.url.param";
   private static WeakHashMap<RDD<?>, Configuration> outputs = new WeakHashMap<>();
@@ -301,6 +303,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       String jobName = findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_KEY, DEFAULTS.getJobName());
       String runId =
           findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID_KEY, DEFAULTS.getParentRunId());
+      Optional<Double> timeout = findSparkConfigKeyDouble(conf, SPARK_CONF_TIMEOUT);
       Optional<String> apiKey =
           findSparkConfigKey(conf, SPARK_CONF_API_KEY).filter(str -> !str.isEmpty());
       Optional<Map<String, String>> urlParams =
@@ -312,7 +315,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
               .filter(v -> v)
               .orElse(false);
       return new ArgumentParser(
-          host, version, namespace, jobName, runId, apiKey, urlParams, consoleMode);
+          host, version, namespace, jobName, runId, timeout, apiKey, urlParams, consoleMode);
     }
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -36,6 +36,7 @@ class ArgumentParserTest {
           RUN_ID,
           false,
           Optional.of("abc"),
+          Optional.empty(),
           Optional.empty()
         });
     pass.add(
@@ -47,6 +48,7 @@ class ArgumentParserTest {
           JOB_NAME,
           RUN_ID,
           false,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty()
         });
@@ -60,6 +62,7 @@ class ArgumentParserTest {
           RUN_ID,
           false,
           Optional.empty(),
+          Optional.empty(),
           Optional.empty()
         });
     pass.add(
@@ -71,6 +74,7 @@ class ArgumentParserTest {
           JOB_NAME,
           null,
           true,
+          Optional.empty(),
           Optional.empty(),
           Optional.empty()
         });
@@ -84,6 +88,7 @@ class ArgumentParserTest {
           RUN_ID,
           false,
           Optional.of("abc"),
+          Optional.empty(),
           Optional.of(Collections.singletonMap("myParam", "xyz"))
         });
     pass.add(
@@ -96,7 +101,34 @@ class ArgumentParserTest {
           RUN_ID,
           false,
           Optional.empty(),
+          Optional.empty(),
           Optional.of(Collections.singletonMap("myParam", "xyz"))
+        });
+    pass.add(
+        new Object[] {
+          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?timeout=5000",
+          URL,
+          "v1",
+          NS_NAME,
+          JOB_NAME,
+          RUN_ID,
+          false,
+          Optional.empty(),
+          Optional.of(5000.0),
+          Optional.empty()
+        });
+    pass.add(
+        new Object[] {
+          "http://localhost:5000/api/v1/namespaces/ns_name/jobs/job_name/runs/ea445b5c-22eb-457a-8007-01c7c52b6e54?timeout=",
+          URL,
+          "v1",
+          NS_NAME,
+          JOB_NAME,
+          RUN_ID,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty()
         });
     return pass;
   }
@@ -112,6 +144,7 @@ class ArgumentParserTest {
       String runId,
       boolean defaultRunId,
       Optional<String> apiKey,
+      Optional<Double> timeout,
       Optional<Map<String, String>> urlParams) {
     ArgumentParser parser = ArgumentParser.parse(input);
     assertEquals(host, parser.getHost());
@@ -124,6 +157,7 @@ class ArgumentParserTest {
       assertEquals(runId, parser.getParentRunId());
     }
     assertEquals(apiKey, parser.getApiKey());
+    assertEquals(timeout, parser.getTimeout());
     assertEquals(urlParams, parser.getUrlParams());
     if (urlParams.isPresent()) {
       urlParams

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
@@ -11,9 +11,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.SparkConf;
 import scala.Option;
 
+@Slf4j
 public class SparkConfUtils {
   private static final String metastoreUriKey = "spark.sql.hive.metastore.uris";
   private static final String metastoreHadoopUriKey = "spark.hadoop.hive.metastore.uris";
@@ -30,6 +33,18 @@ public class SparkConfUtils {
     opt = conf.getOption("spark." + name);
     if (opt.isDefined()) {
       return Optional.of(opt.get());
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<Double> findSparkConfigKeyDouble(SparkConf conf, String name) {
+    String timeoutString = conf.get(name);
+    try {
+      if (StringUtils.isNotBlank(timeoutString)) {
+        return Optional.of(Double.parseDouble(timeoutString));
+      }
+    } catch (NumberFormatException e) {
+      log.warn("Value of timeout is not parsable");
     }
     return Optional.empty();
   }


### PR DESCRIPTION
Signed-off-by: tomasznazarewicz <t.nazarewicz94@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

in some cases when openlineage event is send it takes longer than 5 seconds to respond, which exceeds the timeout value.

Closes: #1012

### Solution

Make timeout configurable by user.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)