### PR TITLE
sql: add macos binary package build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -365,6 +365,22 @@ jobs:
           path: ./target/wheels
           destination: sql-artifacts
 
+  build-integration-sql-macos:
+    working_directory: ~/openlineage/integration/sql
+    macos:
+      xcode: 13.2.1
+    resource_class: large
+    steps:
+      - *checkout_project_root
+      - run: RUN_TESTS=true bash script/build-macos.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./target/wheels/*.whl
+      - store_artifacts:
+          path: ./target/wheels
+          destination: sql-artifacts-macos
+
   build-integration-dbt:
     working_directory: ~/openlineage/integration/dbt
     docker:
@@ -754,6 +770,12 @@ workflows:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
+      - build-integration-sql-macos:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
       - release-python:
           filters:
             tags:
@@ -769,3 +791,4 @@ workflows:
             - build-integration-dagster
             - build-integration-sql-x86
             - build-integration-sql-arm
+            - build-integration-sql-macos

--- a/integration/sql/script/build-macos.sh
+++ b/integration/sql/script/build-macos.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build script for OpenLineage SQL parser.
+# It's assumed that it will be run on MacOS
+set -e
+
+echo "Installing homebrew"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+echo "Installing Python 3.7"
+brew install python@3.7
+
+which python
+which python3
+
+/usr/local/bin/python3.7 -m venv .env
+source .env/bin/activate
+
+which python
+which python3
+
+# Install Rust
+echo "Installing Rust"
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+
+rustup target add aarch64-apple-darwin
+
+# Maturin is build tool that we're using. It can build python wheels based on standard Rust Cargo.toml.
+echo "Installing Maturin"
+python -m pip install maturin
+
+# Disable incremental compilation, since it causes issues.
+export CARGO_INCREMENTAL=0
+
+# Run test if indicated to do so.
+if [[ -z ${RUN_TESTS} ]]; then
+  cargo test --no-default-features
+fi
+
+# Build release wheels
+python -m maturin build --universal2 --out target/wheels
+
+echo "Package build, trying to import"
+echo "Platform:"
+python -c "from distutils import util; print(util.get_platform())"
+# Verify that it imports properly
+python -m pip install openlineage-sql --no-index --find-links target/wheels --force-reinstall
+python -c "import openlineage_sql"
+echo "all good"

--- a/integration/sql/script/build.sh
+++ b/integration/sql/script/build.sh
@@ -32,6 +32,6 @@ fi
 maturin build --sdist --out target/wheels
 
 # Verify that it imports properly
-pip install openlineage-sql --no-index --find-links target/wheels --force-reinstall
+python -m pip install openlineage-sql --no-index --find-links target/wheels --force-reinstall
 python -c "import openlineage_sql"
 echo "all good"


### PR DESCRIPTION
Currently, sql parser has binary builds only for `linux` systems. MacOS users have to install the library from source, which requires pulling whole rust toolchain and maturin build tool.

This PR adds CI step which builds MacOS universal binary wheel - it works both on x86 Intel macs and ARM M1 macs. 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
