### PR TITLE
Include __extra__ case when filtering uri query params.

### DIFF
--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -105,6 +105,29 @@ def test_get_connection_filter_qs_params():
                          'extra__snowflake__warehouse'])
 
 
+def test_get_connection_filter_qs_params_with_boolean_in_conn():
+    conn = Connection(
+        conn_type="redshift",
+        extra={
+            "iam": True,
+            "cluster_identifier": "redshift-cluster-name",
+            "region": "region",
+            "aws_secret_access_key": "AKIAIOSFODNN7EXAMPLE",
+            "aws_access_key_id": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        }
+    )
+    uri = get_connection_uri(conn)
+    parsed = urlparse(uri)
+    qs_dict = parse_qs(parsed.query)
+    assert not any(k in qs_dict.keys()
+                   for k in ['aws_secret_access_key',
+                             'aws_access_key_id'])
+    assert all(k in qs_dict.keys()
+               for k in ['iam',
+                         'cluster_identifier',
+                         'region'])
+
+
 def test_get_location_no_file_path():
     assert get_location(None) is None
     assert get_location("") is None


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

There are cases when Airflow generates URI so that query params go into one single string under `__extra__` key. This caused secrets to be revealed in URI.

Closes: #1141 

### Solution

Include `conn.EXTRA_KEY` in `get_connection_uri` method.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)