### PR TITLE
[Integration][Airflow] Change how pip installs packages in tox environments.

### DIFF
--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -32,12 +32,17 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = python -m pip install {opts} --find-links target/wheels/ --find-links ../sql/target/wheels {packages}
+install_command = python -m pip install {opts} --find-links target/wheels/ \
+				  --find-links ../sql/target/wheels \
+				  --use-deprecated=legacy-resolver \
+				  --constraint=https://raw.githubusercontent.com/apache/airflow/constraints-{env:AIRFLOW_VERSION}/constraints-3.7.txt \
+				  {packages}
 deps = -r dev-requirements.txt
 	pytest
 	mypy>=0.9.6
 	codecov>=1.4.0
 	airflow-2.1.4: apache-airflow==2.1.4
+	airflow-2.2.4: apache-airflow==2.2.4
 	airflow-2.3.1: apache-airflow==2.3.1
 whitelist_externals = bash
 commands = flake8 --extend-exclude tests/integration,scripts/
@@ -49,3 +54,6 @@ setenv =
 	AIRFLOW_HOME = {envdir}
 	PYTHONPATH = {toxinidir}/tests
 	AIRFLOW__CORE__LOGGING_CONFIG_CLASS = log_config.LOGGING_CONFIG
+	airflow-2.1.4: AIRFLOW_VERSION = 2.1.4
+	airflow-2.2.4: AIRFLOW_VERSION = 2.2.4
+	airflow-2.3.4: AIRFLOW_VERSION = 2.3.4

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -17,6 +17,12 @@ collect_ignore = []
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
     collect_ignore.append("test_listener.py")
 
+if parse_version(AIRFLOW_VERSION) < parse_version("2.2.4"):
+    collect_ignore.append("extractors/test_redshift_sql_extractor.py")
+
+if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
+    collect_ignore.append("extractors/test_redshift_data_extractor.py")
+
 
 @pytest.fixture(scope="function")
 def remove_redshift_conn():


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Pip uses new resolver that may cause several issues, including timeouts when installing additional packages (e.g. Airflow providers).

### Solution

Use deprecated resolver and constraints files provided by Airflow.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project