### PR TITLE
sql: add hive create table backtick test, properly pass dialect

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -7,7 +7,6 @@ from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 
 
 class MySqlExtractor(SqlExtractor):
-    default_schema = None
     _information_schema_columns = [
         "table_schema",
         "table_name",
@@ -15,6 +14,14 @@ class MySqlExtractor(SqlExtractor):
         "ordinal_position",
         "column_type",
     ]
+
+    @property
+    def dialect(self):
+        return "mysql"
+
+    @property
+    def default_schema(self):
+        return None
 
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
@@ -48,3 +55,7 @@ class MySqlExtractor(SqlExtractor):
         return MySqlHook(
             mysql_conn_id=self.operator.mysql_conn_id, schema=self.operator.database
         )
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        return name.upper()

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class PostgresExtractor(SqlExtractor):
-    default_schema = "public"
     _information_schema_columns = [
         "table_schema",
         "table_name",
@@ -24,6 +23,10 @@ class PostgresExtractor(SqlExtractor):
         "udt_name",
     ]
     _is_information_schema_cross_db = False
+
+    @property
+    def dialect(self):
+        return "postgres"
 
     @classmethod
     def get_operator_classnames(cls) -> List[str]:

--- a/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
@@ -11,11 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 class RedshiftSQLExtractor(PostgresExtractor):
-    default_schema = "public"
-
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
         return ["RedshiftSQLOperator"]
+
+    @property
+    def dialect(self):
+        return "redshift"
 
     def _get_scheme(self) -> str:
         return "redshift"

--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -13,8 +13,6 @@ from openlineage.airflow.utils import (
 
 def get_check_extractors(super_):
     class BaseSqlCheckExtractor(super_):
-        default_schema = 'public'
-
         def __init__(self, operator):
             super().__init__(operator)
 

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -323,7 +323,7 @@ def try_import_from_string(path: str):
     try:
         return import_from_string(path)
     except ImportError as e:
-        logging.info(e.msg)     # type: ignore
+        logging.info(e.msg)  # type: ignore
         return None
 
 

--- a/integration/airflow/tests/extractors/test_dbapi_utils.py
+++ b/integration/airflow/tests/extractors/test_dbapi_utils.py
@@ -215,9 +215,9 @@ def test_create_filter_clauses():
     assert create_filter_clauses(
         {"Schema1": ["Table1"], "Schema2": ["Table2"]}
     ) == [
-        "( table_schema = 'SCHEMA1' AND table_name IN ('Table1') )",
-        "( table_schema = 'SCHEMA2' AND table_name IN ('Table2') )",
+        "( table_schema = 'Schema1' AND table_name IN ('Table1') )",
+        "( table_schema = 'Schema2' AND table_name IN ('Table2') )",
     ]
     assert create_filter_clauses(
         {"Schema1": ["Table1", "Table2"]}
-    ) == ["( table_schema = 'SCHEMA1' AND table_name IN ('Table1','Table2') )"]
+    ) == ["( table_schema = 'Schema1' AND table_name IN ('Table1','Table2') )"]

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -107,12 +107,15 @@ def get_hook_method(operator):
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
-def test_extract(get_connection, mock_get_table_schemas):
+@mock.patch('openlineage.airflow.extractors.snowflake_extractor.execute_query_on_hook')
+def test_extract(execute_query_on_hook, get_connection, mock_get_table_schemas):
     source = Source(
         scheme='snowflake',
         authority='test_account',
         connection_url=CONN_URI_URIPARSED
     )
