### PR TITLE
spark: Add square brackets for list-based spark configs

### DIFF
--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -91,14 +91,14 @@ The following parameters can be specified in the Spark configuration:
 
 Parameters configuring the Spark integration
 
-| Parameter                                | Definition                                                                                                                   | Example                             |
-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
-| spark.openlineage.transport.type         | The transport type used for event emit, default type is `http`                                                               | http                                |
-| spark.openlineage.namespace              | The default namespace to be applied for any jobs submitted                                                                   | MyNamespace                         |
-| spark.openlineage.parentJobName          | The job name to be used for the parent job facet                                                                             | ParentJobName                       |
-| spark.openlineage.parentRunId            | The RunId of the parent job that initiated this Spark job                                                                    | xxxx-xxxx-xxxx-xxxx                 |
-| spark.openlineage.appName                | Custom value overwriting Spark app name in events                                                                            | AppName                             |
-| spark.openlineage.facets.disabled        | List of facets to disable, enclosed in `[]` and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
+| Parameter                                | Definition                                                                                                                                          | Example                             |
+------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
+| spark.openlineage.transport.type         | The transport type used for event emit, default type is `http`                                                                                      | http                                |
+| spark.openlineage.namespace              | The default namespace to be applied for any jobs submitted                                                                                          | MyNamespace                         |
+| spark.openlineage.parentJobName          | The job name to be used for the parent job facet                                                                                                    | ParentJobName                       |
+| spark.openlineage.parentRunId            | The RunId of the parent job that initiated this Spark job                                                                                           | xxxx-xxxx-xxxx-xxxx                 |
+| spark.openlineage.appName                | Custom value overwriting Spark app name in events                                                                                                   | AppName                             |
+| spark.openlineage.facets.disabled        | List of facets to disable, enclosed in `[]` (required from 0.21.x) and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
 
 ### HTTP
 

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -91,14 +91,14 @@ The following parameters can be specified in the Spark configuration:
 
 Parameters configuring the Spark integration
 
-| Parameter                                | Definition                                                                                        | Example                         |
-------------------------------------------|---------------------------------------------------------------------------------------------------|---------------------------------
-| spark.openlineage.transport.type         | The transport type used for event emit, default type is `http`                                    | http                            |
-| spark.openlineage.namespace              | The default namespace to be applied for any jobs submitted                                        | MyNamespace                     |
-| spark.openlineage.parentJobName          | The job name to be used for the parent job facet                                                  | ParentJobName                   |
-| spark.openlineage.parentRunId            | The RunId of the parent job that initiated this Spark job                                         | xxxx-xxxx-xxxx-xxxx             |
-| spark.openlineage.appName                | Custom value overwriting Spark app name in events                                                 | AppName                         |
-| spark.openlineage.facets.disabled        | `;` separated list of facets to disable, default is `spark_unknown;` (currently must contain `;`) | spark_unknown;spark.logicalPlan |
+| Parameter                                | Definition                                                                                                                   | Example                             |
+------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
+| spark.openlineage.transport.type         | The transport type used for event emit, default type is `http`                                                               | http                                |
+| spark.openlineage.namespace              | The default namespace to be applied for any jobs submitted                                                                   | MyNamespace                         |
+| spark.openlineage.parentJobName          | The job name to be used for the parent job facet                                                                             | ParentJobName                       |
+| spark.openlineage.parentRunId            | The RunId of the parent job that initiated this Spark job                                                                    | xxxx-xxxx-xxxx-xxxx                 |
+| spark.openlineage.appName                | Custom value overwriting Spark app name in events                                                                            | AppName                             |
+| spark.openlineage.facets.disabled        | List of facets to disable, enclosed in `[]` and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
 
 ### HTTP
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -149,9 +149,10 @@ public class ArgumentParser {
           }
           nodePointer = (ObjectNode) nodePointer.get(node);
         }
