### PR TITLE
[INTEGRATION][AIRFLOW] Fix prerequisites for BigQuery integration test

### DIFF
--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -29,9 +29,9 @@ log = logging.getLogger(__name__)
 
 IS_GCP_AUTH = False
 try:
-    creds = json.loads("/opt/config/gcloud/gcloud-service-key.json")
-    if creds:
-        IS_GCP_AUTH = True
+    with open("/opt/config/gcloud/gcloud-service-key.json") as f:
+        if json.load(f):
+            IS_GCP_AUTH = True
 except:  # noqa
     pass
 

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       - app_net
     volumes:
       - ../docker/wait-for-it.sh:/wait-for-it.sh
+      - ../gcloud:/opt/config/gcloud
     depends_on:
       - airflow_scheduler
       - airflow_worker


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

Currently, BigQuery-related integration tests seem to be always skipped even if gcloud-service-key.json is placed in integration/airflow/tests/integration/gcloud, due to the following reasons:

* [The directory above is mounted to the containers based on airflow-base](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/tests/integration/tests/docker-compose.yml#L58) e.g., airflow-worker, but [not to the integration container](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/tests/integration/tests/docker-compose.yml#L98-L99), so gcloud-service-key.json is not accessible from test_integration.py.

* In addition, [test_integration.py tries to load the service key with the `json.loads` function](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/tests/integration/test_integration.py#L32), but it doesn't accept a filepath, but a json string. We should use `json.load` instead here to load json from file.

### Solution

This PR fixes the problems described above in a straightforward way.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
  - I ran the integration tests with this fix locally and got the following errors. Unfortunately, the project id "openlineage-ci" is hard-coded and I don't have a permission on it (of course), so I was not able to make sure if this fix is enough to make all BQ-related tests successful.

```
[2022-12-30T08:45:17.024+0000] {standard_task_runner.py:105} ERROR - Failed to execute job 17 for task bigquery_if_not_exists (403 Access Denied: Dataset openlineage-ci:airflow_integration: Permission bigquery.tables.create denied on dataset openlineage-ci:airflow_integration (or it may not exist).
```

- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2022 contributors to the OpenLineage project