### PR TITLE
[Integration][Airflow] Move get connection URI as extractor's classmethod.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -3,7 +3,7 @@
 from typing import List
 from urllib.parse import urlparse
 
-from openlineage.airflow.utils import get_connection_uri, try_import_from_string
+from openlineage.airflow.utils import try_import_from_string
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 
 
@@ -27,9 +27,6 @@ class MySqlExtractor(SqlExtractor):
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
         return ["MySqlOperator"]
-
-    def _get_connection_uri(self):
-        return get_connection_uri(self.conn)
 
     def _get_scheme(self) -> str:
         return "mysql"

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -3,8 +3,7 @@
 from typing import List
 from urllib.parse import urlparse
 
-from openlineage.airflow.utils import get_normalized_postgres_connection_uri, \
-    try_import_from_string
+from openlineage.airflow.utils import try_import_from_string
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 
 
@@ -18,6 +17,7 @@ class PostgresExtractor(SqlExtractor):
     ]
     _is_information_schema_cross_db = False
 
+    # cluster-identifier
     @property
     def dialect(self):
         return "postgres"
@@ -26,8 +26,12 @@ class PostgresExtractor(SqlExtractor):
     def get_operator_classnames(cls) -> List[str]:
         return ['PostgresOperator']
 
-    def _get_connection_uri(self):
-        return get_normalized_postgres_connection_uri(self.conn)
+    @classmethod
+    def get_connection_uri(cls, conn):
+        uri = super().get_connection_uri(conn)
+        if uri.startswith('postgresql'):
+            uri = uri.replace('postgresql', 'postgres', 1)
+        return uri
 
     def _get_scheme(self):
         return 'postgres'

--- a/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
@@ -9,6 +9,9 @@ if TYPE_CHECKING:
 
 
 class RedshiftSQLExtractor(PostgresExtractor):
+
+    _whitelist_query_params: List[str] = ["cluster_identifier", "region"]
+
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
         return ["RedshiftSQLOperator"]

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -4,7 +4,6 @@ from typing import List, Dict
 
 from openlineage.airflow.extractors.dbapi_utils import execute_query_on_hook
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
-from openlineage.airflow.utils import get_connection_uri  # noqa
 from openlineage.client.facet import BaseFacet, ExternalQueryRunFacet
 
 
@@ -20,6 +19,12 @@ class SnowflakeExtractor(SqlExtractor):
     ]
     _is_information_schema_cross_db = True
     _is_uppercase_names = True
+
+    # extra prefix should be deprecated soon in Airflow
+    _whitelist_query_params: List[str] = ["warehouse", "account", "database", "region"] + [
+        "extra__snowflake__" + el
+        for el in ["warehouse", "account", "database", "region"]
+    ]
 
     @property
     def dialect(self):
@@ -60,9 +65,6 @@ class SnowflakeExtractor(SqlExtractor):
 
     def _get_scheme(self):
         return "snowflake"
-
-    def _get_connection_uri(self):
-        return get_connection_uri(self.conn)
 
     def _get_db_specific_run_facets(self, source, *_) -> Dict[str, BaseFacet]:
         query_ids = self._get_query_ids()

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -66,7 +66,7 @@ class SqlExtractor(BaseExtractor):
         source = Source(
             scheme=self.scheme,
             authority=self._get_authority(),
-            connection_url=self._get_connection_uri(),
+            connection_url=self.get_connection_uri(self.conn),
         )
 
         database = getattr(self.operator, "database", None)
@@ -161,10 +161,6 @@ class SqlExtractor(BaseExtractor):
 
     @abstractmethod
     def _get_hook(self) -> "BaseHook":
-        raise NotImplementedError
-
-    @abstractmethod
-    def _get_connection_uri(self) -> str:
         raise NotImplementedError
 
     def _get_db_specific_run_facets(

--- a/integration/airflow/tests/extractors/test_base.py
+++ b/integration/airflow/tests/extractors/test_base.py
@@ -1,0 +1,30 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from airflow.models import Connection
+from openlineage.airflow.extractors.base import BaseExtractor
+from urllib.parse import urlparse, parse_qs
+
+AIRFLOW_CONN_ID = "test_db"
+AIRFLOW_CONN_URI = "postgres://localhost:5432/testdb"
+CONN_ID = "database://login:password@host:123/role?param=value&param_secret=hideit"
+
+
+def test_get_connection_uri():
+    conn = Connection(conn_id=AIRFLOW_CONN_ID, uri=AIRFLOW_CONN_URI)
+    assert BaseExtractor.get_connection_uri(conn) == AIRFLOW_CONN_URI
+
+
+def test_get_connection_filter_qs_params():
+    conn = Connection(conn_id="snowflake", uri=CONN_ID)
+
+    class TestExtractor(BaseExtractor):
+        _whitelist_query_params = ["param"]
+
+    uri = TestExtractor.get_connection_uri(conn)
+    parsed = urlparse(uri)
+    qs_dict = parse_qs(parsed.query)
+    assert "param" in qs_dict
+    assert "param_secret" not in qs_dict
+    assert not parsed.username
+    assert not parsed.password
+    assert uri == "database://host:123/role?param=value"

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -189,3 +189,15 @@ def create_connection():
 def test_get_connection_returns_one_if_exists(create_connection):
     conn = Connection("does_exist")
     assert get_connection("does_exist").conn_id == conn.conn_id
+
+
+def test_get_connection_from_uri():
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI)
+    assert PostgresExtractor.get_connection_uri(conn) == CONN_URI_WITHOUT_USERPASS
+
+
+def test_get_normalized_postgres_connection_uri():
+    conn = Connection()
+    conn.parse_from_uri(uri=CONN_URI.replace("postgres", "postgresql"))
+    assert PostgresExtractor.get_connection_uri(conn) == CONN_URI_WITHOUT_USERPASS

