### PR TITLE
[INTEGRATION][AIRFLOW] Add a new extractor for S3FileTransformOperator

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -63,7 +63,10 @@ _extractors = list(
             ),
             try_import_from_string(
                 'openlineage.airflow.extractors.s3_extractor.S3CopyObjectExtractor'
-            )
+            ),
+            try_import_from_string(
+                'openlineage.airflow.extractors.s3_extractor.S3FileTransformExtractor'
+            ),
         ],
     )
 )

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -3,6 +3,7 @@
 
 import logging
 from typing import Optional, List
+from urllib.parse import urlparse
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.run import Dataset
 
@@ -15,7 +16,6 @@ class S3CopyObjectExtractor(BaseExtractor):
         return ['S3CopyObjectOperator']
 
     def extract(self) -> Optional[TaskMetadata]:
-
         input_object = Dataset(
             namespace="s3://{}".format(self.operator.source_bucket_name),
             name="s3://{0}/{1}".format(
@@ -31,6 +31,34 @@ class S3CopyObjectExtractor(BaseExtractor):
                 self.operator.dest_bucket_name,
                 self.operator.dest_bucket_key
             ),
+            facets={}
+        )
+
+        return TaskMetadata(
+            name=f"{self.operator.dag_id}.{self.operator.task_id}",
+            inputs=[input_object],
+            outputs=[output_object],
+        )
+
+    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
+        pass
+
+
+class S3FileTransformExtractor(BaseExtractor):
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ['S3FileTransformOperator']
+
+    def extract(self) -> Optional[TaskMetadata]:
+        input_object = Dataset(
+            namespace=f"s3://{urlparse(self.operator.source_s3_key).netloc}",
+            name=self.operator.source_s3_key,
+            facets={}
+        )
+
+        output_object = Dataset(
+            namespace=f"s3://{urlparse(self.operator.dest_s3_key).netloc}",
+            name=self.operator.dest_s3_key,
             facets={}
         )
 

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -3,21 +3,15 @@
 
 import logging
 import unittest
-import random
-import pytz
 from unittest import TestCase
+from airflow.models import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator, S3FileTransformOperator
+from airflow.utils import timezone
+from openlineage.airflow.extractors.base import TaskMetadata
 from openlineage.airflow.extractors.s3_extractor import (
     S3CopyObjectExtractor,
     S3FileTransformExtractor
 )
-from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator, S3FileTransformOperator
-from openlineage.airflow.extractors.base import TaskMetadata
-from datetime import datetime
-from airflow.models import TaskInstance, DAG
-from airflow.utils.state import State
-from airflow.utils import timezone
-from pkg_resources import parse_version
-from airflow.version import version as AIRFLOW_VERSION
 from openlineage.client.run import Dataset
 
 log = logging.getLogger(__name__)
@@ -27,7 +21,6 @@ class TestS3CopyObjectExtractor(TestCase):
     def setUp(self):
         log.debug("TestS3CopyObjectExtractor.setup(): ")
         self.task = TestS3CopyObjectExtractor._get_copy_task()
-        self.ti = TestS3CopyObjectExtractor._get_ti(task=self.task)
         self.extractor = S3CopyObjectExtractor(operator=self.task)
 
     def test_extract(self):
@@ -48,9 +41,7 @@ class TestS3CopyObjectExtractor(TestCase):
                 )
             ],
         )
-
         return_value = self.extractor.extract()
-
         self.assertEqual(return_value, expected_return_value)
 
     @staticmethod
@@ -65,29 +56,13 @@ class TestS3CopyObjectExtractor(TestCase):
             dag=dag,
             start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
         )
-
         return task
-
-    @staticmethod
-    def _get_ti(task):
-        kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
-            kwargs['run_id'] = 'test_run_id'  # change in 2.2.0
-        task_instance = TaskInstance(
-            task=task,
-            execution_date=datetime.utcnow().replace(tzinfo=pytz.utc),
-            state=State.SUCCESS,
-            **kwargs)
-        task_instance.job_id = random.randrange(10000)
-
-        return task_instance
 
 
 class TestS3FileTransformExtractor(TestCase):
     def setUp(self):
         log.debug("TestS3FileTransformExtractor.setup(): ")
         self.task = TestS3FileTransformExtractor._get_copy_task()
-        self.ti = TestS3FileTransformExtractor._get_ti(task=self.task)
         self.extractor = S3FileTransformExtractor(operator=self.task)
 
     def test_extract(self):
@@ -108,9 +83,7 @@ class TestS3FileTransformExtractor(TestCase):
                 )
             ],
         )
-
         return_value = self.extractor.extract()
-
         self.assertEqual(return_value, expected_return_value)
 
     @staticmethod
@@ -127,22 +100,7 @@ class TestS3FileTransformExtractor(TestCase):
             dag=dag,
             start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
         )
-
         return task
-
-    @staticmethod
-    def _get_ti(task):
-        kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
-            kwargs['run_id'] = 'test_run_id'  # change in 2.2.0
-        task_instance = TaskInstance(
-            task=task,
-            execution_date=datetime.utcnow().replace(tzinfo=pytz.utc),
-            state=State.SUCCESS,
-            **kwargs)
-        task_instance.job_id = random.randrange(10000)
-
-        return task_instance
 
 
 if __name__ == '__main__':

--- a/integration/airflow/tests/integration/docker/s3/create-bucket.sh
+++ b/integration/airflow/tests/integration/docker/s3/create-bucket.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+awslocal s3 mb s3://testbucket
+echo "OpenLineage rocks!" > testfile
+awslocal s3 cp testfile s3://testbucket/
+rm testfile

