### PR TITLE
python: remove sqlparse dependency, add optional backup dependency

### DIFF
--- a/integration/airflow/dev-requirements-1.x.txt
+++ b/integration/airflow/dev-requirements-1.x.txt
@@ -1,3 +1,3 @@
 -e ../../client/python
--e ../common[sql]
+-e ../common[python-sql]
 -e .[dev,airflow-1]

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -1,3 +1,4 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0.
 from typing import List
 from urllib.parse import urlparse

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -1,3 +1,4 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0.
 import logging
 from typing import List, Optional, TYPE_CHECKING, Dict, Tuple, Callable
@@ -11,11 +12,9 @@ from openlineage.airflow.extractors.dbapi_utils import (
 from openlineage.airflow.utils import get_connection
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.facet import BaseFacet, SqlJobFacet
-from openlineage.common.sql import SqlMeta, parse
+from openlineage.common.sql import SqlMeta, parse, DbTableMeta
 from openlineage.common.dataset import Dataset, Source
 from abc import abstractmethod
-
-from openlineage.common.sql.parser import DbTableMeta
 
 if TYPE_CHECKING:
     from airflow.models import Connection

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -15,12 +15,14 @@ __version__ = "0.15.0"
 requirements = [
     "attrs>=19.3",
     "requests>=2.20.0",
-    "sqlparse>=0.3.1",
     f"openlineage-integration-common[sql]=={__version__}",
     f"openlineage-python=={__version__}",
 ]
 
 extras_require = {
+    "python-sql": [
+        "sqlparse>=0.3.1",
+    ],
     "tests": [
         "pytest",
         "pytest-cov",

--- a/integration/common/openlineage/common/sql/parser.py
+++ b/integration/common/openlineage/common/sql/parser.py
@@ -11,6 +11,8 @@ from sqlparse.tokens import Punctuation
 
 log = logging.getLogger(__name__)
 
+# Do not import from this package directly. Instead, import from openlineage.common.sql
+
 
 def provider():
     return "python"

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -15,10 +15,12 @@ __version__ = "0.15.0"
 requirements = [
     "attrs>=19.3.0",
     f"openlineage-python=={__version__}",
-    "sqlparse>=0.3.1",
 ]
 
 extras_require = {
+    "python-sql": [
+        "sqlparse>=0.3.1",
+    ],
     "sql": [
         f"openlineage_sql=={__version__}"
     ],

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from datetime import datetime, timezone
 
 from openlineage.client.run import RunEvent, RunState, Run, Job
-from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
+from openlineage.client.client import OpenLineageClient
 from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata
 
 __version__ = "0.15.0"

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -13,7 +13,6 @@ with open("README.md") as readme_file:
 __version__ = "0.15.0"
 
 requirements = [
-    f"sqlparse>=0.2.3,<0.4",
     f"tqdm>=4.62.0",
     f"openlineage-integration-common[dbt]=={__version__}",
 ]


### PR DESCRIPTION
`sqlparse` - Python library, not `sqlparser-rs` - should not be installed by default, as it's unused with systems where Rust parser works.

This add option to install `sqlparse` separately if needed.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
