### PR TITLE
Fix failure tests.

### DIFF
--- a/integration/airflow/tests/integration/docker/up-2.sh
+++ b/integration/airflow/tests/integration/docker/up-2.sh
@@ -39,4 +39,5 @@ export PWD='.'
 docker-compose -f tests/docker-compose-2.yml down -v
 docker-compose -f tests/docker-compose-2.yml build
 docker-compose -f tests/docker-compose-2.yml run integration
+docker-compose -f tests/docker-compose-2.yml logs > tests/airflow/logs/docker.log
 docker-compose -f tests/docker-compose-2.yml down

--- a/integration/airflow/tests/integration/docker/up-failure.sh
+++ b/integration/airflow/tests/integration/docker/up-failure.sh
@@ -34,4 +34,5 @@ esac
 docker-compose -f failures/docker-compose.yml down -v
 docker-compose -f failures/docker-compose.yml build
 OPENLINEAGE_URL=$URL docker-compose -f failures/docker-compose.yml run integration
+docker-compose -f failures/docker-compose.yml logs > failures/airflow/logs/docker.log
 docker-compose -f failures/docker-compose.yml down -v

--- a/integration/airflow/tests/integration/failures/docker-compose.yml
+++ b/integration/airflow/tests/integration/failures/docker-compose.yml
@@ -55,9 +55,9 @@ services:
       - ../docker/wait-for-it.sh:/wait-for-it.sh
     depends_on:
       airflow_scheduler:
-        condition: service_healthy
+        condition: service_started
       airflow_worker:
-        condition: service_healthy
+        condition: service_started
       airflow:
         condition: service_healthy
       backend:


### PR DESCRIPTION
Store logs from docker compose.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Integration failure tests sometimes fails.

### Solution

Change condition from `service_healthy` to `service_started` for Airflow services. This does not need to be healthy at the start of `integration` service.

Also added docker logs to make CI process clearer.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained