### PR TITLE
databricks improvements to send better events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.17.0...HEAD)
 
+### Fixed
+* Spark: databricks improvements to send better events [`#1330`](https://github.com/OpenLineage/OpenLineage/pull/1330) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski) 
+    *Filter unwanted events, provide meaningful job name.*
+
 ## [0.17.0](https://github.com/OpenLineage/OpenLineage/compare/0.16.1...0.17.0) - 2022-11-16
 ### Added
 * Spark: support latest Spark 3.3.1 [`#1183`](https://github.com/OpenLineage/OpenLineage/pull/1183) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -117,7 +117,11 @@ public final class HttpTransport extends Transport implements Closeable {
   private void throwOnHttpError(@NonNull HttpResponse response) throws IOException {
     final int code = response.getStatusLine().getStatusCode();
     if (code >= 400 && code < 600) { // non-2xx
-      throw new OpenLineageClientException(EntityUtils.toString(response.getEntity(), UTF_8));
+      String message =
+          String.format(
+              "code: %d, response: %s", code, EntityUtils.toString(response.getEntity(), UTF_8));
+
+      throw new OpenLineageClientException(message);
     }
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.StageInfo;
@@ -58,6 +59,7 @@ class OpenLineageSparkListenerTest {
 
     when(sparkSession.sparkContext()).thenReturn(sparkContext);
     when(sparkContext.appName()).thenReturn("appName");
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
     when(qe.optimizedPlan())
         .thenReturn(
             new InsertIntoHadoopFsRelationCommand(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -1,0 +1,58 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.filters;
+
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.WholeStageCodegenExec;
+
+/** Class created to filter some types of event sent by Databricks */
+@Slf4j
+public class DatabricksEventFilter implements EventFilter {
+
+  private final OpenLineageContext context;
+
+  private static final List<String> excludedNodes =
+      Arrays.asList(
+          "show_namespaces",
+          "show_tables",
+          "collect_limit",
+          "describe_table",
+          "local_table_scan",
+          "adaptive_spark_plan",
+          "serialize_from_object",
+          "execute_set_catalog_command");
+
+  public DatabricksEventFilter(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  public boolean isDisabled(SparkListenerEvent event) {
+    if (!DatabricksUtils.isRunOnDatabricksPlatform(context)
+        || !context.getQueryExecution().isPresent()) {
+      return false;
+    }
+
+    SparkPlan node = context.getQueryExecution().get().executedPlan();
+
+    // Unwrap SparkPlan from WholeStageCodegen, as that's not a descriptive or helpful job name
+    if (node instanceof WholeStageCodegenExec) {
+      node = ((WholeStageCodegenExec) node).child();
+    }
+    String nodeName = node.nodeName().replace("_", "");
+
+    return excludedNodes.stream()
+        .map(n -> n.replace("_", ""))
+        .filter(n -> n.equalsIgnoreCase(nodeName))
+        .findAny()
+        .isPresent();
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.spark.agent.filters;
 
 import org.apache.spark.scheduler.SparkListenerEvent;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.spark.agent.filters;
 
 import io.openlineage.spark.api.OpenLineageContext;
@@ -15,7 +20,7 @@ public class EventFilterUtils {
    * @return
    */
   public static boolean isDisabled(OpenLineageContext context, SparkListenerEvent event) {
-    return Arrays.asList(new DeltaEventFilter(context)).stream()
+    return Arrays.asList(new DeltaEventFilter(context), new DatabricksEventFilter(context)).stream()
         .filter(filter -> filter.isDisabled(event.getClass().cast(event)))
         .findAny()
         .isPresent();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/DatabricksJobEventBuilderHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/DatabricksJobEventBuilderHook.java
@@ -1,0 +1,83 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.hooks;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+
+public class DatabricksJobEventBuilderHook implements RunEventBuilderHook {
+
+  private static final String SEPARATOR = "_";
+  private final OpenLineageContext openLineageContext;
+
+  public DatabricksJobEventBuilderHook(OpenLineageContext openLineageContext) {
+    this.openLineageContext = openLineageContext;
+  }
+
+  @Override
+  public void preBuild(OpenLineage.RunEventBuilder runEventBuilder) {
+    if (!DatabricksUtils.isRunOnDatabricksPlatform(openLineageContext)) {
+      return;
+    }
+
+    OpenLineage.RunEvent runEvent = runEventBuilder.build();
+    OpenLineage.Job job = runEvent.getJob();
+
+    StringBuilder jobNameBuilder = new StringBuilder();
+    jobNameBuilder.append(
+        job.getName()
+            .replace(
+                "databricks_shell.", // default name
+                extractWorkspaceId(
+                    DatabricksUtils.getWorkspaceUrl(openLineageContext).get()
+                        + SEPARATOR))); // replace default job name with workspace id when no app
+    // name
+    // specified
+
+    if (runEvent.getOutputs() != null) {
+      // append output dataset name to job name
+      runEvent.getOutputs().stream()
+          .findAny()
+          .map(dataset -> dataset.getName())
+          .map(path -> trimPath(path)) // if dataset name is a path -> get last path element
+          .ifPresent(name -> jobNameBuilder.append(SEPARATOR).append(name));
+    }
+
+    OpenLineage.Job newJob =
+        openLineageContext
+            .getOpenLineage()
+            .newJobBuilder()
+            .facets(job.getFacets())
+            .namespace(job.getNamespace())
+            .name(jobNameBuilder.toString().replace(".", SEPARATOR))
+            .build();
+
+    runEventBuilder.job(newJob);
+  }
+
+  private static String extractWorkspaceId(String workspaceUrl) {
+    return workspaceUrl
+        .replace(".cloud.databricks.com/", "") // extract workspace id from workspaceUrl
+        .replace("https://", "");
+  }
+
+  private static String trimPath(String path) {
+    if (path.lastIndexOf("/") > 0) {
+      // is path
+      String[] parts = path.split("/");
+      if (parts.length >= 2) {
+        // concat two last elements of the path
+        return parts[parts.length - 2] + SEPARATOR + parts[parts.length - 1];
+      } else {
+        // get last path element
+        return parts[parts.length - 1];
+      }
+    } else {
+      // is something else
+      return path;
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/HookUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/HookUtils.java
@@ -1,0 +1,18 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.hooks;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.stream.Stream;
+
+public class HookUtils {
+
+  public static void preBuild(
+      OpenLineageContext context, OpenLineage.RunEventBuilder runEventBuilder) {
+    Stream.of(new DatabricksJobEventBuilderHook(context))
+        .forEach(hook -> hook.preBuild(runEventBuilder));
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/RunEventBuilderHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/RunEventBuilderHook.java
@@ -1,0 +1,16 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.hooks;
+
+import io.openlineage.client.OpenLineage;
+
+/**
+ * Definition of a hook method called before running `build` method on {@link
+ * OpenLineage.RunEventBuilder}.
+ */
+public interface RunEventBuilderHook {
+
+  void preBuild(OpenLineage.RunEventBuilder runEventBuilder);
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -26,6 +26,7 @@ import io.openlineage.client.OpenLineage.RunEventBuilder;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.client.OpenLineage.RunFacets;
 import io.openlineage.client.OpenLineage.RunFacetsBuilder;
+import io.openlineage.spark.agent.hooks.HookUtils;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageUtils;
 import io.openlineage.spark.agent.util.FacetUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -302,12 +303,14 @@ class OpenLineageRunEventBuilder {
     RunFacets runFacets = buildRunFacets(nodes, runFacetBuilders, runFacetsBuilder);
     OpenLineage.RunBuilder runBuilder =
         openLineage.newRunBuilder().runId(openLineageContext.getRunUuid()).facets(runFacets);
-    return runEventBuilder
+    runEventBuilder
         .run(runBuilder.build())
         .job(jobBuilder.facets(jobFacets).build())
         .inputs(inputDatasets)
-        .outputs(outputDatasets)
-        .build();
+        .outputs(outputDatasets);
+
+    HookUtils.preBuild(openLineageContext, runEventBuilder);
+    return runEventBuilder.build();
   }
 
   private List<InputDataset> buildInputDatasets(List<Object> nodes) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
@@ -1,0 +1,39 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.QueryExecution;
+
+/** Utils method to help exctact values from Databricks environmemt */
+@Slf4j
+public class DatabricksUtils {
+
+  public static final String SPARK_DATABRICKS_WORKSPACE_URL = "spark.databricks.workspaceUrl";
+
+  /**
+   * Determines if a Spark job is run on Databricks platform
+   *
+   * @return
+   */
+  public static boolean isRunOnDatabricksPlatform(OpenLineageContext context) {
+    return getWorkspaceUrl(context).isPresent();
+  }
+
+  public static Optional<String> getWorkspaceUrl(OpenLineageContext context) {
+    return context
+        .getQueryExecution()
+        .map(QueryExecution::sparkSession)
+        .map(SparkSession::sparkContext)
+        .map(SparkContext::getConf)
+        .filter(conf -> conf.contains(SPARK_DATABRICKS_WORKSPACE_URL))
+        .map(conf -> conf.get(SPARK_DATABRICKS_WORKSPACE_URL));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -1,0 +1,74 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.filters;
+
+import static io.openlineage.spark.agent.util.DatabricksUtils.SPARK_DATABRICKS_WORKSPACE_URL;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.WholeStageCodegenExec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DatabricksEventFilterTest {
+
+  SparkListenerEvent event = mock(SparkListenerEvent.class);
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  DatabricksEventFilter filter = new DatabricksEventFilter(context);
+  QueryExecution queryExecution = mock(QueryExecution.class, RETURNS_DEEP_STUBS);
+  WholeStageCodegenExec node = mock(WholeStageCodegenExec.class);
+
+  @BeforeEach
+  public void setup() {
+    when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(queryExecution
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .contains(SPARK_DATABRICKS_WORKSPACE_URL))
+        .thenReturn(true);
+    when(queryExecution.sparkSession().sparkContext().getConf().get(SPARK_DATABRICKS_WORKSPACE_URL))
+        .thenReturn("some-url");
+    when(queryExecution.executedPlan()).thenReturn(node);
+    when((node).child()).thenReturn(node);
+  }
+
+  @Test
+  public void testDatabricksEventIsFiltered() {
+    when(node.nodeName()).thenReturn("collect_Limit");
+    assertThat(filter.isDisabled(event)).isTrue();
+  }
+
+  @Test
+  public void testDatabricksEventIsFilteredWithoutUnderscore() {
+    when(node.nodeName()).thenReturn("shownamespaces");
+    assertThat(filter.isDisabled(event)).isTrue();
+  }
+
+  @Test
+  public void testDatabricksEventIsNotFiltered() {
+    when(node.nodeName()).thenReturn("action_not_to_be_filtered");
+    assertThat(filter.isDisabled(event)).isFalse();
+  }
+
+  @Test
+  public void testOtherEventIsNotFiltered() {
+    when(queryExecution
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .contains("spark.databricks.workspaceUrl"))
+        .thenReturn(false);
+    when(node.nodeName()).thenReturn("collect_Limit");
+    assertThat(filter.isDisabled(event)).isFalse();
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/DatabricksJobEventBuilderHookTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/DatabricksJobEventBuilderHookTest.java
@@ -1,0 +1,112 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.hooks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.DatabricksUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DatabricksJobEventBuilderHookTest {
+
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  QueryExecution queryExecution = mock(QueryExecution.class, RETURNS_DEEP_STUBS);
+  DatabricksJobEventBuilderHook builderHook = new DatabricksJobEventBuilderHook(context);
+  OpenLineage.RunEventBuilder runEventBuilder;
+
+  @BeforeEach
+  public void setup() {
+    when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    runEventBuilder = context.getOpenLineage().newRunEventBuilder();
+
+    when(context
+            .getQueryExecution()
+            .get()
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .contains(DatabricksUtils.SPARK_DATABRICKS_WORKSPACE_URL))
+        .thenReturn(true);
+    when(context
+            .getQueryExecution()
+            .get()
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .get(DatabricksUtils.SPARK_DATABRICKS_WORKSPACE_URL))
+        .thenReturn("https://dbc-954f5d5f-34dd.cloud.databricks.com/");
+  }
+
+  @Test
+  public void testPreBuildWhenNotRunningOnDatabricksPlatform() {
+    when(queryExecution
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .contains(DatabricksUtils.SPARK_DATABRICKS_WORKSPACE_URL))
+        .thenReturn(false);
+
+    runEventBuilder = mock(OpenLineage.RunEventBuilder.class);
+    builderHook.preBuild(runEventBuilder);
+    verify(runEventBuilder, never()).job(any());
+  }
+
+  @Test
+  public void testPreBuild() {
+    runEventBuilder.job(
+        context
+            .getOpenLineage()
+            .newJobBuilder()
+            .name("databricks_shell.append_data_exec_v1")
+            .build());
+    runEventBuilder.outputs(
+        Collections.singletonList(
+            context
+                .getOpenLineage()
+                .newOutputDatasetBuilder()
+                .namespace("dsnamespace")
+                .name("/user/hive/warehouse/air_companies.db/air_companies")
+                .build()));
+
+    builderHook.preBuild(runEventBuilder);
+    assertThat(runEventBuilder.build().getJob().getName())
+        .isEqualTo("dbc-954f5d5f-34dd_append_data_exec_v1_air_companies_db_air_companies");
+  }
+
+  @Test
+  public void testPreBuildWhenNoOutputDataset() {
+    runEventBuilder.job(
+        context.getOpenLineage().newJobBuilder().name("databricks_shell.append_data").build());
+
+    builderHook.preBuild(runEventBuilder);
+    assertThat(runEventBuilder.build().getJob().getName())
+        .isEqualTo("dbc-954f5d5f-34dd_append_data");
+  }
+
+  @Test
+  public void testPreBuildWhenNotADefaultName() {
+    runEventBuilder.job(
+        context.getOpenLineage().newJobBuilder().name("non-default-name.append_data").build());
+
+    builderHook.preBuild(runEventBuilder);
+    assertThat(runEventBuilder.build().getJob().getName())
+        .isEqualTo("non-default-name_append_data");
+  }
+}


### PR DESCRIPTION
Signed-off-by: Pawel Leszczynski <leszczynski.pawel@gmail.com>

### Problem

Following Spark and Databricks integration issues have been encountered:
 * several unwanted events are sent,
 * spark job name gets repeated and is meaningless,

Closes:  #1251, #1252

### Solution

Following limitation have been discovered: 
 * There is no way to find notebook name nor number of data bricks cell being run (DbUtils packacge delivered by Databricks does not on SparkListened context),
 * No way have been found to get SQL query being executed from a Spark logical plan. 

Based on the problem and limitations, an implemented solution: 
 * filters creating events for specified actions on Databricks platform like show namespace, describe table, etc
 * OL event gets enriched with `ExplainQueryFacet` which contains analyzed logical plan (3 lines of string), which provides human readable kindof information on what is happening within the job
 * job name gets enriched with databricks workspace url and output dataset to prevent name collisions. 

Example Spark job name is: `dbc-954f5d5f-34dd_append_data_exec_v1_air_companies_db_air_companies`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project