### PR TITLE
spark-bigquery: fix a few of the common errors 

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -453,6 +453,9 @@ jobs:
       JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     steps:
       - *checkout_project_root
+      - gcp-cli/install
+      - gcp-cli/initialize
+      - run: mkdir -p app/build/gcloud && echo $GCLOUD_SERVICE_KEY > app/build/gcloud/gcloud-service-key.json && chmod 644 app/build/gcloud/gcloud-service-key.json
       - restore_cache:
           keys:
             - v1-integration-spark-{{ .Branch }}-{{ .Revision }}

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -30,6 +30,7 @@ workflows:
             parameters:
               spark-version: [ '2.4.6', '3.1.3', '3.2.2', '3.3.1' ]
       - integration-test-integration-spark:
+          context: integration-tests
           matrix:
             parameters:
               spark-version: [ '2.4.6', '3.1.3', '3.2.2', '3.3.1' ]

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -83,7 +83,6 @@ public class KinesisTransport extends Transport {
           public void onFailure(Throwable t) {
             log.error("Failed to send to Kinesis lineage event: {}", eventAsJson, t);
           }
-          ;
         };
 
     Futures.addCallback(future, callback, this.listeningExecutor);

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -44,6 +44,7 @@ configurations {
     spark3.extendsFrom testImplementation
     spark32.extendsFrom testImplementation
     spark33.extendsFrom testImplementation
+    pysparkContainerOnly
 }
 
 archivesBaseName='openlineage-spark-app'
@@ -58,10 +59,10 @@ ext {
     shortVersion = sparkVersion.substring(0,3)
 
     versionsMap = [
-            "3.3": ["module": "spark33",    "scala": "2.12", "delta": "NA", "snowflake": "2.11.0-spark_3.3"],
-            "3.2": ["module": "spark32",    "scala": "2.12", "delta": "1.1.0", "snowflake": "2.11.0-spark_3.2"],
-            "3.1": ["module": "spark3",     "scala": "2.12", "delta": "1.0.0", "snowflake": "2.11.0-spark_3.1"],
-            "2.4": ["module": "spark2",     "scala": "2.11", "delta": "NA", "snowflake": "2.9.3-spark_2.4"]
+            "3.3": ["module": "spark33", "scala": "2.12", "delta": "NA",    "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3"],
+            "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2"],
+            "3.1": ["module": "spark3",  "scala": "2.12", "delta": "1.0.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.1"],
+            "2.4": ["module": "spark2",  "scala": "2.11", "delta": "NA",    "gcs": "hadoop2-2.2.9", "snowflake": "2.9.3-spark_2.4"]
     ]
     versions = versionsMap[shortVersion]
 }
@@ -89,7 +90,7 @@ dependencies {
 
     compileOnly "org.apache.spark:spark-core_${versions.scala}:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_${versions.scala}:${sparkVersion}"
-    compileOnly ("com.google.cloud.spark:spark-bigquery_${versions.scala}:${bigqueryVersion}") {
+    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_${versions.scala}:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
         exclude group: 'com.sun.jmx'
@@ -124,6 +125,7 @@ dependencies {
     }
 
     testFixturesApi("org.apache.hadoop:hadoop-client:2.10.2") { force=true }
+    pysparkContainerOnly "com.google.cloud.bigdataoss:gcs-connector:${versions.gcs}:shaded"
 
     if(versions.delta != "NA") { testFixturesApi "io.delta:delta-core_2.12:${versions.delta}" }
 
@@ -171,7 +173,7 @@ task copyDependencies(type: Copy) {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     delete layout.buildDirectory.dir("dependencies")
     def config = configurations."${versions.module}"
-    from config.getFiles()
+    from config.getFiles() + configurations.pysparkContainerOnly.getFiles()
     include "*.jar"
     into layout.buildDirectory.dir("dependencies")
 }

--- a/integration/spark/app/integrations/container/pysparkBigqueryInsertEnd.json
+++ b/integration/spark/app/integrations/container/pysparkBigqueryInsertEnd.json
@@ -1,0 +1,59 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testReadAndWriteFromBigquery",
+    "name": "open_lineage_spark_bigquery.execute_insert_into_hadoop_fs_relation_command"
+  },
+  "inputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_source",
+    "facets": {
+      "dataSource": {
+        "name": "bigquery",
+        "uri": "bigquery"
+      },
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      }
+    },
+    "inputFacets": {}
+  }],
+  "outputs": [{
+    "namespace": "gs://openlineage-spark-bigquery-integration",
+    "facets": {
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      },
+      "columnLineage": {
+        "fields": {
+          "a": {
+            "inputFields": [{
+              "namespace": "namespace",
+              "name": "openlineage-ci.airflow_integration.3_3_1_source",
+              "field": "a"
+            }]
+          },
+          "b": {
+            "inputFields": [{
+              "namespace": "namespace",
+              "name": "openlineage-ci.airflow_integration.3_3_1_source",
+              "field": "b"
+            }]
+          }
+        }
+      }
+    }
+  }]
+}

