### PR TITLE
spark fixes after Databricks test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.14.0...HEAD)
+
+* Spark integration fixes including when no `openlineage.timeout` [`#1069`](https://github.com/OpenLineage/OpenLineage/pull/1069) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski) 
+
 ## [0.14.0](https://github.com/OpenLineage/OpenLineage/compare/0.13.1...0.14.0) - 2022-09-06
 ### Added
 * Support ABFSS and Hadoop Logical Relation in Column-level lineage [`#1008`](https://github.com/OpenLineage/OpenLineage/pull/1008) [@wjohnson](https://github.com/wjohnson)  

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -88,6 +88,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     if (isDisabled) {
       return;
     }
+    initializeContextFactoryIfNotInitialized();
     if (event instanceof SparkListenerSQLExecutionStart) {
       sparkSQLExecStart((SparkListenerSQLExecutionStart) event);
     } else if (event instanceof SparkListenerSQLExecutionEnd) {
@@ -115,6 +116,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     if (isDisabled) {
       return;
     }
+    initializeContextFactoryIfNotInitialized();
     Optional<ActiveJob> activeJob =
         asJavaOptional(
                 SparkSession.getDefaultSession()
@@ -268,6 +270,10 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
    */
   @Override
   public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
+    initializeContextFactoryIfNotInitialized();
+  }
+
+  private void initializeContextFactoryIfNotInitialized() {
     if (contextFactory != null || isDisabled) {
       return;
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
@@ -38,13 +38,18 @@ public class SparkConfUtils {
   }
 
   public static Optional<Double> findSparkConfigKeyDouble(SparkConf conf, String name) {
-    String timeoutString = conf.get(name);
-    try {
-      if (StringUtils.isNotBlank(timeoutString)) {
-        return Optional.of(Double.parseDouble(timeoutString));
+    Option<String> opt = conf.getOption(name);
+    if (!opt.isDefined()) {
+      opt = conf.getOption("spark." + name);
+    }
+    if (opt.isDefined()) {
+      try {
+        if (StringUtils.isNotBlank(opt.get())) {
+          return Optional.of(Double.parseDouble(opt.get()));
+        }
+      } catch (NumberFormatException e) {
+        log.warn("Value of timeout is not parsable");
       }
-    } catch (NumberFormatException e) {
-      log.warn("Value of timeout is not parsable");
     }
     return Optional.empty();
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/SparkConfUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/SparkConfUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.openlineage.spark.agent.util.SparkConfUtils;
+import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+
+public class SparkConfUtilsTest {
+
+  SparkConf conf = new SparkConf();
+
+  @Test
+  void testFindSparkConfigKeyDouble() {
+    conf.set("openlineage.timeout", "30.0");
+    assertEquals(
+        new Double(30), SparkConfUtils.findSparkConfigKeyDouble(conf, "openlineage.timeout").get());
+  }
+
+  @Test
+  void testFindSparkConfigKeyDoubleWhenEntryWithSparkPrefix() {
+    conf.set("spark.openlineage.timeout", "30.0");
+    assertEquals(
+        new Double(30), SparkConfUtils.findSparkConfigKeyDouble(conf, "openlineage.timeout").get());
+  }
+
+  @Test
+  void testFindSparkConfigKeyDoubleWhenNoEntry() {
+    assertEquals(
+        Optional.empty(), SparkConfUtils.findSparkConfigKeyDouble(conf, "openlineage.timeout"));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Testing the following Spark code on Databricks lead to errors:
```
df1 = spark.range(10)
df1.write.mode("overwrite").parquet("dbfs:/tmp/df1")

df2 = spark.read.parquet("dbfs:/tmp/df")
df2.withColumn("col1", df2["id"]*2).write.mode("overwrite").parquet("dbfs:/tmp/df")
```

The observed errors were: 
 * null pointer exception in `OpenLineageSparkListener` as `contextFactory` was not initalized
 * error when no `openlineage.timeout` provided 
 * added extra unit test to column lineage resembling code snippet available [here](https://github.com/OpenLineage/OpenLineage/issues/1054)

### Solution

Fix the observed errors

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)