### PR TITLE
airflow: Use threadpool-based event emission in Airflow 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
     *Creates extractors for `SagemakeProcessingOperator` and `SagemakerTransformOperator`.*
 * Airflow: add S3 extractor for Airflow operators [`#1166`](https://github.com/OpenLineage/OpenLineage/pull/1166) [@fhoda](https://github.com/fhoda)  
     *Creates an extractor for the `S3CopyObject` in the Airflow integration.*
+* Airflow: use threadpool-based event emission in TaskInstance listener [`#1398`](https://github.com/OpenLineage/OpenLineage/pull/1398) [@JDarDagran](https://github.com/JDarDagran), [@mobuchowski](https://github.com/mobuchowski)
 * Spec: add spec file for `ExternalQueryRunFacet` [`#1262`](https://github.com/OpenLineage/OpenLineage/pull/1262) [@howardyoo](https://github.com/howardyoo)  
     *Adds a spec file to make this facet available for the Java client. Includes a README*
 * Docs: add a TSC doc [`#1303`](https://github.com/OpenLineage/OpenLineage/pull/1303) [@merobi-hub](https://github.com/merobi-hub)  
     *Adds a document listing the members of the Technical Steering Committee.*
+
 
 ### Fixed
 * Spark: improve Databricks to send better events [`#1330`](https://github.com/OpenLineage/OpenLineage/pull/1330) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/debug.patch
+++ b/debug.patch
@@ -1,0 +1,205 @@
+diff --git a/airflow/cli/commands/task_command.py b/airflow/cli/commands/task_command.py
+index 078565dc38..c2c327915b 100644
+--- a/airflow/cli/commands/task_command.py
++++ b/airflow/cli/commands/task_command.py
+@@ -331,6 +331,7 @@ def task_run(args, dag=None):
+     """
+     # Load custom airflow config
+ 
++    print(f"task command {args.dag_id}, {args.task_id} {dag} {os.getpid()}")
+     if args.local and args.raw:
+         raise AirflowException(
+             "Option --raw and --local are mutually exclusive. "
+@@ -350,17 +351,21 @@ def task_run(args, dag=None):
+                 f"You provided the option {unsupported_flags}. "
+                 "Delete it to execute the command."
+             )
++    print(f"task command {args.dag_id}, {args.task_id} after raw {os.getpid()}")
+     if dag and args.pickle:
+         raise AirflowException("You cannot use the --pickle option when using DAG.cli() method.")
+     if args.cfg_path:
+         with open(args.cfg_path) as conf_file:
+             conf_dict = json.load(conf_file)
+-
++        
++        print(f"task command {args.dag_id}, {args.task_id} conf_dict {os.getpid()}")
+         if os.path.exists(args.cfg_path):
+             os.remove(args.cfg_path)
+-
++        
+         conf.read_dict(conf_dict, source=args.cfg_path)
++        print(f"task command {args.dag_id}, {args.task_id} read_dict {os.getpid()}")
+         settings.configure_vars()
++        print(f"task command {args.dag_id}, {args.task_id} configure_vars {os.getpid()}")
+ 
+     settings.MASK_SECRETS_IN_LOGS = True
+ 
+@@ -368,20 +373,26 @@ def task_run(args, dag=None):
+     # behind multiple open sleeping connections while heartbeating, which could
+     # easily exceed the database connection limit when
+     # processing hundreds of simultaneous tasks.
++    print(f"task command {args.dag_id}, {args.task_id} reconfigure_orm {os.getpid()}")
+     settings.reconfigure_orm(disable_connection_pool=True)
+ 
+     get_listener_manager().hook.on_starting(component=TaskCommandMarker())
+ 
++    print(f"task command {args.dag_id}, {args.task_id} after on_starting {os.getpid()}")
+     if args.pickle:
+         print(f"Loading pickle id: {args.pickle}")
+         dag = get_dag_by_pickle(args.pickle)
++        print(f"task command {args.dag_id}, {args.task_id} after get_dag_by_pickle {os.getpid()}")
+     elif not dag:
+         dag = get_dag(args.subdir, args.dag_id)
++        print(f"task command {args.dag_id}, {args.task_id} after get_dag {os.getpid()}")
+     else:
+         # Use DAG from parameter
+         pass
+     task = dag.get_task(task_id=args.task_id)
++    print(f"task command {args.dag_id}, {args.task_id} after dag.get_task {os.getpid()}")
+     ti, _ = _get_ti(task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, pool=args.pool)
++    print(f"task command {args.dag_id}, {args.task_id} aftert _get_ti {os.getpid()}")
+     ti.init_run_context(raw=args.raw)
+ 
+     hostname = get_hostname()
+@@ -390,9 +401,11 @@ def task_run(args, dag=None):
+ 
+     try:
+         if args.interactive:
++            print(f"task command {args.dag_id}, {args.task_id} _run_task_by_selected_method interactive {os.getpid()}")
+             _run_task_by_selected_method(args, dag, ti)
+         else:
+             with _capture_task_logs(ti):
++                print(f"task command {args.dag_id}, {args.task_id} _run_task_by_selected_method capture_task_logs {os.getpid()}")
+                 _run_task_by_selected_method(args, dag, ti)
+     finally:
+         try:
+diff --git a/airflow/jobs/base_job.py b/airflow/jobs/base_job.py
+index e3d79d67b9..ad43e7698e 100644
+--- a/airflow/jobs/base_job.py
++++ b/airflow/jobs/base_job.py
+@@ -235,22 +235,28 @@ class BaseJob(Base, LoggingMixin):
+ 
+     def run(self):
+         """Starts the job."""
++        import os
++        self.log.info(f"BaseJob run {os.getpid()}")
+         Stats.incr(self.__class__.__name__.lower() + "_start", 1, 1)
+         # Adding an entry in the DB
+         with create_session() as session:
+             self.state = State.RUNNING
+             session.add(self)
+             session.commit()
++            self.log.info(f"BaseJob session commit {os.getpid()}")
+             make_transient(self)
++            self.log.info(f"BaseJob make_transient {os.getpid()}")
+ 
+             try:
++                self.log.info(f"BaseJob before _execute {os.getpid()}")
+                 self._execute()
+                 # In case of max runs or max duration
+                 self.state = State.SUCCESS
+             except SystemExit:
+                 # In case of ^C or SIGTERM
+                 self.state = State.SUCCESS
+-            except Exception:
++            except Exception as e:
++                self.log.info("BaseJob got exception", e)
+                 self.state = State.FAILED
+                 raise
+             finally:
+diff --git a/airflow/jobs/local_task_job.py b/airflow/jobs/local_task_job.py
+index fe7fc4a561..b95657189f 100644
+--- a/airflow/jobs/local_task_job.py
++++ b/airflow/jobs/local_task_job.py
+@@ -84,7 +84,8 @@ class LocalTaskJob(BaseJob):
+             self.handle_task_exit(128 + signum)
+ 
+         signal.signal(signal.SIGTERM, signal_handler)
+-
++        import os
++        self.log.info(f"LocalTaskJob before check_and_change_state_before_execution, {str(self.task_instance)} {os.getpid()}")
+         if not self.task_instance.check_and_change_state_before_execution(
+             mark_success=self.mark_success,
+             ignore_all_deps=self.ignore_all_deps,
+@@ -99,6 +100,7 @@ class LocalTaskJob(BaseJob):
+             return
+ 
+         try:
++            self.log.info(f"LocalTaskJob before task_runner.start, {str(self.task_instance)} {os.getpid()}")
+             self.task_runner.start()
+ 
+             heartbeat_time_limit = conf.getint("scheduler", "scheduler_zombie_task_threshold")
+diff --git a/airflow/task/task_runner/standard_task_runner.py b/airflow/task/task_runner/standard_task_runner.py
+index 4d2d55e927..5125784a18 100644
+--- a/airflow/task/task_runner/standard_task_runner.py
++++ b/airflow/task/task_runner/standard_task_runner.py
+@@ -39,17 +39,20 @@ class StandardTaskRunner(BaseTaskRunner):
+         self.dag = local_task_job.task_instance.task.dag
+ 
+     def start(self):
++        self.log.info("StandardTaskRunner: start")
+         if CAN_FORK and not self.run_as_user:
+             self.process = self._start_by_fork()
+         else:
+             self.process = self._start_by_exec()
+ 
+     def _start_by_exec(self) -> psutil.Process:
++        self.log.info("StandardTaskRunner _start_by_exec")
+         subprocess = self.run_command()
+         self.process = psutil.Process(subprocess.pid)
+         return self.process
+ 
+     def _start_by_fork(self):
++        self.log.info("StandardTaskRunner: _start_by_fork")
+         pid = os.fork()
+         if pid:
+             self.log.info("Started process %d to run task", pid)
+@@ -57,6 +60,7 @@ class StandardTaskRunner(BaseTaskRunner):
+         else:
+             # Start a new process group
+             set_new_process_group()
++            self.log.info(f"StandardTaskRunner set_new_process_group {os.getpid()}")
+             import signal
+ 
+             signal.signal(signal.SIGINT, signal.SIG_DFL)
+@@ -70,7 +74,9 @@ class StandardTaskRunner(BaseTaskRunner):
+             # between process. The cli code will re-create this as part of its
+             # normal startup
+             settings.engine.pool.dispose()
++            self.log.info(f"StandardTaskRunner after pool dispose {os.getpid()}")
+             settings.engine.dispose()
++            self.log.info(f"StandardTaskRunner after engine dispose {os.getpid()}")
+ 
+             parser = get_parser()
+             # [1:] - remove "airflow" from the start of the command
+@@ -86,6 +92,7 @@ class StandardTaskRunner(BaseTaskRunner):
+             if job_id is not None:
+                 proc_title += " {0.job_id}"
+             setproctitle(proc_title.format(args))
++            self.log.info(f"StandardTaskRunner after setproctitle {os.getpid()}")
+             return_code = 0
+             try:
+                 with _airflow_parsing_context_manager(
+diff --git a/airflow/utils/cli.py b/airflow/utils/cli.py
+index 3ee43fdc4a..eab448e481 100644
+--- a/airflow/utils/cli.py
++++ b/airflow/utils/cli.py
+@@ -90,8 +90,10 @@ def action_cli(func=None, check_db=True):
+             :param kwargs: A passthrough keyword argument
+             """
+             _check_cli_args(args)
++            print(f"wrapper after check args {os.getpid()}", func, f)
+             metrics = _build_metrics(f.__name__, args[0])
+             cli_action_loggers.on_pre_execution(**metrics)
++            print(f"wrapper after pre_execution {os.getpid()}", func, f)
+             verbose = getattr(args[0], "verbose", False)
+             root_logger = logging.getLogger()
+             if verbose:
+@@ -107,6 +109,7 @@ def action_cli(func=None, check_db=True):
+                     synchronize_log_template()
+                 return f(*args, **kwargs)
+             except Exception as e:
++                print(f"wrapper exception {os.getpid()}", func, f, e)
+                 metrics["error"] = e
+                 raise
+             finally:

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -21,7 +21,7 @@ from openlineage.client.facet import (
     ErrorMessageRunFacet,
     ProcessingEngineRunFacet,
 )
-from openlineage.airflow.utils import redact_with_exclusions, DagUtils
+from openlineage.airflow.utils import redact_with_exclusions, DagUtils, print_exception
 from openlineage.client.run import RunEvent, RunState, Run, Job
 import requests.exceptions
 
@@ -199,6 +199,7 @@ class OpenLineageAdapter:
         )
         self.emit(event)
 
+    @print_exception
     def dag_started(
         self,
         dag_run: "DagRun",
@@ -221,6 +222,7 @@ class OpenLineageAdapter:
         )
         self.emit(event)
 
+    @print_exception
     def dag_success(self, dag_run: "DagRun", msg: str):
         event = RunEvent(
             eventType=RunState.COMPLETE,
@@ -233,6 +235,7 @@ class OpenLineageAdapter:
         )
         self.emit(event)
 
+    @print_exception
     def dag_failed(self, dag_run: "DagRun", msg: str):
         event = RunEvent(
             eventType=RunState.FAIL,

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -4,20 +4,17 @@
 import os
 
 from airflow.plugins_manager import AirflowPlugin
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
-
 
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+from openlineage.airflow.utils import is_airflow_version_enough
 
 
 def _is_disabled():
     return os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]
 
 
-if parse_version(AIRFLOW_VERSION) \
-        < parse_version("2.3.0.dev0") or _is_disabled():      # type: ignore
+if not is_airflow_version_enough("2.3.0") or _is_disabled():      # type: ignore
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
         macros = [lineage_run_id, lineage_parent_id]

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -7,8 +7,6 @@ import uuid
 from typing import Optional
 
 from airflow.lineage.backend import LineageBackend
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
 
 
 class Backend:
@@ -93,7 +91,8 @@ class OpenLineageBackend(LineageBackend):
     @classmethod
     def send_lineage(cls, *args, **kwargs):
         # Do not use LineageBackend approach when we can use plugins
-        if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
+        from openlineage.airflow.utils import is_airflow_version_enough
+        if is_airflow_version_enough("2.3.0"):
             return
         # Make this method a noop if OPENLINEAGE_DISABLED is set to true
         if os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:

--- a/integration/airflow/scripts/run-dev-airflow.sh
+++ b/integration/airflow/scripts/run-dev-airflow.sh
@@ -71,7 +71,7 @@ function compose_up() {
     UP_ARGS+="-d"
   fi
 
-  docker-compose -f $YAML_LOCATION/docker-compose.yml -f $YAML_LOCATION/docker-compose-dev.yml down
+  docker-compose -f $YAML_LOCATION/docker-compose.yml -f $YAML_LOCATION/docker-compose-dev.yml down -v
   docker-compose -f $YAML_LOCATION/docker-compose.yml -f $YAML_LOCATION/docker-compose-dev.yml --profile dev up $UP_ARGS
 }
 

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -39,7 +39,7 @@ install_command = python -m pip install {opts} --find-links target/wheels/ \
 	{packages}
 deps = -r dev-requirements.txt
 	pytest
-	mypy>=0.9.6
+	mypy>=0.960
 	codecov>=1.4.0
 	airflow-2.1.4: apache-airflow==2.1.4
 	airflow-2.2.4: apache-airflow==2.2.4

--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -4,7 +4,7 @@ COPY integration/sql /app/openlineage/integration/sql
 COPY integration/common /app/openlineage/integration/common
 COPY integration/airflow /app/openlineage/integration/airflow
 COPY client/python /app/openlineage/client/python
-COPY integration/target /app/openlineage/integration/sql/target
+COPY integration/targe[t] /app/openlineage/integration/sql/target
 USER root
 RUN mkdir -p /opt/data
 RUN apt-get update && apt-get install -y git
@@ -21,6 +21,11 @@ RUN AIRFLOW_VERSION=`airflow version` && \
     pip install --no-cache-dir --use-deprecated=legacy-resolver -r dev-requirements.txt \
     --constraint=https://raw.githubusercontent.com/apache/airflow/constraints-$AIRFLOW_VERSION/constraints-$PYTHON_VERSION.txt
 
+COPY debug.patch /tmp/patch.patch
+RUN if [[ "$(airflow version)" > "2.5" ]]; then \
+    cd /home/airflow/.local/lib/python3.7/site-packages/airflow; \
+    patch -u -p 2 < /tmp/patch.patch; \
+    fi
 
 FROM python:3.7-slim as integration
 RUN mkdir -p /app && mkdir -p /opt/openlineage

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -36,9 +36,10 @@ export BIGQUERY_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")
 export DBT_DATASET_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")_dbt
 # just a hack to have same docker-compose for dev and CI env
 export PWD='.'
-
+EXIT_CODE=0
 docker-compose -f tests/docker-compose.yml down -v
 docker-compose -f tests/docker-compose.yml build
-docker-compose -f tests/docker-compose.yml run integration
+docker-compose -f tests/docker-compose.yml run integration || EXIT_CODE=$?
 docker-compose -f tests/docker-compose.yml logs > tests/airflow/logs/docker.log
 docker-compose -f tests/docker-compose.yml down
+exit $EXIT_CODE

--- a/integration/airflow/tests/integration/server/app.py
+++ b/integration/airflow/tests/integration/server/app.py
@@ -80,11 +80,13 @@ def lineage():
     conn = get_conn()
     if request.method == 'POST':
         job_name = request.json['job']['name']
+        event_time = request.json['eventTime']
         conn.execute("""
-            INSERT INTO requests values (:body, :job_name, CURRENT_TIMESTAMP)
+            INSERT INTO requests values (:body, :job_name, :created_at)
         """, {
             "body": json.dumps(request.json),
-            "job_name": job_name
+            "job_name": job_name,
+            "created_at": event_time,
         })
         logger.info(f"job_name: {job_name}")
         logger.info(json.dumps(request.json, sort_keys=True))

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -7,14 +7,14 @@ import os
 import sys
 from typing import List
 
-from pkg_resources import parse_version
-
 import psycopg2
 import time
 import requests
+from pkg_resources import parse_version
 from retrying import retry
 import pytest
 import unittest
+
 from openlineage.common.test import match, setup_jinja
 
 env = setup_jinja()
@@ -144,7 +144,7 @@ params = [
 ]
 
 
-@retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_delay=1000*10*60)
+@retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_delay=1000*1*60)
 def wait_for_dag(dag_id, airflow_db_conn) -> bool:
     log.info(f"Waiting for DAG '{dag_id}'...")
 
@@ -166,6 +166,8 @@ def wait_for_dag(dag_id, airflow_db_conn) -> bool:
         return False
     elif state != "success":
         raise Exception("Retry!")
+    # just wait a bit until dagrun complete event arrives
+    time.sleep(1.5)
     return True
 
 
@@ -283,7 +285,7 @@ def test_integration(dag_id, request_path, airflow_db_conn):
         "requests/dag_order",
         [],
         marks=pytest.mark.skipif(
-            not IS_AIRFLOW_VERSION_ENOUGH("2.5.0rc2"), reason="Airflow <= 2.5.0rc2"
+            not IS_AIRFLOW_VERSION_ENOUGH("2.5.0"), reason="Airflow <= 2.5.0"
         ),
     )
 ])

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -22,6 +22,8 @@ levels = {
     "great_expectations": "INFO",
     "airflow.lineage": "DEBUG",
     "airflow.processor_manager": "WARNING",
+    "airflow.jobs": "DEBUG",
+    "airflow": "DEBUG",
     "botocore": "INFO",
 }
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -1,12 +1,11 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from airflow import DAG
-from airflow.version import version as AIRFLOW_VERSION
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.dates import days_ago
 
