### PR TITLE
Fix uuid generation conflict for airflow dags with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.14.0...HEAD)
+* Fix uuid generation conflict for airflow dags with same name - 2022-09-07 [@collado-mike](https://github.com/collado-mike)
 
 ## [0.14.1](https://github.com/OpenLineage/OpenLineage/compare/0.14.0...0.14.1) - 2022-09-07
 ### Fixed

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -3,6 +3,7 @@
 
 import os
 import logging
+import uuid
 from typing import Optional, Dict, Type
 
 from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
@@ -55,6 +56,9 @@ class OpenLineageAdapter:
             else:
                 self._client = OpenLineageClient.from_environment()
         return self._client
+
+    def build_dag_run_id(self, dag_id, dag_run_id):
+        return str(uuid.uuid3(uuid.NAMESPACE_URL, f'{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}'))
 
     def emit(self, event: RunEvent):
         event = redact_with_exclusions(event)

--- a/integration/airflow/openlineage/airflow/dag.py
+++ b/integration/airflow/openlineage/airflow/dag.py
@@ -1,14 +1,14 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-import os
 import copy
-import uuid
+import os
+import time
 
 from airflow.models import DAG as AIRFLOW_DAG
 from airflow.utils.state import State
 
+from openlineage.airflow.adapter import OpenLineageAdapter, _DAG_DEFAULT_NAMESPACE
 from openlineage.airflow.extractors.manager import ExtractorManager
 from openlineage.airflow.macros import lineage_run_id, lineage_parent_id
 from openlineage.airflow.utils import (
@@ -17,8 +17,6 @@ from openlineage.airflow.utils import (
     get_custom_facets,
     new_lineage_run_id, get_task_location, openlineage_job_name
 )
-
-from openlineage.airflow.adapter import OpenLineageAdapter, _DAG_DEFAULT_NAMESPACE
 
 _DAG_NAMESPACE = os.getenv('OPENLINEAGE_NAMESPACE', None)
 if not _DAG_NAMESPACE:
@@ -80,7 +78,7 @@ class DAG(AIRFLOW_DAG):
     # scheduler, where tasks are actually started
     def _register_dagrun(self, dagrun, is_external_trigger: bool, execution_date: str):
         self.log.debug(f"self.task_dict: {self.task_dict}")
-        parent_run_id = str(uuid.uuid3(uuid.NAMESPACE_URL, f'{self.dag_id}.{dagrun.run_id}'))
+        parent_run_id = _ADAPTER.build_dag_run_id(self.dag_id, dagrun.run_id)
         # Register each task in the DAG
         for task_id, task in self.task_dict.items():
             t = self._now_ms()
@@ -163,7 +161,7 @@ class DAG(AIRFLOW_DAG):
         run_id = new_lineage_run_id(dagrun.run_id, task.task_id)
 
         if not task_run_id:
-            parent_run_id = str(uuid.uuid3(uuid.NAMESPACE_URL, f'{self.dag_id}.{dagrun.run_id}'))
+            parent_run_id = _ADAPTER.build_dag_run_id(self.dag_id, dagrun.run_id)
             task_run_id = _ADAPTER.start_task(
                 run_id,
                 job_name,

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -1,15 +1,13 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import logging
 import threading
 import uuid
-import copy
-
-import attr
-
 from typing import TYPE_CHECKING, Optional, Callable, Union
 
+import attr
 from airflow.listeners import hookimpl
 
 from openlineage.airflow.adapter import OpenLineageAdapter
@@ -94,7 +92,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
 
         run_id = str(uuid.uuid4())
         run_data_holder.set_active_run(task_instance_copy, run_id)
-        parent_run_id = str(uuid.uuid3(uuid.NAMESPACE_URL, f'{dag.dag_id}.{dagrun.run_id}'))
+        parent_run_id = adapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task)
 

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import uuid
 import time
-
-from pkg_resources import parse_version
+import uuid
+from typing import Optional
 
 from airflow.lineage.backend import LineageBackend
 from airflow.version import version as AIRFLOW_VERSION
-from typing import Optional
+from pkg_resources import parse_version
 
 
 class Backend:
@@ -39,7 +38,7 @@ class Backend:
         dag = context['dag']
         dagrun = context['dag_run']
         task_instance = context['task_instance']
-        dag_run_id = str(uuid.uuid3(uuid.NAMESPACE_URL, f'{dag.dag_id}.{dagrun.run_id}'))
+        dag_run_id = self.adapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
         run_id = str(uuid.uuid4())
         job_name = get_job_name(operator)

--- a/integration/airflow/tests/test_openlineage_dag.py
+++ b/integration/airflow/tests/test_openlineage_dag.py
@@ -758,7 +758,7 @@ def test_openlineage_dag_adds_custom_facets(
 
 
 def make_parent_run_id(dag_id=DAG_ID, dag_run_id=DAG_RUN_ID):
-    return str(uuid.uuid3(uuid.NAMESPACE_URL, f'{dag_id}.{dag_run_id}'))
+    return str(uuid.uuid3(uuid.NAMESPACE_URL, f'{DAG_NAMESPACE}.{dag_id}.{dag_run_id}'))
 
 
 class TestFixtureHookingDummyOperator(DummyOperator):


### PR DESCRIPTION
### Problem

In https://github.com/OpenLineage/OpenLineage/pull/664 , we updated the parent run id to be a UUID calculated from the dag id and the dagrun id (the execution time). Unfortunately, some airflow deployments have multiple DAGs with the same name running in different namespaces. If they happen to have the same scheduled execution time, their dag run ids will conflict, reporting all tasks as children of the same parent job

### Solution

Adds namespace to the UUID calculation to avoid conflicts. This does have the unfortunate consequence of changing the calculated dag run id. This will potentially cause different tasks in the same dag run to report different parent run ids. But given that the jobs will be recorded with the correct namespace, this discrepancy can be corrected with a backfill SQL script

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)