### PR TITLE
[integraion/spark] Modified docker-compose on spark integration jupyter

### DIFF
--- a/integration/spark/docker-compose.yml
+++ b/integration/spark/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 services:
   notebook:
     image: jupyter/pyspark-notebook:spark-3.1.2
+    command: start.sh jupyter notebook --NotebookApp.token=''
     ports:
       - "8888:8888"
     volumes:


### PR DESCRIPTION
Adding additional command argument to remove the need to set tokens each time using jupyter.

Signed-off-by: howardyoo <howardyoo@gmail.com>

# Problem
Closes: #1151 

# Solution
Added commands to unset the app token, so that each time jupyter starts, it will not ask for authentication.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)