### PR TITLE
[SPEC] correctly locating sub-facets in OpenLineage.json

### DIFF
--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/1-0-4/OpenLineage.json",
+  "$id": "https://openlineage.io/spec/1-0-5/OpenLineage.json",
   "$defs": {
     "RunEvent": {
       "type": "object",
@@ -75,14 +75,15 @@
         "facets": {
           "description": "The run facets.",
           "type": "object",
-          "additionalProperties": {
-            "anyOf": [
-              { "$ref": "#/$defs/RunFacet" },
-              { "$ref": "facets/ErrorMessageRunFacet.json" },
-              { "$ref": "facets/NominalTimeRunFacet.json" },
-              { "$ref": "facets/ParentRunFacet.json" }
-            ]
-          }
+          "anyOf": [
+            { 
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/RunFacet" }
+            },
+            { "$ref": "facets/ErrorMessageRunFacet.json" },
+            { "$ref": "facets/NominalTimeRunFacet.json" },
+            { "$ref": "facets/ParentRunFacet.json" }
+          ]
         }
       },
       "required": [
@@ -112,16 +113,17 @@
         "facets": {
           "description": "The job facets.",
           "type": "object",
-          "additionalProperties": {
-            "anyOf": [
-              { "$ref": "#/$defs/JobFacet" },
-              { "$ref": "facets/DocumentationJobFacet.json" },
-              { "$ref": "facets/OwnershipJobFacet.json" },
-              { "$ref": "facets/SourceCodeJobFacet.json" },
-              { "$ref": "facets/SourceCodeLocationJobFacet.json" },
-              { "$ref": "facets/SQLJobFacet.json" }
-            ]
-          }
+          "anyOf": [
+            { 
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/JobFacet" }
+            },
+            { "$ref": "facets/DocumentationJobFacet.json" },
+            { "$ref": "facets/OwnershipJobFacet.json" },
+            { "$ref": "facets/SourceCodeJobFacet.json" },
+            { "$ref": "facets/SourceCodeLocationJobFacet.json" },
+            { "$ref": "facets/SQLJobFacet.json" }
+          ]
         }
       },
       "required": [
@@ -147,12 +149,13 @@
             "inputFacets": {
               "description": "The input facets for this dataset.",
               "type": "object",
-              "additionalProperties": {
-                "anyOf": [
-                  { "$ref": "#/$defs/InputDatasetFacet" },
-                  { "$ref": "facets/DataQualityMetricsInputDatasetFacet.json"}
-                ]
-              }
+              "anyOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": { "$ref": "#/$defs/InputDatasetFacet" }
+                },
+                { "$ref": "facets/DataQualityMetricsInputDatasetFacet.json"}
+              ]
             }
           }
         }
@@ -176,12 +179,13 @@
             "outputFacets": {
               "description": "The output facets for this dataset",
               "type": "object",
-              "additionalProperties": {
-                "anyOf": [
-                  { "$ref": "#/$defs/OutputDatasetFacet" },
-                  { "$ref": "facets/OutputStatisticsOutputDatasetFacet.json"}
-                ]
-              }
+              "anyOf": [
+                { 
+                  "type": "object",
+                  "additionalProperties": { "$ref": "#/$defs/OutputDatasetFacet" }
+                },
+                { "$ref": "facets/OutputStatisticsOutputDatasetFacet.json"}
+              ]
             }
           }
         }
@@ -210,20 +214,21 @@
         "facets": {
           "description": "The facets for this dataset",
           "type": "object",
-          "additionalProperties": {
-            "anyOf": [
-              { "$ref": "#/$defs/DatasetFacet" },
-              { "$ref": "facets/ColumnLineageDatasetFacet.json" },
-              { "$ref": "facets/DatasourceDatasetFacet.json" },
-              { "$ref": "facets/DataQualityAssertionsDatasetFacet.json" },
-              { "$ref": "facets/LifecycleStateChangeDatasetFacet.json" },
-              { "$ref": "facets/OwnershipDatasetFacet.json" },
-              { "$ref": "facets/SchemaDatasetFacet.json" },
-              { "$ref": "facets/StorageDatasetFacet.json" },
-              { "$ref": "facets/SymlinksDatasetFacet.json" },
-              { "$ref": "facets/DatasetVersionDatasetFacet.json" }
-            ]
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/DatasetFacet" }
+            },
+            { "$ref": "facets/ColumnLineageDatasetFacet.json" },
+            { "$ref": "facets/DatasourceDatasetFacet.json" },
+            { "$ref": "facets/DataQualityAssertionsDatasetFacet.json" },
+            { "$ref": "facets/LifecycleStateChangeDatasetFacet.json" },
+            { "$ref": "facets/OwnershipDatasetFacet.json" },
+            { "$ref": "facets/SchemaDatasetFacet.json" },
+            { "$ref": "facets/StorageDatasetFacet.json" },
+            { "$ref": "facets/SymlinksDatasetFacet.json" },
+            { "$ref": "facets/DatasetVersionDatasetFacet.json" }
+          ]
         }
       },
       "required": [

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -81,6 +81,7 @@
               "additionalProperties": { "$ref": "#/$defs/RunFacet" }
             },
             { "$ref": "facets/ErrorMessageRunFacet.json" },
+            { "$ref": "facets/ExternalQueryRunFacet.json" },
             { "$ref": "facets/NominalTimeRunFacet.json" },
             { "$ref": "facets/ParentRunFacet.json" }
           ]


### PR DESCRIPTION
Signed-off-by: howardyoo <howardyoo@gmail.com>

### Problem

The sub-facets under each facet location is located under `additionalProperties` which is not necessary, but rather, should be located on one level above.

### Solution

This PR corrects the current spec's location of the sub-facet types by moving them one-level up.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [x] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project