### PR TITLE
[INTEGRATION][AIRFLOW] Add extractor for Amazon Athena

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -108,6 +108,7 @@ suited to extract metadata from a particular operator (or operators).
 
 * `PostgresOperator`
 * `MySqlOperator`
+* `AthenaOperator`
 * `BigQueryOperator`
 * `SnowflakeOperator`
 * `GreatExpectationsOperator`

--- a/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
@@ -1,0 +1,120 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+from openlineage.client.facet import SqlJobFacet
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta, parse, SqlMeta
+
+
+class AthenaExtractor(BaseExtractor):
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ["AthenaOperator", "AWSAthenaOperator"]
+
+    def extract(self) -> TaskMetadata:
+        task_name = f"{self.operator.dag_id}.{self.operator.task_id}"
+        job_facets = {
+            "sql": SqlJobFacet(query=SqlExtractor._normalize_sql(self.operator.query))
+        }
+
+        sql_meta: Optional[SqlMeta] = parse(self.operator.query, "generic", None)
+        inputs: List[Dataset] = list(filter(None, [
+            self._get_inout_dataset(self.operator.database, table.name)
+            for table in sql_meta.in_tables
+        ])) if sql_meta and sql_meta.in_tables else []
+
+        # Athena can output query result to a new table with CTAS query.
+        # cf. https://docs.aws.amazon.com/athena/latest/ug/ctas.html
+        outputs: List[Dataset] = list(filter(None, [
+            self._get_inout_dataset(self.operator.database, table.name)
+            for table in sql_meta.out_tables
+        ])) if sql_meta and sql_meta.out_tables else []
+
+        # In addition to CTAS query, it's also possible to specify output location on S3
+        # with a mandatory parameter, OutputLocation in ResultConfiguration.
+        # cf. https://docs.aws.amazon.com/athena/latest/APIReference/API_ResultConfiguration.html#athena-Type-ResultConfiguration-OutputLocation  # noqa: E501
+        #
+        # Depending on the query type and the external_location property in the CTAS query,
+        # its behavior changes as follows:
+        #
+        # * Normal SELECT statement
+        #   -> The result is put into output_location as files rather than a table.
+        #
+        # * CTAS statement without external_location (`CREATE TABLE ... AS SELECT ...`)
+        #   -> The result is put into output_location as a table,
+        #      that is, both metadata files and data files are in there.
+        #
+        # * CTAS statement with external_location
+        #   (`CREATE TABLE ... WITH (external_location='s3://bucket/key') AS SELECT ...`)
+        #   -> The result is output as a table, but metadata and data files are
+        #      separated into output_location and external_location respectively.
+        #
+        # For the last case, output_location may be unnecessary as OL's output information,
+        # but we keep it as of now since it may be useful for some purpose.
+        output_location = self.operator.output_location
+        parsed = urlparse(output_location)
+        outputs.append(Dataset(
+            name=parsed.path,
+            source=Source(
+                scheme=parsed.scheme,
+                authority=parsed.netloc,
+                connection_url=output_location
+            )
+        ))
+
+        return TaskMetadata(
+            name=task_name,
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in outputs],
+            run_facets={},
+            job_facets=job_facets,
+        )
+
+    def _get_inout_dataset(self, database, table) -> Optional[Dataset]:
+        # Currently, AthenaOperator and AthenaHook don't have a functionality to specify catalog,
+        # and it seems to implicitly assume that the default catalog (AwsDataCatalog) is target.
+        CATALOG_NAME = "AwsDataCatalog"
+
+        # AthenaHook.get_conn() doesn't return PEP-249 compliant connection object,
+        # but Boto3's Athena.Client instead. So this class doesn't inherit from
+        # SqlExtractor, which depends on PEP-249 compliant connection.
+        client = self.operator.hook.get_conn()
+        try:
+            table_metadata = client.get_table_metadata(
+                CatalogName=CATALOG_NAME,
+                DatabaseName=database,
+                TableName=table
+            )
+
+            table_schema = DbTableSchema(
+                schema_name=database,
+                table_name=DbTableMeta(f"{CATALOG_NAME}.{database}.{table}"),
+                columns=[
+                    DbColumn(name=column["Name"], type=column["Type"], ordinal_position=i)
+                    for i, column in enumerate(table_metadata["TableMetadata"]["Columns"])
+                ]
+            )
+
+            scheme = "awsathena"
+            authority = f"athena.{client._client_config.region_name}.amazonaws.com"
+
+            return Dataset.from_table_schema(
+                source=Source(
+                    scheme=scheme,
+                    authority=authority,
+                    connection_url=f"{scheme}://{authority}",
+                ),
+                table_schema=table_schema,
+                database_name=CATALOG_NAME
+            )
+        except Exception as e:
+            self.log.error(
+                f"Cannot retrieve table metadata from Athena.Client. {e}", exc_info=True
+            )
+            return None

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -40,6 +40,9 @@ _extractors = list(
                 'openlineage.airflow.extractors.redshift_data_extractor.RedshiftDataExtractor'
             ),
             try_import_from_string(
+                'openlineage.airflow.extractors.athena_extractor.AthenaExtractor'
+            ),
+            try_import_from_string(
                 'openlineage.airflow.extractors.sftp_extractor.SFTPExtractor'
             )
         ],
