### PR TITLE
Revert "Update jni requirement from 0.19.0 to 0.20.0 in /integration/sql"

### DIFF
--- a/integration/sql/iface-java/Cargo.toml
+++ b/integration/sql/iface-java/Cargo.toml
@@ -14,5 +14,5 @@ crate-type = ["cdylib"]
 [dependencies]
 openlineage_sql = {path = "../impl"}
 anyhow = {workspace = true}
-jni = "0.20.0"
+jni = "0.19.0"
 sqlparser = {git = "https://github.com/mobuchowski/sqlparser-rs", branch = "sqlp-release"}


### PR DESCRIPTION
Reverts OpenLineage/OpenLineage#1283

This fixes compile failures. https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/5225/workflows/d021a0b1-f22c-49dd-b7f1-b5579b4d89c3/jobs/68828