### PR TITLE
Fix mypy errors and adjust to PEP 484.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -43,7 +43,7 @@ jobs:
       - *checkout_project_root
       - run: pip install -e .[dev]
       - run: python -m flake8 --extend-ignore=F401
-      - run: python -m mypy --ignore-missing-imports openlineage
+      - run: python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
       - run: python -m pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)
 
@@ -606,7 +606,7 @@ jobs:
       - *install_python_client
       - run: pip install -e .[dev]
       - run: flake8
-      - run: python -m mypy --ignore-missing-imports openlineage
+      - run: python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
       - run: pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)
 

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0.
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
 from openlineage.client.run import RunEvent
 
 
@@ -34,5 +35,5 @@ class Transport:
 
 
 class TransportFactory:
-    def create(self) -> Transport:
+    def create(self) -> Transport:  # type: ignore
         pass

--- a/integration/common/openlineage/common/dataset.py
+++ b/integration/common/openlineage/common/dataset.py
@@ -49,7 +49,7 @@ class Field(RedactMixin):
     _skip_redact: List[str] = ['name', 'type', 'tags']
 
     def __init__(self, name: str, type: str,
-                 tags: List[str] = None, description: str = None):
+                 tags: Optional[List[str]] = None, description: Optional[str] = None):
         self.name = name
         self.type = type
         self.tags = tags
@@ -83,11 +83,11 @@ class Dataset(RedactMixin):
     def __init__(
             self,
             source: Source,
-            name: str, fields: List[Field] = None,
+            name: str, fields: Optional[List[Field]] = None,
             description: Optional[str] = None,
-            custom_facets: Dict[str, BaseFacet] = None,
-            input_facets: Dict[str, BaseFacet] = None,
-            output_facets: Dict[str, BaseFacet] = None
+            custom_facets: Optional[Dict[str, BaseFacet]] = None,
+            input_facets: Optional[Dict[str, BaseFacet]] = None,
+            output_facets: Optional[Dict[str, BaseFacet]] = None
     ):
         if fields is None:
             fields = []
@@ -108,8 +108,8 @@ class Dataset(RedactMixin):
     @staticmethod
     def from_table(source: Source,
                    table_name: str,
-                   schema_name: str = None,
-                   database_name: str = None):
+                   schema_name: Optional[str] = None,
+                   database_name: Optional[str] = None):
         return Dataset(
             name=Dataset._to_name(
                 schema_name=schema_name,
@@ -123,7 +123,7 @@ class Dataset(RedactMixin):
     def from_table_schema(
             source: Source,
             table_schema: DbTableSchema,
-            database_name: str = None
+            database_name: Optional[str] = None
     ):
         return Dataset(
             name=Dataset._to_name(
@@ -141,7 +141,7 @@ class Dataset(RedactMixin):
         )
 
     @staticmethod
-    def _to_name(table_name: str, schema_name: str = None, database_name: str = None):
+    def _to_name(table_name: str, schema_name: Optional[str] = None, database_name: Optional[str] = None):  # noqa
         # Prefix the table name with database and schema name using
         # the format: {database_name}.{table_schema}.{table_name}.
         name = [table_name]

--- a/integration/common/openlineage/common/models.py
+++ b/integration/common/openlineage/common/models.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List
+from typing import Optional, List
 from openlineage.common.sql import DbTableMeta
 from openlineage.client.utils import RedactMixin
 
@@ -10,7 +10,7 @@ class DbColumn(RedactMixin):
     _skip_redact: List[str] = ['name', 'type', 'ordinal_position']
 
     def __init__(self, name: str, type: str,
-                 description: str = None, ordinal_position: int = None):
+                 description: Optional[str] = None, ordinal_position: Optional[int] = None):
         self.name = name
         self.type = type
         self.description = description

--- a/integration/common/openlineage/common/provider/great_expectations/results.py
+++ b/integration/common/openlineage/common/provider/great_expectations/results.py
@@ -35,7 +35,7 @@ class ExpectationsParser:
     facet_key: str = ''
 
     @classmethod
-    def can_accept(cls, expectation_result: ExpectationValidationResult) -> bool:
+    def can_accept(cls, expectation_result: ExpectationValidationResult) -> Optional[Any]:
         expectation_type = get_from_nullable_chain(expectation_result,
                                                    ['expectation_config', 'expectation_type'])
         return expectation_type and expectation_type == cls.expectation_key
@@ -67,7 +67,7 @@ class FileSizeExpectationsParser(ExpectationsParser):
     expectation_key = 'expect_file_size_to_be_between'
 
     @staticmethod
-    def parse_expectation_result(expectation_result: dict) -> ExpectationsParserResult:
+    def parse_expectation_result(expectation_result: dict) -> ExpectationsParserResult:  # type: ignore # noqa
         pass  # TODO: file asset validation
 
 
@@ -78,7 +78,7 @@ class ColumnExpectationsParser(ExpectationsParser):
     column = ''
 
     @classmethod
-    def can_accept(cls, expectation_result: ExpectationValidationResult) -> bool:
+    def can_accept(cls, expectation_result: ExpectationValidationResult) -> Optional[Any]:
         expectation_type = get_from_nullable_chain(expectation_result,
                                                    ['expectation_config', 'expectation_type'])
         extracted_column = get_from_nullable_chain(

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -37,6 +37,6 @@ deps = ../../client/python
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
 commands = flake8
-	python -m mypy --ignore-missing-imports openlineage
+	python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
 	pytest --cov=openlineage --junitxml=test-results/junit.xml tests/
 	coverage xml

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -50,7 +50,7 @@ extras_require = {
         "pandas",
         "jinja2",
         "python-dateutil",
-        "mypy>=0.9.6",
+        "mypy>=0.960",
         "types-python-dateutil",
         "types-PyYAML"
     ],


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

circleCI fails on mypy checks.

### Solution

Add `--no-namespace-packages` argument to mypy command and adjust code to PEP 484.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)