### PR TITLE
spark: retry flaky tests

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-test-fixtures'
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }
@@ -158,6 +159,13 @@ task copyDependencies(type: Copy) {
 
 task integrationTest(type: Test) {
     dependsOn shadowJar, copyDependencies
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'signing'
     id 'jacoco'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.github.johnrengelman.shadow" version "7.1.2"
 }
@@ -87,6 +88,13 @@ test {
 }
 
 task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     useJUnitPlatform {
         includeTags "integration-test"
     }

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-test-fixtures'
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }
@@ -94,6 +95,13 @@ test {
 }
 
 task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-test-fixtures'
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }
@@ -101,6 +102,13 @@ test {
 }
 
 task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-test-fixtures'
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }
@@ -103,6 +104,13 @@ test {
 }
 
 task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java-test-fixtures'
     id 'com.diffplug.spotless' version '5.12.1'
     id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.4.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }
@@ -106,6 +107,13 @@ test {
 }
 
 task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"


### PR DESCRIPTION
Due to https://github.com/OpenLineage/OpenLineage/issues/999#issuecomment-1209048556 we have some flaky Spark tests. 

We prefer to keep them (as mostly they do the right thing) and manually retrying tests is not pleasant experience. 

This PR adds retrying of failed flaky integration tests.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
