### PR TITLE
Add AirflowTaskRunFacet facet and deprecate task_info field from AirflowVersionRunFacet

### DIFF
--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -63,7 +63,7 @@ class Backend:
             task=task_metadata,
             run_facets={
                 **task_metadata.run_facets,
-                **get_custom_facets(dagrun, operator, dagrun.external_trigger)
+                **get_custom_facets(dagrun, operator, dagrun.external_trigger, task_instance)
             }
         )
 

--- a/integration/airflow/tests/integration/requests/bigquery.json
+++ b/integration/airflow/tests/integration/requests/bigquery.json
@@ -13,7 +13,30 @@
         "facets": {
             "airflow_runArgs": {
                 "externalTrigger": false
-            }
+            },
+          "airflow_taskRun": {
+            "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.17.0/integration/airflow",
+            "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/BaseFacet",
+            "operator": "***.providers.google.cloud.operators.bigquery.BigQueryExecuteQueryOperator",
+            "taskInfo": {
+              "allow_large_results": false,
+              "create_disposition": "CREATE_IF_NEEDED",
+              "dag": {
+                "dag_id": "bigquery_orders_popular_day_of_week",
+                "schedule_interval": "@once"
+              },
+              "dag_run": {
+                "conf": {},
+                "creating_job_id": 1,
+                "dag_id": "bigquery_orders_popular_day_of_week",
+                "external_trigger": false
+              },
+              "inlets": [],
+              "outlets": [],
+              "task_id": "bigquery_if_not_exists"
+            },
+            "tryNumber": 1
+          }
         }
     }
 },

--- a/integration/airflow/tests/integration/requests/mapped_dag.json
+++ b/integration/airflow/tests/integration/requests/mapped_dag.json
@@ -16,6 +16,36 @@
         "airflow_runArgs": {
           "externalTrigger": false
         },
