### PR TITLE
add missing license text or fix outdated license text in readmes

### DIFF
--- a/.github/header_templates.md
+++ b/.github/header_templates.md
@@ -31,3 +31,7 @@
 // Copyright 2018-2022 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ### Problem
 
 👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:
@@ -27,3 +25,7 @@ If you're contributing a new integration, please specify the scope of the integr
 - [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
 - [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
 - [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -86,5 +86,5 @@ The Project will work towards an equitable resolution in the event of a misunder
 This code is based on the [Hyperledger Project](https://github.com/hyperledger/hyperledger/wiki/Hyperledger-Project-Code-of-Conduct)‘s Code of Conduct.
 
 ----
-License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
-Copyright Contributors to the OpenLineage project.
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -30,3 +30,7 @@ For more information about our approach to quality and security, feel free to re
 - Twitter: [@OpenLineage](https://twitter.com/OpenLineage)
 - Google group: [openlineage@googlegroups.com](https://groups.google.com/g/openlineage)
 - LinkedIn group: [https://www.linkedin.com/groups/13927795](https://www.linkedin.com/groups/13927795)
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -2,7 +2,7 @@
 
 OpenLineage committers are the group of people that drive the content of OpenLineage.
 They take responsibility for [specific components](CODEOWNERS) and help to guide
-new pull requests into master.
+new pull requests into main.
 
 The current OpenLineage committers are:
 
@@ -24,14 +24,14 @@ The current OpenLineage committers are:
 | Michael Robinson   | |
 | Ross Turk          | |
 
-To understand how to become an OpenLineage committer.
-see the [OpenLineage Governance Guide](GOVERNANCE.md).
+To understand how to become an OpenLineage committer,
+read the [OpenLineage Governance Guide](GOVERNANCE.md).
 
 
 ## Emeritus Maintainers
 
 The following people are no longer working on the OpenLineage project.
-However they have been a committer in the past and through their
+However, they have been committers in the past, and, through their
 contributions, we have a strong foundation to build on.
 
 
@@ -40,6 +40,6 @@ contributions, we have a strong foundation to build on.
 
 
 ----
-License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
-Copyright Contributors to the OpenLineage project.
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ OpenLineage uses [GitHub's fork and pull model](https://help.github.com/articles
 to create a contribution.
 
 Make sure to [sign-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work to say that the contributor has the rights to make the contribution and
-agrees with the [Developer Certificate of Origin (DCO)](why-the-dco.md)
+agrees with the [Developer Certificate of Origin (DCO)](why-the-dco.md).
 
 To ensure your pull request is accepted, follow these guidelines:
 
@@ -62,7 +62,7 @@ To ensure your pull request is accepted, follow these guidelines:
 
 ## Proposing changes
 
-Create an issue and tag it as `proposal`
+Create an issue and tag it as `proposal`.
 
 In the description provide the following sections:
  - Purpose (Why?): What is the use case this is for. 
@@ -90,9 +90,9 @@ workflows are merged into a single config file. See existing workflows for examp
 
 ## First-Time Contributors
 
-If this is your first contribution to open source, you can [follow this tutorial][contributiontutorial] or check [this video series][contributionvideos] to learn about the contribution workflow with GitHub.
+If this is your first contribution to open source, you can [follow this tutorial][contributiontutorial] or check out [this video series][contributionvideos] to learn about the contribution workflow with GitHub.
 
-Look tickets labeled ['good first issue'][goodfirstissues] and ['help wanted'][helpwantedissues]. These are a great starting point if you want to contribute. Don't hesitate to ask questions about the issue if you are not sure about the strategy to follow.
+Look for tickets labeled ['good first issue'][goodfirstissues] and ['help wanted'][helpwantedissues]. These are a great starting point if you want to contribute. Don't hesitate to ask questions about the issue if you are not sure about the strategy to follow.
 
 
 [issues]: https://github.com/OpenLineage/OpenLineage/issues
@@ -103,6 +103,10 @@ Look tickets labeled ['good first issue'][goodfirstissues] and ['help wanted'][h
 
 ## Triggering CI runs from forks (committers)
 
-CI runs on forks are disabled due to possibility to access external services via CI run. 
-Once contributor decides PR is ready to be checked, they can use [this script](https://github.com/jklukas/git-push-fork-to-upstream-branch)
-to trigger CI run on separate branch with same commit ID. This will update CI status of a PR.
+CI runs on forks are disabled due to the possibility of access by external services via CI run. 
+Once a contributor decides a PR is ready to be checked, they can use [this script](https://github.com/jklukas/git-push-fork-to-upstream-branch)
+to trigger a CI run on a separate branch with the same commit ID. This will update the CI status of a PR.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,5 +12,5 @@ This file recognizes the people who have make an important contribution to OpenL
 To understand how to become an OpenLineage contributor see the [OpenLineage Contributing Guide](CONTRIBUTING.md).
 
 ----
-License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
-Copyright Contributors to the OpenLineage project.
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -127,7 +127,7 @@ for more general discussion.
 The OpenLineage content is managed in GitHub under [https://github.com/OpenLineage/OpenLineage](https://github.com/OpenLineage/OpenLineage).
 It may be developed using patches, branches from main, or forks/git pull requests.
 Each change should have a [GitHub issue](https://github.com/OpenLineage/OpenLineage/issues) explaining why the change is being made.
-See: [CONTRIBUTING.md]
+For more information about contributing, read the [contributors guide](CONTRIBUTING.md).
 
 When new content proposed to the project, the person contributing is required to sign the contribution
 to confirm it conforms to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
@@ -167,5 +167,5 @@ be resolved by voting. The voting process is a simple majority in which each com
 
 
 ----
-License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
-Copyright Contributors to the OpenLineage project.
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ See [CONTRIBUTING.md](https://github.com/OpenLineage/OpenLineage/blob/main/CONTR
 ## Report a Vulnerability
 
 If you discover a vulnerability in the project, please [open an issue](https://github.com/OpenLineage/OpenLineage/issues/new/choose) and attach the "security" label.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,3 +19,7 @@
 7. Draft a [new release](https://github.com/OpenLineage/OpenLineage/releases/new) using the release notes for `X.Y.Z` in **step 1** as the release description:
 
    ![](./doc/new-release.png)
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/client/java/README.md
+++ b/client/java/README.md
@@ -176,3 +176,6 @@ The Github Actions Super-linter is installed and configured to check for headers
 
 Thanks for your contributions to the project!
 
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/client/python/README.md
+++ b/client/python/README.md
@@ -67,3 +67,7 @@ This way of configuring the client supports only `http` transport, and only a su
 * `OPENLINEAGE_API_KEY` - set if the consumer of OpenLineage events requires a `Bearer` authentication key.
 
 `OPENLINEAGE_URL` and `OPENLINEAGE_API_KEY` can also be set up manually when creating a client instance.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/README.md
+++ b/integration/README.md
@@ -7,3 +7,6 @@
 |Apache Spark|2.4.6, 3.1.2, 3.2.1+, 3.3.1|https://github.com/apache/spark/tags|[README](./spark/README.md)| |
 |Apache Flink|1.14.5, 1.15.1|https://github.com/apache/flink/tags|[README](./spark/README.md)| Flink support is currently experimental |
 
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -242,3 +242,7 @@ This can be helpful when you need to run arbitrary integration tests during deve
 python -m pytest test_integration.py::test_integration[great_expectations_validation-requests/great_expectations.json]
 ```
 ...runs a single test which you can repeat after changes in code.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/dagster/README.md
+++ b/integration/dagster/README.md
@@ -115,3 +115,7 @@ To run the test suite:
 ```bash
 $ pytest
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -47,3 +47,7 @@ The OpenLineage client depends on environment variables:
 To begin collecting dbt metadata with OpenLineage, replace `dbt run` with `dbt-ol run`.
 
 Additional table and column level metadata will be available if `catalog.json`, a result of running `dbt docs generate`, will be found in the target directory.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/flink/README.md
+++ b/integration/flink/README.md
@@ -24,3 +24,7 @@ or Gradle:
 ```groovy
 implementation 'io.openlineage:openlineage-flink:0.16.0'
 ```
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -346,3 +346,7 @@ If contributing changes, additions or fixes to the Spark integration, please inc
 A Github Action checks for headers in new `.java` files when pull requests are opened.
 
 Thank you for your contributions to the project!
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/sql/INTERFACE.md
+++ b/integration/sql/INTERFACE.md
@@ -12,3 +12,7 @@ For Python there is Python object with two lists.
 
 The tables can be in different database schemas or even databases, so we return `DbTableMeta` object that contains up to three-level nested names.
 This object carries three language-specific Strings carrying this information.
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/integration/sql/README.md
+++ b/integration/sql/README.md
@@ -65,3 +65,7 @@ The interface can be manually tested by running the integration test from the `i
 * Support a larger part of the SQL language 
 * Python as a Cargo feature
 * Explore a Java integration
+
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -37,4 +37,6 @@ By default, the OpenLineage proxy uses the following ports:
 $ ./gradlew runShadow
 ```
 
-
+----
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project

--- a/why-the-dco.md
+++ b/why-the-dco.md
@@ -28,5 +28,5 @@ makes it suitable to add to this project.  See
 
 
 ----
-License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
-Copyright Contributors to the OpenLineage project.
+SPDX-License-Identifier: Apache-2.0\
+Copyright 2018-2022 contributors to the OpenLineage project


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

Some READMEs in the project have outdated license text, or the license text is missing.

### Solution

This adds or updates the license text to the SPDX short format where needed in READMEs.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)