--- a/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
@@ -8,6 +8,7 @@ from airflow.models import Connection
 from airflow.utils.dates import days_ago
 from airflow import DAG
 from airflow.utils.session import create_session
+from urllib.parse import urlparse, parse_qs
 
 from openlineage.airflow.utils import get_connection
 from openlineage.common.models import DbTableSchema, DbColumn
@@ -213,6 +214,28 @@ def test_extract_authority_uri(get_connection, mock_get_table_schemas):
     assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
     assert task_metadata.inputs == expected_inputs
     assert task_metadata.outputs == []
+
+
+def test_get_connection_filter_qs_params_with_boolean_in_conn():
+    conn = Connection(
+        conn_type="redshift",
+        extra={
+            "iam": True,
+            "cluster_identifier": "redshift-cluster-name",
+            "region": "region",
+            "aws_secret_access_key": "AKIAIOSFODNN7EXAMPLE",
+            "aws_access_key_id": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        }
+    )
+    uri = RedshiftSQLExtractor.get_connection_uri(conn)
+    parsed = urlparse(uri)
+    qs_dict = parse_qs(parsed.query)
+    assert not any([k in qs_dict.keys()
+                   for k in ['aws_secret_access_key',
+                             'aws_access_key_id']])
+    assert all(k in qs_dict.keys()
+               for k in ['cluster_identifier',
+                         'region'])
 
 
 def test_get_connection_import_returns_none_if_not_exists():

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -3,19 +3,16 @@
 
 import os
 import json
-from urllib.parse import parse_qs, urlparse
 
 import pendulum
 import datetime
-from airflow.models import Connection, DAG as AIRFLOW_DAG
+from airflow.models import DAG as AIRFLOW_DAG
 from airflow.operators.dummy import DummyOperator
 from pkg_resources import parse_version
 
 from openlineage.airflow.utils import (
     url_to_https,
     get_location,
-    get_connection_uri,
-    get_normalized_postgres_connection_uri,
     get_connection,
     to_json_encodable,
     DagUtils,
@@ -58,26 +55,6 @@ TABLE_CHECK_MAPPING = {
 }
 
 
-def test_get_connection_uri():
-    conn = Connection(
-        conn_id=AIRFLOW_CONN_ID,
-        uri=AIRFLOW_CONN_URI
-    )
-    assert get_connection_uri(conn) == AIRFLOW_CONN_URI
-
-
-def test_get_connection_from_uri():
-    conn = Connection()
-    conn.parse_from_uri(uri=AIRFLOW_CONN_URI)
-    assert get_normalized_postgres_connection_uri(conn) == AIRFLOW_CONN_URI
-
-
-def test_get_normalized_postgres_connection_uri():
-    conn = Connection()
-    conn.parse_from_uri(uri="postgresql://localhost:5432/testdb")
-    assert get_normalized_postgres_connection_uri(conn) == AIRFLOW_CONN_URI
-
-
 def test_get_connection():
     os.environ['AIRFLOW_CONN_DEFAULT'] = AIRFLOW_CONN_URI
 
@@ -86,46 +63,6 @@ def test_get_connection():
     assert conn.port == 5432
     assert conn.conn_type == 'postgres'
     assert conn
-
-
-def test_get_connection_filter_qs_params():
-    conn = Connection(conn_id='snowflake', uri=SNOWFLAKE_CONN_URI)
-    uri = get_connection_uri(conn)
-    parsed = urlparse(uri)
-    qs_dict = parse_qs(parsed.query)
-    assert not any(k in qs_dict.keys()
-                   for k in ['extra__snowflake__insecure_mode',
-                             'extra__snowflake__region',
-                             'extra__snowflake__role',
-                             'extra__snowflake__aws_access_key_id',
-                             'extra__snowflake__aws_secret_access_key'])
-    assert all(k in qs_dict.keys()
-               for k in ['extra__snowflake__account',
-                         'extra__snowflake__database',
-                         'extra__snowflake__warehouse'])
-
-
-def test_get_connection_filter_qs_params_with_boolean_in_conn():
-    conn = Connection(
-        conn_type="redshift",
-        extra={
-            "iam": True,
-            "cluster_identifier": "redshift-cluster-name",
-            "region": "region",
-            "aws_secret_access_key": "AKIAIOSFODNN7EXAMPLE",
-            "aws_access_key_id": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        }
-    )
-    uri = get_connection_uri(conn)
-    parsed = urlparse(uri)
-    qs_dict = parse_qs(parsed.query)
-    assert not any(k in qs_dict.keys()
-                   for k in ['aws_secret_access_key',
-                             'aws_access_key_id'])
-    assert all(k in qs_dict.keys()
-               for k in ['iam',
-                         'cluster_identifier',
-                         'region'])
 
 
 def test_get_location_no_file_path():


### PR DESCRIPTION
Whitelist query params in URIs.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

`get_connection_uri` method allowed too many query params resulting in long and/or complex URIs.

### Solution

Change logic to whitelisting per extractor.

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)