+from openlineage.airflow.utils import is_airflow_version_enough
 from openlineage.client import set_producer
-from pkg_resources import parse_version
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 
@@ -29,8 +28,6 @@ default_args = {
 }
 
 
-
-
 dag = DAG(
     'postgres_orders_popular_day_of_week',
     schedule_interval='@once',
@@ -41,8 +38,8 @@ dag = DAG(
     description='Determines the popular day of week orders are placed.'
 )
 
-if parse_version(AIRFLOW_VERSION) < parse_version('2.5.0'):
-    t1 = PostgresOperator(    
+if not is_airflow_version_enough('2.5.0'):
+    t1 = PostgresOperator(
         task_id='postgres_if_not_exists',
         postgres_conn_id='food_delivery_db',
         sql="{{ get_sql() }}",

--- a/integration/airflow/tests/log_config.py
+++ b/integration/airflow/tests/log_config.py
@@ -21,7 +21,9 @@ levels = {
     "openlineage": "DEBUG",
     "great_expectations": "INFO",
     "airflow.lineage": "DEBUG",
+    "airflow.jobs": "DEBUG",
     "botocore": "INFO",
+    "airflow": "DEBUG"
 }
 
 for el, lvl in levels.items():


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>
Credits to: Maciej Obuchowski @mobuchowski 
### Problem

Airflow 2.5 added proper lifecycle methods to plugins. This means we can properly start-and-stop thread pool, without risk that tasks send to it would get killed before the worker process ends. This resolves issue with long running extractions and thread blocks.

Closes: #1226 

### Solution

Create `ThreadPoolExecutor` in lifecycle hooks and submit extraction methods to the pool

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project