### PR TITLE
sql: add redshift dialect

### DIFF
--- a/integration/sql/src/lib.rs
+++ b/integration/sql/src/lib.rs
@@ -17,7 +17,7 @@ use sqlparser::ast::{
 };
 use sqlparser::dialect::{
     AnsiDialect, Dialect, GenericDialect, HiveDialect, MsSqlDialect, MySqlDialect,
-    PostgreSqlDialect, SQLiteDialect, SnowflakeDialect,
+    PostgreSqlDialect, RedshiftSqlDialect, SQLiteDialect, SnowflakeDialect,
 };
 use sqlparser::parser::Parser;
 
@@ -394,7 +394,11 @@ fn parse_stmt(stmt: &Statement, context: &mut Context) -> Result<(), String> {
             Ok(())
         }
         Statement::CreateTable {
-            name, query, like, clone, ..
+            name,
+            query,
+            like,
+            clone,
+            ..
         } => {
             if let Some(boxed_query) = query {
                 parse_query(boxed_query.as_ref(), context)?;
@@ -456,6 +460,7 @@ pub fn get_dialect(name: &str) -> Arc<dyn CanonicalDialect> {
         "snowflake" => Arc::new(SnowflakeDialect),
         "postgres" => Arc::new(PostgreSqlDialect {}),
         "postgresql" => Arc::new(PostgreSqlDialect {}),
+        "redshift" => Arc::new(RedshiftSqlDialect {}),
         "hive" => Arc::new(HiveDialect {}),
         "mysql" => Arc::new(MySqlDialect {}),
         "mssql" => Arc::new(MsSqlDialect {}),

--- a/integration/sql/tests/tests_create.rs
+++ b/integration/sql/tests/tests_create.rs
@@ -48,7 +48,6 @@ fn test_create_table_clone() {
     )
 }
 
-
 #[test]
 fn test_create_and_insert() {
     assert_eq!(

--- a/integration/sql/tests/tests_select.rs
+++ b/integration/sql/tests/tests_select.rs
@@ -109,3 +109,14 @@ fn select_into() {
         }
     )
 }
+
+#[test]
+fn select_redshift() {
+    assert_eq!(
+        test_sql_dialect("SELECT [col1] FROM [test_schema].[test_table]", "redshift"),
+        SqlMeta {
+            in_tables: table("test_schema.test_table"),
+            out_tables: vec![]
+        }
+    )
+}


### PR DESCRIPTION
Support Redshift SQL dialect in OpenLineage's SQL parser. 

Note, this does not add support for all of the Redshift's custom syntax. 
This adds support for Redshift dialect quirks, like usage of square brackets as JSON path.

Closes: https://github.com/OpenLineage/OpenLineage/issues/1062

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>