### PR TITLE
[Integration][Airflow] Add integration test for S3CopyObjectExtractor

### DIFF
--- a/integration/airflow/tests/integration/docker/s3/create-bucket.sh
+++ b/integration/airflow/tests/integration/docker/s3/create-bucket.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+awslocal s3 mb s3://testbucket
+echo "OpenLineage rocks!" > testfile
+awslocal s3 cp testfile s3://testbucket/
+rm testfile

--- a/integration/airflow/tests/integration/requests/s3copy.json
+++ b/integration/airflow/tests/integration/requests/s3copy.json
@@ -1,0 +1,22 @@
+[{
+    "eventType": "START",
+    "inputs": [
+        {
+            "name": "testfile",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "job": {
+        "facets": {},
+        "name": "s3copy_dag.s3copy_task"
+    },
+    "outputs": [
+        {
+            "name": "testfile2",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -134,6 +134,13 @@ params = [
         ),
     ),
     ("sftp_dag", "requests/sftp.json"),
+    pytest.param(
+        "s3copy_dag",
+        "requests/s3copy.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"
+        ),
+    ),
 ]
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
@@ -1,0 +1,16 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
+from airflow.utils.dates import days_ago
+
+
+with DAG(dag_id="s3copy_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
+    S3CopyObjectOperator(
+        task_id="s3copy_task",
+        aws_conn_id="aws_local_conn",
+        source_bucket_name="testbucket",
+        dest_bucket_name="testbucket",
+        source_bucket_key="testfile",
+        dest_bucket_key="testfile2",
+    )

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -49,6 +49,7 @@ x-airflow-base: &airflow-base
     AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json", "variables_file_path": "/opt/data/secrets/variables.json" }'
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=ROBOTS&role=OPENLINEAGE"
     AIRFLOW_CONN_AWS_CONN: "aws://"
+    AIRFLOW_CONN_AWS_LOCAL_CONN: "aws://?aws_access_key_id=k&aws_secret_access_key=v&endpoint_url=http%3A%2F%2Flocalstack%3A4566"
     AIRFLOW_CONN_SFTP_CONN: sftp://airflow:airflow@openssh-server:2222
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
@@ -70,6 +71,8 @@ x-airflow-base: &airflow-base
       condition: service_healthy
     backend:
       condition: service_healthy
+    localstack:
+      condition: service_healthy
 
 services:
   integration:
@@ -89,6 +92,7 @@ services:
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
       AWS_ATHENA_OUTPUT_LOCATION: ${AWS_ATHENA_OUTPUT_LOCATION}
       AWS_ATHENA_SUFFIX: ${AWS_ATHENA_SUFFIX}
+      AIRFLOW_CONN_AWS_LOCAL_CONN: ${AIRFLOW_CONN_AWS_LOCAL_CONN}
     networks:
       - app_net
     volumes:
@@ -273,6 +277,20 @@ services:
       timeout: 30s
       retries: 50
 
+  localstack:
+    image: localstack/localstack
+    networks:
+      - app_net
+    expose:
+      - 4566
+    volumes:
+      - ../docker/s3:/docker-entrypoint-initaws.d
+    healthcheck:
+      test: ["CMD", "awslocal", "s3api", "list-buckets"]
+      interval: 5s
+      timeout: 30s
+      retries: 50
+
 networks:
   app_net:
     driver: bridge
@@ -281,4 +299,3 @@ networks:
       config:
         - subnet: 172.16.238.0/24
           gateway: 172.16.238.1
-


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

Currently, S3CopyObjectExtractor doesn't have an integration test.

### Solution

This PR adds an integration test for S3CopyObjectExtractor. It leverages [LocalStack](https://localstack.cloud/) for pretending S3 so that we can run it without AWS account.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project