### PR TITLE
Fix typo emittled --> emitted

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -146,11 +146,11 @@ def main():
     # or does not exist, do not emit dbt events.
     try:
         if os.stat(processor.run_result_path).st_mtime < pre_run_time:
-            logger.info(f"OpenLineage events not emittled: run_result file "
+            logger.info(f"OpenLineage events not emitted: run_result file "
                         f"({processor.run_result_path}) was not modified by dbt")
             return
     except FileNotFoundError:
-        logger.info(f"OpenLineage events not emittled:"
+        logger.info(f"OpenLineage events not emitted:"
                     f"did not find run_result file ({processor.run_result_path})")
         return
 


### PR DESCRIPTION
Signed-off-by: Benji Lampel <benjamin@astronomer.io>

### Problem

👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

Closes: #1480 

### Solution

Fixed typo in log

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project