### PR TITLE
fix: sql macos build directory

### DIFF
--- a/integration/sql/iface-py/script/build-macos.sh
+++ b/integration/sql/iface-py/script/build-macos.sh
@@ -45,7 +45,8 @@ if [[ -z ${RUN_TESTS} ]]; then
 fi
 
 # Build release wheels
-python -m maturin build --universal2 --out target/wheels
+cd iface-py
+maturin build --universal2 --out target/wheels
 
 echo "Package build, trying to import"
 echo "Platform:"


### PR DESCRIPTION
Since package renaming, mac os CI release build was run in the wrong directory.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

