### PR TITLE
Fix error in the example for column lineage facet

### DIFF
--- a/spec/facets/ColumnLineageDatasetFacet.md
+++ b/spec/facets/ColumnLineageDatasetFacet.md
@@ -22,16 +22,18 @@ Output Dataset example of adding a columnLineage facet:
           ]
         },
 >       "columnLineage": {
->         "{first column of the output dataset}": {
->           "inputFields": [
->             { "namespace": "{input dataset namespace}", name: "{input dataset name}", "field": "{input dataset column name}"},
->             ... other inputs
->           ],
->           "transformationDescription": "identical",
->           "transformationType": "IDENTITY"
->         },
->         "{second column of the output dataset}": ...,
->         ...
+>         "fields": {
+>           "{first column of the output dataset}": {
+>             "inputFields": [
+>               { "namespace": "{input dataset namespace}", name: "{input dataset name}", "field": "{input dataset column name}"},
+>               ... other inputs
+>             ],
+>             "transformationDescription": "identical",
+>             "transformationType": "IDENTITY"
+>           },
+>           "{second column of the output dataset}": ...,
+>           ...
+>         }
 >       }
       }
     }
@@ -74,15 +76,17 @@ Full lineage event example:
           ]
         },
         "columnLineage": {
-          "a": {
-            "inputFields": [
-              {namespace: "my-datasource-namespace", name: "instance.schema.table", "field": "ia"},
-              ... other inputs
-            ],
-            transformationDescription: "identical",
-            transformationType: "IDENTITY"
-          },
-          "b": ... other output fields
+          "fields": {
+            "a": {
+              "inputFields": [
+                {namespace: "my-datasource-namespace", name: "instance.schema.table", "field": "ia"},
+                ... other inputs
+              ],
+              transformationDescription: "identical",
+              transformationType: "IDENTITY"
+            },
+            "b": ... other output fields
+          }
         }
       }
     }


### PR DESCRIPTION
### Problem

The "fields" field was missing in the example

### Solution

Fixing the example
This is backward compatible, doc was wrong.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