+
+    execute_query_on_hook.return_value = "public"
 
     mock_get_table_schemas.return_value = (
         [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
@@ -148,11 +151,14 @@ def test_extract(get_connection, mock_get_table_schemas):
 @pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
-def test_extract_query_ids(get_connection, mock_get_table_schemas):
+@mock.patch('openlineage.airflow.extractors.snowflake_extractor.execute_query_on_hook')
+def test_extract_query_ids(execute_query_on_hook, get_connection, mock_get_table_schemas):
     mock_get_table_schemas.return_value = (
         [],
         [],
     )
+
+    execute_query_on_hook.return_value = "public"
 
     conn = Connection()
     conn.parse_from_uri(uri=CONN_URI)

--- a/integration/airflow/tests/extractors/test_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_sql_extractor.py
@@ -5,31 +5,39 @@ from openlineage.common.sql import DbTableMeta
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 
 
+def normalize_name_lower(name: str) -> str:
+    return name.lower()
+
+
 def test_get_tables_hierarchy():
     assert SqlExtractor._get_tables_hierarchy(
-        [DbTableMeta("Table1"), DbTableMeta("Table2")]
+        [DbTableMeta("Table1"), DbTableMeta("Table2")], normalize_name_lower
     ) == {None: {None: ["Table1", "Table2"]}}
 
     # base check with db, no cross db
     assert SqlExtractor._get_tables_hierarchy(
-        [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")]
+        [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")],
+        normalize_name_lower
     ) == {None: {"schema1": ["Table1"], "schema2": ["Table2"]}}
 
     # same, with cross db
     assert SqlExtractor._get_tables_hierarchy(
         [DbTableMeta("Db.Schema1.Table1"), DbTableMeta("Db.Schema2.Table2")],
+        normalize_name_lower,
         is_cross_db=True,
     ) == {"db": {"schema1": ["Table1"], "schema2": ["Table2"]}}
 
     # explicit db, no cross db
     assert SqlExtractor._get_tables_hierarchy(
         [DbTableMeta("Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        normalize_name_lower,
         database="Db",
     ) == {None: {"schema1": ["Table1", "Table2"]}}
 
     # explicit db, with cross db
     assert SqlExtractor._get_tables_hierarchy(
         [DbTableMeta("Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        normalize_name_lower,
         database="Db",
         is_cross_db=True,
     ) == {"db": {"schema1": ["Table1", "Table2"]}}
@@ -37,6 +45,7 @@ def test_get_tables_hierarchy():
     # mixed db, with cross db
     assert SqlExtractor._get_tables_hierarchy(
         [DbTableMeta("Db2.Schema1.Table1"), DbTableMeta("Schema1.Table2")],
+        normalize_name_lower,
         database="Db",
         is_cross_db=True,
     ) == {"db": {"schema1": ["Table2"]}, "db2": {"schema1": ["Table1"]}}

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -30,7 +30,7 @@ from airflow.utils.file import mkdirs
 # in this file instead of from airflow.cfg. Currently
 # there are other log format and level configurations in
 # settings.py and cli.py. Please see AIRFLOW-1455.
-LOG_LEVEL = 'INFO'  # conf.get('core', 'LOGGING_LEVEL').upper()
+LOG_LEVEL = 'DEBUG'  # conf.get('core', 'LOGGING_LEVEL').upper()
 
 
 # Flask appbuilder's info level log is very verbose,
@@ -91,7 +91,12 @@ LOGGING_CONFIG = {
     },
     'loggers': {
         'openlineage': {
-            'handler': ['console'],
+            'handler': ['console', 'task'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+        'openlineage.airflow': {
+            'handler': ['console', 'task'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -166,6 +166,22 @@ def test_parse_simple_insert_into():
     assert sql_meta.out_tables == [DbTableMeta('table0')]
 
 
+def test_parse_snowflake_dialect_insert():
+    sql_meta = parse(
+        '''
+        INSERT INTO test_orders (ord, str, num)
+        VALUES
+        (1, 'b', 15),
+        (2, 'a', 21),
+        (3, 'b', 7);
+        ''',
+        dialect="snowflake"
+    )
+
+    assert sql_meta.in_tables == []
+    assert sql_meta.out_tables == [DbTableMeta('test_orders')]
+
+
 def test_parse_simple_insert_into_select():
     sql_meta = parse(
         '''

--- a/integration/sql/src/lib.rs
+++ b/integration/sql/src/lib.rs
@@ -461,6 +461,7 @@ pub fn get_dialect(name: &str) -> Arc<dyn CanonicalDialect> {
         "mssql" => Arc::new(MsSqlDialect {}),
         "sqlite" => Arc::new(SQLiteDialect {}),
         "ansi" => Arc::new(AnsiDialect {}),
+        "generic" => Arc::new(GenericDialect),
         _ => Arc::new(GenericDialect),
     }
 }

--- a/integration/sql/tests/tests_create.rs
+++ b/integration/sql/tests/tests_create.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2022 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
 
+use sqlparser::dialect::HiveDialect;
 use openlineage_sql::SqlMeta;
 
 #[macro_use]
@@ -79,3 +80,32 @@ fn create_and_insert_multiple_stmts() {
         }
     )
 }
+
+#[test]
+fn create_hive_external_table_if_not_exist() {
+    assert_eq!(
+        test_sql_dialect("
+            CREATE EXTERNAL TABLE IF NOT EXISTS  Testing_Versions_latest (
+                `ID` INT,
+                `ExperimentID` INT,
+                `Version` SMALLINT,
+                `EnrollmentPeriodInHours` INT,
+                `Started` TIMESTAMP,
+                `EndDate` TIMESTAMP,
+                `IsActive` BOOLEAN,
+                `PercentOfSubjectsToEnroll` SMALLINT,
+                `Created` TIMESTAMP,
+                `Updated` TIMESTAMP,
+                        ds STRING
+                    )
+                    STORED AS PARQUET
+                    LOCATION 's3://abc.ingest/sqlserver/Testing/Versions/ds=2022-08-10'
+                    TBLPROPERTIES ('parquet.compression'='SNAPPY');
+        ", "hive"
+        ), SqlMeta {
+            in_tables: vec![],
+            out_tables: table("Testing_Versions_latest")
+        }
+    )
+}
+

--- a/integration/sql/tests/tests_insert.rs
+++ b/integration/sql/tests/tests_insert.rs
@@ -80,6 +80,17 @@ fn insert_nested_select() {
 }
 
 #[test]
+fn insert_snowflake_table() {
+    assert_eq!(
+        test_sql_dialect("\n    INSERT INTO test_orders (ord, str, num) VALUES\n    (1, 'b', 15),\n    (2, 'a', 21),\n    (3, 'b', 7);\n   ", "snowflake"),
+        SqlMeta {
+            in_tables: vec![],
+            out_tables: table("test_orders")
+        }
+    )
+}
+
+#[test]
 fn insert_overwrite_table() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
This PR adds test for Hive dialect with backticks. Additionally, it properly sets dialects in SqlExtractors.

With Snowflake, default_schema can't be `PUBLIC` - it now selects for `current_schema`. 
Also, it properly upper-or-lowercases depending on database's preference - for example, for Snowflake it's uppercase, where for MySQL it's lowercase.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>