@@ -57,6 +60,7 @@ _check_providers = {
     "MySqlExtractor": "mysql",
     "BigQueryExtractor": ["gcpbigquery", "google_cloud_platform"],
     "SnowflakeExtractor": "snowflake",
+    "AthenaExtractor": "aws",
     "SFTPExtractor": ["sftp", "ssh"],
 }
 

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -31,6 +31,7 @@ AIRFLOW_VERSION=${AIRFLOW_IMAGE##*:}
 
 # Remove -python3.7 from the tag
 export AIRFLOW_VERSION=${AIRFLOW_VERSION::-10}
+export AWS_ATHENA_SUFFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")
 export BIGQUERY_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")
 export DBT_DATASET_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")_dbt
 # just a hack to have same docker-compose for dev and CI env

--- a/integration/airflow/tests/integration/requests/athena.json
+++ b/integration/airflow/tests/integration/requests/athena.json
@@ -1,0 +1,429 @@
+[{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "CREATE DATABASE IF NOT EXISTS openlineage_integration_{{ env_var('AWS_ATHENA_SUFFIX') }}"
+            }
+        },
+        "name": "athena_dag.athena_create_database",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            },
+            "parent": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "parentRun": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sql": {
+                "query": "CREATE DATABASE IF NOT EXISTS openlineage_integration_{{ env_var('AWS_ATHENA_SUFFIX') }}"
+            }
+        },
+        "name": "athena_dag.athena_create_database",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+},{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "\n    CREATE EXTERNAL TABLE IF NOT EXISTS test_orders (\n      ord   INT,\n      str   STRING,\n      num   INT\n    )\n    LOCATION '{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}';\n\n    "
+            }
+        },
+        "name": "athena_dag.athena_create_table",
+        "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            },
+            "parent": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "parentRun": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sql": {
+                "query": "\n    CREATE EXTERNAL TABLE IF NOT EXISTS test_orders (\n      ord   INT,\n      str   STRING,\n      num   INT\n    )\n    LOCATION '{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}';\n\n    "
+            }
+        },
+        "name": "athena_dag.athena_create_table",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com",
+                    "uri": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+                },
+                "schema": {
+                    "fields": [
+                        {
+                            "name": "ord",
+                            "type": "int"
+                        },
+                        {
+                            "name": "str",
+                            "type": "string"
+                        },
+                        {
+                            "name": "num",
+                            "type": "int"
+                        }
+                    ]
+                }
+            },
+            "name": "AwsDataCatalog.openlineage_integration_{{ env_var('AWS_ATHENA_SUFFIX') }}.test_orders",
+            "namespace": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+        },
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+},{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "\n    INSERT INTO test_orders (ord, str, num) VALUES\n    (1, 'b', 15),\n    (2, 'a', 21),\n    (3, 'b', 7);\n\n    "
+            }
+        },
+        "name": "athena_dag.athena_insert",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com",
+                    "uri": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+                },
+                "schema": {
+                    "fields": [
+                        {
+                            "name": "ord",
+                            "type": "int"
+                        },
+                        {
+                            "name": "str",
+                            "type": "string"
+                        },
+                        {
+                            "name": "num",
+                            "type": "int"
+                        }
+                    ]
+                }
+            },
+            "name": "AwsDataCatalog.openlineage_integration_{{ env_var('AWS_ATHENA_SUFFIX') }}.test_orders",
+            "namespace": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+        },
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            },
+            "parent": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "parentRun": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sql": {
+                "query": "\n    INSERT INTO test_orders (ord, str, num) VALUES\n    (1, 'b', 15),\n    (2, 'a', 21),\n    (3, 'b', 7);\n\n    "
+            }
+        },
+        "name": "athena_dag.athena_insert",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com",
+                    "uri": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+                },
+                "schema": {
+                    "fields": [
+                        {
+                            "name": "ord",
+                            "type": "int"
+                        },
+                        {
+                            "name": "str",
+                            "type": "string"
+                        },
+                        {
+                            "name": "num",
+                            "type": "int"
+                        }
+                    ]
+                }
+            },
+            "name": "AwsDataCatalog.openlineage_integration_{{ env_var('AWS_ATHENA_SUFFIX') }}.test_orders",
+            "namespace": "awsathena://athena.{{ env_var('AWS_DEFAULT_REGION') }}.amazonaws.com"
+        },
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+},{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sql": {
+                "query": "DROP TABLE test_orders"
+            }
+        },
+        "name": "athena_dag.athena_drop_table",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            },
+            "parent": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "parentRun": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sql": {
+                "query": "DROP TABLE test_orders"
+            }
+        },
+        "name": "athena_dag.athena_drop_table",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}",
+                    "uri": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX') }}"
+                }
+            },
+            "name": "{{ (env_var('AWS_ATHENA_OUTPUT_LOCATION') ~ env_var('AWS_ATHENA_SUFFIX')) | url_path }}",
+            "namespace": "{{ env_var('AWS_ATHENA_OUTPUT_LOCATION') | url_scheme_authority }}"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+},{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "documentation": {
+                "description": "Determines the popular day of week orders are placed."
+            },
+            "sourceCode": {
+                "language": "python",
+                "source": "def delete_objects():\n    hook = S3Hook(aws_conn_id=CONNECTION)\n    keys = hook.list_keys(bucket_name=S3_BUCKET, prefix=S3_PREFIX)\n    hook.delete_objects(bucket=S3_BUCKET, keys=keys)\n"
+            }
+        },
+        "name": "athena_dag.delete_s3_objects",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow_runArgs": {
+                "externalTrigger": false
+            },
+            "parent": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "parentRun": {
+                "job": {
+                    "name": "athena_dag",
+                    "namespace": "food_delivery"
+                }
+            },
+            "unknownSourceAttribute": {
+                "unknownItems": [
+                    {
+                        "name": "PythonOperator",
+                        "type": "operator"
+                    }
+                ]
+            }
+        }
+    }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {
+            "sourceCode": {
+                "language": "python",
+                "source": "def delete_objects():\n    hook = S3Hook(aws_conn_id=CONNECTION)\n    keys = hook.list_keys(bucket_name=S3_BUCKET, prefix=S3_PREFIX)\n    hook.delete_objects(bucket=S3_BUCKET, keys=keys)\n"
+            }
+        },
+        "name": "athena_dag.delete_s3_objects",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "unknownSourceAttribute": {
+                "unknownItems": [
+                    {
+                        "name": "PythonOperator",
+                        "type": "operator"
+                    }
+                ]
+            }
+        }
+    }
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -55,6 +55,14 @@ params = [
         "requests/dbt_bigquery.json",
         marks=pytest.mark.skipif(not IS_GCP_AUTH, reason="no gcp credentials"),
     ),
