### PR TITLE
Also publish YML version of spec to website

### DIFF
--- a/spec/release.sh
+++ b/spec/release.sh
@@ -38,7 +38,7 @@ else
 fi
 
 # check if there are any changes in spec in the latest commit
-if git diff --name-only --exit-code $PREV_SPEC_COMMIT HEAD 'spec/*.json' >> /dev/null; then
+if git diff --name-only --exit-code $PREV_SPEC_COMMIT HEAD 'spec/*.json' 'spec/OpenLineage.yml' >> /dev/null; then
   echo "no changes in spec detected, skipping publishing spec"
   exit 0
 fi
@@ -48,7 +48,10 @@ echo "Copying spec files from commit $PREV_SPEC_COMMIT"
 # Mark last commit on which we finished copying spec
 echo "$CIRCLE_SHA1" > "$WEBSITE_COMMIT_FILE"
 
-# Copy changed spec fils to target location
+# Copy changed spec YML file to target location
+cp spec/OpenLineage.yml ${WEBSITE_DIR}/static/spec/OpenLineage.yml
+
+# Copy changed spec JSON files to target location
 git diff --name-only $PREV_SPEC_COMMIT HEAD 'spec/*.json' | while read LINE; do
   # extract target file name from $id field in spec files
   URL=$(cat $LINE | jq -r '.["$id"]')


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross.turk@astronomer.io>

### Problem

I would like to have the OpenLineage website auto-generate openAPI docs when the spec is published there, but I need the YML file to do that. Since it's part of the spec, it should probably live in `/spec` in the website.

### Solution

This modification should cause `OpenLineage.yml` to also be copied to `/static/spec` in the website repo.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project