### PR TITLE
Add task policy in Airflow 2.4.0 OL plugin.

### DIFF
--- a/.circleci/workflows/openlineage-integration-airflow.yml
+++ b/.circleci/workflows/openlineage-integration-airflow.yml
@@ -30,7 +30,8 @@ workflows:
                 airflow-version: [
                   'airflow-1.10.15',
                   'airflow-2.1.4',
-                  'airflow-2.3.1'
+                  'airflow-2.3.1',
+                  'airflow-2.4.0'
                 ]
                 install_parser: [ true ]
           requires:
@@ -51,7 +52,8 @@ workflows:
               airflow-image: [
                 'apache/airflow:2.1.4-python3.7',
                 'apache/airflow:2.2.4-python3.7',
-                'apache/airflow:2.3.1-python3.7'
+                'apache/airflow:2.3.1-python3.7',
+                'apache/airflow:2.4.0-python3.7'
               ]
           context: integration-tests
           requires:

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -21,11 +21,18 @@ if parse_version(AIRFLOW_VERSION) \
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
         macros = [lineage_run_id, lineage_parent_id]
-else:
+elif parse_version(AIRFLOW_VERSION) < parse_version("2.4.0"):
     from openlineage.airflow import listener
 
     # Provide entrypoint airflow plugin that registers listener module
     class OpenLineagePlugin(AirflowPlugin):     # type: ignore
         name = "OpenLineagePlugin"
         listeners = [listener]
+        macros = [lineage_run_id, lineage_parent_id]
+else:
+    from openlineage.airflow.task_policy import patch_openlineage_policy
+    patch_openlineage_policy()
+
+    class OpenLineagePlugin(AirflowPlugin):     # type: ignore
+        name = "OpenLineagePlugin"
         macros = [lineage_run_id, lineage_parent_id]

--- a/integration/airflow/openlineage/airflow/task_policy.py
+++ b/integration/airflow/openlineage/airflow/task_policy.py
@@ -1,0 +1,137 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import TYPE_CHECKING, Callable, Union, Optional
+from functools import wraps
+
+from openlineage.airflow.adapter import OpenLineageAdapter
+from openlineage.airflow.extractors import ExtractorManager
+from openlineage.airflow.utils import (
+    execute_in_thread,
+    EventBuilder,
+)
+
+if TYPE_CHECKING:
+    from airflow.models import BaseOperator, MappedOperator
+    from airflow.models.abstractoperator import TaskStateChangeCallback
+
+
+import logging
+
+log = logging.getLogger(__name__)
+
+extractor_manager = ExtractorManager()
+adapter = OpenLineageAdapter()
+
+
+def callback_wrapper(f):
+    @wraps(f)
+    def wrapper(callback: Optional["TaskStateChangeCallback"]):
+        def func(context):
+            task_instance = context["task_instance"]
+            task = task_instance.task
+            dag = context["dag"]
+            dagrun = context["dag_run"]
+
+            try:
+                execute_in_thread(f, args=(context, task_instance, task, dag, dagrun))
+            except Exception as e:
+                log.error(f"Sending OpenLineage failed: {e}.")
+
+            if callback:
+                callback(context)
+
+        return func
+
+    return wrapper
+
+
+@callback_wrapper
+def on_execute(context, task_instance, task, dag, dagrun):
+    run_id = EventBuilder.start_task(
+        adapter=adapter,
+        extractor_manager=extractor_manager,
+        task_instance=task_instance,
+        task=task,
+        dag=dag,
+        dagrun=dagrun,
+    )
+    context["_openlineage_run_id"] = run_id
+
+
+@callback_wrapper
+def on_success(context, task_instance, task, dag, dagrun):
+    run_id = context["_openlineage_run_id"]
+    EventBuilder.complete_task(
+        adapter=adapter,
+        extractor_manager=extractor_manager,
+        task_instance=task_instance,
+        task=task,
+        dagrun=dagrun,
+        run_id=run_id,
+    )
+
+
+@callback_wrapper
+def on_failure(context, task_instance, task, dag, dagrun):
+    run_id = context["_openlineage_run_id"]
+    EventBuilder.fail_task(
+        adapter=adapter,
+        extractor_manager=extractor_manager,
+        task_instance=task_instance,
+        task=task,
+        dagrun=dagrun,
+        run_id=run_id,
+    )
+
+
+def _patch_policy(settings) -> None:
+    if hasattr(settings, "task_policy"):
+        task_policy = _wrap_task_policy(settings.task_policy)
+        settings.task_policy = task_policy
+
+
+def _wrap_task_policy(policy) -> Callable:
+    if policy and hasattr(policy, "_task_policy_patched"):
+        return policy
+
+    def custom_task_policy(task: Union["BaseOperator", "MappedOperator"]) -> None:
+        policy(task)
+        task_policy(task)
+
+    setattr(custom_task_policy, "_task_policy_patched", True)
+    return custom_task_policy
+
+
+def patch_openlineage_policy() -> None:
+    try:
+        import airflow_local_settings as settings
+    except ImportError:
+        from airflow import settings  # type: ignore
+    _patch_policy(settings)
+
+
+def task_policy(task: Union["BaseOperator", "MappedOperator"]) -> None:
+    log.debug(f"Setting task policy for Dag: {task.dag_id} Task: {task.task_id}")
+    if task.__class__.__name__ == "MappedOperator":
+        _task_policy_mapped(task)  # type: ignore
+    else:
+        _task_policy_base(task)  # type: ignore
+
+
+def _task_policy_mapped(task: "MappedOperator") -> None:
+    task.partial_kwargs["on_execute_callback"] = on_execute(
+        task.partial_kwargs["on_execute_callback"]
+    )
+    task.partial_kwargs["on_success_callback"] = on_success(
+        task.partial_kwargs["on_success_callback"]
+    )
+    task.partial_kwargs["on_failure_callback"] = on_failure(
+        task.partial_kwargs["on_failure_callback"]
+    )
+
+
+def _task_policy_base(task: "BaseOperator") -> None:
+    task.on_execute_callback = on_execute(task.on_execute_callback)
+    task.on_success_callback = on_success(task.on_success_callback)
+    task.on_failure_callback = on_failure(task.on_failure_callback)

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -27,7 +27,7 @@ disable_error_code = attr-defined
 
 [tox:tox]
 envlist = 
-	py3-airflow-{1.10.15,2.1.4,2.3.1}
+	py3-airflow-{1.10.15,2.1.4,2.3.1,2.4.0}
 skipsdist = True
 
 [testenv]
@@ -39,6 +39,7 @@ deps = -r dev-requirements-2.x.txt
 	codecov>=1.4.0
 	airflow-2.1.4: apache-airflow==2.1.4
 	airflow-2.3.1: apache-airflow==2.3.1
+	airflow-2.4.0: apache-airflow==2.4.0
 whitelist_externals = bash
 commands = flake8 --extend-exclude tests/integration,scripts/
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Airflow 2.4 changed what is sent in sqlalchemy events. This breaks OpenLineage integration.

Closes: #1121 

### Solution

Use `task_policy` to override `on_execute/success/failure_callback`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)