### PR TITLE
dbt: add support for dbt 1.3 beta's metadata changes

### DIFF
--- a/integration/common/tests/dbt/compiled_code/dbt_project.yml
+++ b/integration/common/tests/dbt/compiled_code/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'small'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `model-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  small:
+    # Config indicated by + and applies to all files under models/example/
+    example:
+      +materialized: view

--- a/integration/common/tests/dbt/compiled_code/profiles.yml
+++ b/integration/common/tests/dbt/compiled_code/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: random-gcp-project
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/compiled_code/result.json
+++ b/integration/common/tests/dbt/compiled_code/result.json
@@ -1,0 +1,119 @@
+[{
+	"eventType": "START",
+	"eventTime": "{{ is_datetime(result) }}",
+	"run": {
+		"runId": "{{ any(result) }}"
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "random-gcp-project.dbt_test1.small.my_first_dbt_model.build.run"
+	},
+	"inputs": [],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_first_dbt_model"
+	}]
+}, {
+	"eventType": "START",
+	"eventTime": "{{ is_datetime(result) }}",
+	"run": {
+		"runId": "{{ any(result) }}"
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "random-gcp-project.dbt_test1.small.my_second_dbt_model.build.run"
+	},
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_first_dbt_model"
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_second_dbt_model"
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "{{ is_datetime(result) }}",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"job": {"name": "dbt-job-name", "namespace": "dbt"},
+				"run": {"runId": "{{ any(result) }}"}
+			},
+			"dbt_version": {
+				"version": "{{ any(result) }}"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "random-gcp-project.dbt_test1.small.my_first_dbt_model.build.run",
+		"facets": {
+			"sql": {
+				"query": "\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data"
+			}
+		}
+	},
+	"inputs": [],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_first_dbt_model",
+		"facets": {
+			"dataSource": {
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"fields": [{
+					"name": "id",
+					"type": null
+				}]
+			}
+		}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "{{ is_datetime(result) }}",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"job": {"name": "dbt-job-name", "namespace": "dbt"},
+				"run": {"runId": "{{ any(result) }}"}
+			},
+			"dbt_version": {
+				"version": "{{ any(result) }}"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "random-gcp-project.dbt_test1.small.my_second_dbt_model.build.run",
+		"facets": {
+			"sql": {
+				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`my_first_dbt_model`\nwhere id = 1"
+			}
+		}
+	},
+	"inputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_first_dbt_model"
+	}],
+	"outputs": [{
+		"namespace": "bigquery",
+		"name": "random-gcp-project.dbt_test1.my_first_dbt_model",
+		"facets": {
+			"dataSource": {
+				"name": "bigquery",
+				"uri": "bigquery"
+			},
+			"schema": {
+				"fields": [{
+					"name": "id",
+					"type": null
+				}]
+			}
+		}
+	}]
+}]

--- a/integration/common/tests/dbt/compiled_code/target/manifest.json
+++ b/integration/common/tests/dbt/compiled_code/target/manifest.json
@@ -1,0 +1,182 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v7.json",
+		"dbt_version": "1.3.0b1",
+		"generated_at": "2022-08-29T14:05:45.647220Z",
+		"invocation_id": "2042a280-76c8-4f34-8415-8c8c3ca9a4ba",
+		"env": {},
+		"project_id": "eb5c1399a871211c7e7ed732d15e3a8b",
+		"user_id": "93b9834f-b02b-466c-a3ca-ec6db35a82ec",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.small.my_second_dbt_model": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["model.small.my_first_dbt_model"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "view",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"fqn": ["small", "example", "my_second_dbt_model"],
+			"unique_id": "model.small.my_second_dbt_model",
+			"raw_code": "select *\nfrom {{ ref('my_first_dbt_model') }}\nwhere id = 1",
+			"language": "sql",
+			"package_name": "small",
+			"root_path": "/Users/mobuchowski/code/dbt-small/small",
+			"path": "example/my_second_dbt_model.sql",
+			"original_file_path": "models/example/my_second_dbt_model.sql",
+			"name": "my_second_dbt_model",
+			"alias": "my_second_dbt_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "b8029463d53034baba6c909f86f523628b72b6eb3b381788d40db2d9e2346b76"
+			},
+			"tags": [],
+			"refs": [
+				["my_first_dbt_model"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "small://models/example/schema.yml",
+			"compiled_path": "target/compiled/small/models/example/my_second_dbt_model.sql",
+			"build_path": "target/run/small/models/example/my_second_dbt_model.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1661781856.4240901,
+			"compiled_code": "select *\nfrom `random-gcp-project`.`dbt_test1`.`my_first_dbt_model`\nwhere id = 1",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`my_second_dbt_model`"
+		},
+		"model.small.my_first_dbt_model": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs"],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "table",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"fqn": ["small", "example", "my_first_dbt_model"],
+			"unique_id": "model.small.my_first_dbt_model",
+			"raw_code": "{{ config(materialized='table') }}\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data",
+			"language": "sql",
+			"package_name": "small",
+			"root_path": "/Users/mobuchowski/code/dbt-small/small",
+			"path": "example/my_first_dbt_model.sql",
+			"original_file_path": "models/example/my_first_dbt_model.sql",
+			"name": "my_first_dbt_model",
+			"alias": "my_first_dbt_model",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "e2d527ecad054c20e0832ba18d22da18acee96c6bc7f180cf7c655308abee160"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"metrics": [],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "small://models/example/schema.yml",
+			"compiled_path": "target/compiled/small/models/example/my_first_dbt_model.sql",
+			"build_path": "target/run/small/models/example/my_first_dbt_model.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1661781856.424562,
+			"compiled_code": "\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`my_first_dbt_model`"
+		}
+	},
+	"sources": {},
+	"macros": {},
+	"docs": {},
+	"exposures": {},
+	"metrics": {},
+	"selectors": {},
+	"disabled": {},
+	"parent_map": {
+		"model.small.my_second_dbt_model": ["model.small.my_first_dbt_model"],
+		"model.small.my_first_dbt_model": []
+	},
+	"child_map": {
+		"model.small.my_second_dbt_model": [],
+		"model.small.my_first_dbt_model": ["model.small.my_second_dbt_model"]
+	}
+}

--- a/integration/common/tests/dbt/compiled_code/target/run_results.json
+++ b/integration/common/tests/dbt/compiled_code/target/run_results.json
@@ -1,0 +1,70 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
+		"dbt_version": "1.3.0b1",
+		"generated_at": "2022-08-29T14:05:52.615555Z",
+		"invocation_id": "2042a280-76c8-4f34-8415-8c8c3ca9a4ba",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-08-29T14:05:46.415698Z",
+			"completed_at": "2022-08-29T14:05:46.419178Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-08-29T14:05:46.419512Z",
+			"completed_at": "2022-08-29T14:05:49.128151Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.7137701511383057,
+		"adapter_response": {
+			"_message": "CREATE TABLE (2.0 rows, 0 processed)",
+			"code": "CREATE TABLE",
+			"rows_affected": 2,
+			"bytes_processed": 0
+		},
+		"message": "CREATE TABLE (2.0 rows, 0 processed)",
+		"failures": null,
+		"unique_id": "model.small.my_first_dbt_model"
+	},{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-08-29T14:05:50.362675Z",
+			"completed_at": "2022-08-29T14:05:50.367062Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-08-29T14:05:50.367424Z",
+			"completed_at": "2022-08-29T14:05:51.330479Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.9700310230255127,
+		"adapter_response": {
+			"_message": "OK",
+			"code": "CREATE VIEW"
+		},
+		"message": "OK",
+		"failures": null,
+		"unique_id": "model.small.my_second_dbt_model"
+	}],
+	"elapsed_time": 6.90785813331604,
+	"args": {
+		"write_json": true,
+		"use_colors": true,
+		"printer_width": 80,
+		"version_check": true,
+		"partial_parse": true,
+		"static_parser": true,
+		"profiles_dir": "./tests/dbt/compiled_code",
+		"send_anonymous_usage_stats": true,
+		"event_buffer_size": 100000,
+		"quiet": false,
+		"no_print": false,
+		"indirect_selection": "eager",
+		"resource_types": [],
+		"which": "build",
+		"rpc_method": "build"
+	}
+}

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -45,6 +45,7 @@ def serialize(inst, field, value):
         "tests/dbt/catalog",
         "tests/dbt/fail",
         "tests/dbt/build",
+        "tests/dbt/compiled_code",
         "tests/dbt/spark/thrift",
         "tests/dbt/spark/odbc"
     ]


### PR DESCRIPTION
dbt 1.3 renamed `compiled_sql` field to `compiled_code` to support Python models. https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.3#for-consumers-of-dbt-artifacts-metadata

This PR makes projects that are composed of only SQL models work on 1.3 beta. 
This PR does not provide support for dbt's python models.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>