--- a/integration/airflow/tests/integration/requests/s3copy.json
+++ b/integration/airflow/tests/integration/requests/s3copy.json
@@ -19,4 +19,15 @@
     "run": {
         "facets": {}
     }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {},
+        "name": "s3copy_dag.s3copy_task"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {}
+    }
 }]

--- a/integration/airflow/tests/integration/requests/s3copy.json
+++ b/integration/airflow/tests/integration/requests/s3copy.json
@@ -1,0 +1,22 @@
+[{
+    "eventType": "START",
+    "inputs": [
+        {
+            "name": "testfile",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "job": {
+        "facets": {},
+        "name": "s3copy_dag.s3copy_task"
+    },
+    "outputs": [
+        {
+            "name": "testfile2",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+}]

--- a/integration/airflow/tests/integration/requests/s3transform.json
+++ b/integration/airflow/tests/integration/requests/s3transform.json
@@ -1,0 +1,22 @@
+[{
+    "eventType": "START",
+    "inputs": [
+        {
+            "name": "testfile",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "job": {
+        "facets": {},
+        "name": "s3transform_dag.s3transform_task"
+    },
+    "outputs": [
+        {
+            "name": "testfile2",
+            "namespace": "s3://testbucket"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+}]

--- a/integration/airflow/tests/integration/requests/s3transform.json
+++ b/integration/airflow/tests/integration/requests/s3transform.json
@@ -19,4 +19,15 @@
     "run": {
         "facets": {}
     }
+},{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "facets": {},
+        "name": "s3transform_dag.s3transform_task"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {}
+    }
 }]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -141,6 +141,20 @@ params = [
         ),
     ),
     ("sftp_dag", "requests/sftp.json"),
+    pytest.param(
+        "s3copy_dag",
+        "requests/s3copy.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"
+        ),
+    ),
+    pytest.param(
+        "s3transform_dag",
+        "requests/s3transform.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"
+        ),
+    ),
 ]
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
@@ -1,0 +1,16 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
+from airflow.utils.dates import days_ago
+
+
+with DAG(dag_id="s3copy_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
+    S3CopyObjectOperator(
+        task_id="s3copy_task",
+        aws_conn_id="aws_local_conn",
+        source_bucket_name="testbucket",
+        dest_bucket_name="testbucket",
+        source_bucket_key="testfile",
+        dest_bucket_key="testfile2",
+    )

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
@@ -1,0 +1,17 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
+from airflow.utils.dates import days_ago
+
+
+with DAG(dag_id="s3transform_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
+    S3FileTransformOperator(
+        task_id="s3transform_task",
+        source_aws_conn_id="aws_local_conn",
+        dest_aws_conn_id="aws_local_conn",
+        source_s3_key="s3://testbucket/testfile",
+        dest_s3_key="s3://testbucket/testfile2",
+        transform_script="cp",
+        replace=True,
+    )

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -49,6 +49,7 @@ x-airflow-base: &airflow-base
     AIRFLOW__SECRETS__BACKEND_KWARGS: '{ "connections_file_path": "/opt/data/secrets/connections.json", "variables_file_path": "/opt/data/secrets/variables.json" }'
     AIRFLOW_CONN_SNOWFLAKE_CONN: "snowflake://${SNOWFLAKE_USER}:${SNOWFLAKE_PASSWORD}@${SNOWFLAKE_URI}/OPENLINEAGE?account=${SNOWFLAKE_ACCOUNT_ID}&database=SANDBOX&region=us-east-1&warehouse=ROBOTS&role=OPENLINEAGE"
     AIRFLOW_CONN_AWS_CONN: "aws://"
+    AIRFLOW_CONN_AWS_LOCAL_CONN: "aws://?aws_access_key_id=k&aws_secret_access_key=v&endpoint_url=http%3A%2F%2Flocalstack%3A4566"
     AIRFLOW_CONN_SFTP_CONN: sftp://airflow:airflow@openssh-server:2222
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
@@ -70,6 +71,8 @@ x-airflow-base: &airflow-base
       condition: service_healthy
     backend:
       condition: service_healthy
+    localstack:
+      condition: service_healthy
 
 services:
   integration:
@@ -89,6 +92,7 @@ services:
       AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
       AWS_ATHENA_OUTPUT_LOCATION: ${AWS_ATHENA_OUTPUT_LOCATION}
       AWS_ATHENA_SUFFIX: ${AWS_ATHENA_SUFFIX}
+      AIRFLOW_CONN_AWS_LOCAL_CONN: ${AIRFLOW_CONN_AWS_LOCAL_CONN}
     networks:
       - app_net
     volumes:
@@ -273,6 +277,20 @@ services:
       timeout: 30s
       retries: 50
 
+  localstack:
+    image: localstack/localstack
+    networks:
+      - app_net
+    expose:
+      - 4566
+    volumes:
+      - ../docker/s3:/docker-entrypoint-initaws.d
+    healthcheck:
+      test: ["CMD", "awslocal", "s3api", "list-buckets"]
+      interval: 5s
+      timeout: 30s
+      retries: 50
+
 networks:
   app_net:
     driver: bridge
@@ -281,4 +299,3 @@ networks:
       config:
         - subnet: 172.16.238.0/24
           gateway: 172.16.238.1
-


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

Currently, there is no extractor for S3FileTransformOperator.

### Solution

This PR adds a new extractor for S3FileTransformOperator.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project