+    pytest.param(
+        "athena_dag",
+        "requests/athena.json",
+        marks=pytest.mark.skipif(
+            os.environ.get("AWS_ACCESS_KEY_ID", "") == "",
+            reason="no aws credentials",
+        ),
+    ),
     ("source_code_dag", "requests/source_code.json"),
     pytest.param(
         "default_extractor_dag",

--- a/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
@@ -1,0 +1,113 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from urllib.parse import urlparse
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.dates import days_ago
+
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.client import set_producer
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+AthenaOperator = try_import_from_string(
+    "airflow.providers.amazon.aws.operators.athena.AthenaOperator"
+)
+if AthenaOperator is None:
+    AthenaOperator = try_import_from_string(
+        "airflow.providers.amazon.aws.operators.athena.AWSAthenaOperator"
+    )
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+dag = DAG(
+    'athena_dag',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Determines the popular day of week orders are placed.'
+)
+
+CONNECTION = "aws_conn"
+AWS_ATHENA_SUFFIX = os.environ["AWS_ATHENA_SUFFIX"]
+DATABASE = f"openlineage_integration_{AWS_ATHENA_SUFFIX}"
+OUTPUT_LOCATION = os.environ["AWS_ATHENA_OUTPUT_LOCATION"] + AWS_ATHENA_SUFFIX
+parsed = urlparse(OUTPUT_LOCATION)
+S3_BUCKET = parsed.netloc
+S3_PREFIX = parsed.path
+
+t0 = AthenaOperator(
+    task_id='athena_create_database',
+    aws_conn_id=CONNECTION,
+    query=f'CREATE DATABASE IF NOT EXISTS {DATABASE};',
+    database=DATABASE,
+    output_location=OUTPUT_LOCATION,
+    max_tries=4,
+    dag=dag
+)
+
+t1 = AthenaOperator(
+    task_id='athena_create_table',
+    aws_conn_id=CONNECTION,
+    query=f'''
+    CREATE EXTERNAL TABLE IF NOT EXISTS test_orders (
+      ord   INT,
+      str   STRING,
+      num   INT
+    )
+    LOCATION '{OUTPUT_LOCATION}';
+    ''',
+    database=DATABASE,
+    output_location=OUTPUT_LOCATION,
+    max_tries=4,
+    dag=dag
+)
+
+t2 = AthenaOperator(
+    task_id='athena_insert',
+    aws_conn_id=CONNECTION,
+    query='''
+    INSERT INTO test_orders (ord, str, num) VALUES
+    (1, 'b', 15),
+    (2, 'a', 21),
+    (3, 'b', 7);
+    ''',
+    database=DATABASE,
+    output_location=OUTPUT_LOCATION,
+    max_tries=4,
+    dag=dag
+)
+
+t3 = AthenaOperator(
+    task_id='athena_drop_table',
+    aws_conn_id=CONNECTION,
+    query="DROP TABLE test_orders;",
+    database=DATABASE,
+    output_location=OUTPUT_LOCATION,
+    max_tries=4,
+    dag=dag
+)
+
+
+def delete_objects():
+    hook = S3Hook(aws_conn_id=CONNECTION)
+    keys = hook.list_keys(bucket_name=S3_BUCKET, prefix=S3_PREFIX)
+    hook.delete_objects(bucket=S3_BUCKET, keys=keys)
+
+
+t4 = PythonOperator(
+    task_id="delete_s3_objects",
+    python_callable=delete_objects,
+    dag=dag
+)
+
+t0 >> t1 >> t2 >> t3 >> t4

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -39,9 +39,15 @@ x-airflow-base: &airflow-base
     SNOWFLAKE_ACCOUNT_ID: ${SNOWFLAKE_ACCOUNT_ID}
     SNOWFLAKE_USER: ${SNOWFLAKE_USER}
     SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD}
