### PR TITLE
Added optional argument --dialect to specify dialect on sql_tester

### DIFF
--- a/integration/sql/tests/python/sql_tester.py
+++ b/integration/sql/tests/python/sql_tester.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage_sql import parse
-import sys, os
+import sys, os, argparse
 
 class bcolors:
     HEADER = '\033[95m'
@@ -19,11 +19,22 @@ class bcolors:
 # via UNIX pipe to the tool. In case of inputing direclty, make sure to press
 # Ctrl+D after the input to EOF the input.
 def main():
+
+    parser = argparse.ArgumentParser(description='Simple tester to parse and test SQL statements.')
+    parser.add_argument('--dialect', nargs='?', default=None, 
+                        help='set the SQL dialect.')
+
+    args = parser.parse_args()
+    # dialect is None if no dialect was specified.
+    dialect = args.dialect
+
     k = 0
     sql = ''
 
     if os.isatty(0):
         print(bcolors.OKGREEN + "Welcome to OpenLineage SQL Parser Tester." + bcolors.ENDC)
+        if dialect is not None:
+            print(f"Dialect selected : {dialect}")
         print("Enter SQL statement, and press Ctrl+D at the last line when finished.\n> ", end='')
 
     try:
@@ -34,7 +45,10 @@ def main():
         pass
 
     if sql != '':
-        meta = parse([sql])
+        if dialect is None:
+            meta = parse([sql])
+        else:
+            meta = parse([sql], dialect=dialect)
         print("\n" + bcolors.OKBLUE + "------ OpenLineage SQL Parser Tester ------" + bcolors.ENDC)
         print(f"> SQL received:\n{sql}")
         if meta is not None:

--- a/integration/sql/tests/python/sql_tester.py
+++ b/integration/sql/tests/python/sql_tester.py
@@ -21,7 +21,7 @@ class bcolors:
 def main():
 
     parser = argparse.ArgumentParser(description='Simple tester to parse and test SQL statements.')
-    parser.add_argument('--dialect', nargs='?', default=None, 
+    parser.add_argument('--dialect', nargs='?', default=None,
                         help='set the SQL dialect.')
 
     args = parser.parse_args()


### PR DESCRIPTION

Signed-off-by: howardyoo <howardyoo@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

The current sql_tester.py does NOT support specifying certain `dialect` of sql statements, making the sql tester only run tests on generic SQL syntax.

Closes: #1060

### Solution

Added an optional argument `--dialect` which sets the parser to user certain dialect of SQL statements for the tester. If not specified, the parser uses generic dialect. Currently the following dialects are supported:

- ansi
- bigquery
- hive
- mssql
- mysql
- postgres
- postgresql
- snowflake
- sqlite

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)