--- a/integration/spark/app/integrations/container/pysparkBigqueryInsertStart.json
+++ b/integration/spark/app/integrations/container/pysparkBigqueryInsertStart.json
@@ -1,0 +1,54 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testReadAndWriteFromBigquery",
+    "name": "open_lineage_spark_bigquery.execute_insert_into_hadoop_fs_relation_command"
+  },
+  "inputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_source",
+    "facets": {
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      }
+    }
+  }],
+  "outputs": [{
+    "namespace": "gs://openlineage-spark-bigquery-integration",
+    "facets": {
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      },
+      "columnLineage": {
+        "fields": {
+          "a": {
+            "inputFields": [{
+              "namespace": "namespace",
+              "name": "openlineage-ci.airflow_integration.3_3_1_source",
+              "field": "a"
+            }]
+          },
+          "b": {
+            "inputFields": [{
+              "namespace": "namespace",
+              "name": "openlineage-ci.airflow_integration.3_3_1_source",
+              "field": "b"
+            }]
+          }
+        }
+      }
+    }
+  }]
+}

--- a/integration/spark/app/integrations/container/pysparkBigquerySaveEnd.json
+++ b/integration/spark/app/integrations/container/pysparkBigquerySaveEnd.json
@@ -1,0 +1,26 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testReadAndWriteFromBigquery",
+    "name": "open_lineage_spark_bigquery.execute_save_into_data_source_command"
+  },
+  "inputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_source",
+    "facets": {
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      }
+    }
+  }],
+  "outputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_target"
+  }]
+}

--- a/integration/spark/app/integrations/container/pysparkBigquerySaveStart.json
+++ b/integration/spark/app/integrations/container/pysparkBigquerySaveStart.json
@@ -1,0 +1,26 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testReadAndWriteFromBigquery",
+    "name": "open_lineage_spark_bigquery.execute_save_into_data_source_command"
+  },
+  "inputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_source",
+    "facets": {
+      "schema": {
+        "fields": [{
+          "name": "a",
+          "type": "long"
+        }, {
+          "name": "b",
+          "type": "long"
+        }]
+      }
+    }
+  }],
+  "outputs": [{
+    "namespace": "bigquery",
+    "name": "openlineage-ci.airflow_integration.3_3_1_target"
+  }]
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -91,7 +91,7 @@ public class EventEmitter {
       log.debug(
           "Emitting lineage completed successfully: {}", OpenLineageClientUtils.toJson(event));
     } catch (OpenLineageClientException exception) {
-      log.error("Could not emit lineage w/ exception", exception);
+      log.error("Could not emit lineage w/ exception", exception.getCause());
     }
   }
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -154,13 +154,16 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
   @Override
   public Collection<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>
       createOutputDatasetFacetBuilders(OpenLineageContext context) {
-    return ImmutableList.<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>builder()
-        .addAll(
-            generate(
-                eventHandlerFactories,
-                factory -> factory.createOutputDatasetFacetBuilders(context)))
-        .add(new OutputStatisticsOutputDatasetFacetBuilder(context))
-        .build();
+    ImmutableList.Builder<CustomFacetBuilder<?, ? extends OutputDatasetFacet>> builder =
+        ImmutableList.<CustomFacetBuilder<?, ? extends OutputDatasetFacet>>builder()
+            .addAll(
+                generate(
+                    eventHandlerFactories,
+                    factory -> factory.createOutputDatasetFacetBuilders(context)));
+    if (context.getSparkVersion().startsWith("3")) {
+      builder.add(new OutputStatisticsOutputDatasetFacetBuilder(context));
+    }
+    return builder.build();
   }
 
   @Override

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
@@ -3,13 +3,9 @@
 /* SPDX-License-Identifier: Apache-2.0
 */
 
