### PR TITLE
Fix up all artifactory paths

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -37,7 +37,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -38,7 +38,7 @@ repositories {
         url = "https://packages.confluent.io/maven/"
     }
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 
@@ -255,7 +255,7 @@ publishing {
     repositories {
         maven {
             url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -35,7 +35,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 
@@ -189,7 +189,7 @@ publishing {
     repositories {
         maven {
             url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -35,7 +35,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven {
-        url = 'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
     }
 }
 

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -132,7 +132,7 @@ publishing {
     repositories {
         maven {
             url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://datakin.jfrog.io/artifactory/maven-public-libs-snapshot'
+                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')


### PR DESCRIPTION
changing all artifactory urls to the same account

Signed-off-by: Harel Shein <harel.shein@gmail.com>

### Problem

In a previous PR, artifactory paths were changes in the build CI script, but not on all paths in the repo.
Closes: #1237

### Solution

This PR changes all artifactory paths to use the same account.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project