### PR TITLE
airflow: add default extractor

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -1,11 +1,11 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
-
+import inspect
 import os
 
 from typing import Type, Optional
 
-from openlineage.airflow.extractors.base import BaseExtractor
+from openlineage.airflow.extractors.base import BaseExtractor, DefaultExtractor
 from openlineage.airflow.utils import import_from_string, try_import_from_string
 from openlineage.airflow.extractors.sql_check_extractors import get_check_extractors
 
@@ -68,6 +68,7 @@ class Extractors:
     def __init__(self):
         # Do not expose extractors relying on external dependencies that are not installed
         self.extractors = {}
+        self.default_extractor = DefaultExtractor
 
         for extractor in _extractors:
             for operator_class in extractor.get_operator_classnames():
@@ -100,6 +101,9 @@ class Extractors:
         name = clazz.__name__
         if name in self.extractors:
             return self.extractors[name]
+        if hasattr(clazz, "get_openlineage_facets") \
+                and inspect.isfunction(clazz.get_openlineage_facets):
+            return self.default_extractor
         return None
 
     def instantiate_abstract_extractors(self, task) -> None:

--- a/integration/airflow/tests/extractors/test_default_extractor.py
+++ b/integration/airflow/tests/extractors/test_default_extractor.py
@@ -1,0 +1,72 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+from airflow.models import BaseOperator
+from airflow.operators.python import PythonOperator
+
+from openlineage.airflow.extractors import Extractors
+from openlineage.airflow.extractors.base import OperatorLineage, DefaultExtractor, TaskMetadata
+from openlineage.airflow.extractors.python_extractor import PythonExtractor
+from openlineage.client.facet import ParentRunFacet, SqlJobFacet
+from openlineage.client.run import Dataset
+
+
+INPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
+OUTPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
+RUN_FACETS = {
+    "parent": ParentRunFacet.create(
+        "3bb703d1-09c1-4a42-8da5-35a0b3216072", "namespace", "parentjob"
+    )
+}
+JOB_FACETS = {"sql": SqlJobFacet(query="SELECT * FROM inputtable")}
+
+
+class ExampleOperator(BaseOperator):
+    def execute(self, context) -> Any:
+        pass
+
+    def get_openlineage_facets(self) -> OperatorLineage:
+        return OperatorLineage(
+            inputs=INPUTS,
+            outputs=OUTPUTS,
+            run_facets=RUN_FACETS,
+            job_facets=JOB_FACETS
+        )
+
+
+class BrokenOperator(BaseOperator):
+    get_openlineage_facets = []
+
+    def execute(self, context) -> Any:
+        pass
+
+
+def test_default_extraction():
+    extractor = Extractors().get_extractor_class(ExampleOperator)
+    assert extractor is DefaultExtractor
+
+    metadata = extractor(ExampleOperator(task_id="test")).extract()
+
+    assert metadata == TaskMetadata(
+        name="adhoc_airflow.test",
+        inputs=INPUTS,
+        outputs=OUTPUTS,
+        run_facets=RUN_FACETS,
+        job_facets=JOB_FACETS
+    )
+
+
+def test_does_not_use_default_extractor_when_not_a_method():
+    extractor = Extractors().get_extractor_class(BrokenOperator)
+    assert extractor is None
+
+
+def test_does_not_use_default_extractor_when_no_get_openlineage_facets():
+    extractor = Extractors().get_extractor_class(BaseOperator)
+    assert extractor is None
+
+
+def test_does_not_use_default_extractor_when_explicite_extractor():
+    extractor = Extractors().get_extractor_class(PythonOperator)
+    assert extractor is PythonExtractor

--- a/integration/airflow/tests/integration/requests/default_extractor.json
+++ b/integration/airflow/tests/integration/requests/default_extractor.json
@@ -1,0 +1,65 @@
+[{
+	"eventType": "COMPLETE",
+	"inputs": [{
+		"facets": {},
+		"name": "inputtable",
+		"namespace": "database://host:port"
+	}],
+	"job": {
+		"facets": {
+			"sql": {
+				"query": "SELECT * FROM inputtable"
+			}
+		},
+		"name": "default_extractor_dag.default_operator_first",
+		"namespace": "food_delivery"
+	},
+	"outputs": [{
+		"facets": {},
+		"name": "inputtable",
+		"namespace": "database://host:port"
+	}],
+	"run": {
+		"facets": {
+			"parent": {
+				"job": {
+					"name": "parentjob",
+					"namespace": "namespace"
+				},
+				"run": {}
+			}
+		}
+	}
+}, {
+	"eventType": "COMPLETE",
+	"inputs": [{
+		"facets": {},
+		"name": "inputtable",
+		"namespace": "database://host:port"
+	}],
+	"job": {
+		"facets": {
+			"sql": {
+				"query": "SELECT * FROM inputtable"
+			}
+		},
+		"name": "default_extractor_dag.default_operator_second",
+		"namespace": "food_delivery"
+	},
+	"outputs": [{
+		"facets": {},
+		"name": "inputtable",
+		"namespace": "database://host:port"
+	}],
+	"run": {
+		"facets": {
+			"parent": {
+				"job": {
+					"name": "parentjob",
+					"namespace": "namespace"
+				},
+				"run": {}
+			}
+		}
+	}
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -56,6 +56,7 @@ params = [
         marks=pytest.mark.skipif(not IS_GCP_AUTH, reason="no gcp credentials"),
     ),
     ("source_code_dag", "requests/source_code.json"),
+    ("default_extractor_dag", "requests/default_extractor.json"),
     ("custom_extractor", "requests/custom_extractor.json"),
     ("unknown_operator_dag", "requests/unknown_operator.json"),
     pytest.param(

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -1,0 +1,64 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.utils.dates import days_ago
+
+from openlineage.airflow.extractors.base import OperatorLineage
+from openlineage.client.facet import ParentRunFacet, SqlJobFacet
+from openlineage.client.run import Dataset
+
+
+INPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
+OUTPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
+RUN_FACETS = {
+    "parent": ParentRunFacet.create(
+        "3bb703d1-09c1-4a42-8da5-35a0b3216072", "namespace", "parentjob"
+    )
+}
+JOB_FACETS = {"sql": SqlJobFacet(query="SELECT * FROM inputtable")}
+
+
+class ExampleOperator(BaseOperator):
+    def execute(self, context) -> Any:
+        pass
+
+    def get_openlineage_facets(self) -> OperatorLineage:
+        return OperatorLineage(
+            inputs=INPUTS,
+            outputs=OUTPUTS,
+            run_facets=RUN_FACETS,
+            job_facets=JOB_FACETS
+        )
+
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+dag = DAG(
+    'default_extractor_dag',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Determines the popular day of week orders are placed.'
+)
+
+
+t1 = ExampleOperator(
+    task_id='default_operator_first',
+    dag=dag
+)
+
+t2 = ExampleOperator(
+    task_id='default_operator_second',
+    dag=dag
+)
+
+t1 >> t2


### PR DESCRIPTION
As a way of extending OpenLineage airflow integration, we are providing a way to add custom extractors. This is great for people who want to add integration with external operators - for example, regular Airflow user who wants to support `GCSToS3Operator`.

However, it's too cumbersome for people who own operators, and want to add default implementation of OpenLineage for their operators for external users. This PR adds support for `DefaultExtractor` which looks up particular method - `get_openlineage_facets` on Operator, and when it's present, uses it to get lineage data.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