-package com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.common;
+package com.google.cloud.bigquery.connector.common;
 
-import com.google.cloud.bigquery.connector.common.BigQueryClient;
-import com.google.cloud.bigquery.connector.common.BigQueryConfig;
-import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.spark.bigquery.repackaged.com.google.common.cache.CacheBuilder;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Binder;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Module;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Provides;
@@ -46,7 +42,7 @@ public class MockBigQueryClientModule implements Module {
         bq,
         Optional.of("materializationProject"),
         Optional.of("materializationDataset"),
-        CacheBuilder.newBuilder().build(),
+        null,
         Collections.emptyMap());
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
@@ -36,6 +37,7 @@ public class SparkContainerUtils {
             DockerImageName.parse("bitnami/spark:" + System.getProperty("spark.version")))
         .withNetwork(network)
         .withNetworkAliases("spark")
+        .withFileSystemBind("build/gcloud", "/opt/gcloud")
         .withFileSystemBind("src/test/resources/test_data", "/test_data")
         .withFileSystemBind("src/test/resources/spark_scripts", "/opt/spark_scripts")
         .withFileSystemBind("build/libs", "/opt/libs")
@@ -59,6 +61,7 @@ public class SparkContainerUtils {
       MockServerContainer mockServerContainer,
       String namespace,
       List<String> urlParams,
+      List<String> sparkConfigParams,
       String... command) {
     return makePysparkContainerWithDefaultConf(
         network,
@@ -67,6 +70,7 @@ public class SparkContainerUtils {
         mockServerContainer,
         namespace,
         urlParams,
+        sparkConfigParams,
         command);
   }
 
@@ -76,7 +80,12 @@ public class SparkContainerUtils {
       String namespace,
       String... command) {
     return makePysparkContainerWithDefaultConf(
-        network, mockServerContainer, namespace, new ArrayList<>(), command);
+        network,
+        mockServerContainer,
+        namespace,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        command);
   }
 
   static GenericContainer<?> makePysparkContainerWithDefaultConf(
@@ -86,6 +95,7 @@ public class SparkContainerUtils {
       MockServerContainer mockServerContainer,
       String namespace,
       List<String> urlParams,
+      List<String> sparkConfigParams,
       String... command) {
 
     //    String urlParamsString = urlParams.isEmpty() ?
@@ -94,34 +104,37 @@ public class SparkContainerUtils {
       paramString = "?" + String.join("&", urlParams);
     }
 
-    List<String> sparkConfigParams = new ArrayList<>();
-    addSparkConfig(sparkConfigParams, "spark.openlineage.host=" + openlineageUrl);
+    List<String> sparkConf = new ArrayList<>();
+    sparkConfigParams.forEach(param -> addSparkConfig(sparkConf, param));
+    addSparkConfig(sparkConf, "spark.openlineage.host=" + openlineageUrl);
     addSparkConfig(
-        sparkConfigParams,
+        sparkConf,
         "spark.openlineage.url="
             + openlineageUrl
             + "/api/v1/namespaces/"
             + namespace
             + paramString);
-    addSparkConfig(
-        sparkConfigParams, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-    addSparkConfig(sparkConfigParams, "spark.sql.warehouse.dir=/tmp/warehouse");
-    addSparkConfig(sparkConfigParams, "spark.sql.shuffle.partitions=1");
-    addSparkConfig(
-        sparkConfigParams, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-    addSparkConfig(sparkConfigParams, "spark.sql.warehouse.dir=/tmp/warehouse");
-    addSparkConfig(sparkConfigParams, "spark.jars.ivy=/tmp/.ivy2/");
-    addSparkConfig(sparkConfigParams, "spark.openlineage.facets.disabled=''");
+    addSparkConfig(sparkConf, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(sparkConf, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(sparkConf, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(sparkConf, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(sparkConf, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(sparkConf, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(sparkConf, "spark.openlineage.facets.disabled=''");
 
     List<String> sparkSubmit =
         new ArrayList(Arrays.asList("./bin/spark-submit", "--master", "local"));
-    sparkSubmit.addAll(sparkConfigParams);
+    sparkSubmit.addAll(sparkConf);
     sparkSubmit.addAll(
         Arrays.asList(
             "--jars",
             "/opt/libs/"
                 + System.getProperty("openlineage.spark.jar")
                 + ",/opt/dependencies/spark-sql-kafka-*.jar"
+                + ",/opt/dependencies/spark-bigquery-with-dependencies*.jar"
+                + ",/opt/dependencies/gcs-connector-hadoop*.jar"
+                + ",/opt/dependencies/google-http-client-*.jar"
+                + ",/opt/dependencies/google-oauth-client-*.jar"
                 + ",/opt/dependencies/kafka-*.jar"
                 + ",/opt/dependencies/spark-token-provider-*.jar"
                 + ",/opt/dependencies/commons-pool2-*.jar"));
@@ -142,7 +155,12 @@ public class SparkContainerUtils {
       String namespace,
       String pysparkFile) {
     runPysparkContainerWithDefaultConf(
-        network, mockServerContainer, namespace, new ArrayList<>(), pysparkFile);
+        network,
+        mockServerContainer,
+        namespace,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        pysparkFile);
   }
 
   static void runPysparkContainerWithDefaultConf(
@@ -150,9 +168,15 @@ public class SparkContainerUtils {
       MockServerContainer mockServerContainer,
       String namespace,
       List<String> urlParams,
+      List<String> sparkConfigParams,
       String pysparkFile) {
     makePysparkContainerWithDefaultConf(
-            network, mockServerContainer, namespace, urlParams, "/opt/spark_scripts/" + pysparkFile)
+            network,
+            mockServerContainer,
+            namespace,
+            urlParams,
+            sparkConfigParams,
+            "/opt/spark_scripts/" + pysparkFile)
         .start();
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkOpenLineageFailuresTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkOpenLineageFailuresTest.java
@@ -13,8 +13,8 @@ import static org.mockserver.model.HttpRequest.request;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -80,7 +80,8 @@ class SparkOpenLineageFailuresTest {
             ".*Spark is fine!.*",
             openLineageClientMockContainer,
             "testFailures",
-            new ArrayList<String>(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             "/opt/spark_scripts/spark_test_failures.py")
         .start();
   }
@@ -96,7 +97,8 @@ class SparkOpenLineageFailuresTest {
             ".*Spark is fine!.*",
             openLineageClientMockContainer,
             "testFailures",
-            new ArrayList<String>(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             "/opt/spark_scripts/spark_test_failures.py")
         .start();
   }
@@ -112,7 +114,8 @@ class SparkOpenLineageFailuresTest {
             ".*Spark is fine!.*",
             openLineageClientMockContainer,
             "testFailures",
-            new ArrayList<String>(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             "/opt/spark_scripts/spark_test_failures.py")
         .start();
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -18,10 +18,10 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.bigquery.MockBigQueryRelationProvider;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.Field;
-import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.MockBigQueryRelationProvider;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.Schema;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.StandardTableDefinition;
@@ -39,6 +39,7 @@ import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.SparkVersionUtils;
 import io.openlineage.spark.agent.util.TestOpenLineageEventHandlerFactory;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -216,8 +217,9 @@ class SparkReadWriteIntegTest {
         .isEqualTo(schemaDatasetFacet);
 
     assertNotNull(output.getFacets().getAdditionalProperties());
-
-    assertThat(output.getOutputFacets().getOutputStatistics()).isNotNull();
+    if (SparkVersionUtils.isSpark3()) {
+      assertThat(output.getOutputFacets().getOutputStatistics()).isNotNull();
+    }
   }
 
   @Test
@@ -271,7 +273,7 @@ class SparkReadWriteIntegTest {
         .satisfies(
             d -> {
               // Spark rowCount metrics currently only working in Spark 3.x
-              if (spark.version().startsWith("3")) {
+              if (SparkVersionUtils.isSpark3()) {
                 assertThat(d.getOutputFacets().getOutputStatistics())
                     .isNotNull()
                     .hasFieldOrPropertyWithValue("rowCount", 2L);
@@ -635,7 +637,7 @@ class SparkReadWriteIntegTest {
         .satisfies(
             d -> {
               // Spark rowCount metrics currently only working in Spark 3.x
-              if (spark.version().startsWith("3")) {
+              if (SparkVersionUtils.isSpark3()) {
                 assertThat(d.getOutputFacets().getOutputStatistics())
                     .isNotNull()
                     .hasFieldOrPropertyWithValue("rowCount", 2L);

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_bigquery.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_bigquery.py
@@ -1,0 +1,43 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .config("parentProject", "openlineage-ci") \
+    .config("credentialsFile", "/opt/gcloud/gcloud-service-key.json") \
+    .config("temporaryGcsBucket", "openlineage-spark-bigquery-integration") \
+    .appName("OpenLineage Spark Bigquery") \
+    .getOrCreate()
+
+
+PROJECT_ID = 'openlineage-ci'
+DATASET_ID = 'airflow_integration'
+
+version_name = str(spark.version).replace(".", "_")
+
+source_table = f"{PROJECT_ID}.{DATASET_ID}.{version_name}_source"
+target_table = f"{PROJECT_ID}.{DATASET_ID}.{version_name}_target"
+
+spark.sparkContext.setLogLevel('info')
+
+
+## ran this once to create source table
+# df = spark.createDataFrame([
+#     {'a': 1, 'b': 2},
+#     {'a': 3, 'b': 4}
+# ])
+# df.write.format('bigquery') \
+#     .option('table', source_table) \
+#     .mode('overwrite') \
+#     .save()
+
+first = spark.read.format('bigquery') \
+    .option('table', source_table) \
+    .load()
+
+first.write.format('bigquery') \
+    .option('table', target_table) \
+    .mode('overwrite') \
+    .save()

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
-    compileOnly ("com.google.cloud.spark:spark-bigquery_2.11:${bigqueryVersion}") {
+    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
@@ -1,0 +1,102 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import com.google.cloud.spark.bigquery.BigQueryRelation;
+import com.google.cloud.spark.bigquery.BigQueryRelationProvider;
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ReflectionUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand;
+import scala.Option;
+
+/**
+ * {@link LogicalPlan} visitor that matches {@link BigQueryRelation}s or {@link
+ * SaveIntoDataSourceCommand}s that use a {@link BigQueryRelationProvider}. This function extracts a
+ * {@link OpenLineage.Dataset} from the BigQuery table referenced by the relation. The convention
+ * used for naming is a URI of <code>
+ * bigquery://&lt;projectId&gt;.&lt;.datasetId&gt;.&lt;tableName&gt;</code> . The namespace for
+ * bigquery tables is always <code>bigquery</code> and the name is the FQN.
+ *
+ * @param <D> the type of {@link OpenLineage.Dataset} created by this visitor
+ */
+@Slf4j
+public class BigQueryNodeOutputVisitor
+    extends QueryPlanVisitor<LogicalPlan, OpenLineage.OutputDataset> {
+  private static final String BIGQUERY_NAMESPACE = "bigquery";
+  private final DatasetFactory<OpenLineage.OutputDataset> factory;
+
+  public BigQueryNodeOutputVisitor(
+      OpenLineageContext context, DatasetFactory<OpenLineage.OutputDataset> factory) {
+    super(context);
+    this.factory = factory;
+  }
+
+  public static boolean hasBigQueryClasses() {
+    try {
+      BigQueryNodeOutputVisitor.class
+          .getClassLoader()
+          .loadClass("com.google.cloud.spark.bigquery.BigQueryRelation");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan plan) {
+    return plan instanceof SaveIntoDataSourceCommand
+        && ((SaveIntoDataSourceCommand) plan).dataSource() instanceof BigQueryRelationProvider;
+  }
+
+  private String getFromSaveIntoDataSourceCommand(SaveIntoDataSourceCommand saveCommand) {
+    SQLContext sqlContext = SparkSession.active().sqlContext();
+    BigQueryRelationProvider bqRelationProvider =
+        (BigQueryRelationProvider) saveCommand.dataSource();
+    SparkBigQueryConfig config =
+        bqRelationProvider.createSparkBigQueryConfig(
+            sqlContext, saveCommand.options(), Option.apply(saveCommand.schema()));
+    return getBigQueryTableName(config).get();
+  }
+
+  private Optional<String> getBigQueryTableName(SparkBigQueryConfig config) {
+    return Stream.of(
+            ReflectionUtils.tryExecuteStaticMethodForClassName(
+                "com.google.cloud.bigquery.connector.common.BigQueryUtil",
+                "friendlyTableName",
+                config.getTableId()),
+            ReflectionUtils.tryExecuteStaticMethodForClassName(
+                "com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.connector.common.BigQueryUtil",
+                "friendlyTableName",
+                config.getTableId()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(x -> (String) x)
+        .findFirst();
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan plan) {
+    SaveIntoDataSourceCommand saveCommand = (SaveIntoDataSourceCommand) plan;
+    return Collections.singletonList(
+        factory.getDataset(
+            getFromSaveIntoDataSourceCommand(saveCommand),
+            BIGQUERY_NAMESPACE,
+            saveCommand.schema()));
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -54,10 +54,16 @@ public class SaveIntoDataSourceCommandVisitor
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    return context.getSparkSession().isPresent()
-        && x instanceof SaveIntoDataSourceCommand
-        && (((SaveIntoDataSourceCommand) x).dataSource() instanceof SchemaRelationProvider
-            || ((SaveIntoDataSourceCommand) x).dataSource() instanceof RelationProvider);
+    if (context.getSparkSession().isPresent() && x instanceof SaveIntoDataSourceCommand) {
+      SaveIntoDataSourceCommand command = (SaveIntoDataSourceCommand) x;
+      if (PlanUtils.safeIsInstanceOf(
+          command.dataSource(), "com.google.cloud.spark.bigquery.BigQueryRelationProvider")) {
+        return false;
+      }
+      return command.dataSource() instanceof SchemaRelationProvider
+          || command.dataSource() instanceof RelationProvider;
+    }
+    return false;
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
@@ -1,0 +1,34 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.MethodUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ClassUtils;
+
+@Slf4j
+public class ReflectionUtils {
+  public static Optional<Object> tryExecuteStaticMethodForClassName(
+      String className, String methodName, Object... args) {
+    Class<?> clazz;
+    try {
+      clazz = ClassUtils.getClass(className);
+    } catch (ClassNotFoundException | Error e) {
+      log.debug("Can't get class {}", className, e);
+      return Optional.empty();
+    }
+    args = ArrayUtils.nullToEmpty(args);
+    Class<?>[] parameterTypes = ClassUtils.toClass(args);
+    try {
+      return Optional.of(MethodUtils.invokeStaticMethod(clazz, methodName, args, parameterTypes));
+    } catch (Error | Exception e) {
+      log.debug("Can't execute static method {}.{}:", className, methodName, e);
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
@@ -1,0 +1,14 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import org.apache.spark.sql.SparkSession;
+
+public class SparkVersionUtils {
+  public static boolean isSpark3() {
+    return SparkSession.active().version().startsWith("3");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -7,7 +7,7 @@ package io.openlineage.spark.api;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
-import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -19,10 +19,10 @@ import org.apache.spark.sql.types.StructType;
 /**
  * Defines factories for creating either {@link OpenLineage.InputDataset}s or {@link
  * OpenLineage.OutputDataset}s. This allows {@link QueryPlanVisitor}s that may identify input or
- * output datasets (e.g., a {@link BigQueryNodeVisitor} or {@link LogicalRelationDatasetBuilder}) to
- * be reused in the construction of both input and output datasets, allowing each to focus on
- * extracting the identifier and general {@link OpenLineage.DatasetFacet}s, while delegating to the
- * factory to construct the correct instance.
+ * output datasets (e.g., a {@link BigQueryNodeOutputVisitor} or {@link
+ * LogicalRelationDatasetBuilder}) to be reused in the construction of both input and output
+ * datasets, allowing each to focus on extracting the identifier and general {@link
+ * OpenLineage.DatasetFacet}s, while delegating to the factory to construct the correct instance.
  *
  * <p>Ideally, this would be a sealed class. We emulate that by using a private constructor and
  * provide two static factory methods - {@link #input(OpenLineageContext)} and {@link

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -19,6 +19,7 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.Tolerate;
 import org.apache.spark.SparkContext;
+import org.apache.spark.package$;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
@@ -86,6 +87,9 @@ public class OpenLineageContext {
 
   /** Optional {@link QueryExecution} for runs that are Spark SQL queries. */
   @Default @NonNull Optional<QueryExecution> queryExecution = Optional.empty();
+
+  /** Spark version of currently running job */
+  String sparkVersion = package$.MODULE$.SPARK_VERSION();
 
   /**
    * Override the default Builder class to take an unwrapped {@link QueryExecution} argument, rather

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -292,7 +292,7 @@ class LogicalPlanSerializerTest {
             SQLConf.get(),
             "",
             Optional.empty(),
-            true);
+            false);
 
     BigQueryRelation bigQueryRelation =
         new BigQueryRelation(

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
@@ -1,4 +1,7 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
 
 package io.openlineage.spark.agent.lifecycle;
 
@@ -100,7 +103,11 @@ public class MatchesMapRecursively extends Condition<Map<String, Object>> {
           eq = val.equals(target.get(k));
         }
         if (!eq) {
-          log.error("Passed object {} does not match target object {}", map.get(k), target.get(k));
+          log.error(
+              "For key {} - passed object {} does not match target object {}",
+              k,
+              map.get(k),
+              target.get(k));
           return false;
         }
       }

--- a/integration/spark/shared/src/test/resources/test_data/serde/bigqueryrelation-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/bigqueryrelation-node.json
@@ -1,69 +1,41 @@
 {
   "@class":"org.apache.spark.sql.execution.datasources.LogicalRelation",
-  "id":1,
   "relation":{
     "@class":"com.google.cloud.spark.bigquery.BigQueryRelation",
-    "id":2,
-    "tableId":{
-      "id":3,
+    "tableId": {
       "dataset":"dataset",
-      "table":"test",
-      "iamresourceName":"projects/null/datasets/dataset/tables/test"
+      "table":"test"
     },
     "tableName":"dataset.test"
   },
   "output":[
     {
-      "id":4,
       "name":"name",
       "dataType":{
-        "id":5,
-        "ordering":{
-          "id":6
-        }
+        "ordering":{}
       },
       "nullable":false,
       "metadata":{
-        "id":7,
-        "map":{
-
-        }
+        "map":{}
       },
-      "exprId":{
-        "id":1,
-        "jvmId":"36158998-6a69-407a-9ac2-5eed26afc168"
-      },
-      "qualifier":[
-
-      ],
-      "origin":{
-        "id":9
-      },
+      "qualifier":[],
+      "origin":{},
       "deterministic":true,
       "resolved":true
     }
   ],
   "isStreaming":false,
-  "origin":9,
   "schema":[
     {
-      "id":10,
-      "name":"name",
-      "dataType":5,
-      "nullable":false,
-      "metadata":7
+      "name": "name",
+      "nullable": false
     }
   ],
   "allAttributes":{
-    "id":11,
-    "attrs":[
-
-    ]
+    "attrs":[]
   },
   "resolved":true,
-  "attributeMap":{
-    "name#1":4
-  },
+  "attributeMap":{},
   "traceEnabled":false,
   "canonicalizedPlan":false
 }

--- a/integration/spark/shared/src/test/resources/test_data/serde/insertintods-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/insertintods-node.json
@@ -4,24 +4,18 @@
     "@class":"org.apache.spark.sql.execution.datasources.LogicalRelation",
     "relation":{
       "@class":"com.google.cloud.spark.bigquery.BigQueryRelation",
-      "tableId":{
-        "dataset":"dataset",
-        "table":"test",
-        "iamresourceName":"projects/null/datasets/dataset/tables/test"
-      },
-      "tableName":"dataset.test"
+      "id": 3,
+      "tableName": "dataset.test",
+      "tableId": {
+          "dataset":"dataset",
+          "table":"test"
+      }
     },
     "output":[
       {
-        "dataType":{
-          "ordering":{
-
-          }
-        },
+        "dataType":{},
         "nullable":false,
-        "qualifier":[
-
-        ],
+        "qualifier":[],
         "deterministic":true,
         "resolved":true
       }
@@ -34,17 +28,13 @@
       }
     ],
     "resolved":true,
-    "attributeMap":{
-
-    },
+    "attributeMap":{},
     "traceEnabled":false,
     "canonicalizedPlan":false
   },
   "overwrite":false,
   "resolved":true,
-  "metrics":{
-
-  },
+  "metrics":{},
   "streaming":false,
   "traceEnabled":false,
   "canonicalizedPlan":false

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -44,16 +44,22 @@ ext {
     sparkVersion = '3.1.3'
     jacksonVersion = '2.10.0'
     lombokVersion = '1.18.20'
+    bigqueryVersion = "0.26.0"
 }
 
 dependencies {
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
+
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     implementation(project(":shared"))
 
+    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.module'
+    }
     compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -5,9 +5,11 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
+import com.google.cloud.spark.bigquery.BigQueryRelation;
 import io.openlineage.spark.agent.lifecycle.Rdds;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ReflectionUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
@@ -15,7 +17,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.rdd.RDD;
@@ -78,6 +82,10 @@ class InputFieldsCollector {
         && (((LogicalRelation) node).relation() instanceof HadoopFsRelation)) {
       HadoopFsRelation relation = (HadoopFsRelation) ((LogicalRelation) node).relation();
       return extractDatasetIdentifier(relation);
+    } else if (node instanceof LogicalRelation
+        && ((LogicalRelation) node).relation() instanceof BigQueryRelation) {
+      BigQueryRelation relation = (BigQueryRelation) ((LogicalRelation) node).relation();
+      return extractDatasetIdentifier(relation);
     } else if (node instanceof LogicalRDD) {
       return extractDatasetIdentifier((LogicalRDD) node);
     } else if (node instanceof LeafNode) {
@@ -100,6 +108,24 @@ class InputFieldsCollector {
     return PlanUtils3.getDatasetIdentifier(context, relation)
         .map(Collections::singletonList)
         .orElse(Collections.emptyList());
+  }
+
+  private static List<DatasetIdentifier> extractDatasetIdentifier(
+      BigQueryRelation bigQueryRelation) {
+
+    return Stream.of(
+            ReflectionUtils.tryExecuteStaticMethodForClassName(
+                "com.google.cloud.bigquery.connector.common.BigQueryUtil",
+                "friendlyTableName",
+                bigQueryRelation.getTableId()),
+            ReflectionUtils.tryExecuteStaticMethodForClassName(
+                "com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.connector.common.BigQueryUtil",
+                "friendlyTableName",
+                bigQueryRelation.getTableId()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(x -> new DatasetIdentifier((String) x, "namespace"))
+        .collect(Collectors.toList());
   }
 
   private static List<DatasetIdentifier> extractDatasetIdentifier(CatalogTable catalogTable) {


### PR DESCRIPTION
This PR fixes few of the common issues with spark-bigquery integration and adds integration test for it, together with the CI configuration for it.

- there are two `spark-bigquery` dependencies - `spark-bigquery` itself, and `spark-bigquery-with-dependencies`. They aren't compatible - for example we use `com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.connector.common.BigQueryUtil` which is `google.cloud.bigquery.connector.common.BigQueryUtil` in the non-with-dependencies version. Previously we mixed those two, now we use with-dependencies version everywhere as it's 10x more popular on maven central and recommended everywhere
- split `BigQueryNodeVisitor` to `BigQueryInputNodeVisitor` and `BigQueryOutputNodeVisitor`. The "output" visitors process only root node, while "input" ones process whole tree. If we have one node visitor who is registered both for input and output events, the root node is double counter. The split prevents that.
- prevent `SaveIntoDataSourceCommandVisitor` from processing `BigQueryRelation`.
- `BigQueryOutputNodeVisitor` does not try to create `BigQueryRelation` to get proper table name, but utilizes `BigQueryUtil.friendlyTableName(config.getTableId())`. This prevents error when output table does not exist and is created by the spark process.