### PR TITLE
Increase webserver's timeout in Airflow integration failure tests.

### DIFF
--- a/integration/airflow/tests/integration/failures/docker-compose.yml
+++ b/integration/airflow/tests/integration/failures/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
       interval: 10s
-      timeout: 10s
+      timeout: 60s
       retries: 5
     restart: always
     depends_on:


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Airflow integration failure tests fail randomly in circleCI.

### Solution

Increase webserver's timeout.