### PR TITLE
Update language on nominating new committers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,12 +78,11 @@ This includes:
 New committers are voted onto the committers list by the existing committers - see
 [committer list](COMMITTERS.md).
 
-The committers vote and if a majority agree then the requester
-is added to the committers list and given write access to the git repositories.
+Upon a new nomination, the committers vote; if there are at least 3 votes in support of the nominee and no vetoes in a period of three days, the nominee becomes a committer. If there are vetoes, a majority of all committers is required to approve the nominee. Once accepted, the nominee is added to the committers list and given write access to the git repositories.
 
-Once confirmed, you can publicly refer to yourself as an OpenLineage committer.
+Once confirmed, nominees can publicly refer to themselves as OpenLineage committers.
 
-#### When does a committer lose maintainer status
+#### When does a committer lose maintainer status?
 
 If a committer is no longer interested or cannot perform the committer duties listed above, they
 should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross.turk@astronomer.io>

This PR updates the governance language related to nomination of new committers.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)