### PR TITLE
dependabot: ignore some of the most troublesome dependencies for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "slf4j"
+        versions: ["2.*"]
 
   - package-ecosystem: "gradle"
     directory: "integration/flink"
@@ -39,6 +42,9 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "slf4j"
+        versions: [ "2.*" ]
 
   - package-ecosystem: "gradle"
     directory: "integration/spark"
@@ -48,6 +54,10 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "jackson*"
+      - dependency-name: "slf4j"
+        versions: [ "2.*" ]
 
   - package-ecosystem: "pip"
     directory: "client/python"
@@ -66,6 +76,9 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "great-expectations"
+
 
   - package-ecosystem: "pip"
     directory: "integration/airflow"
@@ -74,7 +87,9 @@ updates:
       day: "sunday"
     labels:
       - "dependencies"
-      - "dependabot"  
+      - "dependabot"
+    ignore:
+      - dependency-name: "great-expectations"
 
   - package-ecosystem: "pip"
     directory: "integration/dbt"


### PR DESCRIPTION
This PR makes dependabot ignore some of the more troublesome dependencies for updates either because they need to be in the same version as rest ones provided by integrated system (jackson, slf4j) or needs to be updated manually because it often breaks in minor versions (great-expectations). 

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
