### PR TITLE
Add dag_run information to airflow version run facet

### DIFF
--- a/integration/airflow/openlineage/airflow/dag.py
+++ b/integration/airflow/openlineage/airflow/dag.py
@@ -99,7 +99,10 @@ class DAG(AIRFLOW_DAG):
                     DagUtils.get_start_time(execution_date),
                     DagUtils.get_end_time(execution_date, self.following_schedule(execution_date)),
                     task_metadata,
-                    {**task_metadata.run_facets, **get_custom_facets(task, is_external_trigger)}
+                    {
+                        **task_metadata.run_facets,
+                        **get_custom_facets(dagrun, task, is_external_trigger)
+                    }
                 )
 
                 JobIdMapping.set(
@@ -173,7 +176,7 @@ class DAG(AIRFLOW_DAG):
                 DagUtils.to_iso_8601(task_instance.start_date),
                 DagUtils.to_iso_8601(task_instance.end_date),
                 task_metadata,
-                {**task_metadata.run_facets, **get_custom_facets(task, False)}
+                {**task_metadata.run_facets, **get_custom_facets(dagrun, task, False)}
             )
 
             if not task_run_id:

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -25,13 +25,16 @@ class AirflowVersionRunFacet(BaseFacet):
     ]
 
     @classmethod
-    def from_task(cls, task):
+    def from_dagrun_and_task(cls, dagrun, task):
         # task.__dict__ may contain values uncastable to str
         from openlineage.airflow.utils import get_operator_class, to_json_encodable
 
+        task_info = to_json_encodable(task)
+        task_info["dag_run"] = to_json_encodable(dagrun)
+
         return cls(
             f"{get_operator_class(task).__module__}.{get_operator_class(task).__name__}",
-            to_json_encodable(task),
+            task_info,
             AIRFLOW_VERSION,
             OPENLINEAGE_AIRFLOW_VERSION,
         )

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -109,7 +109,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
             task=task_metadata,
             run_facets={
                 **task_metadata.run_facets,
-                **get_custom_facets(task, dagrun.external_trigger, task_instance_copy)
+                **get_custom_facets(dagrun, task, dagrun.external_trigger, task_instance_copy)
             }
         )
 

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -258,11 +258,11 @@ def get_job_name(task):
 
 
 def get_custom_facets(
-    task, is_external_trigger: bool, task_instance: "TaskInstance" = None
+    dagrun, task, is_external_trigger: bool, task_instance: "TaskInstance" = None
 ) -> Dict[str, Any]:
     custom_facets = {
         "airflow_runArgs": AirflowRunArgsRunFacet(is_external_trigger),
-        "airflow_version": AirflowVersionRunFacet.from_task(task),
+        "airflow_version": AirflowVersionRunFacet.from_dagrun_and_task(dagrun, task),
     }
     # check for -1 comes from SmartSensor compatibility with dynamic task mapping
     # this comes from Airflow code

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -64,7 +64,7 @@ class Backend:
                 task=task_metadata,
                 run_facets={
                     **task_metadata.run_facets,
-                    **get_custom_facets(operator, dagrun.external_trigger)
+                    **get_custom_facets(dagrun, operator, dagrun.external_trigger)
                 }
             )
 


### PR DESCRIPTION
Signed-off-by: Minkyu Park <minkyu.park.200@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem
OpenLineage events generated from airflow integration contain the parent run ID but that is not the dag run ID of the airflow. This PR adds `dag_run` to the ` `airflow_version.taskInfo` facet in order to make use of it.

### Solution
Dag run information is already available when the task is run. This PR simply pass and encode the DagRun object and enclose to the `taskInfo`. Following is the sample `dag_run` added to the facet:
```
        "dag_run": {
            "id": 7,
            "conf": {},
            "_state": "running",
            "dag_id": "tutorial_dag",
            "run_id": "manual__2022-10-04T20:56:32.826748+00:00",
            "dag_hash": "f4a452efe940b60ce005fa0b5606f4f3",
            "run_type": "manual",
            "queued_at": "2022-10-04T20:56:32.850049+00:00",
            "start_date": "2022-10-04T20:56:35.791078+00:00",
            "execution_date": "2022-10-04T20:56:32.826748+00:00",
            "log_template_id": 2,
            "external_trigger": true,
            "data_interval_end": "2022-10-04T20:56:32.826748+00:00",
            "_sa_instance_state": "<sqlalchemy.orm.state.InstanceState object at 0x7ff1d83b99d0>",
            "data_interval_start": "2022-10-04T20:56:32.826748+00:00",
            "last_scheduling_decision": "2022-10-04T20:57:06.781225+00:00"
          }
```

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)