### PR TITLE
configure dependabot to ignore Guava

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,19 +49,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    ignore:
-      - dependency-name: "jackson-databind"
-      - dependency-name: "jackson-core"
-      - dependency-name: "jackson-annotations"
-      - dependency-name: "jackson-dataformat-yaml"
-      - dependency-name: "jackson-datatype-jdk8"
-      - dependency-name: "jackson-datatype-jsr310"
     labels:
       - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "com.fasterxml.jackson*"
       - dependency-name: "org.slf4j.slf4j-api"
+      - dependency-name: "jackson-databind"
+      - dependency-name: "jackson-core"
+      - dependency-name: "jackson-annotations"
+      - dependency-name: "jackson-dataformat-yaml"
+      - dependency-name: "jackson-datatype-jdk8"
+      - dependency-name: "jackson-datatype-jsr310"
+      - dependency-name: "com.google.guava*"
 
   - package-ecosystem: "pip"
     directory: "client/python"


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

We don't need to be managing PRs from dependabot to update Guava in the Spark integration.

### Solution

This adds Guava to the list of deps dependabot ignores in `integration/spark`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project