### PR TITLE
Change to `get_openlineage_facets_on_start/complete` behaviour.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 import json
 
 from openlineage.client.run import Dataset
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Callable
 from openlineage.client.facet import BaseFacet
 from openlineage.airflow.utils import LoggingMixin, get_job_name
 
@@ -18,6 +18,9 @@ class OperatorLineage:
     outputs: List[Dataset] = attr.ib(factory=list)
     run_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
     job_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
+
+
+GetOpenLineageFacetsMethod = Callable[[], OperatorLineage]
 
 
 @attr.s
@@ -55,7 +58,7 @@ class BaseExtractor(ABC, LoggingMixin):
         raise NotImplementedError()
 
     def validate(self):
-        assert (self.operator.__class__.__name__ in self.get_operator_classnames())
+        assert self.operator.__class__.__name__ in self.get_operator_classnames()
 
     @abstractmethod
     def extract(self) -> Optional[TaskMetadata]:
@@ -76,7 +79,7 @@ class BaseExtractor(ABC, LoggingMixin):
         parsed = urlparse(conn_uri)
 
         # Remove username and password
-        netloc = f'{parsed.hostname}' + (f':{parsed.port}' if parsed.port else "")
+        netloc = f"{parsed.hostname}" + (f":{parsed.port}" if parsed.port else "")
         parsed = parsed._replace(netloc=netloc)
         if parsed.query:
             query_dict = dict(parse_qsl(parsed.query))
@@ -99,17 +102,29 @@ class DefaultExtractor(BaseExtractor):
         return []
 
     def extract(self) -> Optional[TaskMetadata]:
-        return self._get_openlineage_facets(on_complete=False)
+        try:
+            return self._get_openlineage_facets(
+                self.operator.get_openlineage_facets_on_start
+            )
+        except AttributeError:
+            return None
 
     def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        return self._get_openlineage_facets(on_complete=True)
+        on_complete = getattr(self.operator, 'get_openlineage_facets_on_complete', None)
+        if on_complete and callable(on_complete):
+            return self._get_openlineage_facets(
+                on_complete
+            )
+        return self.extract()
 
-    def _get_openlineage_facets(self, on_complete: bool) -> Optional[TaskMetadata]:
-        facets: OperatorLineage = self.operator.get_openlineage_facets(on_complete=on_complete)
+    def _get_openlineage_facets(
+        self, get_facets_method: GetOpenLineageFacetsMethod
+    ) -> Optional[TaskMetadata]:
+        facets: OperatorLineage = get_facets_method()
         return TaskMetadata(
             name=get_job_name(task=self.operator),
             inputs=facets.inputs,
             outputs=facets.outputs,
             run_facets=facets.run_facets,
-            job_facets=facets.job_facets
+            job_facets=facets.job_facets,
         )

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -100,7 +100,15 @@ class Extractors:
         name = clazz.__name__
         if name in self.extractors:
             return self.extractors[name]
-        if hasattr(clazz, "get_openlineage_facets") and callable(clazz.get_openlineage_facets):
+
+        def method_exists(method_name):
+            method = getattr(clazz, method_name, None)
+            if method:
+                return callable(method)
+
+        if method_exists("get_openlineage_facets_on_start") or method_exists(
+            "get_openlineage_facets_on_complete"
+        ):
             return self.default_extractor
         return None
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -31,21 +31,21 @@ class ExampleOperator(BaseOperator):
     def execute(self, context) -> Any:
         pass
 
-    def get_openlineage_facets(self, on_complete: bool) -> OperatorLineage:
-        if on_complete:
-            return OperatorLineage(
-                inputs=INPUTS,
-                outputs=OUTPUTS,
-                run_facets=RUN_FACETS,
-                job_facets={"complete": CompleteRunFacet(True)},
-            )
-        else:
-            return OperatorLineage(
-                inputs=INPUTS,
-                outputs=OUTPUTS,
-                run_facets=RUN_FACETS,
-                job_facets=JOB_FACETS,
-            )
+    def get_openlineage_facets_on_start(self) -> OperatorLineage:
+        return OperatorLineage(
+            inputs=INPUTS,
+            outputs=OUTPUTS,
+            run_facets=RUN_FACETS,
+            job_facets=JOB_FACETS,
+        )
+
+    def get_openlineage_facets_on_complete(self) -> OperatorLineage:
+        return OperatorLineage(
+            inputs=INPUTS,
+            outputs=OUTPUTS,
+            run_facets=RUN_FACETS,
+            job_facets={"complete": CompleteRunFacet(True)},
+        )
 
 
 default_args = {


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

Splitting to multiple methods may be more understandable and easy to maintain for user.


### Solution

Change to `get_openlineage_facets_on_start/complete` behaviour.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_) - **will do later**
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)