### PR TITLE
add `dependabot.yml` to configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,51 +1,63 @@
+# For information about how to configure Dependabot, see: 
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file
 
 version: 2
-
-# Maintain all dependencies for Composer
-# updates:
-#   - package-ecosystem: "composer"
-#     directory: "/"
-#     schedule:
-#       interval: "weekly"
-#     allow:
-#       - dependency-type: "all"
-#
-# Maintain only certain deps for pip
-#   - package-ecosystem: "pip"
-    # directory: "/"
-    # schedule:
-    #   interval: "weekly"
-    # allow:
-    #   # Allow only direct updates for
-    #   # Django and any packages starting "django"
-    #   - dependency-name: "django*"
-    #     dependency-type: "direct"
-    #   # Allow only production updates for Sphinx
-    #   - dependency-name: "sphinx"
-    #     dependency-type: "production"
-
 updates:
   # Supported package managers:
-      # bundler
-      # cargo
-      # composer
-      # docker
-      # mix
-      # elm
-      # gitsubmodule
-      # github-actions
-      # gomod
-      # gradle
-      # maven
-      # npm
-      # nuget
-      # pip, pipenv, pip-compile, poetry (use 'pip')
-      # pub
-      # terraform
-      # yarn (use 'npm')
+  # bundler
+  # cargo
+  # composer
+  # docker
+  # mix
+  # elm
+  # gitsubmodule
+  # github-actions
+  # gomod
+  # gradle
+  # maven
+  # npm
+  # nuget
+  # pip, pipenv, pip-compile, poetry (use 'pip')
+  # pub
+  # terraform
+  # yarn (use 'npm')
   - package-ecosystem: "gradle"
     directory: "client/java"
     schedule:
-    # intervals: daily, weekly, monthly
+    # supported intervals: daily, weekly, monthly
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "integration/flink"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "integration/spark"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "client/python"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "integration/common"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "integration/airflow"
+    schedule:
+      interval: "weekly"  
+
+  - package-ecosystem: "pip"
+    directory: "integration/dbt"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "integration/sql"
+    schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file
+
+version: 2
+
+# Maintain all dependencies for Composer
+# updates:
+#   - package-ecosystem: "composer"
+#     directory: "/"
+#     schedule:
+#       interval: "weekly"
+#     allow:
+#       - dependency-type: "all"
+#
+# Maintain only certain deps for pip
+#   - package-ecosystem: "pip"
+    # directory: "/"
+    # schedule:
+    #   interval: "weekly"
+    # allow:
+    #   # Allow only direct updates for
+    #   # Django and any packages starting "django"
+    #   - dependency-name: "django*"
+    #     dependency-type: "direct"
+    #   # Allow only production updates for Sphinx
+    #   - dependency-name: "sphinx"
+    #     dependency-type: "production"
+
+updates:
+  # Supported package managers:
+      # bundler
+      # cargo
+      # composer
+      # docker
+      # mix
+      # elm
+      # gitsubmodule
+      # github-actions
+      # gomod
+      # gradle
+      # maven
+      # npm
+      # nuget
+      # pip, pipenv, pip-compile, poetry (use 'pip')
+      # pub
+      # terraform
+      # yarn (use 'npm')
+  - package-ecosystem: "gradle"
+    directory: "client/java"
+    schedule:
+    # intervals: daily, weekly, monthly
+      interval: "weekly"


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

The LFAI requires automated dependency monitoring, which we have not yet implemented. GitHub's built-in solution, Dependabot, appears to be relatively easy to deploy and configure, and we are already using it in Marquez (for security updates only). The tool can be turned on in GitHub in the Settings tab, and all configuration can be done in a single YAML file in the `.github` directory.

Closes: #1179 

### Solution

This change adds a `dependabot.yml` file to `.github` containing a link to a guide to configuring the tool, examples (commented) of configurations for two packages, and an entry to configure Gradle monitoring in the Java client. A list of all the supported package managers is also included. **In comments, would you please share feedback on the included configuration for Gradle along with the names of any additional package managers that should be included and, finally, which dependencies to ignore, if any, for each?** Thank you in advance for your help with this project.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)