### PR TITLE
[DOC] Javadoc publish automation

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -651,6 +651,18 @@ jobs:
       - run: mkdir -p target/wheels && cp target/wheels/* dist/
       - run: python -m twine upload --non-interactive --verbose --repository pypi dist/*
 
+  publish-javadoc:
+    working_directory: ~/openlineage/client/java
+    docker:
+      - image: cimg/openjdk:11.0
+    steps:
+      - *checkout_project_root
+      - add_ssh_keys:
+          fingerprints:
+            - "01:93:41:8a:7b:81:b6:cf:d4:b2:34:52:c6:ff:ac:53"
+      - run: ./gradlew javadoc
+      - run: ./release-javadoc.sh
+
   publish-spec:
     working_directory: ~/openlineage
     docker:

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -42,9 +42,13 @@ workflows:
           context: release
           requires:
             - integration-test-integration-spark
+      - publish-javadoc:
+          filters:
+            branches:
+              only: main
+          context: release
       - workflow_complete:
           requires:
-            - publish-javadoc
             - publish-snapshot-integration-spark
             - integration-test-integration-spark
             - integration-test-integration-flink

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -44,6 +44,7 @@ workflows:
             - integration-test-integration-spark
       - workflow_complete:
           requires:
+            - publish-javadoc
             - publish-snapshot-integration-spark
             - integration-test-integration-spark
             - integration-test-integration-flink

--- a/client/java/release-javadoc.sh
+++ b/client/java/release-javadoc.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+function git-website() {
+  command git --git-dir "$WEBSITE_DIR/.git" --work-tree "$WEBSITE_DIR" $@
+}
+
+git config --global user.email "openlineage-bot-key@openlineage.io"
+git config --global user.name "OpenLineage deploy bot"
+
+WEBSITE_DIR=${WEBSITE_DIR:-$HOME/build/website}
+REPO="git@github.com:OpenLineage/website"
+
+if [[ -d $WEBSITE_DIR ]]; then
+  # Check if we're in git repository and the repository points at website
+  if [[ $(git-website rev-parse --is-inside-work-tree) == "true" && $(git-website config --get remote.origin.url) == "$REPO" ]]; then
+    # Make sure we're at the head of the main branch
+    git checkout main
+    git reset --hard origin/master
+  else
+    echo "$WEBSITE_DIR is not empty - failing"
+    exit 1
+  fi
+else
+  git clone --depth 1 $REPO $WEBSITE_DIR
+fi
+
+# check if there are any changes in javadoc in the latest commit
+if [[ $(diff -qr $WEBSITE_DIR/static/apidocs/javadoc './build/docs/javadoc' | wc -l) -eq 0 ]]; then
+  echo "no changes in javadoc detected, skipping publishing javadoc"
+  exit 0
+fi
+
+echo "Changes detected, updating javadoc..."
+rm -rf $WEBSITE_DIR/static/apidocs/javadoc
+mv ./build/docs/javadoc $WEBSITE_DIR/static/apidocs
+
+# commit new spec and push
+git-website add -A static/apidocs/javadoc
+git --git-dir "$WEBSITE_DIR/.git" --work-tree "$WEBSITE_DIR" commit -m "openlineage javadoc update"
+git-website push


### PR DESCRIPTION
### Problem

Currently there is no `automated` way to publish javadoc, when there is a change in the java classes for java client library in openlineage.

Closes: #40 

### Solution

Introducing two items:
1. publish_javadoc which builds javadoc, and then publishes the javadoc to website
2. workflow in circleci that will trigger publish_javadoc only during release of main branch. If there is no changes between the new and previous javadocs, the update will simply skip.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project