### PR TITLE
Publish spec into new website repo location

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -657,7 +657,7 @@ jobs:
       - *checkout_project_root
       - add_ssh_keys:
           fingerprints:
-            - "1c:d1:da:e8:76:d7:f7:04:31:07:18:fd:55:ca:e1:2e"
+            - "bf:81:9a:73:cf:b6:8e:f9:d8:2c:c0:9b:eb:64:86:23"
       - run: spec/release.sh
 
   build-proxy-backend:

--- a/spec/release.sh
+++ b/spec/release.sh
@@ -11,7 +11,7 @@ git config --global user.email "openlineage-bot-key@openlineage.io"
 git config --global user.name "OpenLineage deploy bot"
 
 WEBSITE_DIR=${WEBSITE_DIR:-$HOME/build/website}
-REPO="git@github.com:OpenLineage/OpenLineage.github.io"
+REPO="git@github.com:OpenLineage/website"
 
 if [[ -d $WEBSITE_DIR ]]; then
   # Check if we're in git repository and the repository points at website
@@ -54,7 +54,7 @@ git diff --name-only HEAD~1 HEAD 'spec/*.json' | while read LINE; do
   URL=$(cat $LINE | jq -r '.["$id"]')
 
   # extract target location in website repo
-  LOC="${WEBSITE_DIR}/${URL#*//*/}"
+  LOC="${WEBSITE_DIR}/static/${URL#*//*/}"
   LOC_DIR="${LOC%/*}"
 
   # create dir if necessary, and copy files


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

### Problem

The current release.sh script publishes the spec into the `openlineage.github.io` website repo, and it should publish it into the `website` repo.

### Solution

I created a new deploy key, added it to CircleCI & GitHub, and made the necessary changes to the `release.sh` script.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project