+        "airflow_taskRun": {
+          "operator": "***.operators.python.PythonOperator",
+          "taskInfo": {
+            "_inlets": [],
+            "_outlets": [],
+            "args": {
+              "task_id": "get_input"
+            },
+            "dag": {
+              "dag_id": "mapped_dag",
+              "schedule_interval": "@once",
+              "tags": []
+            },
+            "dag_run": {
+              "conf": {},
+              "creating_job_id": 1,
+              "dag_id": "mapped_dag",
+              "external_trigger": false
+            },
+            "downstream_task_ids": "{'multiply'}",
+            "inlets": [],
+            "outlets": [],
+            "task_id": "get_input",
+            "trigger_rule": "all_success",
+            "upstream_task_ids": "set()",
+            "wait_for_downstream": false,
+            "weight_rule": "downstream"
+          },
+          "tryNumber": 1
+        },
         "parent": {
           "job": {
             "name": "mapped_dag",

--- a/integration/airflow/tests/integration/requests/postgres.json
+++ b/integration/airflow/tests/integration/requests/postgres.json
@@ -1,119 +1,183 @@
-[{
+[
+  {
     "eventType": "START",
     "job": {
-        "facets": {
-            "documentation": {
-                "description": "Determines the popular day of week orders are placed."
-            },
-            "sql": {
-                "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    )"
-            }
+      "facets": {
+        "documentation": {
+          "description": "Determines the popular day of week orders are placed."
         },
-        "name": "postgres_orders_popular_day_of_week.postgres_if_not_exists",
-        "namespace": "food_delivery"
+        "sql": {
+          "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    )"
+        }
+      },
+      "name": "postgres_orders_popular_day_of_week.postgres_if_not_exists",
+      "namespace": "food_delivery"
     },
     "run": {
-        "facets": {
-            "airflow_runArgs": {
-              "externalTrigger": false
-            }
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "airflow_taskRun": {
+          "operator": "***.providers.postgres.operators.postgres.PostgresOperator",
+          "taskInfo": {
+            "autocommit": false,
+            "dag": {
+              "dag_id": "postgres_orders_popular_day_of_week",
+              "schedule_interval": "@once"
+            },
+            "dag_run": {
+              "conf": {},
+              "creating_job_id": 1,
+              "dag_id": "postgres_orders_popular_day_of_week",
+              "external_trigger": false,
+              "run_type": "scheduled"
+            },
+            "downstream_task_ids": "{'postgres_insert'}",
+            "inlets": [],
+            "outlets": [],
+            "owner": "datascience",
+            "sql": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    );",
+            "task_id": "postgres_if_not_exists"
+          },
+          "tryNumber": 1
         }
+      }
     }
-},
-{
+  },
+  {
     "eventType": "START",
     "job": {
-        "facets": {
-            "documentation": {
-                "description": "Determines the popular day of week orders are placed."
-            },
-            "sql": {
-                "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on\n    "
-            }
+      "facets": {
+        "documentation": {
+          "description": "Determines the popular day of week orders are placed."
         },
-        "name": "postgres_orders_popular_day_of_week.postgres_insert",
-        "namespace": "food_delivery"
+        "sql": {
+          "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on\n    "
+        }
+      },
+      "name": "postgres_orders_popular_day_of_week.postgres_insert",
+      "namespace": "food_delivery"
     },
     "run": {
-        "facets": {
-            "airflow_runArgs": {
-                "externalTrigger": false
-            }
+      "facets": {
+        "airflow_runArgs": {
+          "externalTrigger": false
+        },
+        "airflow_taskRun": {
+          "operator": "***.providers.postgres.operators.postgres.PostgresOperator",
+          "taskInfo": {
+            "autocommit": false,
+            "dag": {
+              "dag_id": "postgres_orders_popular_day_of_week",
+              "schedule_interval": "@once"
+            },
+            "dag_run": {
+              "conf": {},
+              "creating_job_id": 1,
+              "dag_id": "postgres_orders_popular_day_of_week",
+              "external_trigger": false,
+              "run_type": "scheduled"
+            },
+            "upstream_task_ids": "{'postgres_if_not_exists'}",
+            "inlets": [],
+            "outlets": [],
+            "owner": "datascience",
+            "sql": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on\n    ",
+            "task_id": "postgres_insert"
+          },
+          "tryNumber": 1
         }
+      }
     }
-},
-{
+  },
+  {
     "eventType": "COMPLETE",
     "inputs": [],
     "job": {
-        "facets": {
-            "sql": {
-                "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    )"
-            }
-        },
-        "name": "postgres_orders_popular_day_of_week.postgres_if_not_exists",
-        "namespace": "food_delivery"
+      "facets": {
+        "sql": {
+          "query": "\n    CREATE TABLE IF NOT EXISTS popular_orders_day_of_week (\n      order_day_of_week VARCHAR(64) NOT NULL,\n      order_placed_on   TIMESTAMP NOT NULL,\n      orders_placed     INTEGER NOT NULL\n    )"
+        }
+      },
+      "name": "postgres_orders_popular_day_of_week.postgres_if_not_exists",
+      "namespace": "food_delivery"
     },
-    "outputs": [{
-		"facets": {
-			"schema": {
-				"fields": [{
-					"name": "order_day_of_week",
-					"type": "varchar"
-				}, {
-					"name": "order_placed_on",
-					"type": "timestamp"
-				}, {
-					"name": "orders_placed",
-					"type": "int4"
-				}]
-			}
-		},
-		"name": "food_delivery.public.popular_orders_day_of_week",
-		"namespace": "postgres://postgres:5432"
-	}]
-},
-{
-	"eventType": "COMPLETE",
-	"inputs": [{
-		"facets": {
-			"dataSource": {
-				"name": "postgres://postgres:5432",
-				"uri": "postgres://postgres:5432/food_delivery"
-			}
-		},
-		"name": "food_delivery.public.top_delivery_times",
-		"namespace": "postgres://postgres:5432"
-	}],
-	"job": {
-		"facets": {
-			"sql": {
-                "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on\n    "
-			}
-		},
-		"name": "postgres_orders_popular_day_of_week.postgres_insert",
-		"namespace": "food_delivery"
-	},
-	"outputs": [{
-		"facets": {
-			"dataSource": {
-				"name": "postgres://postgres:5432",
-				"uri": "postgres://postgres:5432/food_delivery"
-			},
-			"schema": {
-				"fields": [{
-					"name": "order_day_of_week",
-					"type": "varchar"
-				}, {
-					"name": "order_placed_on",
-					"type": "timestamp"
-				}, {
-					"name": "orders_placed",
-					"type": "int4"
-				}]
-			}
-		},
-		"name": "food_delivery.public.popular_orders_day_of_week",
-		"namespace": "postgres://postgres:5432"
-	}]
-}]
+    "outputs": [
+      {
+        "facets": {
+          "schema": {
+            "fields": [
+              {
+                "name": "order_day_of_week",
+                "type": "varchar"
+              },
+              {
+                "name": "order_placed_on",
+                "type": "timestamp"
+              },
+              {
+                "name": "orders_placed",
+                "type": "int4"
+              }
+            ]
+          }
+        },
+        "name": "food_delivery.public.popular_orders_day_of_week",
+        "namespace": "postgres://postgres:5432"
+      }
+    ]
+  },
+  {
+    "eventType": "COMPLETE",
+    "inputs": [
+      {
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432/food_delivery"
+          }
+        },
+        "name": "food_delivery.public.top_delivery_times",
+        "namespace": "postgres://postgres:5432"
+      }
+    ],
+    "job": {
+      "facets": {
+        "sql": {
+          "query": "\n    INSERT INTO popular_orders_day_of_week (order_day_of_week, order_placed_on,orders_placed)\n    SELECT EXTRACT(ISODOW FROM order_placed_on) AS order_day_of_week,\n           order_placed_on,\n           COUNT(*) AS orders_placed\n      FROM top_delivery_times\n     GROUP BY order_placed_on\n    "
+        }
+      },
+      "name": "postgres_orders_popular_day_of_week.postgres_insert",
+      "namespace": "food_delivery"
+    },
+    "outputs": [
+      {
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432/food_delivery"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "order_day_of_week",
+                "type": "varchar"
+              },
+              {
+                "name": "order_placed_on",
+                "type": "timestamp"
+              },
+              {
+                "name": "orders_placed",
+                "type": "int4"
+              }
+            ]
+          }
+        },
+        "name": "food_delivery.public.popular_orders_day_of_week",
+        "namespace": "postgres://postgres:5432"
+      }
+    ]
+  }
+]

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -14,7 +14,7 @@ from openlineage.airflow.utils import (
     url_to_https,
     get_location,
     get_connection,
-    to_json_encodable,
+    task_to_json_encodable,
     DagUtils,
     SafeStrDict,
     _is_name_redactable,
@@ -90,7 +90,7 @@ def test_to_json_encodable():
                       catchup=False)
     task = DummyOperator(task_id='test_task', dag=dag)
 
-    encodable = to_json_encodable(task)
+    encodable = task_to_json_encodable(task)
     encoded = json.dumps(encodable)
     decoded = json.loads(encoded)
     assert decoded == encodable


### PR DESCRIPTION
### Problem

Closes: #986 

### Solution

This adds a new `AirflowTaskRunFacet` with some descriptive information about the task instance. Originally intended to address getting the task attempt number into the OL event, I started adding the tryNumber to the `airflow_version` facet, but I felt that facet has too much information that isn't really relevant to the Airflow version. Instead, I created a new facet that contains information specific to the task and dag run, including the try number. I also fixed some of the ugly serialized fields that we get from the TaskInstance and the DagRun (such as `_BaseOperator__init_kwargs`). I think we should deprecate the `taskInfo` and `operator` fields of the `airflow_version` facet and instead move that information to the `AirflowTaskRunFacet`. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project