### PR TITLE
Set log level of Init OpenLineageContext to DEBUG

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -63,7 +63,7 @@ public class EventEmitter {
     argument.getTimeout().ifPresent(builder::timeout);
 
     this.client = OpenLineageClient.builder().transport(builder.build()).build();
-    log.info(
+    log.debug(
         String.format(
             "Init OpenLineageContext: Args: %s URI: %s", argument, lineageURI.toString()));
   }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

This log statement used to write sensitive information like apiKey and other url params to the log.

Closes: #1011 

### Solution

Changing log level to debug so that the statement only gets logged in debug mode.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)