### PR TITLE
Feature - Airflow S3CopyObject extractor

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -54,6 +54,9 @@ _extractors = list(
             ),
             try_import_from_string(
                 'openlineage.airflow.extractors.sagemaker_extractors.SageMakerTransformExtractor'
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.s3_extractor.S3CopyObjectExtractor'
             )
         ],
     )

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -1,3 +1,6 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Optional, List
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -1,0 +1,41 @@
+import logging
+from typing import Optional, List
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.client.run import Dataset
+
+log = logging.getLogger(__name__)
+
+
+class S3CopyObjectExtractor(BaseExtractor):
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['S3CopyObjectOperator']
+
+    def extract(self) -> Optional[TaskMetadata]:
+
+        input_object = Dataset(
+            namespace="s3://{}".format(self.operator.source_bucket_name),
+            name="s3://{0}/{1}".format(
+                self.operator.source_bucket_name,
+                self.operator.source_bucket_key
+            ),
+            facets={}
+        )
+
+        output_object = Dataset(
+            namespace="s3://{}".format(self.operator.dest_bucket_name),
+            name="s3://{0}/{1}".format(
+                self.operator.dest_bucket_name,
+                self.operator.dest_bucket_key
+            ),
+            facets={}
+        )
+
+        return TaskMetadata(
+            name=f"{self.operator.dag_id}.{self.operator.task_id}",
+            inputs=[input_object],
+            outputs=[output_object],
+        )
+
+    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
+        pass

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -17,11 +17,9 @@ collect_ignore = []
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
     collect_ignore.append("test_listener.py")
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.1.4"):
-    collect_ignore.append("extractors/test_s3_extractor.py")
-
 if parse_version(AIRFLOW_VERSION) < parse_version("2.2.4"):
     collect_ignore.append("extractors/test_redshift_sql_extractor.py")
+    collect_ignore.append("extractors/test_s3_extractor.py")
 
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
     collect_ignore.append("extractors/test_redshift_data_extractor.py")

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -17,6 +17,9 @@ collect_ignore = []
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
     collect_ignore.append("test_listener.py")
 
+if parse_version(AIRFLOW_VERSION) < parse_version("2.1.4"):
+    collect_ignore.append("extractors/test_s3_extractor.py")
+
 if parse_version(AIRFLOW_VERSION) < parse_version("2.2.4"):
     collect_ignore.append("extractors/test_redshift_sql_extractor.py")
 

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -1,3 +1,6 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import unittest
 import random

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -1,0 +1,81 @@
+from unittest import TestCase
+import logging
+import unittest
+from unittest import mock, TestCase
+import random
+import pytz
+from openlineage.airflow.extractors.s3_extractor import S3CopyObjectExtractor
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
+from openlineage.airflow.extractors.base import TaskMetadata
+from datetime import datetime
+from airflow.models import TaskInstance, DAG
+from airflow.utils.state import State
+from airflow.utils import timezone
+from pkg_resources import parse_version
+from airflow.version import version as AIRFLOW_VERSION
+from openlineage.client.run import Dataset
+
+log = logging.getLogger(__name__)
+
+
+class TestS3CopyObjectExtractor(TestCase):
+    def setUp(self):
+        log.debug("TestS3CopyObjectExtractor.setup(): ")
+        self.task = TestS3CopyObjectExtractor._get_copy_task()
+        self.ti = TestS3CopyObjectExtractor._get_ti(task=self.task)
+        self.extractor = S3CopyObjectExtractor(operator=self.task)
+
+    def test_extract(self):
+        expected_return_value = TaskMetadata(
+            name="TestS3CopyObjectExtractor.task_id",
+            inputs=[
+                Dataset(
+                    namespace="s3://source-bucket",
+                    name="s3://source-bucket/path/to/source_file.csv",
+                    facets={}
+                )
+            ],
+            outputs=[
+                Dataset(
+                    namespace="s3://destination-bucket",
+                    name="s3://destination-bucket/path/to/destination_file.csv",
+                    facets={}
+                )
+            ],
+        )
+
+        return_value = self.extractor.extract()
+
+        self.assertEqual(return_value, expected_return_value)
+
+    @staticmethod
+    def _get_copy_task():
+        dag = DAG(dag_id="TestS3CopyObjectExtractor")
+        task = S3CopyObjectOperator(
+            task_id="task_id",
+            source_bucket_name="source-bucket",
+            source_bucket_key="path/to/source_file.csv",
+            dest_bucket_name="destination-bucket",
+            dest_bucket_key="path/to/destination_file.csv",
+            dag=dag,
+            start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
+        )
+
+        return task
+
+    @staticmethod
+    def _get_ti(task):
+        kwargs = {}
+        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+            kwargs['run_id'] = 'test_run_id'  # change in 2.2.0
+        task_instance = TaskInstance(
+            task=task,
+            execution_date=datetime.utcnow().replace(tzinfo=pytz.utc),
+            state=State.SUCCESS,
+            **kwargs)
+        task_instance.job_id = random.randrange(10000)
+
+        return task_instance
+
+    if __name__ == '__main__':
+        unittest.main()

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -1,9 +1,8 @@
-from unittest import TestCase
 import logging
 import unittest
-from unittest import mock, TestCase
 import random
 import pytz
+from unittest import TestCase
 from openlineage.airflow.extractors.s3_extractor import S3CopyObjectExtractor
 from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
 from openlineage.airflow.extractors.base import TaskMetadata


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

There is no S3 extractor currently for Airflow operators.


### Solution

Created an extractor for the S3CopyObject Operator in Airflow.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

This has been smoke tested locally in Airflow and in Astronomer (Astro)  with S3 as a custom extractor.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)