### PR TITLE
Release all specs since last_spec_commit_id, not just HEAD~1

### DIFF
--- a/spec/release.sh
+++ b/spec/release.sh
@@ -49,7 +49,7 @@ echo "Copying spec files from commit $PREV_SPEC_COMMIT"
 echo "$CIRCLE_SHA1" > "$WEBSITE_COMMIT_FILE"
 
 # Copy changed spec fils to target location
-git diff --name-only HEAD~1 HEAD 'spec/*.json' | while read LINE; do
+git diff --name-only $PREV_SPEC_COMMIT HEAD 'spec/*.json' | while read LINE; do
   # extract target file name from $id field in spec files
   URL=$(cat $LINE | jq -r '.["$id"]')
 


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

### Problem

The `spec/release.sh` script keeps track of the last time it shipped specs by storing the commit hash in `.last_spec_commit_id' in the website repo. However, when it comes time to ship the specs, it only ships the ones that have changed in the most recent commit.

This works in normal operation, since the script should only ship a new spec on commits where the spec has changed, but it is resulting in a failure when we try to run it against the new website repo. This is because there are no spec changes in the most recent commit.

### Solution

The script can safely ship all specs that have changed since `.last_spec_commit_id`, they don't necessarily have to have changed in the most recent commit.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)
