### PR TITLE
avoid integration tests launch on README.md updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           function check_change () {
             MOD=$1
             shift
-            if [ $(git diff --name-only main $MOD | wc -l) -gt 0 ]; then
+            if [ $(git diff --name-only main $MOD | grep -v "README.md" | wc -l) -gt 0 ]; then
               echo "Change found in $MOD"
               if [ "$1" == "*" ]; then
                 ls -d $PWD/.circleci/workflows/* > workflow_files.txt


### PR DESCRIPTION
Signed-off-by: versaurabh <saurabh.verma@datastax.com>

### Problem

- PRs like https://github.com/OpenLineage/OpenLineage/pull/1402 which change only README.md should not trigger the corresponding module's integration tests (as these are documentation changes which need to be reviewed explicitly by reviewers anyway)

Closes: #1403 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project