### PR TITLE
sql parser: do not fail whole extraction on partial failures, report ExtractionErrorRunFacet

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -796,12 +796,27 @@ workflows:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
+      - compile-integration-sql-java-linux:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+      - compile-integration-sql-java-macos:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
       - build-integration-sql-java:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
+          requires:
+            - compile-integration-sql-java-linux
+            - compile-integration-sql-java-macos
       - build-integration-sql:
           matrix:
             alias: build-integration-sql-x86

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -376,6 +376,10 @@ class ProcessingEngineRunFacet(BaseFacet):
     name: str = attr.ib()
     openlineageAdapterVersion: str = attr.ib()
 
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/ProcessingEngineRunFacet"
+
 
 @attr.s
 class ExtractionError(BaseFacet):
@@ -390,3 +394,7 @@ class ExtractionErrorRunFacet(BaseFacet):
     totalTasks: int = attr.ib()
     failedTasks: int = attr.ib()
     errors: List[ExtractionError] = attr.ib()
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/ExtractionErrorRunFacet"

--- a/integration/airflow/tests/integration/requests/failed_sql_extraction.json
+++ b/integration/airflow/tests/integration/requests/failed_sql_extraction.json
@@ -1,0 +1,49 @@
+[
+  {
+    "eventType": "START",
+    "job": {
+      "facets": {
+        "sql": {
+          "query": "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)"
+        }
+      },
+      "name": "failed_sql_extraction.fail"
+    },
+    "run": {
+      "facets": {
+        "extractionError": {
+          "totalTasks": 1,
+          "failedTasks": 1,
+          "errors": [{
+            "errorMessage": "Expected an object type after CREATE, found: TYPE",
+            "task": "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)",
+            "taskNumber": 0
+          }]
+        }
+      }
+    }
+  }, {
+    "eventType": "COMPLETE",
+    "job": {
+      "facets": {
+        "sql": {
+          "query": "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)"
+        }
+      },
+      "name": "failed_sql_extraction.fail"
+    },
+    "run": {
+      "facets": {
+        "extractionError": {
+          "totalTasks": 1,
+          "failedTasks": 1,
+          "errors": [{
+            "errorMessage": "Expected an object type after CREATE, found: TYPE",
+            "task": "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)",
+            "taskNumber": 0
+          }]
+        }
+      }
+    }
+  }
+]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -46,6 +46,7 @@ IS_AIRFLOW_VERSION_ENOUGH = lambda x: parse_version(
 
 params = [
     ("postgres_orders_popular_day_of_week", "requests/postgres.json"),
+    ("failed_sql_extraction", "requests/failed_sql_extraction.json"),
     ("great_expectations_validation", "requests/great_expectations.json"),
     pytest.param(
         "bigquery_orders_popular_day_of_week",

--- a/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
@@ -1,0 +1,49 @@
+# Copyright 2018-2022 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from airflow import DAG
+from airflow.version import version as AIRFLOW_VERSION
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.utils.dates import days_ago
+
+from openlineage.client import set_producer
+from pkg_resources import parse_version
+set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
+
+
+default_args = {
+    'owner': 'datascience',
+    'depends_on_past': False,
+    'start_date': days_ago(7),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'email': ['datascience@example.com']
+}
+
+
+dag = DAG(
+    'failed_sql_extraction',
+    schedule_interval='@once',
+    default_args=default_args,
+    description='Determines the popular day of week orders are placed.'
+)
+
+
+# Some sql-parser unsupported syntax
+sql = "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)"
+
+
+if parse_version(AIRFLOW_VERSION) < parse_version('2.5.0'):
+    t1 = PostgresOperator(
+        task_id='fail',
+        postgres_conn_id='food_delivery_db',
+        sql=sql,
+        dag=dag
+    )
+else:
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+    t1 = SQLExecuteQueryOperator(
+        task_id='fail',
+        conn_id='food_delivery_db',
+        sql=sql,
+        dag=dag
+    )

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -10,6 +10,7 @@ from openlineage_sql import (  # noqa: F401
     DbTableMeta,  # noqa: F401
     ColumnLineage,  # noqa: F401
     ColumnMeta,  # noqa: F401
+    ExtractionError,  # noqa: F401
     provider  # noqa: F401
 )  # noqa: F401
 

--- a/integration/sql/iface-java/script/build.sh
+++ b/integration/sql/iface-java/script/build.sh
@@ -33,7 +33,7 @@ fi
 
 # Run a simple integration test
 printf "\n------ Running smoke test ------\n"
-EXPECTED="{{\"inTables\": [table1], \"outTables\": [], \"columnLineage\": []}}"
+EXPECTED="{{\"inTables\": [table1], \"outTables\": [], \"columnLineage\": [], \"errors\": []}}"
 OUTPUT=$(./src/test/integration/run_test.sh "SELECT * FROM table1;")
 if [ "$OUTPUT" = "$EXPECTED" ]; then
     printf "\n${GREEN}Smoke Test Passed!${NC}\n"

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ExtractionError.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ExtractionError.java
@@ -1,0 +1,60 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.sql;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class ExtractionError {
+  private final long index;
+  private final String message;
+  private final String originStatement;
+
+  public ExtractionError(long index, String message, String originStatement) {
+    this.index = index;
+    this.message = message;
+    this.originStatement = originStatement;
+  }
+
+  private long index() {
+    return index;
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public String originStatement() {
+    return originStatement;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "{{\"index\": %d, \"message\": %s, \"originStatement\": %s}}",
+        index, message, originStatement);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof ExtractionError)) {
+      return false;
+    }
+
+    ExtractionError other = (ExtractionError) o;
+    return other.index() == index
+        && other.message().equals(message)
+        && other.originStatement().equals(originStatement);
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(index).append(message).append(originStatement).toHashCode();
+  }
+}

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
@@ -13,11 +13,17 @@ public class SqlMeta {
   private final List<DbTableMeta> inTables;
   private final List<DbTableMeta> outTables;
   private final List<ColumnLineage> columnLineage;
+  private final List<ExtractionError> errors;
 
-  public SqlMeta(List<DbTableMeta> in, List<DbTableMeta> out, List<ColumnLineage> columnLineage) {
+  public SqlMeta(
+      List<DbTableMeta> in,
+      List<DbTableMeta> out,
+      List<ColumnLineage> columnLineage,
+      List<ExtractionError> errors) {
     this.inTables = in;
     this.outTables = out;
     this.columnLineage = columnLineage;
+    this.errors = errors;
   }
 
   public List<DbTableMeta> inTables() {
@@ -32,13 +38,18 @@ public class SqlMeta {
     return columnLineage;
   }
 
+  public List<ExtractionError> errors() {
+    return errors;
+  }
+
   @Override
   public String toString() {
     return String.format(
-        "{{\"inTables\": %s, \"outTables\": %s, \"columnLineage\": %s}}",
+        "{{\"inTables\": %s, \"outTables\": %s, \"columnLineage\": %s, \"errors\": %s}}",
         Arrays.toString(inTables.toArray()),
         Arrays.toString(outTables.toArray()),
-        Arrays.toString(columnLineage.toArray()));
+        Arrays.toString(columnLineage.toArray()),
+        Arrays.toString(errors.toArray()));
   }
 
   @Override
@@ -54,7 +65,8 @@ public class SqlMeta {
     SqlMeta other = (SqlMeta) o;
     return other.inTables.equals(inTables)
         && other.outTables.equals(outTables)
-        && other.columnLineage.equals(columnLineage);
+        && other.columnLineage.equals(columnLineage)
+        && other.errors.equals(errors);
   }
 
   @Override
@@ -63,6 +75,7 @@ public class SqlMeta {
         .append(inTables)
         .append(outTables)
         .append(columnLineage)
+        .append(errors)
         .toHashCode();
   }
 }

--- a/integration/sql/iface-py/script/setup-macos.sh
+++ b/integration/sql/iface-py/script/setup-macos.sh
@@ -25,4 +25,4 @@ rustup target add aarch64-apple-darwin
 
 # Maturin is build tool that we're using. It can build python wheels based on standard Rust Cargo.toml.
 echo "Installing Maturin"
-python -m pip install maturin
+python3.7 -m pip install maturin

--- a/integration/sql/impl/src/lineage.rs
+++ b/integration/sql/impl/src/lineage.rs
@@ -6,9 +6,17 @@ use crate::CanonicalDialect;
 use sqlparser::dialect::SnowflakeDialect;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExtractionError {
+    pub index: usize,
+    pub message: String,
+    pub origin_statement: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SqlMeta {
     pub table_lineage: TableLineage,
     pub column_lineage: Vec<ColumnLineage>,
+    pub errors: Vec<ExtractionError>,
 }
 
 impl SqlMeta {
@@ -16,6 +24,7 @@ impl SqlMeta {
         mut in_tables: Vec<DbTableMeta>,
         mut out_tables: Vec<DbTableMeta>,
         mut column_lineage: Vec<ColumnLineage>,
+        mut errors: Vec<ExtractionError>,
     ) -> Self {
         in_tables.sort();
         out_tables.sort();
@@ -27,6 +36,7 @@ impl SqlMeta {
                 out_tables,
             },
             column_lineage,
+            errors,
         }
     }
 }

--- a/integration/sql/impl/tests/table_lineage/mod.rs
+++ b/integration/sql/impl/tests/table_lineage/mod.rs
@@ -2,6 +2,7 @@ pub mod tests_copy;
 pub mod tests_create;
 pub mod tests_cte;
 pub mod tests_delete;
+pub mod tests_error_handling;
 pub mod tests_insert;
 pub mod tests_merge;
 pub mod tests_select;

--- a/integration/sql/impl/tests/table_lineage/tests_copy.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_copy.rs
@@ -1,14 +1,13 @@
 // Copyright 2018-2022 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
 
-use openlineage_sql::parse_sql;
+use openlineage_sql::{parse_sql, SqlMeta, TableLineage};
 use sqlparser::dialect::SnowflakeDialect;
 
 #[test]
 fn parse_copy_from() {
-    assert_eq!(
-        parse_sql(
-            "
+    let meta = parse_sql(
+        "
             COPY INTO SCHEMA.SOME_MONITORING_SYSTEM
                 FROM (
                 SELECT
@@ -38,11 +37,13 @@ fn parse_copy_from() {
                 CURRENT_TIMESTAMP AS lts
                 FROM @schema.general_finished AS t
             )",
-            &SnowflakeDialect {},
-            None
-        )
-        .unwrap_err()
-        .to_string(),
-        "sql parser error: Expected FROM or TO, found: SCHEMA"
+        &SnowflakeDialect {},
+        None,
+    )
+    .unwrap();
+    assert_eq!(meta.errors.len(), 1);
+    assert_eq!(
+        meta.errors.get(0).unwrap().message,
+        "Expected FROM or TO, found: SCHEMA".to_string()
     )
 }

--- a/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
@@ -1,0 +1,46 @@
+use crate::test_utils::*;
+use openlineage_sql::{
+    ColumnLineage, ColumnMeta, DbTableMeta, ExtractionError, SqlMeta, TableLineage,
+};
+
+#[test]
+fn test_failing_statement_with_insert() {
+    assert_eq!(
+        test_multiple_sql(vec![
+            "FAILING STATEMENT;",
+            "INSERT INTO Persons SELECT key FROM temp.table;",
+            "INSERT ALSO FAILING"
+        ])
+        .unwrap(),
+        SqlMeta {
+            table_lineage: TableLineage {
+                in_tables: tables(vec!["temp.table"]),
+                out_tables: tables(vec!["Persons"])
+            },
+            column_lineage: vec![ColumnLineage {
+                descendant: ColumnMeta {
+                    origin: None,
+                    name: "key".to_string()
+                },
+                lineage: vec![ColumnMeta {
+                    origin: Some(DbTableMeta::new_default_dialect("temp.table".to_string())),
+                    name: "key".to_string(),
+                }],
+            }],
+            errors: vec![
+                ExtractionError {
+                    index: 0,
+                    message: "Expected an SQL statement, found: FAILING".to_string(),
+                    origin_statement: "FAILING STATEMENT;".to_string(),
+                },
+                ExtractionError {
+                    index: 2,
+                    message:
+                        "Expected SELECT, VALUES, or a subquery in the query body, found: FAILING"
+                            .to_string(),
+                    origin_statement: "INSERT ALSO FAILING".to_string(),
+                }
+            ],
+        }
+    )
+}


### PR DESCRIPTION
This PR adds an ability for a SQL parser to report errors to integration that's calling it, and integrations to report those error using `ExtractionErrorRunFacet`. 

Additionally, the behavior (and API) of parser changes - if it fails to parse some part of SQL statements send to it, it won't raise exception and fail whole extraction, but report partial failure from which some input and output datasets still can be extracted. PR also changes integrations to take care of that API change.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>

Closes: #1052, partially closes #1333