### PR TITLE
fix: sql bumpversion

### DIFF
--- a/integration/sql/.bumpversion.cfg
+++ b/integration/sql/.bumpversion.cfg
@@ -1,6 +1,10 @@
 [bumpversion]
 current_version = 0.16.0
 
-[bumpversion:file:Cargo.toml]
+[bumpversion:file:iface-py/Cargo.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:impl/Cargo.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"


### PR DESCRIPTION
Cargo.toml moved in the new release. Fix that for the release script.