### PR TITLE
Airflow: Fix collect_ignore. Add flags to pytest so that output is cleaner.

### DIFF
--- a/integration/airflow/pytest.ini
+++ b/integration/airflow/pytest.ini
@@ -6,3 +6,4 @@ log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 log_level = DEBUG
 norecursedirs = tests/integration
+addopts = --import-mode=importlib -p no:warnings

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -49,7 +49,7 @@ deps = -r dev-requirements.txt
 whitelist_externals = bash
 commands = flake8 --extend-exclude tests/integration,scripts/
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}
-	pytest --cov=openlineage --junitxml=test-results/junit.xml
+	python -m pytest --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml
 setenv = 
 	AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///{envdir}/airflow.db

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -11,7 +11,7 @@ from airflow.version import version as AIRFLOW_VERSION
 from mock import patch
 log = logging.getLogger(__name__)
 
-collect_ignore = ['extractors']
+collect_ignore = []
 
 
 if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):

--- a/integration/airflow/tests/test_location.py
+++ b/integration/airflow/tests/test_location.py
@@ -7,7 +7,7 @@ import sys
 from unittest.mock import patch
 
 import pytest
-from .mocks.git_mock import execute_git_mock
+from tests.mocks.git_mock import execute_git_mock
 
 from openlineage.airflow.utils import get_location
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Pytest ignores `extractors` directory.

Closes: #1434 

### Solution

Remove directory from ignored list. Slightly improve running unit tests experience.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project