### PR TITLE
[PROXY] Add helm chart for proxy backend

### DIFF
--- a/proxy/chart/README.md
+++ b/proxy/chart/README.md
@@ -42,7 +42,7 @@ helm delete ol-proxy
 | `proxy.replicaCount`        | Number of desired replicas           | `1`                 |
 | `proxy.image.registry`      | Proxy image registry                 | `docker.io`         |
 | `proxy.image.repository`    | Proxy image repository               | `openlineage/proxy` |
-| `proxy.image.tag`           | Proxy image tag                      | `0.15.0`            |
+| `proxy.image.tag`           | Proxy image tag                      | `0.1.0`             |
 | `proxy.image.pullPolicy`    | Image pull policy                    | `IfNotPresent`      |
 | `proxy.host`                | Proxy host                           | `localhost`         |
 | `proxy.port`                | API host port                        | `5000`              |

--- a/proxy/chart/README.md
+++ b/proxy/chart/README.md
@@ -1,0 +1,59 @@
+# OpenLineage Proxy [Helm Chart](https://helm.sh)
+
+Helm Chart for [OpenLineage Proxy](https://github.com/OpenLineage/OpenLineage/tree/main/proxy).
+
+## TL;DR
+
+```bash
+helm install ol-proxy . --dependency-update
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install ol-proxy .
+```
+
+> **Note:** For a list of parameters that can be overridden during installation, see the [configuration](#configuration) section.
+
+## Uninstalling the Chart
+
+To uninstall the `ol-proxy` deployment:
+
+```bash
+helm delete ol-proxy
+```
+
+## Configuration
+
+### [Common](https://artifacthub.io/packages/helm/bitnami/common) **parameters**
+
+| Parameter              | Description                         | Default |
+|------------------------|-------------------------------------|---------|
+| `commonLabels`         | Labels common to all resources      | `{}`    |
+| `commonAnnotations`    | Annotations common to all resources | `{}`    |
+
+### [OpenLineage Proxy](https://github.com/OpenLineage/OpenLineage/tree/main/proxy) **parameters**
+
+| Parameter                   | Description                          | Default             |
+|-----------------------------|--------------------------------------|---------------------|
+| `proxy.replicaCount`        | Number of desired replicas           | `1`                 |
+| `proxy.image.registry`      | Proxy image registry                 | `docker.io`         |
+| `proxy.image.repository`    | Proxy image repository               | `openlineage/proxy` |
+| `proxy.image.tag`           | Proxy image tag                      | `0.15.0`            |
+| `proxy.image.pullPolicy`    | Image pull policy                    | `IfNotPresent`      |
+| `proxy.host`                | Proxy host                           | `localhost`         |
+| `proxy.port`                | API host port                        | `5000`              |
+| `proxy.adminPort`           | Heath/Liveness host port             | `5001`              |
+| `proxy.resources.limits`    | K8s resource limit overrides         | `nil`               |
+| `proxy.resources.requests`  | K8s resource requests overrides      | `nil`               |
+| `proxy.service.type`        | K8s service type                     | `ClusterIP`         |
+| `proxy.service.port`        | K8s service port                     | `8080`              |
+| `proxy.service.annotations` | K8s service annotations              | `{}`                |
+| `proxy.ingress.enabled`     | Enables ingress settings             | `false`             |
+| `proxy.ingress.annotations` | Annotations applied to ingress       | `nil`               |
+| `proxy.ingress.hosts`       | Hostname applied to ingress routes   | `nil`               |
+| `proxy.ingress.tls`         | TLS settings for hostname            | `nil`               |
+| `proxy.podAnnotations`      | Additional pod annotations for Proxy | `{}`                |


### PR DESCRIPTION
### Problem

We don't have a helm chart defined for deploying the [proxy](https://github.com/OpenLineage/OpenLineage/tree/main/proxy) backend on k8s.

Closes: #1067 

### Solution

Add hem chart for proxy backend.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)