### PR TITLE
Add `task_instance` argument to `get_openlineage_facets_on_complete`.

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -115,6 +115,7 @@ suited to extract metadata from a particular operator (or operators).
 
 SQL Operators utilize the SQL parser. There is an experimental SQL parser activated if you install [openlineage-sql](https://pypi.org/project/openlineage-sql) on your Airflow worker.
 
+
 #### Custom Extractors
 
 If your DAGs contain additional operators from which you want to extract lineage data, fear not - you can always
@@ -128,6 +129,23 @@ OPENLINEAGE_EXTRACTORS=full.path.to.ExtractorClass;full.path.to.AnotherExtractor
 ```
 
 To ensure OpenLineage logging propagation to custom extractors you should use `self.log` instead of creating a logger yourself.
+
+#### Default Extractor
+
+When you own operators' code this is not neccessary to provide custom extractors. You can also use Default Extractor's capability.
+
+In order to do that you should define at least one of two methods in operator:
+
+* `get_openlineage_facets_on_start()`
+
+Extracts metadata on start of task.
+
+* `get_openlineage_facets_on_complete(task_instance: TaskInstance)`
+
+Extracts metadata on complete of task. This should accept `task_instance` argument, similar to `extract_on_complete` method in base extractors.
+
+If you don't define `get_openlineage_facets_on_complete` method it would fall back to `get_openlineage_facets_on_start`.
+
 
 #### Great Expectations
 

--- a/integration/airflow/tests/extractors/test_default_extractor.py
+++ b/integration/airflow/tests/extractors/test_default_extractor.py
@@ -48,7 +48,7 @@ class ExampleOperator(BaseOperator):
             job_facets=JOB_FACETS,
         )
 
-    def get_openlineage_facets_on_complete(self) -> OperatorLineage:
+    def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage:
         return OperatorLineage(
             inputs=INPUTS,
             outputs=OUTPUTS,
@@ -74,7 +74,7 @@ class OperatorWihoutStart(BaseOperator):
     def execute(self, context) -> Any:
         pass
 
-    def get_openlineage_facets_on_complete(self) -> OperatorLineage:
+    def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage:
         return OperatorLineage(
             inputs=INPUTS,
             outputs=OUTPUTS,

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -39,7 +39,7 @@ class ExampleOperator(BaseOperator):
             job_facets=JOB_FACETS,
         )
 
-    def get_openlineage_facets_on_complete(self) -> OperatorLineage:
+    def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage:
         return OperatorLineage(
             inputs=INPUTS,
             outputs=OUTPUTS,


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

<!-- SPDX-License-Identifier: Apache-2.0 -->

### Problem

DefaultExtractor should accept `task_instance` in `get_openlineage_facets_on_complete`.

Closes: #1256 

### Solution

Add `task_instance` argument.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)