### PR TITLE
Fix README typos for java client and spark integration #1401

### DIFF
--- a/client/java/README.md
+++ b/client/java/README.md
@@ -178,7 +178,7 @@ If contributing changes, additions or fixes to the Java client, please include t
 
 ```
 /*
-/* Copyright 2018-2002 contributors to the OpenLineage project
+/* Copyright 2018-2022 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0 
 */
 ```

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -339,7 +339,7 @@ If contributing changes, additions or fixes to the Spark integration, please inc
 
 ```
 /* 
-/* Copyright 2018-2002 contributors to the OpenLineage project
+/* Copyright 2018-2022 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0 
 */
 ```


### PR DESCRIPTION
Signed-off-by: versaurabh <saurabh.verma@datastax.com>

### Problem

- The line at https://github.com/OpenLineage/OpenLineage/blob/main/client/java/README.md?plain=1#L181 says `2018-2002` which should be `2018-2022`
- Similar typo at https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/README.md?plain=1#L342

Closes: #1401 

### Solution
- Fixes the typos appropriately

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project