-        if (isArrayType(value)) {
+        if (isArrayType(value) || SPARK_CONF_DISABLED_FACETS.equals("spark.openlineage." + keyPath)) {
           ArrayNode arrayNode = nodePointer.putArray(leaf);
-          Arrays.stream(value.substring(1, value.length() - 1).split(DISABLED_FACETS_SEPARATOR))
+          String valueWithoutBrackets = isArrayType(value) ? value.substring(1, value.length() - 1) : value;
+          Arrays.stream(valueWithoutBrackets.split(DISABLED_FACETS_SEPARATOR))
               .filter(StringUtils::isNotBlank)
               .forEach(arrayNode::add);
         } else {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -42,7 +42,9 @@ public class ArgumentParser {
   public static final String SPARK_CONF_PARENT_RUN_ID = "spark.openlineage.parentRunId";
   public static final String SPARK_CONF_APP_NAME = "spark.openlineage.appName";
   public static final String SPARK_CONF_DISABLED_FACETS = "spark.openlineage.facets.disabled";
-  public static final String DEFAULT_DISABLED_FACETS = "spark_unknown;";
+  public static final String DEFAULT_DISABLED_FACETS = "[spark_unknown;]";
+  public static final String ARRAY_PREFIX_CHAR = "[";
+  public static final String ARRAY_SUFFIX_CHAR = "]";
   public static final String DISABLED_FACETS_SEPARATOR = ";";
   public static final String SPARK_CONF_TRANSPORT_TYPE = "spark.openlineage.transport.type";
   public static final String SPARK_CONF_HTTP_URL = "spark.openlineage.transport.url";
@@ -147,9 +149,9 @@ public class ArgumentParser {
           }
           nodePointer = (ObjectNode) nodePointer.get(node);
         }
-        if (value.contains(DISABLED_FACETS_SEPARATOR)) {
+        if (isArrayType(value)) {
           ArrayNode arrayNode = nodePointer.putArray(leaf);
-          Arrays.stream(value.split(DISABLED_FACETS_SEPARATOR))
+          Arrays.stream(value.substring(1, value.length() - 1).split(DISABLED_FACETS_SEPARATOR))
               .filter(StringUtils::isNotBlank)
               .forEach(arrayNode::add);
         } else {
@@ -184,5 +186,11 @@ public class ArgumentParser {
                 })
             .orElseGet(() -> Arrays.asList(keyPath.split("\\.")));
     return pathKeys;
+  }
+
+  private static boolean isArrayType(String value) {
+    return value.startsWith(ARRAY_PREFIX_CHAR)
+            && value.endsWith(ARRAY_SUFFIX_CHAR)
+            && value.contains(DISABLED_FACETS_SEPARATOR);
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -149,9 +149,11 @@ public class ArgumentParser {
           }
           nodePointer = (ObjectNode) nodePointer.get(node);
         }
-        if (isArrayType(value) || SPARK_CONF_DISABLED_FACETS.equals("spark.openlineage." + keyPath)) {
+        if (isArrayType(value)
+            || SPARK_CONF_DISABLED_FACETS.equals("spark.openlineage." + keyPath)) {
           ArrayNode arrayNode = nodePointer.putArray(leaf);
-          String valueWithoutBrackets = isArrayType(value) ? value.substring(1, value.length() - 1) : value;
+          String valueWithoutBrackets =
+              isArrayType(value) ? value.substring(1, value.length() - 1) : value;
           Arrays.stream(valueWithoutBrackets.split(DISABLED_FACETS_SEPARATOR))
               .filter(StringUtils::isNotBlank)
               .forEach(arrayNode::add);
@@ -191,7 +193,7 @@ public class ArgumentParser {
 
   private static boolean isArrayType(String value) {
     return value.startsWith(ARRAY_PREFIX_CHAR)
-            && value.endsWith(ARRAY_SUFFIX_CHAR)
-            && value.contains(DISABLED_FACETS_SEPARATOR);
+        && value.endsWith(ARRAY_SUFFIX_CHAR)
+        && value.contains(DISABLED_FACETS_SEPARATOR);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -23,7 +23,7 @@ class ArgumentParserTest {
   private static final String URL = "http://localhost:5000";
   private static final String RUN_ID = "ea445b5c-22eb-457a-8007-01c7c52b6e54";
   private static final String APP_NAME = "test";
-  private static final String DISABLED_FACETS = "facet1;facet2";
+  private static final String DISABLED_FACETS = "[facet1;facet2]";
   private static final String ENDPOINT = "api/v1/lineage";
   private static final String AUTH_TYPE = "api_key";
   private static final String API_KEY = "random_token";
@@ -32,7 +32,7 @@ class ArgumentParserTest {
   void testDefaults() {
     ArgumentParser argumentParser = ArgumentParser.parse(new SparkConf());
     assertEquals(
-        ArgumentParser.DEFAULT_DISABLED_FACETS.split(";")[0],
+        ArgumentParser.DEFAULT_DISABLED_FACETS.substring(1, ArgumentParser.DEFAULT_DISABLED_FACETS.length() - 1).split(";")[0],
         argumentParser.getOpenLineageYaml().getFacetsConfig().getDisabledFacets()[0]);
     assert (argumentParser.getOpenLineageYaml().getTransportConfig() instanceof HttpConfig);
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -32,7 +32,9 @@ class ArgumentParserTest {
   void testDefaults() {
     ArgumentParser argumentParser = ArgumentParser.parse(new SparkConf());
     assertEquals(
-        ArgumentParser.DEFAULT_DISABLED_FACETS.substring(1, ArgumentParser.DEFAULT_DISABLED_FACETS.length() - 1).split(";")[0],
+        ArgumentParser.DEFAULT_DISABLED_FACETS.substring(
+                1, ArgumentParser.DEFAULT_DISABLED_FACETS.length() - 1)
+            .split(";")[0],
         argumentParser.getOpenLineageYaml().getFacetsConfig().getDisabledFacets()[0]);
     assert (argumentParser.getOpenLineageYaml().getTransportConfig() instanceof HttpConfig);
   }


### PR DESCRIPTION
Signed-off-by: Varun Singh <varunsingh@microsoft.com>

### Problem

Currently, all spark configs with semicolons in their value are being split into lists but some configs like EventHub secret keys require semicolons in their value.

Closes: #1506 

### Solution

Added `[]` around the values that need to be converted into lists.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project