### PR TITLE
CI: build macos release package on medium resouce class

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -379,7 +379,7 @@ jobs:
     working_directory: ~/openlineage/integration/sql
     macos:
       xcode: 13.2.1
-    resource_class: large
+    resource_class: medium
     steps:
       - *checkout_project_root
       - run: RUN_TESTS=true bash script/build-macos.sh


### PR DESCRIPTION
MacOS release fails because the resource class is too large.

https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/4766/workflows/85948d7a-26f8-4983-af0b-4f4f02d80160/jobs/59011

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>