### PR TITLE
[INTEGRATION][dbt] add postgres support to the dbt integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.18.0...HEAD)
 
+### Added
+* dbt: add support for postgres datasources [`#1417`](https://github.com/OpenLineage/OpenLineage/pull/1417) [@julienledem](https://github.com/julienledem)
+    * Adds the previously unsupported postgres datasource type
+
 ## [0.18.0](https://github.com/OpenLineage/OpenLineage/compare/0.17.0...0.18.0) - 2022-12-6
 ### Added
 * Airflow: support `SQLExecuteQueryOperator` [`#1379`](https://github.com/OpenLineage/OpenLineage/pull/1379) [@JDarDagran](https://github.com/JDarDagran)  

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -33,6 +33,7 @@ class Adapter(Enum):
     SNOWFLAKE = 'snowflake'
     REDSHIFT = 'redshift'
     SPARK = 'spark'
+    POSTGRES = 'postgres'
 
     @staticmethod
     def adapters() -> str:
@@ -215,7 +216,10 @@ class DbtArtifactProcessor:
         profile_dir = run_result['args']['profiles_dir']
 
         if not self.profile_name:
-            self.profile_name = self.project['profile']
+            if self.project.get('profile'):
+                self.profile_name = self.project.get('profile')
+            else:
+                raise KeyError(f'profile not found in {self.project}')
 
         profile = self.load_yaml_with_jinja(
             os.path.join(profile_dir, 'profiles.yml')
@@ -688,6 +692,8 @@ class DbtArtifactProcessor:
             return "bigquery"
         elif self.adapter_type == Adapter.REDSHIFT:
             return f"redshift://{profile['host']}:{profile['port']}"
+        elif self.adapter_type == Adapter.POSTGRES:
+            return f"postgres://{profile['host']}:{profile['port']}"
         elif self.adapter_type == Adapter.SPARK:
             port = ""
 

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -3,6 +3,7 @@
 
 import os
 import logging
+import json
 from dateutil.parser import parse
 from jinja2 import Environment
 from typing import Any, Optional
@@ -110,7 +111,10 @@ def match(expected, result) -> bool:
                     return False
             else:
                 if not match(x, result[i]):
-                    log.error(f"List not matched expected: {x} result: {result[i]}")
+                    log.error(
+                        f"List not matched at {i}\n" +
+                        f"  expected:\n{json.dumps(x)}\n" +
+                        f"  result: \n{json.dumps(result[i])}")
                     return False
     elif isinstance(expected, str):
         if '{{' in expected:

--- a/integration/common/tests/dbt/postgres/dbt_project.yml
+++ b/integration/common/tests/dbt/postgres/dbt_project.yml
@@ -1,0 +1,26 @@
+name: 'jaffle_shop'
+
+config-version: 2
+version: '0.1'
+
+profile: 'postgres_profile'
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+analysis-paths: ["analysis"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+    - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+
+models:
+  jaffle_shop:
+      materialized: table
+      staging:
+        materialized: view

--- a/integration/common/tests/dbt/postgres/profiles.yml
+++ b/integration/common/tests/dbt/postgres/profiles.yml
@@ -1,0 +1,11 @@
+postgres_profile:
+  outputs:
+    dev:
+      dbname: 'POSTGRES_DATABASE'
+      host: 'POSTGRES_HOST'
+      pass: 'POSTGRES_PASSWORD'
+      port: 1234
+      schema: 'POSTGRES_SCHEMA'
+      type: postgres
+      user: 'POSTGRES_USER'
+  target: dev

--- a/integration/common/tests/dbt/postgres/result.json
+++ b/integration/common/tests/dbt/postgres/result.json
@@ -1,0 +1,967 @@
+[{
+	"eventType": "START",
+	"eventTime": "2022-12-14T21:28:16.899571Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_customers",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "customer_id",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "START",
+	"eventTime": "2022-12-14T21:28:16.997052Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_orders",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "START",
+	"eventTime": "2022-12-14T21:28:17.045744Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_payments",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "START",
+	"eventTime": "2022-12-14T21:28:17.093727Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.customers",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "customer_id",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "non_empty_column",
+					"type": null,
+					"description": "This is a test column"
+				}, {
+					"name": "empty_column",
+					"type": null,
+					"description": "This is a test column"
+				}, {
+					"name": "customer_id",
+					"type": null,
+					"description": "This is a unique identifier for a customer"
+				}, {
+					"name": "first_name",
+					"type": null,
+					"description": "Customer's first name. PII."
+				}, {
+					"name": "last_name",
+					"type": null,
+					"description": "Customer's last name. PII."
+				}, {
+					"name": "first_order",
+					"type": null,
+					"description": "Date (UTC) of a customer's first order"
+				}, {
+					"name": "most_recent_order",
+					"type": null,
+					"description": "Date (UTC) of a customer's most recent order"
+				}, {
+					"name": "number_of_orders",
+					"type": null,
+					"description": "Count of the number of orders a customer has placed"
+				}, {
+					"name": "total_order_amount",
+					"type": null,
+					"description": "Total value (AUD) of a customer's orders"
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "START",
+	"eventTime": "2022-12-14T21:28:17.156316Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.orders",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "\n\nwith orders as (\n\n    select * from \"postgres\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"postgres\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": "This is a unique identifier for an order"
+				}, {
+					"name": "customer_id",
+					"type": null,
+					"description": "Foreign key to the customers table"
+				}, {
+					"name": "order_date",
+					"type": null,
+					"description": "Date (UTC) that the order was placed"
+				}, {
+					"name": "status",
+					"type": null,
+					"description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+				}, {
+					"name": "amount",
+					"type": null,
+					"description": "Total amount (AUD) of the order"
+				}, {
+					"name": "credit_card_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by credit card"
+				}, {
+					"name": "coupon_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by coupon"
+				}, {
+					"name": "bank_transfer_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by bank transfer"
+				}, {
+					"name": "gift_card_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by gift card"
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2022-12-14T21:28:16.964210Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_customers",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "customer_id",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2022-12-14T21:28:17.030362Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_orders",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2022-12-14T21:28:17.076892Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.stg_payments",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with source as (\n    select * from \"postgres\".\"public\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2022-12-14T21:28:17.140203Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.customers",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "customer_id",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.customers",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "non_empty_column",
+					"type": null,
+					"description": "This is a test column"
+				}, {
+					"name": "empty_column",
+					"type": null,
+					"description": "This is a test column"
+				}, {
+					"name": "customer_id",
+					"type": null,
+					"description": "This is a unique identifier for a customer"
+				}, {
+					"name": "first_name",
+					"type": null,
+					"description": "Customer's first name. PII."
+				}, {
+					"name": "last_name",
+					"type": null,
+					"description": "Customer's last name. PII."
+				}, {
+					"name": "first_order",
+					"type": null,
+					"description": "Date (UTC) of a customer's first order"
+				}, {
+					"name": "most_recent_order",
+					"type": null,
+					"description": "Date (UTC) of a customer's most recent order"
+				}, {
+					"name": "number_of_orders",
+					"type": null,
+					"description": "Count of the number of orders a customer has placed"
+				}, {
+					"name": "total_order_amount",
+					"type": null,
+					"description": "Total value (AUD) of a customer's orders"
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}, {
+	"eventType": "COMPLETE",
+	"eventTime": "2022-12-14T21:28:17.196590Z",
+	"run": {
+		"runId": "{{ any(result) }}",
+		"facets": {
+			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/ParentRunFacet",
+				"run": {
+					"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+				},
+				"job": {
+					"namespace": "dbt",
+					"name": "dbt-job-name"
+				}
+			},
+			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "1.3.1"
+			}
+		}
+	},
+	"job": {
+		"namespace": "job-namespace",
+		"name": "postgres.public.jaffle_shop.orders",
+		"facets": {
+			"sql": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
+				"query": "\n\nwith orders as (\n\n    select * from \"postgres\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"postgres\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final"
+			}
+		}
+	},
+	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+	"inputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "status",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}, {
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.stg_payments",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "payment_id",
+					"type": null,
+					"description": ""
+				}, {
+					"name": "payment_method",
+					"type": null,
+					"description": ""
+				}]
+			}
+		}
+	}],
+	"outputs": [{
+		"namespace": "postgres://POSTGRES_HOST:1234",
+		"name": "postgres.public.orders",
+		"facets": {
+			"dataSource": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
+				"name": "postgres://POSTGRES_HOST:1234",
+				"uri": "postgres://POSTGRES_HOST:1234"
+			},
+			"schema": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SchemaDatasetFacet",
+				"fields": [{
+					"name": "order_id",
+					"type": null,
+					"description": "This is a unique identifier for an order"
+				}, {
+					"name": "customer_id",
+					"type": null,
+					"description": "Foreign key to the customers table"
+				}, {
+					"name": "order_date",
+					"type": null,
+					"description": "Date (UTC) that the order was placed"
+				}, {
+					"name": "status",
+					"type": null,
+					"description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+				}, {
+					"name": "amount",
+					"type": null,
+					"description": "Total amount (AUD) of the order"
+				}, {
+					"name": "credit_card_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by credit card"
+				}, {
+					"name": "coupon_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by coupon"
+				}, {
+					"name": "bank_transfer_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by bank transfer"
+				}, {
+					"name": "gift_card_amount",
+					"type": null,
+					"description": "Amount of the order (AUD) paid for by gift card"
+				}]
+			}
+		},
+		"outputFacets": {}
+	}]
+}]

