### PR TITLE
airflow: lazy load BigQuery client

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -15,7 +15,6 @@ from openlineage.airflow.extractors.base import (
     TaskMetadata
 )
 from openlineage.airflow.utils import get_job_name, try_import_from_string
-from google.cloud.bigquery import Client
 
 _BIGQUERY_CONN_URL = 'bigquery'
 
@@ -78,6 +77,8 @@ class BigQueryExtractor(BaseExtractor):
         )
 
     def _get_client(self):
+        # lazy-load the bigquery Client due to its slow import
+        from google.cloud.bigquery import Client
         # Get client using Airflow hook - this way we use the same credentials as Airflow
         if hasattr(self.operator, 'hook') and self.operator.hook:
             hook = self.operator.hook

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0.
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 import traceback

--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -3,7 +3,6 @@
 from typing import List, Optional, Dict
 
 from openlineage.airflow.extractors.base import TaskMetadata
-from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
 from openlineage.client.facet import BaseFacet
 from openlineage.airflow.utils import (
     build_column_check_facets,
@@ -20,6 +19,7 @@ def get_check_extractors(super_):
             pass
 
         def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
+            from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
             if issubclass(BigQueryExtractor, BaseSqlCheckExtractor):
                 return super().extract_on_complete(task_instance)
             return super().extract()

--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -1,3 +1,4 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional, Dict

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -43,8 +43,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         airflow_1_version="airflow.contrib.operators.bigquery_operator.BigQueryHook",
         airflow_2_version='airflow.providers.google.cloud.operators.bigquery.BigQueryHook'
     ))
-    @mock.patch('openlineage.common.provider.bigquery.Client')
-    def test_extract(self, mock_client, mock_hook):
+    def test_extract(self, mock_hook):
         log.info("test_extractor")
 
         job_details = self.read_file_json(
@@ -56,8 +55,6 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         bq_job_id = "foo.bq.job_id"
 
-        mock_client = mock.MagicMock()
-
         mock_hook.return_value \
             .run_query.return_value = bq_job_id
 
@@ -65,6 +62,8 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
             .get_conn.return_value \
             .cursor.return_value \
             .run_query.return_value = bq_job_id
+
+        mock_client = mock.MagicMock()
 
         project_id = "test"
         mock_hook.return_value.project_id = project_id

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -5,11 +5,7 @@ import json
 import logging
 import traceback
 import attr
-from typing import TYPE_CHECKING
-
-from typing import Tuple, Optional, Dict, List
-
-from google.cloud.bigquery import Client
+from typing import Tuple, Optional, Dict, List, TYPE_CHECKING
 
 from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbTableSchema, DbColumn
@@ -24,9 +20,11 @@ _BIGQUERY_CONN_URL = 'bigquery'
 # we lazy-load bigquery Client in BigQueryDatasetsProvider if not type-checking
 if TYPE_CHECKING:
     from google.cloud.bigquery import Client
-    client_type = Client
-else:
-    client_type = None
+
+
+def get_bq_client():
+    from google.cloud.bigquery import Client
+    return Client
 
 
 @attr.s
@@ -93,14 +91,12 @@ class BigQueryFacets:
 class BigQueryDatasetsProvider:
     def __init__(
         self,
-        client: Optional[client_type] = None,
+        client: Optional["Client"] = None,
         logger: Optional[logging.Logger] = None
     ):
         if client is None:
             # lazy-load bigquery client since its slow to import (primarily due to pandas)
-            if not TYPE_CHECKING:
-                from google.cloud.bigquery import Client
-            self.client = Client()
+            self.client = get_bq_client()
         else:
             self.client = client
         if logger is None:


### PR DESCRIPTION
Problem
BigQuery client indirectly imports pandas. Importing it at top-level can significantly increase DAG import time, by around 
20%.

Solution
Move to local imports.
