### PR TITLE
[Integration][Airflow] Add support for SQLExecuteQueryOperator.

### DIFF
--- a/.circleci/workflows/openlineage-integration-airflow.yml
+++ b/.circleci/workflows/openlineage-integration-airflow.yml
@@ -27,7 +27,8 @@ workflows:
                 airflow-version: [
                   'airflow-2.1.4',
                   'airflow-2.2.4',
-                  'airflow-2.3.4'
+                  'airflow-2.3.4',
+                  'airflow-2.5.0'
                 ]
                 install_parser: [ true ]
           requires:
@@ -38,7 +39,8 @@ workflows:
               airflow-image: [
                 'apache/airflow:2.1.4-python3.7',
                 'apache/airflow:2.2.4-python3.7',
-                'apache/airflow:2.3.4-python3.7'
+                'apache/airflow:2.3.4-python3.7',
+                'apache/airflow:2.5.0-python3.7'
               ]
           context: integration-tests
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.17.0...HEAD)
+### Added
+* Airflow: support SQLExecuteQueryOperator [`#1379`](https://github.com/OpenLineage/OpenLineage/pull/1379) [@JDarDagran](https://github.com/JDarDagran) 
 
 ### Fixed
 * Spark: databricks improvements to send better events [`#1330`](https://github.com/OpenLineage/OpenLineage/pull/1330) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski) 

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -42,9 +42,6 @@ class MySqlExtractor(SqlExtractor):
             parsed = urlparse(self.conn.get_uri())
             return f"{parsed.hostname}:{parsed.port}"
 
-    def _conn_id(self):
-        return self.operator.mysql_conn_id
-
     def _get_hook(self):
         MySqlHook = try_import_from_string("airflow.providers.mysql.hooks.mysql.MySqlHook")
         return MySqlHook(

--- a/integration/airflow/openlineage/airflow/extractors/sql_execute_query.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_execute_query.py
@@ -1,0 +1,17 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+sql_extractors = {
+    "bigquery": "BigQueryExtractor",
+    "mysql": "MysqlExtractor",
+    "postgres": "PostgresExtractor",
+    "redshift": "RedshiftExtractor",
+    "snowflake": "SnowflakeExtractor",
+}
+
+
+def get_sql_execute_query_extractor(super_):
+    class SQLExecuteQueryExtractor(super_):
+        pass
+
+    return SQLExecuteQueryExtractor

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -110,6 +110,8 @@ class SqlExtractor(BaseExtractor):
         )
 
     def _conn_id(self) -> str:
+        if hasattr(self.hook, "conn_id"):
+            return "conn_id"
         return getattr(self.hook, self.hook.conn_name_attr)
 
     @property
@@ -123,7 +125,7 @@ class SqlExtractor(BaseExtractor):
     @property
     def hook(self):
         if not self._hook:
-            self._hook = self._get_hook()
+            self._hook = SqlExtractor._get_hook(self) or self._get_hook()
         return self._hook
 
     @property
@@ -159,9 +161,8 @@ class SqlExtractor(BaseExtractor):
             parsed = urlparse(self.conn.get_uri())
             return f"{parsed.hostname}:{parsed.port}"
 
-    @abstractmethod
-    def _get_hook(self) -> "BaseHook":
-        raise NotImplementedError
+    def _get_hook(self) -> "Optional[BaseHook]":
+        return getattr(self.operator, "_hook", None)
 
     def _get_db_specific_run_facets(
         self,

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -27,7 +27,7 @@ disable_error_code = attr-defined
 
 [tox:tox]
 envlist = 
-	py3-airflow-{2.1.4,2.2.4,2.3.4}
+	py3-airflow-{2.1.4,2.2.4,2.3.4,2.5.0}
 skipsdist = True
 
 [testenv]
@@ -43,7 +43,8 @@ deps = -r dev-requirements.txt
 	codecov>=1.4.0
 	airflow-2.1.4: apache-airflow==2.1.4
 	airflow-2.2.4: apache-airflow==2.2.4
-	airflow-2.3.1: apache-airflow==2.3.1
+	airflow-2.3.4: apache-airflow==2.3.4
+	airflow-2.5.0: apache-airflow==2.5.0
 whitelist_externals = bash
 commands = flake8 --extend-exclude tests/integration,scripts/
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}
@@ -57,3 +58,4 @@ setenv =
 	airflow-2.1.4: AIRFLOW_VERSION = 2.1.4
 	airflow-2.2.4: AIRFLOW_VERSION = 2.2.4
 	airflow-2.3.4: AIRFLOW_VERSION = 2.3.4
+	airflow-2.5.0: AIRFLOW_VERSION = 2.5.0

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -76,6 +76,19 @@ def test_instantiate_abstract_extractors(mock_hook):
     assert sql_check_extractor._get_scheme() == "postgres"
 
 
+@patch.object(BaseHook, "get_connection", return_value=Connection(conn_id="postgres_default", conn_type="postgres"))  # noqa
+def test_instantiate_abstract_extractors_sql_execute(mock_hook):
+    class SQLExecuteQueryOperator:
+        conn_id = "postgres_default"
+
+    extractors = Extractors()
+    extractors.instantiate_abstract_extractors(task=SQLExecuteQueryOperator())
+    sql_check_extractor = extractors.extractors["SQLExecuteQueryOperator"](
+        "SQLExecuteQueryOperator"
+    )
+    assert sql_check_extractor._get_scheme() == "postgres"
+
+
 @patch('airflow.models.connection.Connection')
 @patch.object(BaseHook, "get_connection", return_value=Connection(conn_id="notimplemented", conn_type="notimplementeddb"))  # noqa
 def test_instantiate_abstract_extractors_value_error(mock_hook, mock_conn):

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -95,7 +95,7 @@ TASK = MySqlOperator(
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract(get_connection, mock_get_table_schemas):
     source = Source(
         scheme='mysql',
@@ -133,7 +133,7 @@ def test_extract(get_connection, mock_get_table_schemas):
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract_authority_uri(get_connection, mock_get_table_schemas):
     source = Source(
         scheme='mysql',
@@ -192,7 +192,7 @@ def test_get_connection_returns_one_if_exists(create_connection):
     assert get_connection("does_exist").conn_id == conn.conn_id
 
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_information_schema_query(get_connection):
     extractor = MySqlExtractor(TASK)
 

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -97,7 +97,7 @@ TASK = PostgresOperator(
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract(get_connection, mock_get_table_schemas):
     source = Source(
         scheme='postgres',
@@ -135,7 +135,7 @@ def test_extract(get_connection, mock_get_table_schemas):
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract_authority_uri(get_connection, mock_get_table_schemas):
 
     source = Source(

--- a/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
@@ -74,7 +74,7 @@ TASK = RedshiftSQLOperator(
 
 
 @mock.patch("openlineage.airflow.extractors.sql_extractor.get_table_schemas")  # noqa
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract(get_connection, mock_get_table_schemas):
     source = Source(
         scheme="redshift",
@@ -123,7 +123,7 @@ def test_parsing_hostname():
     )
 
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")  # noqa
 def test_authority_with_clustername_in_host(get_connection):
     conn = Connection()
     conn.parse_from_uri(uri=CONN_URI)
@@ -134,7 +134,7 @@ def test_authority_with_clustername_in_host(get_connection):
     )
 
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")  # noqa
 def test_authority_with_iam(get_connection):
     conn = Connection(
         extra={
@@ -150,7 +150,7 @@ def test_authority_with_iam(get_connection):
         == "redshift-cluster-name.region:5439"
     )
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")  # noqa
 def test_authority_with_iam_and_implicit_region(get_connection):
     import os
     os.environ['AWS_DEFAULT_REGION'] = 'region_2'
@@ -168,7 +168,7 @@ def test_authority_with_iam_and_implicit_region(get_connection):
     )
 
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")  # noqa
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")  # noqa
 def test_authority_without_iam_wrong_connection(get_connection):
     conn = Connection(
         extra={
@@ -183,7 +183,7 @@ def test_authority_without_iam_wrong_connection(get_connection):
 
 
 @mock.patch("openlineage.airflow.extractors.sql_extractor.get_table_schemas")  # noqa
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_extract_authority_uri(get_connection, mock_get_table_schemas):
 
     source = Source(

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -134,7 +134,7 @@ def test_get_connection_filter_qs_params_with_extra_prefix():
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 @mock.patch('openlineage.airflow.extractors.snowflake_extractor.execute_query_on_hook')
 def test_extract(execute_query_on_hook, get_connection, mock_get_table_schemas):
     source = Source(
@@ -177,7 +177,7 @@ def test_extract(execute_query_on_hook, get_connection, mock_get_table_schemas):
 
 
 @mock.patch('openlineage.airflow.extractors.sql_extractor.get_table_schemas')  # noqa
-@mock.patch('openlineage.airflow.extractors.sql_extractor.get_connection')
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 @mock.patch('openlineage.airflow.extractors.snowflake_extractor.execute_query_on_hook')
 def test_extract_query_ids(execute_query_on_hook, get_connection, mock_get_table_schemas):
     mock_get_table_schemas.return_value = (
@@ -199,7 +199,7 @@ def test_extract_query_ids(execute_query_on_hook, get_connection, mock_get_table
     assert task_metadata.run_facets["externalQuery"].externalQueryId == "1500100900"
 
 
-@mock.patch("openlineage.airflow.extractors.sql_extractor.get_connection")
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
 def test_information_schema_query(get_connection):
     extractor = SnowflakeExtractor(TASK)
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Airflow 2.5 introduces `SQLExecuteQueryOperator` from which multiple SQL Operators inherit. This requires changes in extractors.

Closes: #1352 

### Solution

Make changes to SQLExtractor and support dynamic assignment of extractors based on `conn_type`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project