--- a/integration/common/tests/dbt/postgres/target/manifest.json
+++ b/integration/common/tests/dbt/postgres/target/manifest.json
@@ -1,0 +1,9171 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v7.json",
+		"dbt_version": "1.3.1",
+		"generated_at": "2022-12-14T21:28:16.748601Z",
+		"invocation_id": "1269f08d-da04-4fbd-8207-1ddc9110cb1b",
+		"env": {},
+		"project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+		"user_id": "d4ca93bc-5407-4697-af99-bdaaa8f38ab6",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "postgres"
+	},
+	"nodes": {
+		"model.jaffle_shop.customers": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": [],
+				"nodes": ["model.jaffle_shop.stg_customers", "model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "table",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "customers"],
+			"unique_id": "model.jaffle_shop.customers",
+			"raw_code": "with\n  customers as (\n\n    select *\n    from {{ ref('stg_customers') }}\n\n  ),\n\n  orders as (\n\n    select *\n    from {{ ref('stg_orders') }}\n\n  ),\n\n  payments as (\n\n    select *\n    from {{ ref('stg_payments') }}\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "customers.sql",
+			"original_file_path": "models/customers.sql",
+			"name": "customers",
+			"alias": "customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "5388003af87ae7b287b4c65a097fd536d706568f47c3464b8a9d6b64e44e4f7a"
+			},
+			"tags": [],
+			"refs": [
+				["stg_customers"],
+				["stg_orders"],
+				["stg_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+			"columns": {
+				"non_empty_column": {
+					"name": "non_empty_column",
+					"description": "This is a test column",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"empty_column": {
+					"name": "empty_column",
+					"description": "This is a test column",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"description": "This is a unique identifier for a customer",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"first_name": {
+					"name": "first_name",
+					"description": "Customer's first name. PII.",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"last_name": {
+					"name": "last_name",
+					"description": "Customer's last name. PII.",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"first_order": {
+					"name": "first_order",
+					"description": "Date (UTC) of a customer's first order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"most_recent_order": {
+					"name": "most_recent_order",
+					"description": "Date (UTC) of a customer's most recent order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"number_of_orders": {
+					"name": "number_of_orders",
+					"description": "Count of the number of orders a customer has placed",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"total_order_amount": {
+					"name": "total_order_amount",
+					"description": "Total value (AUD) of a customer's orders",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": "jaffle_shop://models/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/customers.sql",
+			"build_path": "target/run/jaffle_shop/models/customers.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1670976638.457581,
+			"compiled_code": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "\"postgres\".\"public\".\"customers\""
+		},
+		"model.jaffle_shop.orders": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": [],
+				"nodes": ["model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "table",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "orders"],
+			"unique_id": "model.jaffle_shop.orders",
+			"raw_code": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "orders.sql",
+			"original_file_path": "models/orders.sql",
+			"name": "orders",
+			"alias": "orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "53950235d8e29690d259e95ee49bda6a5b7911b44c739b738a646dc6014bcfcd"
+			},
+			"tags": [],
+			"refs": [
+				["stg_orders"],
+				["stg_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "This table has basic information about orders, as well as some derived facts based on payments",
+			"columns": {
+				"order_id": {
+					"name": "order_id",
+					"description": "This is a unique identifier for an order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"description": "Foreign key to the customers table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"order_date": {
+					"name": "order_date",
+					"description": "Date (UTC) that the order was placed",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"status": {
+					"name": "status",
+					"description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"amount": {
+					"name": "amount",
+					"description": "Total amount (AUD) of the order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"credit_card_amount": {
+					"name": "credit_card_amount",
+					"description": "Amount of the order (AUD) paid for by credit card",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"coupon_amount": {
+					"name": "coupon_amount",
+					"description": "Amount of the order (AUD) paid for by coupon",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"bank_transfer_amount": {
+					"name": "bank_transfer_amount",
+					"description": "Amount of the order (AUD) paid for by bank transfer",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"gift_card_amount": {
+					"name": "gift_card_amount",
+					"description": "Amount of the order (AUD) paid for by gift card",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": "jaffle_shop://models/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/orders.sql",
+			"build_path": "target/run/jaffle_shop/models/orders.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1670976638.4602447,
+			"compiled_code": "\n\nwith orders as (\n\n    select * from \"postgres\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"postgres\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "\"postgres\".\"public\".\"orders\""
+		},
+		"model.jaffle_shop.stg_customers": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": [],
+				"nodes": ["seed.jaffle_shop.raw_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "view",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_customers"],
+			"unique_id": "model.jaffle_shop.stg_customers",
+			"raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "staging/stg_customers.sql",
+			"original_file_path": "models/staging/stg_customers.sql",
+			"name": "stg_customers",
+			"alias": "stg_customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "6f18a29204dad1de6dbb0c288144c4990742e0a1e065c3b2a67b5f98334c22ba"
+			},
+			"tags": [],
+			"refs": [
+				["raw_customers"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {
+				"customer_id": {
+					"name": "customer_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_customers.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1670976638.4903996,
+			"compiled_code": "with source as (\n    select * from \"postgres\".\"public\".\"raw_customers\"\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "\"postgres\".\"public\".\"stg_customers\""
+		},
+		"model.jaffle_shop.stg_orders": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": [],
+				"nodes": ["seed.jaffle_shop.raw_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "view",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_orders"],
+			"unique_id": "model.jaffle_shop.stg_orders",
+			"raw_code": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "staging/stg_orders.sql",
+			"original_file_path": "models/staging/stg_orders.sql",
+			"name": "stg_orders",
+			"alias": "stg_orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "afffa9cbc57e5fd2cf5898ebf571d444a62c9d6d7929d8133d30567fb9a2ce97"
+			},
+			"tags": [],
+			"refs": [
+				["raw_orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {
+				"order_id": {
+					"name": "order_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"status": {
+					"name": "status",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_orders.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1670976638.4910421,
+			"compiled_code": "with source as (\n    select * from \"postgres\".\"public\".\"raw_orders\"\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "\"postgres\".\"public\".\"stg_orders\""
+		},
+		"model.jaffle_shop.stg_payments": {
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": [],
+				"nodes": ["seed.jaffle_shop.raw_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "view",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_payments"],
+			"unique_id": "model.jaffle_shop.stg_payments",
+			"raw_code": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "staging/stg_payments.sql",
+			"original_file_path": "models/staging/stg_payments.sql",
+			"name": "stg_payments",
+			"alias": "stg_payments",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "eb899938258d1fba27fca716a7c334119912a2f9601282026097a7b6ce8cfcd2"
+			},
+			"tags": [],
+			"refs": [
+				["raw_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {
+				"payment_id": {
+					"name": "payment_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"payment_method": {
+					"name": "payment_method",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_payments.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1670976638.491755,
+			"compiled_code": "with source as (\n    select * from \"postgres\".\"public\".\"raw_payments\"\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "\"postgres\".\"public\".\"stg_payments\""
+		},
+		"seed.jaffle_shop.raw_customers": {
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "seed",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_customers"],
+			"unique_id": "seed.jaffle_shop.raw_customers",
+			"raw_code": "",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "raw_customers.csv",
+			"original_file_path": "seeds/raw_customers.csv",
+			"name": "raw_customers",
+			"alias": "raw_customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "24579b4b26098d43265376f3c50be8b10faf8e8fd95f5508074f10f76a12671d"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4417398
+		},
+		"seed.jaffle_shop.raw_orders": {
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "seed",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_orders"],
+			"unique_id": "seed.jaffle_shop.raw_orders",
+			"raw_code": "",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "raw_orders.csv",
+			"original_file_path": "seeds/raw_orders.csv",
+			"name": "raw_orders",
+			"alias": "raw_orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "ee6c68d1639ec2b23a4495ec12475e09b8ed4b61e23ab0411ea7ec76648356f7"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4431272
+		},
+		"seed.jaffle_shop.raw_payments": {
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "seed",
+				"incremental_strategy": null,
+				"persist_docs": {},
+				"quoting": {},
+				"column_types": {},
+				"full_refresh": null,
+				"unique_key": null,
+				"on_schema_change": "ignore",
+				"grants": {},
+				"packages": [],
+				"docs": {
+					"show": true,
+					"node_color": null
+				},
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "postgres",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_payments"],
+			"unique_id": "seed.jaffle_shop.raw_payments",
+			"raw_code": "",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "raw_payments.csv",
+			"original_file_path": "seeds/raw_payments.csv",
+			"name": "raw_payments",
+			"alias": "raw_payments",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "03fd407f3135f84456431a923f22fc185a2154079e210c20b690e3ab11687d11"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4446492
+		},
+		"test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": {
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('customers')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.customers"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "unique_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+			"raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "unique_customers_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "unique_customers_customer_id",
+			"alias": "unique_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["customers"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4646447,
+			"column_name": "customer_id",
+			"file_key_name": "models.customers"
+		},
+		"test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('customers')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.customers"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_customers_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_customers_customer_id",
+			"alias": "not_null_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["customers"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4659085,
+			"column_name": "customer_id",
+			"file_key_name": "models.customers"
+		},
+		"test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "order_id",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "unique_orders_order_id"],
+			"unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+			"raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "unique_orders_order_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "unique_orders_order_id",
+			"alias": "unique_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4668329,
+			"column_name": "order_id",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_order_id.cf6c17daed": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "order_id",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_order_id"],
+			"unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_order_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_order_id",
+			"alias": "not_null_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4677434,
+			"column_name": "order_id",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_customer_id.c5f02694af": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_customer_id",
+			"alias": "not_null_orders_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4690251,
+			"column_name": "customer_id",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": {
+			"test_metadata": {
+				"name": "relationships",
+				"kwargs": {
+					"to": "ref('customers')",
+					"field": "customer_id",
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_relationships", "macro.dbt.get_where_subquery"],
+				"nodes": ["model.jaffle_shop.customers", "model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "relationships_orders_customer_id__customer_id__ref_customers_"],
+			"unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+			"raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "relationships_orders_customer_id__customer_id__ref_customers_.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "relationships_orders_customer_id__customer_id__ref_customers_",
+			"alias": "relationships_orders_customer_id__customer_id__ref_customers_",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["customers"],
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4711032,
+			"column_name": "customer_id",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": {
+			"test_metadata": {
+				"name": "accepted_values",
+				"kwargs": {
+					"values": ["placed", "shipped", "completed", "return_pending", "returned"],
+					"column_name": "status",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.get_where_subquery"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"],
+			"unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+			"raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+			"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
+			},
+			"created_at": 1670976638.4787478,
+			"column_name": "status",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_amount.106140f9fd": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "amount",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_amount",
+			"alias": "not_null_orders_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4844713,
+			"column_name": "amount",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "credit_card_amount",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_credit_card_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_credit_card_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_credit_card_amount",
+			"alias": "not_null_orders_credit_card_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4856763,
+			"column_name": "credit_card_amount",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "coupon_amount",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_coupon_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_coupon_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_coupon_amount",
+			"alias": "not_null_orders_coupon_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4870396,
+			"column_name": "coupon_amount",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "bank_transfer_amount",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_bank_transfer_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_bank_transfer_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_bank_transfer_amount",
+			"alias": "not_null_orders_bank_transfer_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4881222,
+			"column_name": "bank_transfer_amount",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "gift_card_amount",
+					"model": "{{ get_where_subquery(ref('orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "not_null_orders_gift_card_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_orders_gift_card_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_gift_card_amount",
+			"alias": "not_null_orders_gift_card_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4891124,
+			"column_name": "gift_card_amount",
+			"file_key_name": "models.orders"
+		},
+		"test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": {
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('stg_customers')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "unique_stg_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+			"raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "unique_stg_customers_customer_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_customers_customer_id",
+			"alias": "unique_stg_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_customers"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4921725,
+			"column_name": "customer_id",
+			"file_key_name": "models.stg_customers"
+		},
+		"test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "customer_id",
+					"model": "{{ get_where_subquery(ref('stg_customers')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "not_null_stg_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_stg_customers_customer_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_customers_customer_id",
+			"alias": "not_null_stg_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_customers"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4931448,
+			"column_name": "customer_id",
+			"file_key_name": "models.stg_customers"
+		},
+		"test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": {
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "order_id",
+					"model": "{{ get_where_subquery(ref('stg_orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "unique_stg_orders_order_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+			"raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "unique_stg_orders_order_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_orders_order_id",
+			"alias": "unique_stg_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.4940598,
+			"column_name": "order_id",
+			"file_key_name": "models.stg_orders"
+		},
+		"test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "order_id",
+					"model": "{{ get_where_subquery(ref('stg_orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "not_null_stg_orders_order_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_stg_orders_order_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_orders_order_id",
+			"alias": "not_null_stg_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.49496,
+			"column_name": "order_id",
+			"file_key_name": "models.stg_orders"
+		},
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": {
+			"test_metadata": {
+				"name": "accepted_values",
+				"kwargs": {
+					"values": ["placed", "shipped", "completed", "return_pending", "returned"],
+					"column_name": "status",
+					"model": "{{ get_where_subquery(ref('stg_orders')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.get_where_subquery"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"],
+			"unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+			"raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+			"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+			},
+			"created_at": 1670976638.4964771,
+			"column_name": "status",
+			"file_key_name": "models.stg_orders"
+		},
+		"test.jaffle_shop.unique_stg_payments_payment_id.3744510712": {
+			"test_metadata": {
+				"name": "unique",
+				"kwargs": {
+					"column_name": "payment_id",
+					"model": "{{ get_where_subquery(ref('stg_payments')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "unique_stg_payments_payment_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+			"raw_code": "{{ test_unique(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "unique_stg_payments_payment_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_payments_payment_id",
+			"alias": "unique_stg_payments_payment_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.503398,
+			"column_name": "payment_id",
+			"file_key_name": "models.stg_payments"
+		},
+		"test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": {
+			"test_metadata": {
+				"name": "not_null",
+				"kwargs": {
+					"column_name": "payment_id",
+					"model": "{{ get_where_subquery(ref('stg_payments')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "not_null_stg_payments_payment_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+			"raw_code": "{{ test_not_null(**_dbt_generic_test_kwargs) }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "not_null_stg_payments_payment_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_payments_payment_id",
+			"alias": "not_null_stg_payments_payment_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1670976638.5057337,
+			"column_name": "payment_id",
+			"file_key_name": "models.stg_payments"
+		},
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": {
+			"test_metadata": {
+				"name": "accepted_values",
+				"kwargs": {
+					"values": ["credit_card", "coupon", "bank_transfer", "gift_card"],
+					"column_name": "payment_method",
+					"model": "{{ get_where_subquery(ref('stg_payments')) }}"
+				},
+				"namespace": null
+			},
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.get_where_subquery"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"meta": {},
+				"materialized": "test",
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0"
+			},
+			"database": "postgres",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "staging", "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"],
+			"unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+			"raw_code": "{{ test_accepted_values(**_dbt_generic_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+			"language": "sql",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+			"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": [],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"metrics": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+			},
+			"created_at": 1670976638.5071638,
+			"column_name": "payment_method",
+			"file_key_name": "models.stg_payments"
+		}
+	},
+	"sources": {},
+	"macros": {
+		"macro.dbt_postgres.postgres__current_timestamp": {
+			"unique_id": "macro.dbt_postgres.postgres__current_timestamp",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/timestamps.sql",
+			"original_file_path": "macros/timestamps.sql",
+			"name": "postgres__current_timestamp",
+			"macro_sql": "{% macro postgres__current_timestamp() -%}\n    now()\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976637.983402,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__snapshot_string_as_time": {
+			"unique_id": "macro.dbt_postgres.postgres__snapshot_string_as_time",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/timestamps.sql",
+			"original_file_path": "macros/timestamps.sql",
+			"name": "postgres__snapshot_string_as_time",
+			"macro_sql": "{% macro postgres__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"'\" ~ timestamp ~ \"'::timestamp without time zone\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976637.9836495,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__snapshot_get_time": {
+			"unique_id": "macro.dbt_postgres.postgres__snapshot_get_time",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/timestamps.sql",
+			"original_file_path": "macros/timestamps.sql",
+			"name": "postgres__snapshot_get_time",
+			"macro_sql": "{% macro postgres__snapshot_get_time() -%}\n  {{ current_timestamp() }}::timestamp without time zone\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976637.9837613,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__current_timestamp_backcompat": {
+			"unique_id": "macro.dbt_postgres.postgres__current_timestamp_backcompat",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/timestamps.sql",
+			"original_file_path": "macros/timestamps.sql",
+			"name": "postgres__current_timestamp_backcompat",
+			"macro_sql": "{% macro postgres__current_timestamp_backcompat() %}\n    current_timestamp::{{ type_timestamp() }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.type_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976637.983869,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__current_timestamp_in_utc_backcompat": {
+			"unique_id": "macro.dbt_postgres.postgres__current_timestamp_in_utc_backcompat",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/timestamps.sql",
+			"original_file_path": "macros/timestamps.sql",
+			"name": "postgres__current_timestamp_in_utc_backcompat",
+			"macro_sql": "{% macro postgres__current_timestamp_in_utc_backcompat() %}\n    (current_timestamp at time zone 'utc')::{{ type_timestamp() }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.type_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976637.9839983,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__create_table_as": {
+			"unique_id": "macro.dbt_postgres.postgres__create_table_as",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__create_table_as",
+			"macro_sql": "{% macro postgres__create_table_as(temporary, relation, sql) -%}\n  {%- set unlogged = config.get('unlogged', default=false) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary -%}\n    temporary\n  {%- elif unlogged -%}\n    unlogged\n  {%- endif %} table {{ relation }}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.007407,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__get_create_index_sql": {
+			"unique_id": "macro.dbt_postgres.postgres__get_create_index_sql",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__get_create_index_sql",
+			"macro_sql": "{% macro postgres__get_create_index_sql(relation, index_dict) -%}\n  {%- set index_config = adapter.parse_index(index_dict) -%}\n  {%- set comma_separated_columns = \", \".join(index_config.columns) -%}\n  {%- set index_name = index_config.render(relation) -%}\n\n  create {% if index_config.unique -%}\n    unique\n  {%- endif %} index if not exists\n  \"{{ index_name }}\"\n  on {{ relation }} {% if index_config.type -%}\n    using {{ index_config.type }}\n  {%- endif %}\n  ({{ comma_separated_columns }});\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0079176,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__create_schema": {
+			"unique_id": "macro.dbt_postgres.postgres__create_schema",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__create_schema",
+			"macro_sql": "{% macro postgres__create_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier().include(database=False) }}\n  {%- endcall -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.008235,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__drop_schema": {
+			"unique_id": "macro.dbt_postgres.postgres__drop_schema",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__drop_schema",
+			"macro_sql": "{% macro postgres__drop_schema(relation) -%}\n  {% if relation.database -%}\n    {{ adapter.verify_database(relation.database) }}\n  {%- endif -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier().include(database=False) }} cascade\n  {%- endcall -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0085428,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__get_columns_in_relation": {
+			"unique_id": "macro.dbt_postgres.postgres__get_columns_in_relation",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__get_columns_in_relation",
+			"macro_sql": "{% macro postgres__get_columns_in_relation(relation) -%}\n  {% call statement('get_columns_in_relation', fetch_result=True) %}\n      select\n          column_name,\n          data_type,\n          character_maximum_length,\n          numeric_precision,\n          numeric_scale\n\n      from {{ relation.information_schema('columns') }}\n      where table_name = '{{ relation.identifier }}'\n        {% if relation.schema %}\n        and table_schema = '{{ relation.schema }}'\n        {% endif %}\n      order by ordinal_position\n\n  {% endcall %}\n  {% set table = load_result('get_columns_in_relation').table %}\n  {{ return(sql_convert_columns_in_relation(table)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement", "macro.dbt.sql_convert_columns_in_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0090754,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__list_relations_without_caching": {
+			"unique_id": "macro.dbt_postgres.postgres__list_relations_without_caching",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__list_relations_without_caching",
+			"macro_sql": "{% macro postgres__list_relations_without_caching(schema_relation) %}\n  {% call statement('list_relations_without_caching', fetch_result=True) -%}\n    select\n      '{{ schema_relation.database }}' as database,\n      tablename as name,\n      schemaname as schema,\n      'table' as type\n    from pg_tables\n    where schemaname ilike '{{ schema_relation.schema }}'\n    union all\n    select\n      '{{ schema_relation.database }}' as database,\n      viewname as name,\n      schemaname as schema,\n      'view' as type\n    from pg_views\n    where schemaname ilike '{{ schema_relation.schema }}'\n  {% endcall %}\n  {{ return(load_result('list_relations_without_caching').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0094335,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__information_schema_name": {
+			"unique_id": "macro.dbt_postgres.postgres__information_schema_name",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__information_schema_name",
+			"macro_sql": "{% macro postgres__information_schema_name(database) -%}\n  {% if database_name -%}\n    {{ adapter.verify_database(database_name) }}\n  {%- endif -%}\n  information_schema\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.009599,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__list_schemas": {
+			"unique_id": "macro.dbt_postgres.postgres__list_schemas",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__list_schemas",
+			"macro_sql": "{% macro postgres__list_schemas(database) %}\n  {% if database -%}\n    {{ adapter.verify_database(database) }}\n  {%- endif -%}\n  {% call statement('list_schemas', fetch_result=True, auto_begin=False) %}\n    select distinct nspname from pg_namespace\n  {% endcall %}\n  {{ return(load_result('list_schemas').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0099404,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__check_schema_exists": {
+			"unique_id": "macro.dbt_postgres.postgres__check_schema_exists",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__check_schema_exists",
+			"macro_sql": "{% macro postgres__check_schema_exists(information_schema, schema) -%}\n  {% if information_schema.database -%}\n    {{ adapter.verify_database(information_schema.database) }}\n  {%- endif -%}\n  {% call statement('check_schema_exists', fetch_result=True, auto_begin=False) %}\n    select count(*) from pg_namespace where nspname = '{{ schema }}'\n  {% endcall %}\n  {{ return(load_result('check_schema_exists').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0103188,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__make_relation_with_suffix": {
+			"unique_id": "macro.dbt_postgres.postgres__make_relation_with_suffix",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__make_relation_with_suffix",
+			"macro_sql": "{% macro postgres__make_relation_with_suffix(base_relation, suffix, dstring) %}\n    {% if dstring %}\n      {% set dt = modules.datetime.datetime.now() %}\n      {% set dtstring = dt.strftime(\"%H%M%S%f\") %}\n      {% set suffix = suffix ~ dtstring %}\n    {% endif %}\n    {% set suffix_length = suffix|length %}\n    {% set relation_max_name_length = base_relation.relation_max_name_length() %}\n    {% if suffix_length > relation_max_name_length %}\n        {% do exceptions.raise_compiler_error('Relation suffix is too long (' ~ suffix_length ~ ' characters). Maximum length is ' ~ relation_max_name_length ~ ' characters.') %}\n    {% endif %}\n    {% set identifier = base_relation.identifier[:relation_max_name_length - suffix_length] ~ suffix %}\n\n    {{ return(base_relation.incorporate(path={\"identifier\": identifier })) }}\n\n  {% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0111668,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__make_intermediate_relation": {
+			"unique_id": "macro.dbt_postgres.postgres__make_intermediate_relation",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__make_intermediate_relation",
+			"macro_sql": "{% macro postgres__make_intermediate_relation(base_relation, suffix) %}\n    {{ return(postgres__make_relation_with_suffix(base_relation, suffix, dstring=False)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_relation_with_suffix"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0113623,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__make_temp_relation": {
+			"unique_id": "macro.dbt_postgres.postgres__make_temp_relation",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__make_temp_relation",
+			"macro_sql": "{% macro postgres__make_temp_relation(base_relation, suffix) %}\n    {% set temp_relation = postgres__make_relation_with_suffix(base_relation, suffix, dstring=True) %}\n    {{ return(temp_relation.incorporate(path={\"schema\": none,\n                                              \"database\": none})) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_relation_with_suffix"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0116735,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__make_backup_relation": {
+			"unique_id": "macro.dbt_postgres.postgres__make_backup_relation",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__make_backup_relation",
+			"macro_sql": "{% macro postgres__make_backup_relation(base_relation, backup_relation_type, suffix) %}\n    {% set backup_relation = postgres__make_relation_with_suffix(base_relation, suffix, dstring=False) %}\n    {{ return(backup_relation.incorporate(type=backup_relation_type)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_relation_with_suffix"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0119505,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres_escape_comment": {
+			"unique_id": "macro.dbt_postgres.postgres_escape_comment",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres_escape_comment",
+			"macro_sql": "{% macro postgres_escape_comment(comment) -%}\n  {% if comment is not string %}\n    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}\n  {% endif %}\n  {%- set magic = '$dbt_comment_literal_block$' -%}\n  {%- if magic in comment -%}\n    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}\n  {%- endif -%}\n  {{ magic }}{{ comment }}{{ magic }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0123582,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__alter_relation_comment": {
+			"unique_id": "macro.dbt_postgres.postgres__alter_relation_comment",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__alter_relation_comment",
+			"macro_sql": "{% macro postgres__alter_relation_comment(relation, comment) %}\n  {% set escaped_comment = postgres_escape_comment(comment) %}\n  comment on {{ relation.type }} {{ relation }} is {{ escaped_comment }};\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres_escape_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0125718,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__alter_column_comment": {
+			"unique_id": "macro.dbt_postgres.postgres__alter_column_comment",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__alter_column_comment",
+			"macro_sql": "{% macro postgres__alter_column_comment(relation, column_dict) %}\n  {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute=\"name\") | list %}\n  {% for column_name in column_dict if (column_name in existing_columns) %}\n    {% set comment = column_dict[column_name]['description'] %}\n    {% set escaped_comment = postgres_escape_comment(comment) %}\n    comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres_escape_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0132985,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__get_show_grant_sql": {
+			"unique_id": "macro.dbt_postgres.postgres__get_show_grant_sql",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__get_show_grant_sql",
+			"macro_sql": "\n\n{%- macro postgres__get_show_grant_sql(relation) -%}\n  select grantee, privilege_type\n  from {{ relation.information_schema('role_table_grants') }}\n      where grantor = current_role\n        and grantee != current_role\n        and table_schema = '{{ relation.schema }}'\n        and table_name = '{{ relation.identifier }}'\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.013549,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__copy_grants": {
+			"unique_id": "macro.dbt_postgres.postgres__copy_grants",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "postgres__copy_grants",
+			"macro_sql": "{% macro postgres__copy_grants() %}\n    {{ return(False) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0136704,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__get_catalog": {
+			"unique_id": "macro.dbt_postgres.postgres__get_catalog",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/catalog.sql",
+			"original_file_path": "macros/catalog.sql",
+			"name": "postgres__get_catalog",
+			"macro_sql": "{% macro postgres__get_catalog(information_schema, schemas) -%}\n\n  {%- call statement('catalog', fetch_result=True) -%}\n    {#\n      If the user has multiple databases set and the first one is wrong, this will fail.\n      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.\n    #}\n    {% set database = information_schema.database %}\n    {{ adapter.verify_database(database) }}\n\n    select\n        '{{ database }}' as table_database,\n        sch.nspname as table_schema,\n        tbl.relname as table_name,\n        case tbl.relkind\n            when 'v' then 'VIEW'\n            else 'BASE TABLE'\n        end as table_type,\n        tbl_desc.description as table_comment,\n        col.attname as column_name,\n        col.attnum as column_index,\n        pg_catalog.format_type(col.atttypid, col.atttypmod) as column_type,\n        col_desc.description as column_comment,\n        pg_get_userbyid(tbl.relowner) as table_owner\n\n    from pg_catalog.pg_namespace sch\n    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid\n    join pg_catalog.pg_attribute col on col.attrelid = tbl.oid\n    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)\n    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)\n\n    where (\n        {%- for schema in schemas -%}\n          upper(sch.nspname) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n      )\n      and not pg_is_other_temp_schema(sch.oid) -- not a temporary schema belonging to another session\n      and tbl.relpersistence in ('p', 'u') -- [p]ermanent table or [u]nlogged table. Exclude [t]emporary tables\n      and tbl.relkind in ('r', 'v', 'f', 'p') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table, [m]aterialized view\n      and col.attnum > 0 -- negative numbers are used for system columns such as oid\n      and not col.attisdropped -- column as not been dropped\n\n    order by\n        sch.nspname,\n        tbl.relname,\n        col.attnum\n\n  {%- endcall -%}\n\n  {{ return(load_result('catalog').table) }}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0203385,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres_get_relations": {
+			"unique_id": "macro.dbt_postgres.postgres_get_relations",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/relations.sql",
+			"original_file_path": "macros/relations.sql",
+			"name": "postgres_get_relations",
+			"macro_sql": "{% macro postgres_get_relations () -%}\n\n  {#\n      -- in pg_depend, objid is the dependent, refobjid is the referenced object\n      --  > a pg_depend entry indicates that the referenced object cannot be\n      --  > dropped without also dropping the dependent object.\n  #}\n\n  {%- call statement('relations', fetch_result=True) -%}\n    with relation as (\n        select\n            pg_rewrite.ev_class as class,\n            pg_rewrite.oid as id\n        from pg_rewrite\n    ),\n    class as (\n        select\n            oid as id,\n            relname as name,\n            relnamespace as schema,\n            relkind as kind\n        from pg_class\n    ),\n    dependency as (\n        select distinct\n            pg_depend.objid as id,\n            pg_depend.refobjid as ref\n        from pg_depend\n    ),\n    schema as (\n        select\n            pg_namespace.oid as id,\n            pg_namespace.nspname as name\n        from pg_namespace\n        where nspname != 'information_schema' and nspname not like 'pg\\_%'\n    ),\n    referenced as (\n        select\n            relation.id AS id,\n            referenced_class.name ,\n            referenced_class.schema ,\n            referenced_class.kind\n        from relation\n        join class as referenced_class on relation.class=referenced_class.id\n        where referenced_class.kind in ('r', 'v')\n    ),\n    relationships as (\n        select\n            referenced.name as referenced_name,\n            referenced.schema as referenced_schema_id,\n            dependent_class.name as dependent_name,\n            dependent_class.schema as dependent_schema_id,\n            referenced.kind as kind\n        from referenced\n        join dependency on referenced.id=dependency.id\n        join class as dependent_class on dependency.ref=dependent_class.id\n        where\n            (referenced.name != dependent_class.name or\n             referenced.schema != dependent_class.schema)\n    )\n\n    select\n        referenced_schema.name as referenced_schema,\n        relationships.referenced_name as referenced_name,\n        dependent_schema.name as dependent_schema,\n        relationships.dependent_name as dependent_name\n    from relationships\n    join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id\n    join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id\n    group by referenced_schema, referenced_name, dependent_schema, dependent_name\n    order by referenced_schema, referenced_name, dependent_schema, dependent_name;\n\n  {%- endcall -%}\n\n  {{ return(load_result('relations').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.022431,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__any_value": {
+			"unique_id": "macro.dbt_postgres.postgres__any_value",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/any_value.sql",
+			"original_file_path": "macros/utils/any_value.sql",
+			"name": "postgres__any_value",
+			"macro_sql": "{% macro postgres__any_value(expression) -%}\n\n    min({{ expression }})\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0237532,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__split_part": {
+			"unique_id": "macro.dbt_postgres.postgres__split_part",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/split_part.sql",
+			"original_file_path": "macros/utils/split_part.sql",
+			"name": "postgres__split_part",
+			"macro_sql": "{% macro postgres__split_part(string_text, delimiter_text, part_number) %}\n\n  {% if part_number >= 0 %}\n    {{ dbt.default__split_part(string_text, delimiter_text, part_number) }}\n  {% else %}\n    {{ dbt._split_part_negative(string_text, delimiter_text, part_number) }}\n  {% endif %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__split_part", "macro.dbt._split_part_negative"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0252132,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__datediff": {
+			"unique_id": "macro.dbt_postgres.postgres__datediff",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/datediff.sql",
+			"original_file_path": "macros/utils/datediff.sql",
+			"name": "postgres__datediff",
+			"macro_sql": "{% macro postgres__datediff(first_date, second_date, datepart) -%}\n\n    {% if datepart == 'year' %}\n        (date_part('year', ({{second_date}})::date) - date_part('year', ({{first_date}})::date))\n    {% elif datepart == 'quarter' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 4 + date_part('quarter', ({{second_date}})::date) - date_part('quarter', ({{first_date}})::date))\n    {% elif datepart == 'month' %}\n        ({{ datediff(first_date, second_date, 'year') }} * 12 + date_part('month', ({{second_date}})::date) - date_part('month', ({{first_date}})::date))\n    {% elif datepart == 'day' %}\n        (({{second_date}})::date - ({{first_date}})::date)\n    {% elif datepart == 'week' %}\n        ({{ datediff(first_date, second_date, 'day') }} / 7 + case\n            when date_part('dow', ({{first_date}})::timestamp) <= date_part('dow', ({{second_date}})::timestamp) then\n                case when {{first_date}} <= {{second_date}} then 0 else -1 end\n            else\n                case when {{first_date}} <= {{second_date}} then 1 else 0 end\n        end)\n    {% elif datepart == 'hour' %}\n        ({{ datediff(first_date, second_date, 'day') }} * 24 + date_part('hour', ({{second_date}})::timestamp) - date_part('hour', ({{first_date}})::timestamp))\n    {% elif datepart == 'minute' %}\n        ({{ datediff(first_date, second_date, 'hour') }} * 60 + date_part('minute', ({{second_date}})::timestamp) - date_part('minute', ({{first_date}})::timestamp))\n    {% elif datepart == 'second' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60 + floor(date_part('second', ({{second_date}})::timestamp)) - floor(date_part('second', ({{first_date}})::timestamp)))\n    {% elif datepart == 'millisecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000 + floor(date_part('millisecond', ({{second_date}})::timestamp)) - floor(date_part('millisecond', ({{first_date}})::timestamp)))\n    {% elif datepart == 'microsecond' %}\n        ({{ datediff(first_date, second_date, 'minute') }} * 60000000 + floor(date_part('microsecond', ({{second_date}})::timestamp)) - floor(date_part('microsecond', ({{first_date}})::timestamp)))\n    {% else %}\n        {{ exceptions.raise_compiler_error(\"Unsupported datepart for macro datediff in postgres: {!r}\".format(datepart)) }}\n    {% endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.datediff"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0292282,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__listagg": {
+			"unique_id": "macro.dbt_postgres.postgres__listagg",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/listagg.sql",
+			"original_file_path": "macros/utils/listagg.sql",
+			"name": "postgres__listagg",
+			"macro_sql": "{% macro postgres__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n\n    {% if limit_num -%}\n    array_to_string(\n        (array_agg(\n            {{ measure }}\n            {% if order_by_clause -%}\n            {{ order_by_clause }}\n            {%- endif %}\n        ))[1:{{ limit_num }}],\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    string_agg(\n        {{ measure }},\n        {{ delimiter_text }}\n        {% if order_by_clause -%}\n        {{ order_by_clause }}\n        {%- endif %}\n        )\n    {%- endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0306103,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__dateadd": {
+			"unique_id": "macro.dbt_postgres.postgres__dateadd",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/dateadd.sql",
+			"original_file_path": "macros/utils/dateadd.sql",
+			"name": "postgres__dateadd",
+			"macro_sql": "{% macro postgres__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    {{ from_date_or_timestamp }} + ((interval '1 {{ datepart }}') * ({{ interval }}))\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0317142,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__last_day": {
+			"unique_id": "macro.dbt_postgres.postgres__last_day",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/utils/last_day.sql",
+			"original_file_path": "macros/utils/last_day.sql",
+			"name": "postgres__last_day",
+			"macro_sql": "{% macro postgres__last_day(date, datepart) -%}\n\n    {%- if datepart == 'quarter' -%}\n    -- postgres dateadd does not support quarter interval.\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd('month', '3', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n    {%- else -%}\n    {{dbt.default_last_day(date, datepart)}}\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.dateadd", "macro.dbt.date_trunc", "macro.dbt.default_last_day"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0336168,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__get_incremental_default_sql": {
+			"unique_id": "macro.dbt_postgres.postgres__get_incremental_default_sql",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/materializations/incremental_strategies.sql",
+			"original_file_path": "macros/materializations/incremental_strategies.sql",
+			"name": "postgres__get_incremental_default_sql",
+			"macro_sql": "{% macro postgres__get_incremental_default_sql(arg_dict) %}\n\n  {% if arg_dict[\"unique_key\"] %}\n    {% do return(get_incremental_delete_insert_sql(arg_dict)) %}\n  {% else %}\n    {% do return(get_incremental_append_sql(arg_dict)) %}\n  {% endif %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_incremental_delete_insert_sql", "macro.dbt.get_incremental_append_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.035281,
+			"supported_languages": null
+		},
+		"macro.dbt_postgres.postgres__snapshot_merge_sql": {
+			"unique_id": "macro.dbt_postgres.postgres__snapshot_merge_sql",
+			"package_name": "dbt_postgres",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/postgres",
+			"path": "macros/materializations/snapshot_merge.sql",
+			"original_file_path": "macros/materializations/snapshot_merge.sql",
+			"name": "postgres__snapshot_merge_sql",
+			"macro_sql": "{% macro postgres__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    update {{ target }}\n    set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_scd_id::text = {{ target }}.dbt_scd_id::text\n      and DBT_INTERNAL_SOURCE.dbt_change_type::text in ('update'::text, 'delete'::text)\n      and {{ target }}.dbt_valid_to is null;\n\n    insert into {{ target }} ({{ insert_cols_csv }})\n    select {% for column in insert_cols -%}\n        DBT_INTERNAL_SOURCE.{{ column }} {%- if not loop.last %}, {%- endif %}\n    {%- endfor %}\n    from {{ source }} as DBT_INTERNAL_SOURCE\n    where DBT_INTERNAL_SOURCE.dbt_change_type::text = 'insert'::text;\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0369773,
+			"supported_languages": null
+		},
+		"macro.dbt.current_timestamp": {
+			"unique_id": "macro.dbt.current_timestamp",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "current_timestamp",
+			"macro_sql": "{%- macro current_timestamp() -%}\n    {{ adapter.dispatch('current_timestamp', 'dbt')() }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.038283,
+			"supported_languages": null
+		},
+		"macro.dbt.default__current_timestamp": {
+			"unique_id": "macro.dbt.default__current_timestamp",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "default__current_timestamp",
+			"macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter ' + adapter.type()) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0384371,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_get_time": {
+			"unique_id": "macro.dbt.snapshot_get_time",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "snapshot_get_time",
+			"macro_sql": "\n\n{%- macro snapshot_get_time() -%}\n    {{ adapter.dispatch('snapshot_get_time', 'dbt')() }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__snapshot_get_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0385787,
+			"supported_languages": null
+		},
+		"macro.dbt.default__snapshot_get_time": {
+			"unique_id": "macro.dbt.default__snapshot_get_time",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "default__snapshot_get_time",
+			"macro_sql": "{% macro default__snapshot_get_time() %}\n    {{ current_timestamp() }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0386813,
+			"supported_languages": null
+		},
+		"macro.dbt.current_timestamp_backcompat": {
+			"unique_id": "macro.dbt.current_timestamp_backcompat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "current_timestamp_backcompat",
+			"macro_sql": "{% macro current_timestamp_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__current_timestamp_backcompat"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0388386,
+			"supported_languages": null
+		},
+		"macro.dbt.default__current_timestamp_backcompat": {
+			"unique_id": "macro.dbt.default__current_timestamp_backcompat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "default__current_timestamp_backcompat",
+			"macro_sql": "{% macro default__current_timestamp_backcompat() %}\n    current_timestamp::timestamp\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0389233,
+			"supported_languages": null
+		},
+		"macro.dbt.current_timestamp_in_utc_backcompat": {
+			"unique_id": "macro.dbt.current_timestamp_in_utc_backcompat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "current_timestamp_in_utc_backcompat",
+			"macro_sql": "{% macro current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_in_utc_backcompat', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__current_timestamp_in_utc_backcompat"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0390792,
+			"supported_languages": null
+		},
+		"macro.dbt.default__current_timestamp_in_utc_backcompat": {
+			"unique_id": "macro.dbt.default__current_timestamp_in_utc_backcompat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/timestamps.sql",
+			"original_file_path": "macros/adapters/timestamps.sql",
+			"name": "default__current_timestamp_in_utc_backcompat",
+			"macro_sql": "{% macro default__current_timestamp_in_utc_backcompat() %}\n    {{ return(adapter.dispatch('current_timestamp_backcompat', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.current_timestamp_backcompat", "macro.dbt_postgres.postgres__current_timestamp_backcompat"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0392387,
+			"supported_languages": null
+		},
+		"macro.dbt.get_catalog": {
+			"unique_id": "macro.dbt.get_catalog",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "get_catalog",
+			"macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog', 'dbt')(information_schema, schemas)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__get_catalog"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0416863,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_catalog": {
+			"unique_id": "macro.dbt.default__get_catalog",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "default__get_catalog",
+			"macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0419962,
+			"supported_languages": null
+		},
+		"macro.dbt.information_schema_name": {
+			"unique_id": "macro.dbt.information_schema_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "information_schema_name",
+			"macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name', 'dbt')(database)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__information_schema_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0421994,
+			"supported_languages": null
+		},
+		"macro.dbt.default__information_schema_name": {
+			"unique_id": "macro.dbt.default__information_schema_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "default__information_schema_name",
+			"macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0423598,
+			"supported_languages": null
+		},
+		"macro.dbt.list_schemas": {
+			"unique_id": "macro.dbt.list_schemas",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "list_schemas",
+			"macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas', 'dbt')(database)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__list_schemas"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.042543,
+			"supported_languages": null
+		},
+		"macro.dbt.default__list_schemas": {
+			"unique_id": "macro.dbt.default__list_schemas",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "default__list_schemas",
+			"macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.information_schema_name", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0428824,
+			"supported_languages": null
+		},
+		"macro.dbt.check_schema_exists": {
+			"unique_id": "macro.dbt.check_schema_exists",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "check_schema_exists",
+			"macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists', 'dbt')(information_schema, schema)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__check_schema_exists"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0431087,
+			"supported_languages": null
+		},
+		"macro.dbt.default__check_schema_exists": {
+			"unique_id": "macro.dbt.default__check_schema_exists",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "default__check_schema_exists",
+			"macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.replace", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0435212,
+			"supported_languages": null
+		},
+		"macro.dbt.list_relations_without_caching": {
+			"unique_id": "macro.dbt.list_relations_without_caching",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "list_relations_without_caching",
+			"macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching', 'dbt')(schema_relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__list_relations_without_caching"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0438817,
+			"supported_languages": null
+		},
+		"macro.dbt.default__list_relations_without_caching": {
+			"unique_id": "macro.dbt.default__list_relations_without_caching",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/metadata.sql",
+			"original_file_path": "macros/adapters/metadata.sql",
+			"name": "default__list_relations_without_caching",
+			"macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0441697,
+			"supported_languages": null
+		},
+		"macro.dbt.create_schema": {
+			"unique_id": "macro.dbt.create_schema",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/schema.sql",
+			"original_file_path": "macros/adapters/schema.sql",
+			"name": "create_schema",
+			"macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema', 'dbt')(relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__create_schema"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0463543,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_schema": {
+			"unique_id": "macro.dbt.default__create_schema",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/schema.sql",
+			"original_file_path": "macros/adapters/schema.sql",
+			"name": "default__create_schema",
+			"macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.046612,
+			"supported_languages": null
+		},
+		"macro.dbt.drop_schema": {
+			"unique_id": "macro.dbt.drop_schema",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/schema.sql",
+			"original_file_path": "macros/adapters/schema.sql",
+			"name": "drop_schema",
+			"macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema', 'dbt')(relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__drop_schema"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0467896,
+			"supported_languages": null
+		},
+		"macro.dbt.default__drop_schema": {
+			"unique_id": "macro.dbt.default__drop_schema",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/schema.sql",
+			"original_file_path": "macros/adapters/schema.sql",
+			"name": "default__drop_schema",
+			"macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0470035,
+			"supported_languages": null
+		},
+		"macro.dbt.alter_column_comment": {
+			"unique_id": "macro.dbt.alter_column_comment",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "alter_column_comment",
+			"macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment', 'dbt')(relation, column_dict)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__alter_column_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0491555,
+			"supported_languages": null
+		},
+		"macro.dbt.default__alter_column_comment": {
+			"unique_id": "macro.dbt.default__alter_column_comment",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "default__alter_column_comment",
+			"macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0493495,
+			"supported_languages": null
+		},
+		"macro.dbt.alter_relation_comment": {
+			"unique_id": "macro.dbt.alter_relation_comment",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "alter_relation_comment",
+			"macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment', 'dbt')(relation, relation_comment)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__alter_relation_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0495603,
+			"supported_languages": null
+		},
+		"macro.dbt.default__alter_relation_comment": {
+			"unique_id": "macro.dbt.default__alter_relation_comment",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "default__alter_relation_comment",
+			"macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0497274,
+			"supported_languages": null
+		},
+		"macro.dbt.persist_docs": {
+			"unique_id": "macro.dbt.persist_docs",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "persist_docs",
+			"macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs', 'dbt')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__persist_docs"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.050006,
+			"supported_languages": null
+		},
+		"macro.dbt.default__persist_docs": {
+			"unique_id": "macro.dbt.default__persist_docs",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/persist_docs.sql",
+			"original_file_path": "macros/adapters/persist_docs.sql",
+			"name": "default__persist_docs",
+			"macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query", "macro.dbt.alter_relation_comment", "macro.dbt.alter_column_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0505085,
+			"supported_languages": null
+		},
+		"macro.dbt.copy_grants": {
+			"unique_id": "macro.dbt.copy_grants",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "copy_grants",
+			"macro_sql": "{% macro copy_grants() %}\n    {{ return(adapter.dispatch('copy_grants', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__copy_grants"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0533037,
+			"supported_languages": null
+		},
+		"macro.dbt.default__copy_grants": {
+			"unique_id": "macro.dbt.default__copy_grants",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__copy_grants",
+			"macro_sql": "{% macro default__copy_grants() %}\n    {{ return(True) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0534384,
+			"supported_languages": null
+		},
+		"macro.dbt.support_multiple_grantees_per_dcl_statement": {
+			"unique_id": "macro.dbt.support_multiple_grantees_per_dcl_statement",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "support_multiple_grantees_per_dcl_statement",
+			"macro_sql": "{% macro support_multiple_grantees_per_dcl_statement() %}\n    {{ return(adapter.dispatch('support_multiple_grantees_per_dcl_statement', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__support_multiple_grantees_per_dcl_statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0536041,
+			"supported_languages": null
+		},
+		"macro.dbt.default__support_multiple_grantees_per_dcl_statement": {
+			"unique_id": "macro.dbt.default__support_multiple_grantees_per_dcl_statement",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__support_multiple_grantees_per_dcl_statement",
+			"macro_sql": "\n\n{%- macro default__support_multiple_grantees_per_dcl_statement() -%}\n    {{ return(True) }}\n{%- endmacro -%}\n\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0537121,
+			"supported_languages": null
+		},
+		"macro.dbt.should_revoke": {
+			"unique_id": "macro.dbt.should_revoke",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "should_revoke",
+			"macro_sql": "{% macro should_revoke(existing_relation, full_refresh_mode=True) %}\n\n    {% if not existing_relation %}\n        {#-- The table doesn't already exist, so no grants to copy over --#}\n        {{ return(False) }}\n    {% elif full_refresh_mode %}\n        {#-- The object is being REPLACED -- whether grants are copied over depends on the value of user config --#}\n        {{ return(copy_grants()) }}\n    {% else %}\n        {#-- The table is being merged/upserted/inserted -- grants will be carried over --#}\n        {{ return(True) }}\n    {% endif %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.copy_grants"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.054055,
+			"supported_languages": null
+		},
+		"macro.dbt.get_show_grant_sql": {
+			"unique_id": "macro.dbt.get_show_grant_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "get_show_grant_sql",
+			"macro_sql": "{% macro get_show_grant_sql(relation) %}\n    {{ return(adapter.dispatch(\"get_show_grant_sql\", \"dbt\")(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__get_show_grant_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0544326,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_show_grant_sql": {
+			"unique_id": "macro.dbt.default__get_show_grant_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__get_show_grant_sql",
+			"macro_sql": "{% macro default__get_show_grant_sql(relation) %}\n    show grants on {{ relation }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0545347,
+			"supported_languages": null
+		},
+		"macro.dbt.get_grant_sql": {
+			"unique_id": "macro.dbt.get_grant_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "get_grant_sql",
+			"macro_sql": "{% macro get_grant_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_grant_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_grant_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0547466,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_grant_sql": {
+			"unique_id": "macro.dbt.default__get_grant_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__get_grant_sql",
+			"macro_sql": "\n\n{%- macro default__get_grant_sql(relation, privilege, grantees) -%}\n    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0549452,
+			"supported_languages": null
+		},
+		"macro.dbt.get_revoke_sql": {
+			"unique_id": "macro.dbt.get_revoke_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "get_revoke_sql",
+			"macro_sql": "{% macro get_revoke_sql(relation, privilege, grantees) %}\n    {{ return(adapter.dispatch('get_revoke_sql', 'dbt')(relation, privilege, grantees)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_revoke_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0551674,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_revoke_sql": {
+			"unique_id": "macro.dbt.default__get_revoke_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__get_revoke_sql",
+			"macro_sql": "\n\n{%- macro default__get_revoke_sql(relation, privilege, grantees) -%}\n    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}\n{%- endmacro -%}\n\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0553687,
+			"supported_languages": null
+		},
+		"macro.dbt.get_dcl_statement_list": {
+			"unique_id": "macro.dbt.get_dcl_statement_list",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "get_dcl_statement_list",
+			"macro_sql": "{% macro get_dcl_statement_list(relation, grant_config, get_dcl_macro) %}\n    {{ return(adapter.dispatch('get_dcl_statement_list', 'dbt')(relation, grant_config, get_dcl_macro)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_dcl_statement_list"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0556605,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_dcl_statement_list": {
+			"unique_id": "macro.dbt.default__get_dcl_statement_list",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__get_dcl_statement_list",
+			"macro_sql": "\n\n{%- macro default__get_dcl_statement_list(relation, grant_config, get_dcl_macro) -%}\n    {#\n      -- Unpack grant_config into specific privileges and the set of users who need them granted/revoked.\n      -- Depending on whether this database supports multiple grantees per statement, pass in the list of\n      -- all grantees per privilege, or (if not) template one statement per privilege-grantee pair.\n      -- `get_dcl_macro` will be either `get_grant_sql` or `get_revoke_sql`\n    #}\n    {%- set dcl_statements = [] -%}\n    {%- for privilege, grantees in grant_config.items() %}\n        {%- if support_multiple_grantees_per_dcl_statement() and grantees -%}\n          {%- set dcl = get_dcl_macro(relation, privilege, grantees) -%}\n          {%- do dcl_statements.append(dcl) -%}\n        {%- else -%}\n          {%- for grantee in grantees -%}\n              {% set dcl = get_dcl_macro(relation, privilege, [grantee]) %}\n              {%- do dcl_statements.append(dcl) -%}\n          {% endfor -%}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return(dcl_statements) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.support_multiple_grantees_per_dcl_statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0564039,
+			"supported_languages": null
+		},
+		"macro.dbt.call_dcl_statements": {
+			"unique_id": "macro.dbt.call_dcl_statements",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "call_dcl_statements",
+			"macro_sql": "{% macro call_dcl_statements(dcl_statement_list) %}\n    {{ return(adapter.dispatch(\"call_dcl_statements\", \"dbt\")(dcl_statement_list)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__call_dcl_statements"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.056593,
+			"supported_languages": null
+		},
+		"macro.dbt.default__call_dcl_statements": {
+			"unique_id": "macro.dbt.default__call_dcl_statements",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__call_dcl_statements",
+			"macro_sql": "{% macro default__call_dcl_statements(dcl_statement_list) %}\n    {#\n      -- By default, supply all grant + revoke statements in a single semicolon-separated block,\n      -- so that they're all processed together.\n\n      -- Some databases do not support this. Those adapters will need to override this macro\n      -- to run each statement individually.\n    #}\n    {% call statement('grants') %}\n        {% for dcl_statement in dcl_statement_list %}\n            {{ dcl_statement }};\n        {% endfor %}\n    {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.056824,
+			"supported_languages": null
+		},
+		"macro.dbt.apply_grants": {
+			"unique_id": "macro.dbt.apply_grants",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "apply_grants",
+			"macro_sql": "{% macro apply_grants(relation, grant_config, should_revoke) %}\n    {{ return(adapter.dispatch(\"apply_grants\", \"dbt\")(relation, grant_config, should_revoke)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__apply_grants"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0570579,
+			"supported_languages": null
+		},
+		"macro.dbt.default__apply_grants": {
+			"unique_id": "macro.dbt.default__apply_grants",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/apply_grants.sql",
+			"original_file_path": "macros/adapters/apply_grants.sql",
+			"name": "default__apply_grants",
+			"macro_sql": "{% macro default__apply_grants(relation, grant_config, should_revoke=True) %}\n    {#-- If grant_config is {} or None, this is a no-op --#}\n    {% if grant_config %}\n        {% if should_revoke %}\n            {#-- We think previous grants may have carried over --#}\n            {#-- Show current grants and calculate diffs --#}\n            {% set current_grants_table = run_query(get_show_grant_sql(relation)) %}\n            {% set current_grants_dict = adapter.standardize_grants_dict(current_grants_table) %}\n            {% set needs_granting = diff_of_two_dicts(grant_config, current_grants_dict) %}\n            {% set needs_revoking = diff_of_two_dicts(current_grants_dict, grant_config) %}\n            {% if not (needs_granting or needs_revoking) %}\n                {{ log('On ' ~ relation ~': All grants are in place, no revocation or granting needed.')}}\n            {% endif %}\n        {% else %}\n            {#-- We don't think there's any chance of previous grants having carried over. --#}\n            {#-- Jump straight to granting what the user has configured. --#}\n            {% set needs_revoking = {} %}\n            {% set needs_granting = grant_config %}\n        {% endif %}\n        {% if needs_granting or needs_revoking %}\n            {% set revoke_statement_list = get_dcl_statement_list(relation, needs_revoking, get_revoke_sql) %}\n            {% set grant_statement_list = get_dcl_statement_list(relation, needs_granting, get_grant_sql) %}\n            {% set dcl_statement_list = revoke_statement_list + grant_statement_list %}\n            {% if dcl_statement_list %}\n                {{ call_dcl_statements(dcl_statement_list) }}\n            {% endif %}\n        {% endif %}\n    {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query", "macro.dbt.get_show_grant_sql", "macro.dbt.get_dcl_statement_list", "macro.dbt.call_dcl_statements"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.058159,
+			"supported_languages": null
+		},
+		"macro.dbt.get_create_index_sql": {
+			"unique_id": "macro.dbt.get_create_index_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/indexes.sql",
+			"original_file_path": "macros/adapters/indexes.sql",
+			"name": "get_create_index_sql",
+			"macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql', 'dbt')(relation, index_dict)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__get_create_index_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0602639,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_create_index_sql": {
+			"unique_id": "macro.dbt.default__get_create_index_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/indexes.sql",
+			"original_file_path": "macros/adapters/indexes.sql",
+			"name": "default__get_create_index_sql",
+			"macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0604212,
+			"supported_languages": null
+		},
+		"macro.dbt.create_indexes": {
+			"unique_id": "macro.dbt.create_indexes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/indexes.sql",
+			"original_file_path": "macros/adapters/indexes.sql",
+			"name": "create_indexes",
+			"macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes', 'dbt')(relation) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.06058,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_indexes": {
+			"unique_id": "macro.dbt.default__create_indexes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/indexes.sql",
+			"original_file_path": "macros/adapters/indexes.sql",
+			"name": "default__create_indexes",
+			"macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_create_index_sql", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.061002,
+			"supported_languages": null
+		},
+		"macro.dbt.get_columns_in_relation": {
+			"unique_id": "macro.dbt.get_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "get_columns_in_relation",
+			"macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__get_columns_in_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0639343,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_columns_in_relation": {
+			"unique_id": "macro.dbt.default__get_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "default__get_columns_in_relation",
+			"macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0641086,
+			"supported_languages": null
+		},
+		"macro.dbt.sql_convert_columns_in_relation": {
+			"unique_id": "macro.dbt.sql_convert_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "sql_convert_columns_in_relation",
+			"macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.064416,
+			"supported_languages": null
+		},
+		"macro.dbt.get_columns_in_query": {
+			"unique_id": "macro.dbt.get_columns_in_query",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "get_columns_in_query",
+			"macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query', 'dbt')(select_sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_columns_in_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0645957,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_columns_in_query": {
+			"unique_id": "macro.dbt.default__get_columns_in_query",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "default__get_columns_in_query",
+			"macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        select * from (\n            {{ select_sql }}\n        ) as __dbt_sbq\n        where false\n        limit 0\n    {% endcall %}\n\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0870824,
+			"supported_languages": null
+		},
+		"macro.dbt.alter_column_type": {
+			"unique_id": "macro.dbt.alter_column_type",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "alter_column_type",
+			"macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type', 'dbt')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__alter_column_type"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0873826,
+			"supported_languages": null
+		},
+		"macro.dbt.default__alter_column_type": {
+			"unique_id": "macro.dbt.default__alter_column_type",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "default__alter_column_type",
+			"macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0880013,
+			"supported_languages": null
+		},
+		"macro.dbt.alter_relation_add_remove_columns": {
+			"unique_id": "macro.dbt.alter_relation_add_remove_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "alter_relation_add_remove_columns",
+			"macro_sql": "{% macro alter_relation_add_remove_columns(relation, add_columns = none, remove_columns = none) -%}\n  {{ return(adapter.dispatch('alter_relation_add_remove_columns', 'dbt')(relation, add_columns, remove_columns)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__alter_relation_add_remove_columns"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0882633,
+			"supported_languages": null
+		},
+		"macro.dbt.default__alter_relation_add_remove_columns": {
+			"unique_id": "macro.dbt.default__alter_relation_add_remove_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/columns.sql",
+			"original_file_path": "macros/adapters/columns.sql",
+			"name": "default__alter_relation_add_remove_columns",
+			"macro_sql": "{% macro default__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}\n\n  {% if add_columns is none %}\n    {% set add_columns = [] %}\n  {% endif %}\n  {% if remove_columns is none %}\n    {% set remove_columns = [] %}\n  {% endif %}\n\n  {% set sql -%}\n\n     alter {{ relation.type }} {{ relation }}\n\n            {% for column in add_columns %}\n               add column {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}\n            {% endfor %}{{ ',' if add_columns and remove_columns }}\n\n            {% for column in remove_columns %}\n                drop column {{ column.name }}{{ ',' if not loop.last }}\n            {% endfor %}\n\n  {%- endset -%}\n\n  {% do run_query(sql) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0890667,
+			"supported_languages": null
+		},
+		"macro.dbt.collect_freshness": {
+			"unique_id": "macro.dbt.collect_freshness",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/freshness.sql",
+			"original_file_path": "macros/adapters/freshness.sql",
+			"name": "collect_freshness",
+			"macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness', 'dbt')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__collect_freshness"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.090646,
+			"supported_languages": null
+		},
+		"macro.dbt.default__collect_freshness": {
+			"unique_id": "macro.dbt.default__collect_freshness",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/freshness.sql",
+			"original_file_path": "macros/adapters/freshness.sql",
+			"name": "default__collect_freshness",
+			"macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement", "macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0912406,
+			"supported_languages": null
+		},
+		"macro.dbt.make_intermediate_relation": {
+			"unique_id": "macro.dbt.make_intermediate_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "make_intermediate_relation",
+			"macro_sql": "{% macro make_intermediate_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_intermediate_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_intermediate_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0953004,
+			"supported_languages": null
+		},
+		"macro.dbt.default__make_intermediate_relation": {
+			"unique_id": "macro.dbt.default__make_intermediate_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__make_intermediate_relation",
+			"macro_sql": "{% macro default__make_intermediate_relation(base_relation, suffix) %}\n    {{ return(default__make_temp_relation(base_relation, suffix)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__make_temp_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0954807,
+			"supported_languages": null
+		},
+		"macro.dbt.make_temp_relation": {
+			"unique_id": "macro.dbt.make_temp_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "make_temp_relation",
+			"macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation', 'dbt')(base_relation, suffix)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_temp_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.095697,
+			"supported_languages": null
+		},
+		"macro.dbt.default__make_temp_relation": {
+			"unique_id": "macro.dbt.default__make_temp_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__make_temp_relation",
+			"macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {%- set temp_identifier = base_relation.identifier ~ suffix -%}\n    {%- set temp_relation = base_relation.incorporate(\n                                path={\"identifier\": temp_identifier}) -%}\n\n    {{ return(temp_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0960083,
+			"supported_languages": null
+		},
+		"macro.dbt.make_backup_relation": {
+			"unique_id": "macro.dbt.make_backup_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "make_backup_relation",
+			"macro_sql": "{% macro make_backup_relation(base_relation, backup_relation_type, suffix='__dbt_backup') %}\n    {{ return(adapter.dispatch('make_backup_relation', 'dbt')(base_relation, backup_relation_type, suffix)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__make_backup_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0962512,
+			"supported_languages": null
+		},
+		"macro.dbt.default__make_backup_relation": {
+			"unique_id": "macro.dbt.default__make_backup_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__make_backup_relation",
+			"macro_sql": "{% macro default__make_backup_relation(base_relation, backup_relation_type, suffix) %}\n    {%- set backup_identifier = base_relation.identifier ~ suffix -%}\n    {%- set backup_relation = base_relation.incorporate(\n                                  path={\"identifier\": backup_identifier},\n                                  type=backup_relation_type\n    ) -%}\n    {{ return(backup_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0965555,
+			"supported_languages": null
+		},
+		"macro.dbt.drop_relation": {
+			"unique_id": "macro.dbt.drop_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "drop_relation",
+			"macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__drop_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0967305,
+			"supported_languages": null
+		},
+		"macro.dbt.default__drop_relation": {
+			"unique_id": "macro.dbt.default__drop_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__drop_relation",
+			"macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0969462,
+			"supported_languages": null
+		},
+		"macro.dbt.truncate_relation": {
+			"unique_id": "macro.dbt.truncate_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "truncate_relation",
+			"macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation', 'dbt')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__truncate_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0971267,
+			"supported_languages": null
+		},
+		"macro.dbt.default__truncate_relation": {
+			"unique_id": "macro.dbt.default__truncate_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__truncate_relation",
+			"macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0972831,
+			"supported_languages": null
+		},
+		"macro.dbt.rename_relation": {
+			"unique_id": "macro.dbt.rename_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "rename_relation",
+			"macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation', 'dbt')(from_relation, to_relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__rename_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.097477,
+			"supported_languages": null
+		},
+		"macro.dbt.default__rename_relation": {
+			"unique_id": "macro.dbt.default__rename_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__rename_relation",
+			"macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0978487,
+			"supported_languages": null
+		},
+		"macro.dbt.get_or_create_relation": {
+			"unique_id": "macro.dbt.get_or_create_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "get_or_create_relation",
+			"macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) -%}\n  {{ return(adapter.dispatch('get_or_create_relation', 'dbt')(database, schema, identifier, type)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_or_create_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0981143,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_or_create_relation": {
+			"unique_id": "macro.dbt.default__get_or_create_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "default__get_or_create_relation",
+			"macro_sql": "{% macro default__get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0987823,
+			"supported_languages": null
+		},
+		"macro.dbt.load_cached_relation": {
+			"unique_id": "macro.dbt.load_cached_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "load_cached_relation",
+			"macro_sql": "{% macro load_cached_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.099132,
+			"supported_languages": null
+		},
+		"macro.dbt.load_relation": {
+			"unique_id": "macro.dbt.load_relation",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "load_relation",
+			"macro_sql": "{% macro load_relation(relation) %}\n    {{ return(load_cached_relation(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.load_cached_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0992882,
+			"supported_languages": null
+		},
+		"macro.dbt.drop_relation_if_exists": {
+			"unique_id": "macro.dbt.drop_relation_if_exists",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/relation.sql",
+			"original_file_path": "macros/adapters/relation.sql",
+			"name": "drop_relation_if_exists",
+			"macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.0994885,
+			"supported_languages": null
+		},
+		"macro.dbt.statement": {
+			"unique_id": "macro.dbt.statement",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/statement.sql",
+			"original_file_path": "macros/etc/statement.sql",
+			"name": "statement",
+			"macro_sql": "\n{%- macro statement(name=None, fetch_result=False, auto_begin=True, language='sql') -%}\n  {%- if execute: -%}\n    {%- set compiled_code = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime {} for node \"{}\"'.format(language, model['unique_id'])) }}\n      {{ write(compiled_code) }}\n    {%- endif -%}\n    {%- if language == 'sql'-%}\n      {%- set res, table = adapter.execute(compiled_code, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- elif language == 'python' -%}\n      {%- set res = submit_python_job(model, compiled_code) -%}\n      {#-- TODO: What should table be for python models? --#}\n      {%- set table = None -%}\n    {%- else -%}\n      {% do exceptions.raise_compiler_error(\"statement macro didn't get supported language\") %}\n    {%- endif -%}\n\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1024253,
+			"supported_languages": null
+		},
+		"macro.dbt.noop_statement": {
+			"unique_id": "macro.dbt.noop_statement",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/statement.sql",
+			"original_file_path": "macros/etc/statement.sql",
+			"name": "noop_statement",
+			"macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1030097,
+			"supported_languages": null
+		},
+		"macro.dbt.run_query": {
+			"unique_id": "macro.dbt.run_query",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/statement.sql",
+			"original_file_path": "macros/etc/statement.sql",
+			"name": "run_query",
+			"macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.103294,
+			"supported_languages": null
+		},
+		"macro.dbt.convert_datetime": {
+			"unique_id": "macro.dbt.convert_datetime",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "convert_datetime",
+			"macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.106328,
+			"supported_languages": null
+		},
+		"macro.dbt.dates_in_range": {
+			"unique_id": "macro.dbt.dates_in_range",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "dates_in_range",
+			"macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partiton start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.convert_datetime"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1075816,
+			"supported_languages": null
+		},
+		"macro.dbt.partition_range": {
+			"unique_id": "macro.dbt.partition_range",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "partition_range",
+			"macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.dates_in_range"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1084485,
+			"supported_languages": null
+		},
+		"macro.dbt.py_current_timestring": {
+			"unique_id": "macro.dbt.py_current_timestring",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "py_current_timestring",
+			"macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1086988,
+			"supported_languages": null
+		},
+		"macro.dbt.generate_schema_name": {
+			"unique_id": "macro.dbt.generate_schema_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_schema.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+			"name": "generate_schema_name",
+			"macro_sql": "{% macro generate_schema_name(custom_schema_name=none, node=none) -%}\n    {{ return(adapter.dispatch('generate_schema_name', 'dbt')(custom_schema_name, node)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__generate_schema_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1102245,
+			"supported_languages": null
+		},
+		"macro.dbt.default__generate_schema_name": {
+			"unique_id": "macro.dbt.default__generate_schema_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_schema.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+			"name": "default__generate_schema_name",
+			"macro_sql": "{% macro default__generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1105096,
+			"supported_languages": null
+		},
+		"macro.dbt.generate_schema_name_for_env": {
+			"unique_id": "macro.dbt.generate_schema_name_for_env",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_schema.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_schema.sql",
+			"name": "generate_schema_name_for_env",
+			"macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1108124,
+			"supported_languages": null
+		},
+		"macro.dbt.generate_database_name": {
+			"unique_id": "macro.dbt.generate_database_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_database.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_database.sql",
+			"name": "generate_database_name",
+			"macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name', 'dbt')(custom_database_name, node)) %}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__generate_database_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.112515,
+			"supported_languages": null
+		},
+		"macro.dbt.default__generate_database_name": {
+			"unique_id": "macro.dbt.default__generate_database_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_database.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_database.sql",
+			"name": "default__generate_database_name",
+			"macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1129613,
+			"supported_languages": null
+		},
+		"macro.dbt.generate_alias_name": {
+			"unique_id": "macro.dbt.generate_alias_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_alias.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+			"name": "generate_alias_name",
+			"macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_alias_name', 'dbt')(custom_alias_name, node)) %}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__generate_alias_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.114693,
+			"supported_languages": null
+		},
+		"macro.dbt.default__generate_alias_name": {
+			"unique_id": "macro.dbt.default__generate_alias_name",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/get_custom_name/get_custom_alias.sql",
+			"original_file_path": "macros/get_custom_name/get_custom_alias.sql",
+			"name": "default__generate_alias_name",
+			"macro_sql": "{% macro default__generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name is none -%}\n\n        {{ node.name }}\n\n    {%- else -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1150029,
+			"supported_languages": null
+		},
+		"macro.dbt.bool_or": {
+			"unique_id": "macro.dbt.bool_or",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/bool_or.sql",
+			"original_file_path": "macros/utils/bool_or.sql",
+			"name": "bool_or",
+			"macro_sql": "{% macro bool_or(expression) -%}\n    {{ return(adapter.dispatch('bool_or', 'dbt') (expression)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__bool_or"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1165488,
+			"supported_languages": null
+		},
+		"macro.dbt.default__bool_or": {
+			"unique_id": "macro.dbt.default__bool_or",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/bool_or.sql",
+			"original_file_path": "macros/utils/bool_or.sql",
+			"name": "default__bool_or",
+			"macro_sql": "{% macro default__bool_or(expression) -%}\n\n    bool_or({{ expression }})\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.116663,
+			"supported_languages": null
+		},
+		"macro.dbt.cast_bool_to_text": {
+			"unique_id": "macro.dbt.cast_bool_to_text",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/cast_bool_to_text.sql",
+			"original_file_path": "macros/utils/cast_bool_to_text.sql",
+			"name": "cast_bool_to_text",
+			"macro_sql": "{% macro cast_bool_to_text(field) %}\n  {{ adapter.dispatch('cast_bool_to_text', 'dbt') (field) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__cast_bool_to_text"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1179743,
+			"supported_languages": null
+		},
+		"macro.dbt.default__cast_bool_to_text": {
+			"unique_id": "macro.dbt.default__cast_bool_to_text",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/cast_bool_to_text.sql",
+			"original_file_path": "macros/utils/cast_bool_to_text.sql",
+			"name": "default__cast_bool_to_text",
+			"macro_sql": "{% macro default__cast_bool_to_text(field) %}\n    cast({{ field }} as {{ api.Column.translate_type('string') }})\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1181557,
+			"supported_languages": null
+		},
+		"macro.dbt.any_value": {
+			"unique_id": "macro.dbt.any_value",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/any_value.sql",
+			"original_file_path": "macros/utils/any_value.sql",
+			"name": "any_value",
+			"macro_sql": "{% macro any_value(expression) -%}\n    {{ return(adapter.dispatch('any_value', 'dbt') (expression)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__any_value"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.119244,
+			"supported_languages": null
+		},
+		"macro.dbt.default__any_value": {
+			"unique_id": "macro.dbt.default__any_value",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/any_value.sql",
+			"original_file_path": "macros/utils/any_value.sql",
+			"name": "default__any_value",
+			"macro_sql": "{% macro default__any_value(expression) -%}\n\n    any_value({{ expression }})\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1193798,
+			"supported_languages": null
+		},
+		"macro.dbt.split_part": {
+			"unique_id": "macro.dbt.split_part",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/split_part.sql",
+			"original_file_path": "macros/utils/split_part.sql",
+			"name": "split_part",
+			"macro_sql": "{% macro split_part(string_text, delimiter_text, part_number) %}\n  {{ return(adapter.dispatch('split_part', 'dbt') (string_text, delimiter_text, part_number)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__split_part"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1206546,
+			"supported_languages": null
+		},
+		"macro.dbt.default__split_part": {
+			"unique_id": "macro.dbt.default__split_part",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/split_part.sql",
+			"original_file_path": "macros/utils/split_part.sql",
+			"name": "default__split_part",
+			"macro_sql": "{% macro default__split_part(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n        {{ part_number }}\n        )\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1208355,
+			"supported_languages": null
+		},
+		"macro.dbt._split_part_negative": {
+			"unique_id": "macro.dbt._split_part_negative",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/split_part.sql",
+			"original_file_path": "macros/utils/split_part.sql",
+			"name": "_split_part_negative",
+			"macro_sql": "{% macro _split_part_negative(string_text, delimiter_text, part_number) %}\n\n    split_part(\n        {{ string_text }},\n        {{ delimiter_text }},\n          length({{ string_text }})\n          - length(\n              replace({{ string_text }},  {{ delimiter_text }}, '')\n          ) + 2 {{ part_number }}\n        )\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1210835,
+			"supported_languages": null
+		},
+		"macro.dbt.position": {
+			"unique_id": "macro.dbt.position",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/position.sql",
+			"original_file_path": "macros/utils/position.sql",
+			"name": "position",
+			"macro_sql": "{% macro position(substring_text, string_text) -%}\n    {{ return(adapter.dispatch('position', 'dbt') (substring_text, string_text)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__position"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.122245,
+			"supported_languages": null
+		},
+		"macro.dbt.default__position": {
+			"unique_id": "macro.dbt.default__position",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/position.sql",
+			"original_file_path": "macros/utils/position.sql",
+			"name": "default__position",
+			"macro_sql": "{% macro default__position(substring_text, string_text) %}\n\n    position(\n        {{ substring_text }} in {{ string_text }}\n    )\n\n{%- endmacro -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.122406,
+			"supported_languages": null
+		},
+		"macro.dbt.array_construct": {
+			"unique_id": "macro.dbt.array_construct",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_construct.sql",
+			"original_file_path": "macros/utils/array_construct.sql",
+			"name": "array_construct",
+			"macro_sql": "{% macro array_construct(inputs=[], data_type=api.Column.translate_type('integer')) -%}\n  {{ return(adapter.dispatch('array_construct', 'dbt')(inputs, data_type)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__array_construct"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1239305,
+			"supported_languages": null
+		},
+		"macro.dbt.default__array_construct": {
+			"unique_id": "macro.dbt.default__array_construct",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_construct.sql",
+			"original_file_path": "macros/utils/array_construct.sql",
+			"name": "default__array_construct",
+			"macro_sql": "{% macro default__array_construct(inputs, data_type) -%}\n    {% if inputs|length > 0 %}\n    array[ {{ inputs|join(' , ') }} ]\n    {% else %}\n    array[]::{{data_type}}[]\n    {% endif %}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.124493,
+			"supported_languages": null
+		},
+		"macro.dbt.hash": {
+			"unique_id": "macro.dbt.hash",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/hash.sql",
+			"original_file_path": "macros/utils/hash.sql",
+			"name": "hash",
+			"macro_sql": "{% macro hash(field) -%}\n  {{ return(adapter.dispatch('hash', 'dbt') (field)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__hash"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1259496,
+			"supported_languages": null
+		},
+		"macro.dbt.default__hash": {
+			"unique_id": "macro.dbt.default__hash",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/hash.sql",
+			"original_file_path": "macros/utils/hash.sql",
+			"name": "default__hash",
+			"macro_sql": "{% macro default__hash(field) -%}\n    md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1261265,
+			"supported_languages": null
+		},
+		"macro.dbt.datediff": {
+			"unique_id": "macro.dbt.datediff",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/datediff.sql",
+			"original_file_path": "macros/utils/datediff.sql",
+			"name": "datediff",
+			"macro_sql": "{% macro datediff(first_date, second_date, datepart) %}\n  {{ return(adapter.dispatch('datediff', 'dbt')(first_date, second_date, datepart)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__datediff"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1277564,
+			"supported_languages": null
+		},
+		"macro.dbt.default__datediff": {
+			"unique_id": "macro.dbt.default__datediff",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/datediff.sql",
+			"original_file_path": "macros/utils/datediff.sql",
+			"name": "default__datediff",
+			"macro_sql": "{% macro default__datediff(first_date, second_date, datepart) -%}\n\n    datediff(\n        {{ datepart }},\n        {{ first_date }},\n        {{ second_date }}\n        )\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1279452,
+			"supported_languages": null
+		},
+		"macro.dbt.listagg": {
+			"unique_id": "macro.dbt.listagg",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/listagg.sql",
+			"original_file_path": "macros/utils/listagg.sql",
+			"name": "listagg",
+			"macro_sql": "{% macro listagg(measure, delimiter_text=\"','\", order_by_clause=none, limit_num=none) -%}\n    {{ return(adapter.dispatch('listagg', 'dbt') (measure, delimiter_text, order_by_clause, limit_num)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__listagg"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.129723,
+			"supported_languages": null
+		},
+		"macro.dbt.default__listagg": {
+			"unique_id": "macro.dbt.default__listagg",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/listagg.sql",
+			"original_file_path": "macros/utils/listagg.sql",
+			"name": "default__listagg",
+			"macro_sql": "{% macro default__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}\n\n    {% if limit_num -%}\n    array_to_string(\n        array_slice(\n            array_agg(\n                {{ measure }}\n            ){% if order_by_clause -%}\n            within group ({{ order_by_clause }})\n            {%- endif %}\n            ,0\n            ,{{ limit_num }}\n        ),\n        {{ delimiter_text }}\n        )\n    {%- else %}\n    listagg(\n        {{ measure }},\n        {{ delimiter_text }}\n        )\n        {% if order_by_clause -%}\n        within group ({{ order_by_clause }})\n        {%- endif %}\n    {%- endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.130178,
+			"supported_languages": null
+		},
+		"macro.dbt.replace": {
+			"unique_id": "macro.dbt.replace",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/replace.sql",
+			"original_file_path": "macros/utils/replace.sql",
+			"name": "replace",
+			"macro_sql": "{% macro replace(field, old_chars, new_chars) -%}\n    {{ return(adapter.dispatch('replace', 'dbt') (field, old_chars, new_chars)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__replace"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.131567,
+			"supported_languages": null
+		},
+		"macro.dbt.default__replace": {
+			"unique_id": "macro.dbt.default__replace",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/replace.sql",
+			"original_file_path": "macros/utils/replace.sql",
+			"name": "default__replace",
+			"macro_sql": "{% macro default__replace(field, old_chars, new_chars) %}\n\n    replace(\n        {{ field }},\n        {{ old_chars }},\n        {{ new_chars }}\n    )\n\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1317449,
+			"supported_languages": null
+		},
+		"macro.dbt.array_concat": {
+			"unique_id": "macro.dbt.array_concat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_concat.sql",
+			"original_file_path": "macros/utils/array_concat.sql",
+			"name": "array_concat",
+			"macro_sql": "{% macro array_concat(array_1, array_2) -%}\n  {{ return(adapter.dispatch('array_concat', 'dbt')(array_1, array_2)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__array_concat"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1329787,
+			"supported_languages": null
+		},
+		"macro.dbt.default__array_concat": {
+			"unique_id": "macro.dbt.default__array_concat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_concat.sql",
+			"original_file_path": "macros/utils/array_concat.sql",
+			"name": "default__array_concat",
+			"macro_sql": "{% macro default__array_concat(array_1, array_2) -%}\n    array_cat({{ array_1 }}, {{ array_2 }})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1331308,
+			"supported_languages": null
+		},
+		"macro.dbt.intersect": {
+			"unique_id": "macro.dbt.intersect",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/intersect.sql",
+			"original_file_path": "macros/utils/intersect.sql",
+			"name": "intersect",
+			"macro_sql": "{% macro intersect() %}\n  {{ return(adapter.dispatch('intersect', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__intersect"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1343997,
+			"supported_languages": null
+		},
+		"macro.dbt.default__intersect": {
+			"unique_id": "macro.dbt.default__intersect",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/intersect.sql",
+			"original_file_path": "macros/utils/intersect.sql",
+			"name": "default__intersect",
+			"macro_sql": "{% macro default__intersect() %}\n\n    intersect\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.134485,
+			"supported_languages": null
+		},
+		"macro.dbt.date_trunc": {
+			"unique_id": "macro.dbt.date_trunc",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/date_trunc.sql",
+			"original_file_path": "macros/utils/date_trunc.sql",
+			"name": "date_trunc",
+			"macro_sql": "{% macro date_trunc(datepart, date) -%}\n  {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__date_trunc"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.135919,
+			"supported_languages": null
+		},
+		"macro.dbt.default__date_trunc": {
+			"unique_id": "macro.dbt.default__date_trunc",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/date_trunc.sql",
+			"original_file_path": "macros/utils/date_trunc.sql",
+			"name": "default__date_trunc",
+			"macro_sql": "{% macro default__date_trunc(datepart, date) -%}\n    date_trunc('{{datepart}}', {{date}})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1360765,
+			"supported_languages": null
+		},
+		"macro.dbt.escape_single_quotes": {
+			"unique_id": "macro.dbt.escape_single_quotes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/escape_single_quotes.sql",
+			"original_file_path": "macros/utils/escape_single_quotes.sql",
+			"name": "escape_single_quotes",
+			"macro_sql": "{% macro escape_single_quotes(expression) %}\n      {{ return(adapter.dispatch('escape_single_quotes', 'dbt') (expression)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__escape_single_quotes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1374903,
+			"supported_languages": null
+		},
+		"macro.dbt.default__escape_single_quotes": {
+			"unique_id": "macro.dbt.default__escape_single_quotes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/escape_single_quotes.sql",
+			"original_file_path": "macros/utils/escape_single_quotes.sql",
+			"name": "default__escape_single_quotes",
+			"macro_sql": "{% macro default__escape_single_quotes(expression) -%}\n{{ expression | replace(\"'\",\"''\") }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1376534,
+			"supported_languages": null
+		},
+		"macro.dbt.array_append": {
+			"unique_id": "macro.dbt.array_append",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_append.sql",
+			"original_file_path": "macros/utils/array_append.sql",
+			"name": "array_append",
+			"macro_sql": "{% macro array_append(array, new_element) -%}\n  {{ return(adapter.dispatch('array_append', 'dbt')(array, new_element)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__array_append"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1392357,
+			"supported_languages": null
+		},
+		"macro.dbt.default__array_append": {
+			"unique_id": "macro.dbt.default__array_append",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/array_append.sql",
+			"original_file_path": "macros/utils/array_append.sql",
+			"name": "default__array_append",
+			"macro_sql": "{% macro default__array_append(array, new_element) -%}\n    array_append({{ array }}, {{ new_element }})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1394308,
+			"supported_languages": null
+		},
+		"macro.dbt.string_literal": {
+			"unique_id": "macro.dbt.string_literal",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/literal.sql",
+			"original_file_path": "macros/utils/literal.sql",
+			"name": "string_literal",
+			"macro_sql": "{%- macro string_literal(value) -%}\n  {{ return(adapter.dispatch('string_literal', 'dbt') (value)) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__string_literal"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.141029,
+			"supported_languages": null
+		},
+		"macro.dbt.default__string_literal": {
+			"unique_id": "macro.dbt.default__string_literal",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/literal.sql",
+			"original_file_path": "macros/utils/literal.sql",
+			"name": "default__string_literal",
+			"macro_sql": "{% macro default__string_literal(value) -%}\n    '{{ value }}'\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1413252,
+			"supported_languages": null
+		},
+		"macro.dbt.safe_cast": {
+			"unique_id": "macro.dbt.safe_cast",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/safe_cast.sql",
+			"original_file_path": "macros/utils/safe_cast.sql",
+			"name": "safe_cast",
+			"macro_sql": "{% macro safe_cast(field, type) %}\n  {{ return(adapter.dispatch('safe_cast', 'dbt') (field, type)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__safe_cast"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1428874,
+			"supported_languages": null
+		},
+		"macro.dbt.default__safe_cast": {
+			"unique_id": "macro.dbt.default__safe_cast",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/safe_cast.sql",
+			"original_file_path": "macros/utils/safe_cast.sql",
+			"name": "default__safe_cast",
+			"macro_sql": "{% macro default__safe_cast(field, type) %}\n    {# most databases don't support this function yet\n    so we just need to use cast #}\n    cast({{field}} as {{type}})\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1430664,
+			"supported_languages": null
+		},
+		"macro.dbt.dateadd": {
+			"unique_id": "macro.dbt.dateadd",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/dateadd.sql",
+			"original_file_path": "macros/utils/dateadd.sql",
+			"name": "dateadd",
+			"macro_sql": "{% macro dateadd(datepart, interval, from_date_or_timestamp) %}\n  {{ return(adapter.dispatch('dateadd', 'dbt')(datepart, interval, from_date_or_timestamp)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__dateadd"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1445959,
+			"supported_languages": null
+		},
+		"macro.dbt.default__dateadd": {
+			"unique_id": "macro.dbt.default__dateadd",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/dateadd.sql",
+			"original_file_path": "macros/utils/dateadd.sql",
+			"name": "default__dateadd",
+			"macro_sql": "{% macro default__dateadd(datepart, interval, from_date_or_timestamp) %}\n\n    dateadd(\n        {{ datepart }},\n        {{ interval }},\n        {{ from_date_or_timestamp }}\n        )\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1447942,
+			"supported_languages": null
+		},
+		"macro.dbt.last_day": {
+			"unique_id": "macro.dbt.last_day",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/last_day.sql",
+			"original_file_path": "macros/utils/last_day.sql",
+			"name": "last_day",
+			"macro_sql": "{% macro last_day(date, datepart) %}\n  {{ return(adapter.dispatch('last_day', 'dbt') (date, datepart)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__last_day"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1461318,
+			"supported_languages": null
+		},
+		"macro.dbt.default_last_day": {
+			"unique_id": "macro.dbt.default_last_day",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/last_day.sql",
+			"original_file_path": "macros/utils/last_day.sql",
+			"name": "default_last_day",
+			"macro_sql": "\n\n{%- macro default_last_day(date, datepart) -%}\n    cast(\n        {{dbt.dateadd('day', '-1',\n        dbt.dateadd(datepart, '1', dbt.date_trunc(datepart, date))\n        )}}\n        as date)\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.dateadd", "macro.dbt.date_trunc"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.146508,
+			"supported_languages": null
+		},
+		"macro.dbt.default__last_day": {
+			"unique_id": "macro.dbt.default__last_day",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/last_day.sql",
+			"original_file_path": "macros/utils/last_day.sql",
+			"name": "default__last_day",
+			"macro_sql": "{% macro default__last_day(date, datepart) -%}\n    {{dbt.default_last_day(date, datepart)}}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default_last_day"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1467319,
+			"supported_languages": null
+		},
+		"macro.dbt.right": {
+			"unique_id": "macro.dbt.right",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/right.sql",
+			"original_file_path": "macros/utils/right.sql",
+			"name": "right",
+			"macro_sql": "{% macro right(string_text, length_expression) -%}\n    {{ return(adapter.dispatch('right', 'dbt') (string_text, length_expression)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__right"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1482468,
+			"supported_languages": null
+		},
+		"macro.dbt.default__right": {
+			"unique_id": "macro.dbt.default__right",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/right.sql",
+			"original_file_path": "macros/utils/right.sql",
+			"name": "default__right",
+			"macro_sql": "{% macro default__right(string_text, length_expression) %}\n\n    right(\n        {{ string_text }},\n        {{ length_expression }}\n    )\n\n{%- endmacro -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1484,
+			"supported_languages": null
+		},
+		"macro.dbt.type_string": {
+			"unique_id": "macro.dbt.type_string",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_string",
+			"macro_sql": "\n\n{%- macro type_string() -%}\n  {{ return(adapter.dispatch('type_string', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_string"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1502428,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_string": {
+			"unique_id": "macro.dbt.default__type_string",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_string",
+			"macro_sql": "{% macro default__type_string() %}\n    {{ return(api.Column.translate_type(\"string\")) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1504114,
+			"supported_languages": null
+		},
+		"macro.dbt.type_timestamp": {
+			"unique_id": "macro.dbt.type_timestamp",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_timestamp",
+			"macro_sql": "\n\n{%- macro type_timestamp() -%}\n  {{ return(adapter.dispatch('type_timestamp', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1505756,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_timestamp": {
+			"unique_id": "macro.dbt.default__type_timestamp",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_timestamp",
+			"macro_sql": "{% macro default__type_timestamp() %}\n    {{ return(api.Column.translate_type(\"timestamp\")) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1507318,
+			"supported_languages": null
+		},
+		"macro.dbt.type_float": {
+			"unique_id": "macro.dbt.type_float",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_float",
+			"macro_sql": "\n\n{%- macro type_float() -%}\n  {{ return(adapter.dispatch('type_float', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_float"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1509151,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_float": {
+			"unique_id": "macro.dbt.default__type_float",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_float",
+			"macro_sql": "{% macro default__type_float() %}\n    {{ return(api.Column.translate_type(\"float\")) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.151074,
+			"supported_languages": null
+		},
+		"macro.dbt.type_numeric": {
+			"unique_id": "macro.dbt.type_numeric",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_numeric",
+			"macro_sql": "\n\n{%- macro type_numeric() -%}\n  {{ return(adapter.dispatch('type_numeric', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_numeric"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1512365,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_numeric": {
+			"unique_id": "macro.dbt.default__type_numeric",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_numeric",
+			"macro_sql": "{% macro default__type_numeric() %}\n    {{ return(api.Column.numeric_type(\"numeric\", 28, 6)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1514218,
+			"supported_languages": null
+		},
+		"macro.dbt.type_bigint": {
+			"unique_id": "macro.dbt.type_bigint",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_bigint",
+			"macro_sql": "\n\n{%- macro type_bigint() -%}\n  {{ return(adapter.dispatch('type_bigint', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_bigint"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1517282,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_bigint": {
+			"unique_id": "macro.dbt.default__type_bigint",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_bigint",
+			"macro_sql": "{% macro default__type_bigint() %}\n    {{ return(api.Column.translate_type(\"bigint\")) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1520598,
+			"supported_languages": null
+		},
+		"macro.dbt.type_int": {
+			"unique_id": "macro.dbt.type_int",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_int",
+			"macro_sql": "\n\n{%- macro type_int() -%}\n  {{ return(adapter.dispatch('type_int', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_int"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1522417,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_int": {
+			"unique_id": "macro.dbt.default__type_int",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_int",
+			"macro_sql": "{%- macro default__type_int() -%}\n  {{ return(api.Column.translate_type(\"integer\")) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.152396,
+			"supported_languages": null
+		},
+		"macro.dbt.type_boolean": {
+			"unique_id": "macro.dbt.type_boolean",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "type_boolean",
+			"macro_sql": "\n\n{%- macro type_boolean() -%}\n  {{ return(adapter.dispatch('type_boolean', 'dbt')()) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__type_boolean"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1525557,
+			"supported_languages": null
+		},
+		"macro.dbt.default__type_boolean": {
+			"unique_id": "macro.dbt.default__type_boolean",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/data_types.sql",
+			"original_file_path": "macros/utils/data_types.sql",
+			"name": "default__type_boolean",
+			"macro_sql": "{%- macro default__type_boolean() -%}\n  {{ return(api.Column.translate_type(\"boolean\")) }}\n{%- endmacro -%}\n\n",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.152699,
+			"supported_languages": null
+		},
+		"macro.dbt.except": {
+			"unique_id": "macro.dbt.except",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/except.sql",
+			"original_file_path": "macros/utils/except.sql",
+			"name": "except",
+			"macro_sql": "{% macro except() %}\n  {{ return(adapter.dispatch('except', 'dbt')()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__except"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.154105,
+			"supported_languages": null
+		},
+		"macro.dbt.default__except": {
+			"unique_id": "macro.dbt.default__except",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/except.sql",
+			"original_file_path": "macros/utils/except.sql",
+			"name": "default__except",
+			"macro_sql": "{% macro default__except() %}\n\n    except\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1542,
+			"supported_languages": null
+		},
+		"macro.dbt.concat": {
+			"unique_id": "macro.dbt.concat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/concat.sql",
+			"original_file_path": "macros/utils/concat.sql",
+			"name": "concat",
+			"macro_sql": "{% macro concat(fields) -%}\n  {{ return(adapter.dispatch('concat', 'dbt')(fields)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__concat"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.156088,
+			"supported_languages": null
+		},
+		"macro.dbt.default__concat": {
+			"unique_id": "macro.dbt.default__concat",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/concat.sql",
+			"original_file_path": "macros/utils/concat.sql",
+			"name": "default__concat",
+			"macro_sql": "{% macro default__concat(fields) -%}\n    {{ fields|join(' || ') }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1562285,
+			"supported_languages": null
+		},
+		"macro.dbt.length": {
+			"unique_id": "macro.dbt.length",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/length.sql",
+			"original_file_path": "macros/utils/length.sql",
+			"name": "length",
+			"macro_sql": "{% macro length(expression) -%}\n    {{ return(adapter.dispatch('length', 'dbt') (expression)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__length"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.157551,
+			"supported_languages": null
+		},
+		"macro.dbt.default__length": {
+			"unique_id": "macro.dbt.default__length",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/utils/length.sql",
+			"original_file_path": "macros/utils/length.sql",
+			"name": "default__length",
+			"macro_sql": "{% macro default__length(expression) %}\n\n    length(\n        {{ expression }}\n    )\n\n{%- endmacro -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.157668,
+			"supported_languages": null
+		},
+		"macro.dbt.default__test_relationships": {
+			"unique_id": "macro.dbt.default__test_relationships",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/generic_test_sql/relationships.sql",
+			"original_file_path": "macros/generic_test_sql/relationships.sql",
+			"name": "default__test_relationships",
+			"macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nwith child as (\n    select {{ column_name }} as from_field\n    from {{ model }}\n    where {{ column_name }} is not null\n),\n\nparent as (\n    select {{ field }} as to_field\n    from {{ to }}\n)\n\nselect\n    from_field\n\nfrom child\nleft join parent\n    on child.from_field = parent.to_field\n\nwhere parent.to_field is null\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1591609,
+			"supported_languages": null
+		},
+		"macro.dbt.default__test_unique": {
+			"unique_id": "macro.dbt.default__test_unique",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/generic_test_sql/unique.sql",
+			"original_file_path": "macros/generic_test_sql/unique.sql",
+			"name": "default__test_unique",
+			"macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }} as unique_field,\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1603386,
+			"supported_languages": null
+		},
+		"macro.dbt.default__test_not_null": {
+			"unique_id": "macro.dbt.default__test_not_null",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/generic_test_sql/not_null.sql",
+			"original_file_path": "macros/generic_test_sql/not_null.sql",
+			"name": "default__test_not_null",
+			"macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\n{% set column_list = '*' if should_store_failures() else column_name %}\n\nselect {{ column_list }}\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_store_failures"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1614301,
+			"supported_languages": null
+		},
+		"macro.dbt.default__test_accepted_values": {
+			"unique_id": "macro.dbt.default__test_accepted_values",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/generic_test_sql/accepted_values.sql",
+			"original_file_path": "macros/generic_test_sql/accepted_values.sql",
+			"name": "default__test_accepted_values",
+			"macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by {{ column_name }}\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1627378,
+			"supported_languages": null
+		},
+		"macro.dbt.build_ref_function": {
+			"unique_id": "macro.dbt.build_ref_function",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/python_model/python.sql",
+			"original_file_path": "macros/python_model/python.sql",
+			"name": "build_ref_function",
+			"macro_sql": "{% macro build_ref_function(model) %}\n\n    {%- set ref_dict = {} -%}\n    {%- for _ref in model.refs -%}\n        {%- set resolved = ref(*_ref) -%}\n        {%- do ref_dict.update({_ref | join(\".\"): resolved.quote(database=False, schema=False, identifier=False) | string}) -%}\n    {%- endfor -%}\n\ndef ref(*args,dbt_load_df_function):\n    refs = {{ ref_dict | tojson }}\n    key = \".\".join(args)\n    return dbt_load_df_function(refs[key])\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1649725,
+			"supported_languages": null
+		},
+		"macro.dbt.build_source_function": {
+			"unique_id": "macro.dbt.build_source_function",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/python_model/python.sql",
+			"original_file_path": "macros/python_model/python.sql",
+			"name": "build_source_function",
+			"macro_sql": "{% macro build_source_function(model) %}\n\n    {%- set source_dict = {} -%}\n    {%- for _source in model.sources -%}\n        {%- set resolved = source(*_source) -%}\n        {%- do source_dict.update({_source | join(\".\"): resolved.quote(database=False, schema=False, identifier=False) | string}) -%}\n    {%- endfor -%}\n\ndef source(*args, dbt_load_df_function):\n    sources = {{ source_dict | tojson }}\n    key = \".\".join(args)\n    return dbt_load_df_function(sources[key])\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.16545,
+			"supported_languages": null
+		},
+		"macro.dbt.build_config_dict": {
+			"unique_id": "macro.dbt.build_config_dict",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/python_model/python.sql",
+			"original_file_path": "macros/python_model/python.sql",
+			"name": "build_config_dict",
+			"macro_sql": "{% macro build_config_dict(model) %}\n    {%- set config_dict = {} -%}\n    {%- for key in model.config.config_keys_used -%}\n        {# weird type testing with enum, would be much easier to write this logic in Python! #}\n        {%- if key == 'language' -%}\n          {%- set value = 'python' -%}\n        {%- endif -%}\n        {%- set value = model.config[key] -%}\n        {%- do config_dict.update({key: value}) -%}\n    {%- endfor -%}\nconfig_dict = {{ config_dict }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.165991,
+			"supported_languages": null
+		},
+		"macro.dbt.py_script_postfix": {
+			"unique_id": "macro.dbt.py_script_postfix",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/python_model/python.sql",
+			"original_file_path": "macros/python_model/python.sql",
+			"name": "py_script_postfix",
+			"macro_sql": "{% macro py_script_postfix(model) %}\n# This part is user provided model code\n# you will need to copy the next section to run the code\n# COMMAND ----------\n# this part is dbt logic for get ref work, do not modify\n\n{{ build_ref_function(model ) }}\n{{ build_source_function(model ) }}\n{{ build_config_dict(model) }}\n\nclass config:\n    def __init__(self, *args, **kwargs):\n        pass\n\n    @staticmethod\n    def get(key, default=None):\n        return config_dict.get(key, default)\n\nclass this:\n    \"\"\"dbt.this() or dbt.this.identifier\"\"\"\n    database = '{{ this.database }}'\n    schema = '{{ this.schema }}'\n    identifier = '{{ this.identifier }}'\n    def __repr__(self):\n        return '{{ this }}'\n\n\nclass dbtObj:\n    def __init__(self, load_df_function) -> None:\n        self.source = lambda *args: source(*args, dbt_load_df_function=load_df_function)\n        self.ref = lambda *args: ref(*args, dbt_load_df_function=load_df_function)\n        self.config = config\n        self.this = this()\n        self.is_incremental = {{ is_incremental() }}\n\n# COMMAND ----------\n{{py_script_comment()}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.build_ref_function", "macro.dbt.build_source_function", "macro.dbt.build_config_dict", "macro.dbt.is_incremental", "macro.dbt.py_script_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1664665,
+			"supported_languages": null
+		},
+		"macro.dbt.py_script_comment": {
+			"unique_id": "macro.dbt.py_script_comment",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/python_model/python.sql",
+			"original_file_path": "macros/python_model/python.sql",
+			"name": "py_script_comment",
+			"macro_sql": "{%macro py_script_comment()%}\n{%endmacro%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1665525,
+			"supported_languages": null
+		},
+		"macro.dbt.run_hooks": {
+			"unique_id": "macro.dbt.run_hooks",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/hooks.sql",
+			"original_file_path": "macros/materializations/hooks.sql",
+			"name": "run_hooks",
+			"macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1692612,
+			"supported_languages": null
+		},
+		"macro.dbt.make_hook_config": {
+			"unique_id": "macro.dbt.make_hook_config",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/hooks.sql",
+			"original_file_path": "macros/materializations/hooks.sql",
+			"name": "make_hook_config",
+			"macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1695664,
+			"supported_languages": null
+		},
+		"macro.dbt.before_begin": {
+			"unique_id": "macro.dbt.before_begin",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/hooks.sql",
+			"original_file_path": "macros/materializations/hooks.sql",
+			"name": "before_begin",
+			"macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.169737,
+			"supported_languages": null
+		},
+		"macro.dbt.in_transaction": {
+			"unique_id": "macro.dbt.in_transaction",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/hooks.sql",
+			"original_file_path": "macros/materializations/hooks.sql",
+			"name": "in_transaction",
+			"macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1698847,
+			"supported_languages": null
+		},
+		"macro.dbt.after_commit": {
+			"unique_id": "macro.dbt.after_commit",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/hooks.sql",
+			"original_file_path": "macros/materializations/hooks.sql",
+			"name": "after_commit",
+			"macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.17006,
+			"supported_languages": null
+		},
+		"macro.dbt.set_sql_header": {
+			"unique_id": "macro.dbt.set_sql_header",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/configs.sql",
+			"original_file_path": "macros/materializations/configs.sql",
+			"name": "set_sql_header",
+			"macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1715496,
+			"supported_languages": null
+		},
+		"macro.dbt.should_full_refresh": {
+			"unique_id": "macro.dbt.should_full_refresh",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/configs.sql",
+			"original_file_path": "macros/materializations/configs.sql",
+			"name": "should_full_refresh",
+			"macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.171882,
+			"supported_languages": null
+		},
+		"macro.dbt.should_store_failures": {
+			"unique_id": "macro.dbt.should_store_failures",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/configs.sql",
+			"original_file_path": "macros/materializations/configs.sql",
+			"name": "should_store_failures",
+			"macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.172215,
+			"supported_languages": null
+		},
+		"macro.dbt.get_quoted_csv": {
+			"unique_id": "macro.dbt.get_quoted_csv",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/column_helpers.sql",
+			"original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+			"name": "get_quoted_csv",
+			"macro_sql": "{% macro get_quoted_csv(column_names) %}\n\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1746712,
+			"supported_languages": null
+		},
+		"macro.dbt.diff_columns": {
+			"unique_id": "macro.dbt.diff_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/column_helpers.sql",
+			"original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+			"name": "diff_columns",
+			"macro_sql": "{% macro diff_columns(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% set source_names = source_columns | map(attribute = 'column') | list %}\n  {% set target_names = target_columns | map(attribute = 'column') | list %}\n\n   {# --check whether the name attribute exists in the target - this does not perform a data type check #}\n   {% for sc in source_columns %}\n     {% if sc.name not in target_names %}\n        {{ result.append(sc) }}\n     {% endif %}\n   {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1752462,
+			"supported_languages": null
+		},
+		"macro.dbt.diff_column_data_types": {
+			"unique_id": "macro.dbt.diff_column_data_types",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/column_helpers.sql",
+			"original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+			"name": "diff_column_data_types",
+			"macro_sql": "{% macro diff_column_data_types(source_columns, target_columns) %}\n\n  {% set result = [] %}\n  {% for sc in source_columns %}\n    {% set tc = target_columns | selectattr(\"name\", \"equalto\", sc.name) | list | first %}\n    {% if tc %}\n      {% if sc.data_type != tc.data_type and not sc.can_expand_to(other_column=tc) %}\n        {{ result.append( { 'column_name': tc.name, 'new_type': sc.data_type } ) }}\n      {% endif %}\n    {% endif %}\n  {% endfor %}\n\n  {{ return(result) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.175933,
+			"supported_languages": null
+		},
+		"macro.dbt.get_merge_update_columns": {
+			"unique_id": "macro.dbt.get_merge_update_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/column_helpers.sql",
+			"original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+			"name": "get_merge_update_columns",
+			"macro_sql": "{% macro get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {{ return(adapter.dispatch('get_merge_update_columns', 'dbt')(merge_update_columns, merge_exclude_columns, dest_columns)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_merge_update_columns"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.176175,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_merge_update_columns": {
+			"unique_id": "macro.dbt.default__get_merge_update_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/column_helpers.sql",
+			"original_file_path": "macros/materializations/models/incremental/column_helpers.sql",
+			"name": "default__get_merge_update_columns",
+			"macro_sql": "{% macro default__get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) %}\n  {%- set default_cols = dest_columns | map(attribute=\"quoted\") | list -%}\n\n  {%- if merge_update_columns and merge_exclude_columns -%}\n    {{ exceptions.raise_compiler_error(\n        'Model cannot specify merge_update_columns and merge_exclude_columns. Please update model to use only one config'\n    )}}\n  {%- elif merge_update_columns -%}\n    {%- set update_columns = merge_update_columns -%}\n  {%- elif merge_exclude_columns -%}\n    {%- set update_columns = [] -%}\n    {%- for column in dest_columns -%}\n      {% if column.column | lower not in merge_exclude_columns | map(\"lower\") | list %}\n        {%- do update_columns.append(column.quoted) -%}\n      {% endif %}\n    {%- endfor -%}\n  {%- else -%}\n    {%- set update_columns = default_cols -%}\n  {%- endif -%}\n\n  {{ return(update_columns) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.176874,
+			"supported_languages": null
+		},
+		"macro.dbt.get_incremental_append_sql": {
+			"unique_id": "macro.dbt.get_incremental_append_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_incremental_append_sql",
+			"macro_sql": "{% macro get_incremental_append_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_append_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_incremental_append_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1790745,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_incremental_append_sql": {
+			"unique_id": "macro.dbt.default__get_incremental_append_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "default__get_incremental_append_sql",
+			"macro_sql": "{% macro default__get_incremental_append_sql(arg_dict) %}\n\n  {% do return(get_insert_into_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_insert_into_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1793358,
+			"supported_languages": null
+		},
+		"macro.dbt.get_incremental_delete_insert_sql": {
+			"unique_id": "macro.dbt.get_incremental_delete_insert_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_incremental_delete_insert_sql",
+			"macro_sql": "{% macro get_incremental_delete_insert_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_delete_insert_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_incremental_delete_insert_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.179531,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_incremental_delete_insert_sql": {
+			"unique_id": "macro.dbt.default__get_incremental_delete_insert_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "default__get_incremental_delete_insert_sql",
+			"macro_sql": "{% macro default__get_incremental_delete_insert_sql(arg_dict) %}\n\n  {% do return(get_delete_insert_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_delete_insert_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1797976,
+			"supported_languages": null
+		},
+		"macro.dbt.get_incremental_merge_sql": {
+			"unique_id": "macro.dbt.get_incremental_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_incremental_merge_sql",
+			"macro_sql": "{% macro get_incremental_merge_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_incremental_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1799986,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_incremental_merge_sql": {
+			"unique_id": "macro.dbt.default__get_incremental_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "default__get_incremental_merge_sql",
+			"macro_sql": "{% macro default__get_incremental_merge_sql(arg_dict) %}\n\n  {% do return(get_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"unique_key\"], arg_dict[\"dest_columns\"])) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1802628,
+			"supported_languages": null
+		},
+		"macro.dbt.get_incremental_insert_overwrite_sql": {
+			"unique_id": "macro.dbt.get_incremental_insert_overwrite_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_incremental_insert_overwrite_sql",
+			"macro_sql": "{% macro get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_insert_overwrite_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_incremental_insert_overwrite_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1804488,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_incremental_insert_overwrite_sql": {
+			"unique_id": "macro.dbt.default__get_incremental_insert_overwrite_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "default__get_incremental_insert_overwrite_sql",
+			"macro_sql": "{% macro default__get_incremental_insert_overwrite_sql(arg_dict) %}\n\n  {% do return(get_insert_overwrite_merge_sql(arg_dict[\"target_relation\"], arg_dict[\"temp_relation\"], arg_dict[\"dest_columns\"], arg_dict[\"predicates\"])) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_insert_overwrite_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1807184,
+			"supported_languages": null
+		},
+		"macro.dbt.get_incremental_default_sql": {
+			"unique_id": "macro.dbt.get_incremental_default_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_incremental_default_sql",
+			"macro_sql": "{% macro get_incremental_default_sql(arg_dict) %}\n\n  {{ return(adapter.dispatch('get_incremental_default_sql', 'dbt')(arg_dict)) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__get_incremental_default_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.181028,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_incremental_default_sql": {
+			"unique_id": "macro.dbt.default__get_incremental_default_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "default__get_incremental_default_sql",
+			"macro_sql": "{% macro default__get_incremental_default_sql(arg_dict) %}\n\n  {% do return(get_incremental_append_sql(arg_dict)) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_incremental_append_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.1811914,
+			"supported_languages": null
+		},
+		"macro.dbt.get_insert_into_sql": {
+			"unique_id": "macro.dbt.get_insert_into_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/strategies.sql",
+			"original_file_path": "macros/materializations/models/incremental/strategies.sql",
+			"name": "get_insert_into_sql",
+			"macro_sql": "{% macro get_insert_into_sql(target_relation, temp_relation, dest_columns) %}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ temp_relation }}\n    )\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.181487,
+			"supported_languages": null
+		},
+		"macro.dbt.get_merge_sql": {
+			"unique_id": "macro.dbt.get_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "get_merge_sql",
+			"macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}\n  {{ adapter.dispatch('get_merge_sql', 'dbt')(target, source, unique_key, dest_columns, predicates) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.20365,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_merge_sql": {
+			"unique_id": "macro.dbt.default__get_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "default__get_merge_sql",
+			"macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set merge_update_columns = config.get('merge_update_columns') -%}\n    {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}\n    {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}\n            {% for key in unique_key %}\n                {% set this_key_match %}\n                    DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}\n                {% endset %}\n                {% do predicates.append(this_key_match) %}\n            {% endfor %}\n        {% else %}\n            {% set unique_key_match %}\n                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n            {% endset %}\n            {% do predicates.append(unique_key_match) %}\n        {% endif %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{ predicates | join(' and ') }}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv", "macro.dbt.get_merge_update_columns"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2054405,
+			"supported_languages": null
+		},
+		"macro.dbt.get_delete_insert_merge_sql": {
+			"unique_id": "macro.dbt.get_delete_insert_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "get_delete_insert_merge_sql",
+			"macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql', 'dbt')(target, source, unique_key, dest_columns) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_delete_insert_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2057555,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_delete_insert_merge_sql": {
+			"unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "default__get_delete_insert_merge_sql",
+			"macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key %}\n        {% if unique_key is sequence and unique_key is not string %}\n            delete from {{target }}\n            using {{ source }}\n            where (\n                {% for key in unique_key %}\n                    {{ source }}.{{ key }} = {{ target }}.{{ key }}\n                    {{ \"and \" if not loop.last }}\n                {% endfor %}\n            );\n        {% else %}\n            delete from {{ target }}\n            where (\n                {{ unique_key }}) in (\n                select ({{ unique_key }})\n                from {{ source }}\n            );\n\n        {% endif %}\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    )\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.206538,
+			"supported_languages": null
+		},
+		"macro.dbt.get_insert_overwrite_merge_sql": {
+			"unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "get_insert_overwrite_merge_sql",
+			"macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql', 'dbt')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_insert_overwrite_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2068198,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_insert_overwrite_merge_sql": {
+			"unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/merge.sql",
+			"original_file_path": "macros/materializations/models/incremental/merge.sql",
+			"name": "default__get_insert_overwrite_merge_sql",
+			"macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {#-- The only time include_sql_header is True: --#}\n    {#-- BigQuery + insert_overwrite strategy + \"static\" partitions config --#}\n    {#-- We should consider including the sql header at the materialization level instead --#}\n\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2074778,
+			"supported_languages": null
+		},
+		"macro.dbt.is_incremental": {
+			"unique_id": "macro.dbt.is_incremental",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/is_incremental.sql",
+			"original_file_path": "macros/materializations/models/incremental/is_incremental.sql",
+			"name": "is_incremental",
+			"macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_full_refresh"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2094634,
+			"supported_languages": null
+		},
+		"macro.dbt.incremental_validate_on_schema_change": {
+			"unique_id": "macro.dbt.incremental_validate_on_schema_change",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"name": "incremental_validate_on_schema_change",
+			"macro_sql": "{% macro incremental_validate_on_schema_change(on_schema_change, default='ignore') %}\n\n   {% if on_schema_change not in ['sync_all_columns', 'append_new_columns', 'fail', 'ignore'] %}\n\n     {% set log_message = 'Invalid value for on_schema_change (%s) specified. Setting default value of %s.' % (on_schema_change, default) %}\n     {% do log(log_message) %}\n\n     {{ return(default) }}\n\n   {% else %}\n\n     {{ return(on_schema_change) }}\n\n   {% endif %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2155488,
+			"supported_languages": null
+		},
+		"macro.dbt.check_for_schema_changes": {
+			"unique_id": "macro.dbt.check_for_schema_changes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"name": "check_for_schema_changes",
+			"macro_sql": "{% macro check_for_schema_changes(source_relation, target_relation) %}\n\n  {% set schema_changed = False %}\n\n  {%- set source_columns = adapter.get_columns_in_relation(source_relation) -%}\n  {%- set target_columns = adapter.get_columns_in_relation(target_relation) -%}\n  {%- set source_not_in_target = diff_columns(source_columns, target_columns) -%}\n  {%- set target_not_in_source = diff_columns(target_columns, source_columns) -%}\n\n  {% set new_target_types = diff_column_data_types(source_columns, target_columns) %}\n\n  {% if source_not_in_target != [] %}\n    {% set schema_changed = True %}\n  {% elif target_not_in_source != [] or new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% elif new_target_types != [] %}\n    {% set schema_changed = True %}\n  {% endif %}\n\n  {% set changes_dict = {\n    'schema_changed': schema_changed,\n    'source_not_in_target': source_not_in_target,\n    'target_not_in_source': target_not_in_source,\n    'source_columns': source_columns,\n    'target_columns': target_columns,\n    'new_target_types': new_target_types\n  } %}\n\n  {% set msg %}\n    In {{ target_relation }}:\n        Schema changed: {{ schema_changed }}\n        Source columns not in target: {{ source_not_in_target }}\n        Target columns not in source: {{ target_not_in_source }}\n        New column types: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(msg) %}\n\n  {{ return(changes_dict) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.diff_columns", "macro.dbt.diff_column_data_types"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2169151,
+			"supported_languages": null
+		},
+		"macro.dbt.sync_column_schemas": {
+			"unique_id": "macro.dbt.sync_column_schemas",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"name": "sync_column_schemas",
+			"macro_sql": "{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}\n\n  {%- if on_schema_change == 'append_new_columns'-%}\n     {%- if add_to_target_arr | length > 0 -%}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, none) -%}\n     {%- endif -%}\n\n  {% elif on_schema_change == 'sync_all_columns' %}\n     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}\n     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}\n\n     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 %}\n       {%- do alter_relation_add_remove_columns(target_relation, add_to_target_arr, remove_from_target_arr) -%}\n     {% endif %}\n\n     {% if new_target_types != [] %}\n       {% for ntt in new_target_types %}\n         {% set column_name = ntt['column_name'] %}\n         {% set new_type = ntt['new_type'] %}\n         {% do alter_column_type(target_relation, column_name, new_type) %}\n       {% endfor %}\n     {% endif %}\n\n  {% endif %}\n\n  {% set schema_change_message %}\n    In {{ target_relation }}:\n        Schema change approach: {{ on_schema_change }}\n        Columns added: {{ add_to_target_arr }}\n        Columns removed: {{ remove_from_target_arr }}\n        Data types changed: {{ new_target_types }}\n  {% endset %}\n\n  {% do log(schema_change_message) %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.alter_relation_add_remove_columns", "macro.dbt.alter_column_type"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2183342,
+			"supported_languages": null
+		},
+		"macro.dbt.process_schema_changes": {
+			"unique_id": "macro.dbt.process_schema_changes",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"original_file_path": "macros/materializations/models/incremental/on_schema_change.sql",
+			"name": "process_schema_changes",
+			"macro_sql": "{% macro process_schema_changes(on_schema_change, source_relation, target_relation) %}\n\n    {% if on_schema_change == 'ignore' %}\n\n     {{ return({}) }}\n\n    {% else %}\n\n      {% set schema_changes_dict = check_for_schema_changes(source_relation, target_relation) %}\n\n      {% if schema_changes_dict['schema_changed'] %}\n\n        {% if on_schema_change == 'fail' %}\n\n          {% set fail_msg %}\n              The source and target schemas on this incremental model are out of sync!\n              They can be reconciled in several ways:\n                - set the `on_schema_change` config to either append_new_columns or sync_all_columns, depending on your situation.\n                - Re-run the incremental model with `full_refresh: True` to update the target schema.\n                - update the schema manually and re-run the process.\n\n              Additional troubleshooting context:\n                 Source columns not in target: {{ schema_changes_dict['source_not_in_target'] }}\n                 Target columns not in source: {{ schema_changes_dict['target_not_in_source'] }}\n                 New column types: {{ schema_changes_dict['new_target_types'] }}\n          {% endset %}\n\n          {% do exceptions.raise_compiler_error(fail_msg) %}\n\n        {# -- unless we ignore, run the sync operation per the config #}\n        {% else %}\n\n          {% do sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}\n\n        {% endif %}\n\n      {% endif %}\n\n      {{ return(schema_changes_dict['source_columns']) }}\n\n    {% endif %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.check_for_schema_changes", "macro.dbt.sync_column_schemas"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2192254,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_incremental_default": {
+			"unique_id": "macro.dbt.materialization_incremental_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/incremental/incremental.sql",
+			"original_file_path": "macros/materializations/models/incremental/incremental.sql",
+			"name": "materialization_incremental_default",
+			"macro_sql": "{% materialization incremental, default -%}\n\n  -- relations\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') -%}\n  {%- set temp_relation = make_temp_relation(target_relation)-%}\n  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n\n  -- configs\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}\n  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}\n\n  -- the temp_ and backup_ relations should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation. This has to happen before\n  -- BEGIN, in a separate transaction\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n   -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n\n  {% if existing_relation is none %}\n      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}\n  {% elif full_refresh_mode %}\n      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n  {% else %}\n    {% do run_query(get_create_table_as_sql(True, temp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n             from_relation=temp_relation,\n             to_relation=target_relation) %}\n    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}\n    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}\n    {% if not dest_columns %}\n      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}\n    {% endif %}\n\n    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}\n    {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}\n    {% set incremental_predicates = config.get('incremental_predicates', none) %}\n    {% set strategy_sql_macro_func = adapter.get_incremental_strategy_macro(context, incremental_strategy) %}\n    {% set strategy_arg_dict = ({'target_relation': target_relation, 'temp_relation': temp_relation, 'unique_key': unique_key, 'dest_columns': dest_columns, 'predicates': incremental_predicates }) %}\n    {% set build_sql = strategy_sql_macro_func(strategy_arg_dict) %}\n\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %}\n      {% do adapter.rename_relation(target_relation, backup_relation) %}\n      {% do adapter.rename_relation(intermediate_relation, target_relation) %}\n      {% do to_drop.append(backup_relation) %}\n  {% endif %}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.load_cached_relation", "macro.dbt.make_temp_relation", "macro.dbt.make_intermediate_relation", "macro.dbt.make_backup_relation", "macro.dbt.should_full_refresh", "macro.dbt.incremental_validate_on_schema_change", "macro.dbt.drop_relation_if_exists", "macro.dbt.run_hooks", "macro.dbt.get_create_table_as_sql", "macro.dbt.run_query", "macro.dbt.process_schema_changes", "macro.dbt.statement", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs", "macro.dbt.create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2257576,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.handle_existing_table": {
+			"unique_id": "macro.dbt.handle_existing_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/helpers.sql",
+			"original_file_path": "macros/materializations/models/view/helpers.sql",
+			"name": "handle_existing_table",
+			"macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__handle_existing_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2271867,
+			"supported_languages": null
+		},
+		"macro.dbt.default__handle_existing_table": {
+			"unique_id": "macro.dbt.default__handle_existing_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/helpers.sql",
+			"original_file_path": "macros/materializations/models/view/helpers.sql",
+			"name": "default__handle_existing_table",
+			"macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2274437,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_view_default": {
+			"unique_id": "macro.dbt.materialization_view_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/view.sql",
+			"original_file_path": "macros/materializations/models/view/view.sql",
+			"name": "materialization_view_default",
+			"macro_sql": "{%- materialization view, default -%}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='view') -%}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"existing_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the existing_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the existing_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if existing_relation is not none %}\n    {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.load_cached_relation", "macro.dbt.make_intermediate_relation", "macro.dbt.make_backup_relation", "macro.dbt.run_hooks", "macro.dbt.drop_relation_if_exists", "macro.dbt.statement", "macro.dbt.get_create_view_as_sql", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2307599,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.get_create_view_as_sql": {
+			"unique_id": "macro.dbt.get_create_view_as_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/create_view_as.sql",
+			"original_file_path": "macros/materializations/models/view/create_view_as.sql",
+			"name": "get_create_view_as_sql",
+			"macro_sql": "{% macro get_create_view_as_sql(relation, sql) -%}\n  {{ adapter.dispatch('get_create_view_as_sql', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_create_view_as_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2320492,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_create_view_as_sql": {
+			"unique_id": "macro.dbt.default__get_create_view_as_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/create_view_as.sql",
+			"original_file_path": "macros/materializations/models/view/create_view_as.sql",
+			"name": "default__get_create_view_as_sql",
+			"macro_sql": "{% macro default__get_create_view_as_sql(relation, sql) -%}\n  {{ return(create_view_as(relation, sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.create_view_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2322314,
+			"supported_languages": null
+		},
+		"macro.dbt.create_view_as": {
+			"unique_id": "macro.dbt.create_view_as",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/create_view_as.sql",
+			"original_file_path": "macros/materializations/models/view/create_view_as.sql",
+			"name": "create_view_as",
+			"macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as', 'dbt')(relation, sql) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_view_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2325265,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_view_as": {
+			"unique_id": "macro.dbt.default__create_view_as",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/create_view_as.sql",
+			"original_file_path": "macros/materializations/models/view/create_view_as.sql",
+			"name": "default__create_view_as",
+			"macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2328498,
+			"supported_languages": null
+		},
+		"macro.dbt.create_or_replace_view": {
+			"unique_id": "macro.dbt.create_or_replace_view",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/view/create_or_replace_view.sql",
+			"original_file_path": "macros/materializations/models/view/create_or_replace_view.sql",
+			"name": "create_or_replace_view",
+			"macro_sql": "{% macro create_or_replace_view() %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n  {% set grant_config = config.get('grants') %}\n\n  {{ run_hooks(pre_hooks) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_view_as_sql(target_relation, sql) }}\n  {%- endcall %}\n\n  {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=True) %}\n\n  {{ run_hooks(post_hooks) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.handle_existing_table", "macro.dbt.should_full_refresh", "macro.dbt.statement", "macro.dbt.get_create_view_as_sql", "macro.dbt.should_revoke", "macro.dbt.apply_grants"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2355158,
+			"supported_languages": null
+		},
+		"macro.dbt.get_create_table_as_sql": {
+			"unique_id": "macro.dbt.get_create_table_as_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/table/create_table_as.sql",
+			"original_file_path": "macros/materializations/models/table/create_table_as.sql",
+			"name": "get_create_table_as_sql",
+			"macro_sql": "{% macro get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ adapter.dispatch('get_create_table_as_sql', 'dbt')(temporary, relation, sql) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_create_table_as_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.237533,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_create_table_as_sql": {
+			"unique_id": "macro.dbt.default__get_create_table_as_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/table/create_table_as.sql",
+			"original_file_path": "macros/materializations/models/table/create_table_as.sql",
+			"name": "default__get_create_table_as_sql",
+			"macro_sql": "{% macro default__get_create_table_as_sql(temporary, relation, sql) -%}\n  {{ return(create_table_as(temporary, relation, sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.create_table_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2377892,
+			"supported_languages": null
+		},
+		"macro.dbt.create_table_as": {
+			"unique_id": "macro.dbt.create_table_as",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/table/create_table_as.sql",
+			"original_file_path": "macros/materializations/models/table/create_table_as.sql",
+			"name": "create_table_as",
+			"macro_sql": "{% macro create_table_as(temporary, relation, compiled_code, language='sql') -%}\n  {# backward compatibility for create_table_as that does not support language #}\n  {% if language == \"sql\" %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code)}}\n  {% else %}\n    {{ adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language) }}\n  {% endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__create_table_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2383006,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_table_as": {
+			"unique_id": "macro.dbt.default__create_table_as",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/table/create_table_as.sql",
+			"original_file_path": "macros/materializations/models/table/create_table_as.sql",
+			"name": "default__create_table_as",
+			"macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  as (\n    {{ sql }}\n  );\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2388356,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_table_default": {
+			"unique_id": "macro.dbt.materialization_table_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/models/table/table.sql",
+			"original_file_path": "macros/materializations/models/table/table.sql",
+			"name": "materialization_table_default",
+			"macro_sql": "{% materialization table, default %}\n\n  {%- set existing_relation = load_cached_relation(this) -%}\n  {%- set target_relation = this.incorporate(type='table') %}\n  {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}\n  -- the intermediate_relation should not already exist in the database; get_relation\n  -- will return None in that case. Otherwise, we get a relation that we can drop\n  -- later, before we try to use this name for the current operation\n  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}\n  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}\n  -- as above, the backup_relation should not already exist\n  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}\n  -- grab current tables grants config for comparision later on\n  {% set grant_config = config.get('grants') %}\n\n  -- drop the temp relations if they exist already in the database\n  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}\n  {{ drop_relation_if_exists(preexisting_backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ get_create_table_as_sql(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if existing_relation is not none %}\n      {{ adapter.rename_relation(existing_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.load_cached_relation", "macro.dbt.make_intermediate_relation", "macro.dbt.make_backup_relation", "macro.dbt.drop_relation_if_exists", "macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.get_create_table_as_sql", "macro.dbt.create_indexes", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2423978,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.strategy_dispatch": {
+			"unique_id": "macro.dbt.strategy_dispatch",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "strategy_dispatch",
+			"macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2470906,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_hash_arguments": {
+			"unique_id": "macro.dbt.snapshot_hash_arguments",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "snapshot_hash_arguments",
+			"macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments', 'dbt')(args) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2473176,
+			"supported_languages": null
+		},
+		"macro.dbt.default__snapshot_hash_arguments": {
+			"unique_id": "macro.dbt.default__snapshot_hash_arguments",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "default__snapshot_hash_arguments",
+			"macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2476041,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_timestamp_strategy": {
+			"unique_id": "macro.dbt.snapshot_timestamp_strategy",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "snapshot_timestamp_strategy",
+			"macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/dbt-labs/dbt-core/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2487981,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_string_as_time": {
+			"unique_id": "macro.dbt.snapshot_string_as_time",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "snapshot_string_as_time",
+			"macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time', 'dbt')(timestamp) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__snapshot_string_as_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2490258,
+			"supported_languages": null
+		},
+		"macro.dbt.default__snapshot_string_as_time": {
+			"unique_id": "macro.dbt.default__snapshot_string_as_time",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "default__snapshot_string_as_time",
+			"macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2492082,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_check_all_get_existing_columns": {
+			"unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "snapshot_check_all_get_existing_columns",
+			"macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) -%}\n    {%- if not target_exists -%}\n        {#-- no table yet -> return whatever the query does --#}\n        {{ return((false, query_columns)) }}\n    {%- endif -%}\n\n    {#-- handle any schema changes --#}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=node.alias) -%}\n\n    {% if check_cols_config == 'all' %}\n        {%- set query_columns = get_columns_in_query(node['compiled_code']) -%}\n\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {#-- query for proper casing/quoting, to support comparison below --#}\n        {%- set select_check_cols_from_target -%}\n          select {{ check_cols_config | join(', ') }} from ({{ node['compiled_code'] }}) subq\n        {%- endset -%}\n        {% set query_columns = get_columns_in_query(select_check_cols_from_target) %}\n\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set existing_cols = adapter.get_columns_in_relation(target_relation) | map(attribute = 'name') | list -%}\n    {%- set ns = namespace() -%} {#-- handle for-loop scoping with a namespace --#}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(adapter.quote(col)) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return((ns.column_added, intersection)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_columns_in_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2509747,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_check_strategy": {
+			"unique_id": "macro.dbt.snapshot_check_strategy",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/strategies.sql",
+			"original_file_path": "macros/materializations/snapshots/strategies.sql",
+			"name": "snapshot_check_strategy",
+			"macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    {% set updated_at = config.get('updated_at', snapshot_get_time()) %}\n\n    {% set column_added = false %}\n\n    {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists, check_cols_config) %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        {{ get_true_sql() }}\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_get_time", "macro.dbt.snapshot_check_all_get_existing_columns", "macro.dbt.get_true_sql", "macro.dbt.snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2527447,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_snapshot_default": {
+			"unique_id": "macro.dbt.materialization_snapshot_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshots/snapshot.sql",
+			"name": "materialization_snapshot_default",
+			"macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n  -- grab current tables grants config for comparision later on\n  {%- set grant_config = config.get('grants') -%}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_or_create_relation", "macro.dbt.run_hooks", "macro.dbt.strategy_dispatch", "macro.dbt.build_snapshot_table", "macro.dbt.create_table_as", "macro.dbt.build_snapshot_staging_table", "macro.dbt.create_columns", "macro.dbt.snapshot_merge_sql", "macro.dbt.statement", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs", "macro.dbt.create_indexes", "macro.dbt.post_snapshot"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.259596,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.create_columns": {
+			"unique_id": "macro.dbt.create_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "create_columns",
+			"macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns', 'dbt')(relation, columns) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_columns"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2645774,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_columns": {
+			"unique_id": "macro.dbt.default__create_columns",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "default__create_columns",
+			"macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.264862,
+			"supported_languages": null
+		},
+		"macro.dbt.post_snapshot": {
+			"unique_id": "macro.dbt.post_snapshot",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "post_snapshot",
+			"macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot', 'dbt')(staging_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__post_snapshot"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2650406,
+			"supported_languages": null
+		},
+		"macro.dbt.default__post_snapshot": {
+			"unique_id": "macro.dbt.default__post_snapshot",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "default__post_snapshot",
+			"macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.265123,
+			"supported_languages": null
+		},
+		"macro.dbt.get_true_sql": {
+			"unique_id": "macro.dbt.get_true_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "get_true_sql",
+			"macro_sql": "{% macro get_true_sql() %}\n  {{ adapter.dispatch('get_true_sql', 'dbt')() }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_true_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2652562,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_true_sql": {
+			"unique_id": "macro.dbt.default__get_true_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "default__get_true_sql",
+			"macro_sql": "{% macro default__get_true_sql() %}\n    {{ return('TRUE') }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2653632,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_staging_table": {
+			"unique_id": "macro.dbt.snapshot_staging_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "snapshot_staging_table",
+			"macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n  {{ adapter.dispatch('snapshot_staging_table', 'dbt')(strategy, source_sql, target_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__snapshot_staging_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2655475,
+			"supported_languages": null
+		},
+		"macro.dbt.default__snapshot_staging_table": {
+			"unique_id": "macro.dbt.default__snapshot_staging_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "default__snapshot_staging_table",
+			"macro_sql": "{% macro default__snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n\n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n\n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_get_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2663739,
+			"supported_languages": null
+		},
+		"macro.dbt.build_snapshot_table": {
+			"unique_id": "macro.dbt.build_snapshot_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "build_snapshot_table",
+			"macro_sql": "{% macro build_snapshot_table(strategy, sql) -%}\n  {{ adapter.dispatch('build_snapshot_table', 'dbt')(strategy, sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__build_snapshot_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.266549,
+			"supported_languages": null
+		},
+		"macro.dbt.default__build_snapshot_table": {
+			"unique_id": "macro.dbt.default__build_snapshot_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "default__build_snapshot_table",
+			"macro_sql": "{% macro default__build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2667909,
+			"supported_languages": null
+		},
+		"macro.dbt.build_snapshot_staging_table": {
+			"unique_id": "macro.dbt.build_snapshot_staging_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/helpers.sql",
+			"original_file_path": "macros/materializations/snapshots/helpers.sql",
+			"name": "build_snapshot_staging_table",
+			"macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set temp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, temp_relation, select) }}\n    {% endcall %}\n\n    {% do return(temp_relation) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_temp_relation", "macro.dbt.snapshot_staging_table", "macro.dbt.statement", "macro.dbt.create_table_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2672377,
+			"supported_languages": null
+		},
+		"macro.dbt.snapshot_merge_sql": {
+			"unique_id": "macro.dbt.snapshot_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/snapshot_merge.sql",
+			"original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+			"name": "snapshot_merge_sql",
+			"macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql', 'dbt')(target, source, insert_cols) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_postgres.postgres__snapshot_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2687323,
+			"supported_languages": null
+		},
+		"macro.dbt.default__snapshot_merge_sql": {
+			"unique_id": "macro.dbt.default__snapshot_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshots/snapshot_merge.sql",
+			"original_file_path": "macros/materializations/snapshots/snapshot_merge.sql",
+			"name": "default__snapshot_merge_sql",
+			"macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.26904,
+			"supported_languages": null
+		},
+		"macro.dbt.create_csv_table": {
+			"unique_id": "macro.dbt.create_csv_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "create_csv_table",
+			"macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.274552,
+			"supported_languages": null
+		},
+		"macro.dbt.default__create_csv_table": {
+			"unique_id": "macro.dbt.default__create_csv_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__create_csv_table",
+			"macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.275583,
+			"supported_languages": null
+		},
+		"macro.dbt.reset_csv_table": {
+			"unique_id": "macro.dbt.reset_csv_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "reset_csv_table",
+			"macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table', 'dbt')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__reset_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2758186,
+			"supported_languages": null
+		},
+		"macro.dbt.default__reset_csv_table": {
+			"unique_id": "macro.dbt.default__reset_csv_table",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__reset_csv_table",
+			"macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.create_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2762895,
+			"supported_languages": null
+		},
+		"macro.dbt.get_csv_sql": {
+			"unique_id": "macro.dbt.get_csv_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "get_csv_sql",
+			"macro_sql": "{% macro get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ adapter.dispatch('get_csv_sql', 'dbt')(create_or_truncate_sql, insert_sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_csv_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2764716,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_csv_sql": {
+			"unique_id": "macro.dbt.default__get_csv_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__get_csv_sql",
+			"macro_sql": "{% macro default__get_csv_sql(create_or_truncate_sql, insert_sql) %}\n    {{ create_or_truncate_sql }};\n    -- dbt seed --\n    {{ insert_sql }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2766,
+			"supported_languages": null
+		},
+		"macro.dbt.get_binding_char": {
+			"unique_id": "macro.dbt.get_binding_char",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "get_binding_char",
+			"macro_sql": "{% macro get_binding_char() -%}\n  {{ adapter.dispatch('get_binding_char', 'dbt')() }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_binding_char"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2769132,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_binding_char": {
+			"unique_id": "macro.dbt.default__get_binding_char",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__get_binding_char",
+			"macro_sql": "{% macro default__get_binding_char() %}\n  {{ return('%s') }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2770967,
+			"supported_languages": null
+		},
+		"macro.dbt.get_batch_size": {
+			"unique_id": "macro.dbt.get_batch_size",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "get_batch_size",
+			"macro_sql": "{% macro get_batch_size() -%}\n  {{ return(adapter.dispatch('get_batch_size', 'dbt')()) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_batch_size"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.27726,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_batch_size": {
+			"unique_id": "macro.dbt.default__get_batch_size",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__get_batch_size",
+			"macro_sql": "{% macro default__get_batch_size() %}\n  {{ return(10000) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2773788,
+			"supported_languages": null
+		},
+		"macro.dbt.get_seed_column_quoted_csv": {
+			"unique_id": "macro.dbt.get_seed_column_quoted_csv",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "get_seed_column_quoted_csv",
+			"macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.277909,
+			"supported_languages": null
+		},
+		"macro.dbt.load_csv_rows": {
+			"unique_id": "macro.dbt.load_csv_rows",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "load_csv_rows",
+			"macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows', 'dbt')(model, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__load_csv_rows"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2781122,
+			"supported_languages": null
+		},
+		"macro.dbt.default__load_csv_rows": {
+			"unique_id": "macro.dbt.default__load_csv_rows",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/helpers.sql",
+			"original_file_path": "macros/materializations/seeds/helpers.sql",
+			"name": "default__load_csv_rows",
+			"macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n\n  {% set batch_size = get_batch_size() %}\n\n  {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n  {% set bindings = [] %}\n\n  {% set statements = [] %}\n\n  {% for chunk in agate_table.rows | batch(batch_size) %}\n      {% set bindings = [] %}\n\n      {% for row in chunk %}\n          {% do bindings.extend(row) %}\n      {% endfor %}\n\n      {% set sql %}\n          insert into {{ this.render() }} ({{ cols_sql }}) values\n          {% for row in chunk -%}\n              ({%- for column in agate_table.column_names -%}\n                  {{ get_binding_char() }}\n                  {%- if not loop.last%},{%- endif %}\n              {%- endfor -%})\n              {%- if not loop.last%},{%- endif %}\n          {%- endfor %}\n      {% endset %}\n\n      {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n      {% if loop.index0 == 0 %}\n          {% do statements.append(sql) %}\n      {% endif %}\n  {% endfor %}\n\n  {# Return SQL so we can render it out into the compiled files #}\n  {{ return(statements[0]) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_batch_size", "macro.dbt.get_seed_column_quoted_csv", "macro.dbt.get_binding_char"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2795122,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_seed_default": {
+			"unique_id": "macro.dbt.materialization_seed_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seeds/seed.sql",
+			"original_file_path": "macros/materializations/seeds/seed.sql",
+			"name": "materialization_seed_default",
+			"macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set grant_config = config.get('grants') -%}\n  {%- set agate_table = load_agate_table() -%}\n  -- grab current tables grants config for comparision later on\n\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ get_csv_sql(create_table_sql, sql) }};\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n\n  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}\n  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_full_refresh", "macro.dbt.run_hooks", "macro.dbt.reset_csv_table", "macro.dbt.create_csv_table", "macro.dbt.load_csv_rows", "macro.dbt.noop_statement", "macro.dbt.get_csv_sql", "macro.dbt.should_revoke", "macro.dbt.apply_grants", "macro.dbt.persist_docs", "macro.dbt.create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2840195,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.get_test_sql": {
+			"unique_id": "macro.dbt.get_test_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/tests/helpers.sql",
+			"original_file_path": "macros/materializations/tests/helpers.sql",
+			"name": "get_test_sql",
+			"macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_test_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.285277,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_test_sql": {
+			"unique_id": "macro.dbt.default__get_test_sql",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/tests/helpers.sql",
+			"original_file_path": "macros/materializations/tests/helpers.sql",
+			"name": "default__get_test_sql",
+			"macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2856886,
+			"supported_languages": null
+		},
+		"macro.dbt.materialization_test_default": {
+			"unique_id": "macro.dbt.materialization_test_default",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/tests/test.sql",
+			"original_file_path": "macros/materializations/tests/test.sql",
+			"name": "materialization_test_default",
+			"macro_sql": "{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type='table') -%} %}\n\n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n\n    {% call statement(auto_begin=True) %}\n        {{ create_table_as(False, target_relation, sql) }}\n    {% endcall %}\n\n    {% do relations.append(target_relation) %}\n\n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n\n    {{ adapter.commit() }}\n\n  {% else %}\n\n      {% set main_sql = sql %}\n\n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n\n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_store_failures", "macro.dbt.statement", "macro.dbt.create_table_as", "macro.dbt.get_test_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2888842,
+			"supported_languages": ["sql"]
+		},
+		"macro.dbt.get_where_subquery": {
+			"unique_id": "macro.dbt.get_where_subquery",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/tests/where_subquery.sql",
+			"original_file_path": "macros/materializations/tests/where_subquery.sql",
+			"name": "get_where_subquery",
+			"macro_sql": "{% macro get_where_subquery(relation) -%}\n    {% do return(adapter.dispatch('get_where_subquery', 'dbt')(relation)) %}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_where_subquery"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2907372,
+			"supported_languages": null
+		},
+		"macro.dbt.default__get_where_subquery": {
+			"unique_id": "macro.dbt.default__get_where_subquery",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/tests/where_subquery.sql",
+			"original_file_path": "macros/materializations/tests/where_subquery.sql",
+			"name": "default__get_where_subquery",
+			"macro_sql": "{% macro default__get_where_subquery(relation) -%}\n    {% set where = config.get('where', '') %}\n    {% if where %}\n        {%- set filtered -%}\n            (select * from {{ relation }} where {{ where }}) dbt_subquery\n        {%- endset -%}\n        {% do return(filtered) %}\n    {%- else -%}\n        {% do return(relation) %}\n    {%- endif -%}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2911294,
+			"supported_languages": null
+		},
+		"macro.dbt.test_unique": {
+			"unique_id": "macro.dbt.test_unique",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "tests/generic/builtin.sql",
+			"original_file_path": "tests/generic/builtin.sql",
+			"name": "test_unique",
+			"macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_unique"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2929757,
+			"supported_languages": null
+		},
+		"macro.dbt.test_not_null": {
+			"unique_id": "macro.dbt.test_not_null",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "tests/generic/builtin.sql",
+			"original_file_path": "tests/generic/builtin.sql",
+			"name": "test_not_null",
+			"macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null', 'dbt') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_not_null"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2932017,
+			"supported_languages": null
+		},
+		"macro.dbt.test_accepted_values": {
+			"unique_id": "macro.dbt.test_accepted_values",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "tests/generic/builtin.sql",
+			"original_file_path": "tests/generic/builtin.sql",
+			"name": "test_accepted_values",
+			"macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values', 'dbt') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_accepted_values"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.2934666,
+			"supported_languages": null
+		},
+		"macro.dbt.test_relationships": {
+			"unique_id": "macro.dbt.test_relationships",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "tests/generic/builtin.sql",
+			"original_file_path": "tests/generic/builtin.sql",
+			"name": "test_relationships",
+			"macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships', 'dbt') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_relationships"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true,
+				"node_color": null
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1670976638.293719,
+			"supported_languages": null
+		}
+	},
+	"docs": {
+		"jaffle_shop.orders_status": {
+			"unique_id": "jaffle_shop.orders_status",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "docs.md",
+			"original_file_path": "models/docs.md",
+			"name": "orders_status",
+			"block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+		},
+		"jaffle_shop.__overview__": {
+			"unique_id": "jaffle_shop.__overview__",
+			"package_name": "jaffle_shop",
+			"root_path": "/usr/local/airflow/dbt/jaffle_shop",
+			"path": "overview.md",
+			"original_file_path": "models/overview.md",
+			"name": "__overview__",
+			"block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+		},
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/usr/local/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--select` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/introduction)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [dbt Community](https://www.getdbt.com/community/) for questions and discussion"
+		}
+	},
+	"exposures": {},
+	"metrics": {},
+	"selectors": {},
+	"disabled": {},
+	"parent_map": {
+		"model.jaffle_shop.customers": ["model.jaffle_shop.stg_customers", "model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"],
+		"model.jaffle_shop.orders": ["model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"],
+		"model.jaffle_shop.stg_customers": ["seed.jaffle_shop.raw_customers"],
+		"model.jaffle_shop.stg_orders": ["seed.jaffle_shop.raw_orders"],
+		"model.jaffle_shop.stg_payments": ["seed.jaffle_shop.raw_payments"],
+		"seed.jaffle_shop.raw_customers": [],
+		"seed.jaffle_shop.raw_orders": [],
+		"seed.jaffle_shop.raw_payments": [],
+		"test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": ["model.jaffle_shop.customers"],
+		"test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": ["model.jaffle_shop.customers"],
+		"test.jaffle_shop.unique_orders_order_id.fed79b3a6e": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_order_id.cf6c17daed": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_customer_id.c5f02694af": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": ["model.jaffle_shop.customers", "model.jaffle_shop.orders"],
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_amount.106140f9fd": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": ["model.jaffle_shop.stg_customers"],
+		"test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": ["model.jaffle_shop.stg_customers"],
+		"test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.unique_stg_payments_payment_id.3744510712": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": ["model.jaffle_shop.stg_payments"]
+	},
+	"child_map": {
+		"model.jaffle_shop.customers": ["test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d", "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2", "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1"],
+		"model.jaffle_shop.orders": ["test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3", "test.jaffle_shop.not_null_orders_amount.106140f9fd", "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49", "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625", "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59", "test.jaffle_shop.not_null_orders_customer_id.c5f02694af", "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a", "test.jaffle_shop.not_null_orders_order_id.cf6c17daed", "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2", "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"],
+		"model.jaffle_shop.stg_customers": ["model.jaffle_shop.customers", "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa", "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada"],
+		"model.jaffle_shop.stg_orders": ["model.jaffle_shop.customers", "model.jaffle_shop.orders", "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad", "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64", "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a"],
+		"model.jaffle_shop.stg_payments": ["model.jaffle_shop.customers", "model.jaffle_shop.orders", "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278", "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075", "test.jaffle_shop.unique_stg_payments_payment_id.3744510712"],
+		"seed.jaffle_shop.raw_customers": ["model.jaffle_shop.stg_customers"],
+		"seed.jaffle_shop.raw_orders": ["model.jaffle_shop.stg_orders"],
+		"seed.jaffle_shop.raw_payments": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1": [],
+		"test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d": [],
+		"test.jaffle_shop.unique_orders_order_id.fed79b3a6e": [],
+		"test.jaffle_shop.not_null_orders_order_id.cf6c17daed": [],
+		"test.jaffle_shop.not_null_orders_customer_id.c5f02694af": [],
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2": [],
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3": [],
+		"test.jaffle_shop.not_null_orders_amount.106140f9fd": [],
+		"test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59": [],
+		"test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625": [],
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49": [],
+		"test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a": [],
+		"test.jaffle_shop.unique_stg_customers_customer_id.c7614daada": [],
+		"test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa": [],
+		"test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a": [],
+		"test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64": [],
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad": [],
+		"test.jaffle_shop.unique_stg_payments_payment_id.3744510712": [],
+		"test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075": [],
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278": []
+	}
+}

--- a/integration/common/tests/dbt/postgres/target/run_results.json
+++ b/integration/common/tests/dbt/postgres/target/run_results.json
@@ -1,0 +1,134 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
+		"dbt_version": "1.3.1",
+		"generated_at": "2022-12-14T21:28:17.216927Z",
+		"invocation_id": "1269f08d-da04-4fbd-8207-1ddc9110cb1b",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-12-14T21:28:16.888948Z",
+			"completed_at": "2022-12-14T21:28:16.898154Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-12-14T21:28:16.899571Z",
+			"completed_at": "2022-12-14T21:28:16.964210Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.07901287078857422,
+		"adapter_response": {
+			"_message": "CREATE VIEW",
+			"code": "CREATE VIEW",
+			"rows_affected": -1
+		},
+		"message": "CREATE VIEW",
+		"failures": null,
+		"unique_id": "model.jaffle_shop.stg_customers"
+	}, {
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-12-14T21:28:16.972100Z",
+			"completed_at": "2022-12-14T21:28:16.977442Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-12-14T21:28:16.997052Z",
+			"completed_at": "2022-12-14T21:28:17.030362Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.06149768829345703,
+		"adapter_response": {
+			"_message": "CREATE VIEW",
+			"code": "CREATE VIEW",
+			"rows_affected": -1
+		},
+		"message": "CREATE VIEW",
+		"failures": null,
+		"unique_id": "model.jaffle_shop.stg_orders"
+	}, {
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-12-14T21:28:17.037765Z",
+			"completed_at": "2022-12-14T21:28:17.044089Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-12-14T21:28:17.045744Z",
+			"completed_at": "2022-12-14T21:28:17.076892Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.04267001152038574,
+		"adapter_response": {
+			"_message": "CREATE VIEW",
+			"code": "CREATE VIEW",
+			"rows_affected": -1
+		},
+		"message": "CREATE VIEW",
+		"failures": null,
+		"unique_id": "model.jaffle_shop.stg_payments"
+	}, {
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-12-14T21:28:17.085055Z",
+			"completed_at": "2022-12-14T21:28:17.092345Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-12-14T21:28:17.093727Z",
+			"completed_at": "2022-12-14T21:28:17.140203Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.058419227600097656,
+		"adapter_response": {
+			"_message": "SELECT 100",
+			"code": "SELECT",
+			"rows_affected": 100
+		},
+		"message": "SELECT 100",
+		"failures": null,
+		"unique_id": "model.jaffle_shop.customers"
+	}, {
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2022-12-14T21:28:17.148674Z",
+			"completed_at": "2022-12-14T21:28:17.154923Z"
+		}, {
+			"name": "execute",
+			"started_at": "2022-12-14T21:28:17.156316Z",
+			"completed_at": "2022-12-14T21:28:17.196590Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 0.0513913631439209,
+		"adapter_response": {
+			"_message": "SELECT 99",
+			"code": "SELECT",
+			"rows_affected": 99
+		},
+		"message": "SELECT 99",
+		"failures": null,
+		"unique_id": "model.jaffle_shop.orders"
+	}],
+	"elapsed_time": 0.40049314498901367,
+	"args": {
+		"write_json": true,
+		"use_colors": true,
+		"printer_width": 80,
+		"version_check": true,
+		"partial_parse": true,
+		"static_parser": true,
+		"profiles_dir": "./tests/dbt/postgres",
+		"send_anonymous_usage_stats": true,
+		"event_buffer_size": 100000,
+		"quiet": false,
+		"no_print": false,
+		"project_dir": "/usr/local/airflow/dbt/jaffle_shop",
+		"profile": "postgres_profile",
+		"which": "run",
+		"rpc_method": "run",
+		"indirect_selection": "eager"
+	}
+}

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -47,7 +47,8 @@ def serialize(inst, field, value):
         "tests/dbt/build",
         "tests/dbt/compiled_code",
         "tests/dbt/spark/thrift",
-        "tests/dbt/spark/odbc"
+        "tests/dbt/spark/odbc",
+        "tests/dbt/postgres"
     ]
 )
 def test_dbt_parse_and_compare_event(path, parent_run_metadata):


### PR DESCRIPTION
Signed-off-by: Julien Le Dem <julien@apache.org>

### Problem

The openlineage-dbt integration did not support postgres as a datasource.

### Solution

I have added support for postgres profiles. This does not change existing behavior and is backwards compatible.

This change does not change the spec, nor facets 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project