### PR TITLE
airflow: use threadpool-based event emission on Airflow 2.5

### DIFF
--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -4,20 +4,17 @@
 import os
 
 from airflow.plugins_manager import AirflowPlugin
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
-
 
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+from openlineage.airflow.utils import is_airflow_version_enough
 
 
 def _is_disabled():
     return os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]
 
 
-if parse_version(AIRFLOW_VERSION) \
-        < parse_version("2.3.0.dev0") or _is_disabled():      # type: ignore
+if not is_airflow_version_enough("2.3.0") or _is_disabled():      # type: ignore
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
         macros = [lineage_run_id, lineage_parent_id]

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 from typing import Optional
 from airflow.models import DAG as AIRFLOW_DAG
+from pkg_resources import parse_version
 
 from openlineage.airflow.facets import (
     AirflowMappedTaskRunFacet,
@@ -396,3 +397,10 @@ class LoggingMixin:
                 "openlineage.airflow.extractors."
                 f"{self.__class__.__module__}.{self.__class__.__name__}"
             )
+
+
+def is_airflow_version_enough(version):
+    from airflow.version import version as AIRFLOW_VERSION
+    return parse_version(
+        AIRFLOW_VERSION
+    ) >= parse_version(version)

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -7,8 +7,6 @@ import uuid
 from typing import Optional
 
 from airflow.lineage.backend import LineageBackend
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
 
 
 class Backend:
@@ -86,7 +84,8 @@ class OpenLineageBackend(LineageBackend):
     @classmethod
     def send_lineage(cls, *args, **kwargs):
         # Do not use LineageBackend approach when we can use plugins
-        if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
+        from openlineage.airflow.utils import is_airflow_version_enough
+        if is_airflow_version_enough("2.3.0"):
             return
         # Make this method a noop if OPENLINEAGE_DISABLED is set to true
         if os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -7,14 +7,14 @@ import os
 import sys
 from typing import List
 
-from pkg_resources import parse_version
-
 import psycopg2
 import time
 import requests
+from pkg_resources import parse_version
 from retrying import retry
 import pytest
 import unittest
+
 from openlineage.common.test import match, setup_jinja
 
 env = setup_jinja()

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -5,6 +5,7 @@ from airflow.version import version as AIRFLOW_VERSION
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.dates import days_ago
 
+from openlineage.airflow.utils import is_airflow_version_enough
 from openlineage.client import set_producer
 from pkg_resources import parse_version
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
@@ -29,8 +30,6 @@ default_args = {
 }
 
 
-
-
 dag = DAG(
     'postgres_orders_popular_day_of_week',
     schedule_interval='@once',
@@ -41,8 +40,8 @@ dag = DAG(
     description='Determines the popular day of week orders are placed.'
 )
 
-if parse_version(AIRFLOW_VERSION) < parse_version('2.5.0'):
-    t1 = PostgresOperator(    
+if not is_airflow_version_enough('2.5.0'):
+    t1 = PostgresOperator(
         task_id='postgres_if_not_exists',
         postgres_conn_id='food_delivery_db',
         sql="{{ get_sql() }}",

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -1,3 +1,4 @@
+import pytest
 from airflow.models import BaseOperator
 from airflow.models import TaskInstance, DAG
 from airflow.utils.dates import days_ago
@@ -9,6 +10,8 @@ from airflow.listeners.events import (
     register_task_instance_state_events,
     unregister_task_instance_state_events,
 )
+
+from openlineage.airflow.utils import is_airflow_version_enough
 
 
 class TemplateOperator(BaseOperator):
@@ -28,6 +31,7 @@ def render_df():
 
 @patch("airflow.models.TaskInstance.xcom_push")
 @patch("airflow.models.BaseOperator.render_template")
+@pytest.mark.skipif(is_airflow_version_enough("2.5.0"), reason="Airflow >= 2.5.0")
 def test_listener_does_not_change_task_instance(render_mock, xcom_push_mock):
     register_task_instance_state_events()
     render_mock.return_value = render_df()


### PR DESCRIPTION
Airflow 2.5 added proper lifecycle methods to plugins. This means we can properly start-and-stop thread pool, without risk that tasks send to it would get killed before the worker process ends.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