+    AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+    AWS_ATHENA_OUTPUT_LOCATION: ${AWS_ATHENA_OUTPUT_LOCATION}
+    AWS_ATHENA_SUFFIX: ${AWS_ATHENA_SUFFIX}
     AIRFLOW__SECRETS__BACKEND: airflow.secrets.local_filesystem.LocalFilesystemBackend
     AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json", "variables_file_path": "/opt/data/secrets/variables.json" }'
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=ROBOTS&role=OPENLINEAGE"
+    AIRFLOW_CONN_AWS_CONN: "aws://"
     AIRFLOW_CONN_SFTP_CONN: sftp://airflow:airflow@openssh-server:2222
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
@@ -73,6 +79,11 @@ services:
       DBT_DATASET_PREFIX: ${DBT_DATASET_PREFIX}_dbt
       AIRFLOW_VERSION: ${AIRFLOW_VERSION}
       SNOWFLAKE_ACCOUNT_ID: ${SNOWFLAKE_ACCOUNT_ID}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
+      AWS_ATHENA_OUTPUT_LOCATION: ${AWS_ATHENA_OUTPUT_LOCATION}
+      AWS_ATHENA_SUFFIX: ${AWS_ATHENA_SUFFIX}
     networks:
       - app_net
     volumes:

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -6,6 +6,7 @@ import logging
 from dateutil.parser import parse
 from jinja2 import Environment
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 
 log = logging.getLogger(__name__)
@@ -44,12 +45,23 @@ def not_match(result, pattern) -> str:
     return "true"
 
 
+def url_scheme_authority(url) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def url_path(url) -> str:
+    return urlparse(url).path
+
+
 def setup_jinja() -> Environment:
     env = Environment()
     env.globals['any'] = any
     env.globals['is_datetime'] = is_datetime
     env.globals['env_var'] = env_var
     env.globals['not_match'] = not_match
+    env.filters['url_scheme_authority'] = url_scheme_authority
+    env.filters['url_path'] = url_path
     return env
 
 

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -71,6 +71,22 @@ Identifier:
  * Unique name: {database}.{schema}.{table}
    * URI =  redshift://{cluster_identifier}.{region_name}:{port}/{database}.{schema}.{table}
   
+#### Athena:
+Datasource hierarchy:
+ * Host: athena.{region_name}.amazonaws.com
+
+Naming hierarchy:
+ * Catalog
+ * Database
+ * Table
+
+Identifier:
+ * Namespace: awsathena://athena.{region_name}.amazonaws.com of the service instance.
+   * Scheme = awsathena
+   * Authority = athena.{region_name}.amazonaws.com
+ * Unique name: {catalog}.{database}.{table}
+   * URI =  awsathena://athena.{region_name}.amazonaws.com/{catalog}.{database}.{table}
+
 #### Snowflake
 See: [Object Identifiers — Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/identifiers.html)
 


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

Currently, OpenLineage doesn't have an extractor for Amazon Athena.

### Solution

This PR introduces an extractor for AthenaOperator.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project