### PR TITLE
add Kinesis Transport and support config Kinesis in Spark integration

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'org.apache.kafka:kafka-clients:3.1.0'
+    compileOnly 'com.amazonaws:amazon-kinesis-producer:0.14.13'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.transports;
 
 import java.util.Optional;

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
@@ -1,0 +1,20 @@
+package io.openlineage.client.transports;
+
+import java.util.Optional;
+import java.util.Properties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+public final class KinesisConfig implements TransportConfig {
+  @Getter @Setter private String streamName;
+  @Getter @Setter private String region;
+  @Getter @Setter private Optional<String> roleArn;
+
+  // check
+  // https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties
+  @Getter @Setter private Properties properties;
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -1,0 +1,83 @@
+package io.openlineage.client.transports;
+
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.amazonaws.services.kinesis.producer.UserRecord;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientUtils;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class KinesisTransport extends Transport {
+  private final String streamName;
+  private final String region;
+  private final Optional<String> roleArn;
+
+  private final KinesisProducer producer;
+
+  private final Executor listeningExecutor;
+
+  public KinesisTransport(
+      @NonNull final KinesisProducer kinesisProducer, @NonNull final KinesisConfig kinesisConfig) {
+
+    super(Type.KINESIS);
+    this.streamName = kinesisConfig.getStreamName();
+    this.region = kinesisConfig.getRegion();
+    this.roleArn = kinesisConfig.getRoleArn();
+    this.producer = kinesisProducer;
+    this.listeningExecutor = Executors.newSingleThreadExecutor();
+  }
+
+  public KinesisTransport(@NonNull final KinesisConfig kinesisConfig) {
+    super(Type.KINESIS);
+    this.streaName = kinesisConfig.getStreamName();
+    this.region = kinesisConfig.getRegion();
+    this.roleArn = kinesisConfig.getRoleArn();
+
+    KinesisProducerConfiguration config =
+        KinesisProducerConfiguration.fromProperties(kinesisConfig.getProperties());
+    config.setRegion(this.region);
+    roleArn.ifPresent(s -> config.setCredentialsProvider(
+            new STSAssumeRoleSessionCredentialsProvider.Builder(s, "OLProducer").build()));
+
+    this.producer = new KinesisProducer(config);
+    this.listeningExecutor = Executors.newSingleThreadExecutor();
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.RunEvent runEvent) {
+    final String eventAsJson = OpenLineageClientUtils.toJson(runEvent);
+    log.debug("Received lineage event: {}", eventAsJson);
+    ListenableFuture<UserRecordResult> future =
+        this.producer.addUserRecord(
+            new UserRecord(
+                streamName,
+                runEvent.getJob().getNamespace() + ":" + runEvent.getJob().getName(),
+                ByteBuffer.wrap(eventAsJson.getBytes())));
+
+    FutureCallback<UserRecordResult> callback =
+        new FutureCallback<UserRecordResult>() {
+          @Override
+          public void onSuccess(UserRecordResult result) {
+            log.debug("Success to send to Kinesis lineage event: {}", eventAsJson);
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+            log.error("Failed to send to Kinesis lineage event: {}", eventAsJson, t);
+          };
+        };
+
+    Futures.addCallback(future, callback, this.listeningExecutor);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -47,8 +47,10 @@ public class KinesisTransport extends Transport {
     KinesisProducerConfiguration config =
         KinesisProducerConfiguration.fromProperties(kinesisConfig.getProperties());
     config.setRegion(this.region);
-    roleArn.ifPresent(s -> config.setCredentialsProvider(
-            new STSAssumeRoleSessionCredentialsProvider.Builder(s, "OLProducer").build()));
+    roleArn.ifPresent(
+        s ->
+            config.setCredentialsProvider(
+                new STSAssumeRoleSessionCredentialsProvider.Builder(s, "OLProducer").build()));
 
     this.producer = new KinesisProducer(config);
     this.listeningExecutor = Executors.newSingleThreadExecutor();

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -40,7 +40,7 @@ public class KinesisTransport extends Transport {
 
   public KinesisTransport(@NonNull final KinesisConfig kinesisConfig) {
     super(Type.KINESIS);
-    this.streaName = kinesisConfig.getStreamName();
+    this.streamName = kinesisConfig.getStreamName();
     this.region = kinesisConfig.getRegion();
     this.roleArn = kinesisConfig.getRoleArn();
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.transports;
 
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
@@ -77,7 +82,8 @@ public class KinesisTransport extends Transport {
           @Override
           public void onFailure(Throwable t) {
             log.error("Failed to send to Kinesis lineage event: {}", eventAsJson, t);
-          };
+          }
+          ;
         };
 
     Futures.addCallback(future, callback, this.listeningExecutor);

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -13,6 +13,7 @@ public abstract class Transport {
     CONSOLE,
     HTTP,
     KAFKA,
+    KINESIS,
     NOOP
   };
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportFactory.java
@@ -43,9 +43,12 @@ public final class TransportFactory {
       }
       kafkaConfig.getProperties().put("server.id", kafkaConfig.getLocalServerId());
       return new KafkaTransport(kafkaConfig);
+    } else if (transportConfig instanceof KinesisConfig) {
+      final KinesisConfig config = (KinesisConfig) transportConfig;
+      return new KinesisTransport(config);
     } else {
       throw new IllegalArgumentException(
-          "Transport must be of type 'Console', 'HTTP', or 'Kafka'.");
+          "Transport must be of type 'Console', 'HTTP', 'Kafka' or 'Kinesis'.");
     }
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
@@ -16,6 +16,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -30,7 +31,7 @@ class KinesisTransportTest {
     properties.setProperty("MinConnections", "1");
 
     config.setRegion("us-west-2");
-    config.setRoleArn("test-role");
+    config.setRoleArn(Optional.of("test-role"));
     config.setStreamName("test-stream");
     config.setProperties(properties);
 

--- a/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
@@ -1,0 +1,54 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.UserRecord;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClient;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class KinesisTransportTest {
+  @Test
+  void clientEmitsKinesisTransport() throws IOException {
+    KinesisProducer producer = mock(KinesisProducer.class);
+    KinesisConfig config = new KinesisConfig();
+
+    Properties properties = new Properties();
+    properties.setProperty("MinConnections", "1");
+
+    config.setRegion("us-west-2");
+    config.setRoleArn("test-role");
+    config.setStreamName("test-stream");
+    config.setProperties(properties);
+
+    KinesisTransport transport = new KinesisTransport(producer, config);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    when(producer.addUserRecord(any(UserRecord.class))).thenReturn(mock(ListenableFuture.class));
+
+    client.emit(
+        new OpenLineage(URI.create("http://test.producer"))
+            .newRunEventBuilder()
+            .job(new OpenLineage.JobBuilder().name("test-job").namespace("test-ns").build())
+            .build());
+
+    ArgumentCaptor<UserRecord> captor = ArgumentCaptor.forClass(UserRecord.class);
+
+    verify(producer, times(1)).addUserRecord(captor.capture());
+
+    assertThat(captor.getValue().getStreamName()).isEqualTo("test-stream");
+  }
+}

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -91,6 +91,7 @@ also defined in configuration or not.
 #### Config entries
 
 The following parameters can be specified in the Spark configuration
+
 | Parameter | Definition | Example |
 ------------|------------|---------
 | spark.openlineage.host | The hostname of the OpenLineage API server where events should be reported | http://localhost:5000 |
@@ -103,6 +104,18 @@ The following parameters can be specified in the Spark configuration
 | spark.openlineage.appName | Custom value overwriting Spark app name in events | AppName |
 | spark.openlineage.url.param.xyz | A url parameter (replace xyz) and value to be included in requests to the OpenLineage API server | abcdefghijk |
 | spark.openlineage.consoleTransport | Events will be emitted to a console, no additional backend is required | true |
+| spark.openlineage.transport.type | The transport type used for event emit, currently only support 'kinesis' | kinesis |
+
+##### Kinesis Transport
+If using `spark.openlineage.transport.type` as `kinesis`, then below parameters would be read and used when building KinesisProducer.
+Also, KinesisTransport depends on you to provide artifact `com.amazonaws:amazon-kinesis-producer:0.14.0` or compatible on your classpath.
+
+| Parameter | Definition | Example |
+------------|------------|---------
+| spark.openlineage.transport.kinesis.streamName | Required, the streamName of the Kinesis Stream | some-stream-name |
+| spark.openlineage.transport.kinesis.region | Required, the region of the stream | us-east-2 |
+| spark.openlineage.transport.kinesis.roleArn | Optional, the roleArn which is allowd to read/write to Kinesis stream | some-role-arn |
+| spark.openlineage.transport.kinesis.[xxx] | Optional, the [xxx] is property of [Kinesis allowd properties](https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties) | 1 |
 
 #### Url
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent;
 
+import io.openlineage.client.transports.TransportConfig;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -43,6 +44,9 @@ public class ArgumentParser {
   @Builder.Default private Optional<String> appName = Optional.empty();
   @Builder.Default private Optional<Map<String, String>> urlParams = Optional.empty();
   @Builder.Default private boolean consoleMode = false;
+
+  @Builder.Default private Optional<TransportConfig> transportConfig = Optional.empty();
+  @Builder.Default private Optional<String> transportMode = Optional.empty();
 
   public static ArgumentParser parse(String clientUrl) {
     URI uri = URI.create(clientUrl);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.transports.ConsoleTransport;
 import io.openlineage.client.transports.HttpTransport;
+import io.openlineage.client.transports.TransportFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -39,6 +40,16 @@ public class EventEmitter {
     if (argument.isConsoleMode()) {
       this.client = new OpenLineageClient(new ConsoleTransport());
       log.info("Init OpenLineageContext: will output events to console");
+      return;
+    }
+
+    if (argument.getTransportConfig().isPresent()) {
+      this.client =
+          new OpenLineageClient(new TransportFactory(argument.getTransportConfig().get()).build());
+      log.info(
+          String.format(
+              "Init OpenLineageContext: use %s as transport, with config %s",
+              argument.getTransportMode().get(), argument.getTransportConfig().get()));
       return;
     }
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -323,10 +323,10 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       return ArgumentParser.parse(url.get());
     } else if (transportType.isPresent()) {
       // go and check the specific transport type setting
-      String mode = transportType.get();
+      String mode = transportType.get().toLowerCase();
       Optional<TransportConfig> transportConfig = Optional.empty();
       switch (mode) {
-        case "Kinesis":
+        case "kinesis":
           Map<String, String> config =
               findSparkConfigKeysStartsWith(conf, "spark.openlineage.transport.kinesis.");
           KinesisConfig kinesisConfig = new KinesisConfig();

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -8,10 +8,13 @@ package io.openlineage.spark.agent;
 import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKey;
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKeyDouble;
+import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkConfigKeysStartsWith;
 import static io.openlineage.spark.agent.util.SparkConfUtils.findSparkUrlParams;
 
 import io.openlineage.client.Environment;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.transports.KinesisConfig;
+import io.openlineage.client.transports.TransportConfig;
 import io.openlineage.spark.agent.lifecycle.ContextFactory;
 import io.openlineage.spark.agent.lifecycle.ExecutionContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -56,6 +59,8 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
       Collections.synchronizedMap(new HashMap<>());
   private static final Map<Integer, ExecutionContext> rddExecutionRegistry =
       Collections.synchronizedMap(new HashMap<>());
+
+  public static final String SPARK_CONF_TRANSPORT_TYPE = "openlineage.transport.type";
   public static final String SPARK_CONF_CONSOLE_TRANSPORT = "openlineage.consoleTransport";
   public static final String SPARK_CONF_URL_KEY = "openlineage.url";
   public static final String SPARK_CONF_HOST_KEY = "openlineage.host";
@@ -297,10 +302,53 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     return Boolean.parseBoolean(isDisabled);
   }
 
+  private void commonConfigParse(ArgumentParser.ArgumentParserBuilder builder, SparkConf conf) {
+    builder
+        .timeout(findSparkConfigKeyDouble(conf, SPARK_CONF_TIMEOUT))
+        .apiKey(findSparkConfigKey(conf, SPARK_CONF_API_KEY).filter(str -> !str.isEmpty()))
+        .appName(findSparkConfigKey(conf, SPARK_CONF_APP_NAME).filter(str -> !str.isEmpty()))
+        .urlParams(findSparkUrlParams(conf, SPARK_CONF_URL_PARAM_PREFIX));
+
+    findSparkConfigKey(conf, SPARK_CONF_HOST_KEY).ifPresent(builder::host);
+    findSparkConfigKey(conf, SPARK_CONF_API_VERSION_KEY).ifPresent(builder::version);
+    findSparkConfigKey(conf, SPARK_CONF_NAMESPACE_KEY).ifPresent(builder::namespace);
+    findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_KEY).ifPresent(builder::jobName);
+    findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID_KEY).ifPresent(builder::parentRunId);
+  }
+
   private ArgumentParser parseConf(SparkConf conf) {
     Optional<String> url = findSparkConfigKey(conf, SPARK_CONF_URL_KEY);
+    Optional<String> transportType = findSparkConfigKey(conf, SPARK_CONF_TRANSPORT_TYPE);
     if (url.isPresent()) {
       return ArgumentParser.parse(url.get());
+    } else if (transportType.isPresent()) {
+      // go and check the specific transport type setting
+      String mode = transportType.get();
+      Optional<TransportConfig> transportConfig = Optional.empty();
+      switch (mode) {
+        case "Kinesis":
+          Map<String, String> config =
+              findSparkConfigKeysStartsWith(conf, "spark.openlineage.transport.kinesis.");
+          KinesisConfig kinesisConfig = new KinesisConfig();
+          kinesisConfig.setStreamName(config.get("streamName"));
+          kinesisConfig.setRegion(config.get("region"));
+          kinesisConfig.setRoleArn(Optional.ofNullable(config.get("roleArn")));
+          Properties properties = new Properties();
+          properties.putAll(config);
+          kinesisConfig.setProperties(properties);
+          transportConfig = Optional.of(kinesisConfig);
+        default:
+          // todo, we may support other java client transport mode in this way in the future
+      }
+      ArgumentParser.ArgumentParserBuilder builder =
+          ArgumentParser.builder()
+              .transportMode(Optional.of(mode))
+              .transportConfig(transportConfig);
+
+      commonConfigParse(builder, conf);
+
+      return builder.build();
+
     } else {
       boolean consoleMode =
           findSparkConfigKey(conf, SPARK_CONF_CONSOLE_TRANSPORT)
@@ -309,19 +357,8 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
               .orElse(false);
 
       ArgumentParser.ArgumentParserBuilder builder =
-          ArgumentParser.builder()
-              .timeout(findSparkConfigKeyDouble(conf, SPARK_CONF_TIMEOUT))
-              .apiKey(findSparkConfigKey(conf, SPARK_CONF_API_KEY).filter(str -> !str.isEmpty()))
-              .appName(findSparkConfigKey(conf, SPARK_CONF_APP_NAME).filter(str -> !str.isEmpty()))
-              .urlParams(findSparkUrlParams(conf, SPARK_CONF_URL_PARAM_PREFIX))
-              .consoleMode(consoleMode);
-
-      findSparkConfigKey(conf, SPARK_CONF_HOST_KEY).ifPresent(builder::host);
-      findSparkConfigKey(conf, SPARK_CONF_API_VERSION_KEY).ifPresent(builder::version);
-      findSparkConfigKey(conf, SPARK_CONF_NAMESPACE_KEY).ifPresent(builder::namespace);
-      findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_KEY).ifPresent(builder::jobName);
-      findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID_KEY).ifPresent(builder::parentRunId);
-
+          ArgumentParser.builder().consoleMode(consoleMode);
+      commonConfigParse(builder, conf);
       return builder.build();
     }
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.SparkConf;
@@ -20,6 +21,11 @@ import scala.Option;
 public class SparkConfUtils {
   private static final String metastoreUriKey = "spark.sql.hive.metastore.uris";
   private static final String metastoreHadoopUriKey = "spark.hadoop.hive.metastore.uris";
+
+  public static Map<String, String> findSparkConfigKeysStartsWith(SparkConf conf, String prefix) {
+    return Arrays.stream(conf.getAllWithPrefix(prefix))
+        .collect(Collectors.toMap(t -> t._1, t -> t._2));
+  }
 
   public static Optional<String> findSparkConfigKey(SparkConf conf, String name) {
     Option<String> opt = conf.getOption(name);


### PR DESCRIPTION
Signed-off-by: yogyang <yogayang.h@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Closes: https://github.com/OpenLineage/OpenLineage/issues/1199

### Solution

add new dependency in client/java
```
https://github.com/OpenLineage/OpenLineage/issues/1199
```

Test the Spark-Integration to Kinesis in Databricks  + AWS Kinesis


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)