### PR TITLE
dependabot: move updates to weekend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
     schedule:
     # supported intervals: daily, weekly, monthly
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"
@@ -34,6 +35,7 @@ updates:
     directory: "integration/flink"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"
@@ -42,6 +44,7 @@ updates:
     directory: "integration/spark"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"
@@ -50,6 +53,7 @@ updates:
     directory: "client/python"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"
@@ -58,6 +62,7 @@ updates:
     directory: "integration/common"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"
@@ -66,6 +71,7 @@ updates:
     directory: "integration/airflow"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"  
@@ -74,6 +80,7 @@ updates:
     directory: "integration/dbt"
     schedule:
       interval: "weekly"
+      day: "sunday"
     labels:
       - "dependencies"
       - "dependabot"


### PR DESCRIPTION
Let's move the update schedule to weekend to not get buried under updates in the middle of a workday.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
