### PR TITLE
ci: use ruff instead of flake8/isort/...

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - *checkout_project_root
       - run: pip install -e .[dev]
-      - run: python -m flake8 --extend-ignore=F401
+      - run: ruff . --no-update-check
       - run: python -m mypy --install-types --non-interactive --ignore-missing-imports --no-namespace-packages openlineage
       - run: python -m pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)
@@ -311,7 +311,7 @@ jobs:
       - *checkout_project_root
       - attach_workspace:
           at: .
-      - run: pip install tox==3.27.1
+      - run: pip install tox==3.27.1 ruff
       - run: tox -p all
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
@@ -452,6 +452,8 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
+      - run: pip install ruff
+      - run: ruff . --no-update-check
       - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
@@ -622,7 +624,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - run: pip install -e .[dev]
-      - run: flake8
+      - run: ruff . --no-update-check
       - run: python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
       - run: pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ junit.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/CODE_QUALITY_AND_SECURITY.md
+++ b/CODE_QUALITY_AND_SECURITY.md
@@ -19,7 +19,7 @@ The specific security and analysis methodologies that we employ include but are 
 ## Analysis
 
 - Use of [PMD](https://pmd.github.io/) and [Spotless](https://github.com/diffplug/spotless) for Java code linting on pull requests and builds
-- Use of [Flake8](https://flake8.pycqa.org/en/latest/) and [Mypy](https://github.com/python/mypy) for Python code linting on pull requests and builds
+- Use of [Ruff](https://github.com//ruff) and [Mypy](https://github.com/python/mypy) for Python code linting on pull requests and builds
 - Use of GitHub Issues for bug reporting and tracking
 
 ## Contact

--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-# flake8: noqa
-
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
 from openlineage.client.facet import set_producer
+
+__all__ = [OpenLineageClient, OpenLineageClientOptions, set_producer]

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -6,13 +6,14 @@ import typing
 from typing import Optional
 
 import attr
+
 if typing.TYPE_CHECKING:
     from requests import Session
     from requests.adapters import HTTPAdapter
 
 from openlineage.client.run import RunEvent
 from openlineage.client.transport import Transport, get_default_factory
-from openlineage.client.transport.http import HttpTransport, HttpConfig
+from openlineage.client.transport.http import HttpConfig, HttpTransport
 
 
 @attr.s

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 import attr
-
 from openlineage.client.constants import DEFAULT_PRODUCER
 from openlineage.client.utils import RedactMixin
 

--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -1,13 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Optional
-from enum import Enum
-from dateutil import parser
-
 import uuid
-import attr
+from enum import Enum
+from typing import Dict, List, Optional
 
+import attr
+from dateutil import parser
 from openlineage.client.facet import NominalTimeRunFacet, ParentRunFacet
 from openlineage.client.utils import RedactMixin
 
@@ -82,6 +81,6 @@ class RunEvent(RedactMixin):
     @eventTime.validator
     def check(self, attribute, value):
         parser.isoparse(value)
-        if not ("t" in value.lower()):
+        if 't' not in value.lower():
             # make sure date-time contains time
             raise ValueError("Parsed date-time has to contain time: {}".format(value))

--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import sys
 import logging
+import sys
 from enum import Enum
-from typing import List, Dict
+from typing import Dict, List
 
 import attr
 

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -1,16 +1,14 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-# flake8: noqa
 from typing import Type
 
-from openlineage.client.transport.noop import NoopTransport
-from openlineage.client.transport.transport import Transport, Config, TransportFactory
-from openlineage.client.transport.factory import DefaultTransportFactory
-from openlineage.client.transport.http import HttpTransport, HttpConfig
-from openlineage.client.transport.kafka import KafkaTransport, KafkaConfig
 from openlineage.client.transport.console import ConsoleTransport
-
+from openlineage.client.transport.factory import DefaultTransportFactory
+from openlineage.client.transport.http import HttpConfig, HttpTransport
+from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
+from openlineage.client.transport.noop import NoopTransport
+from openlineage.client.transport.transport import Config, Transport, TransportFactory
 
 _factory = DefaultTransportFactory()
 _factory.register_transport(HttpTransport.kind, HttpTransport)
@@ -27,3 +25,15 @@ def get_default_factory():
 def register_transport(clazz: Type[Transport]):
     _factory.register_transport(clazz.kind, clazz)
     return clazz
+
+
+__all__ = [
+    Config,
+    TransportFactory,
+    HttpConfig,
+    HttpTransport,
+    KafkaConfig,
+    KafkaTransport,
+    ConsoleTransport,
+    NoopTransport
+]

--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -5,7 +5,7 @@ import logging
 
 from openlineage.client.run import RunEvent
 from openlineage.client.serde import Serde
-from openlineage.client.transport.transport import Transport, Config
+from openlineage.client.transport.transport import Config, Transport
 
 
 class ConsoleConfig(Config):

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import logging
 import os
 import sys
-import logging
-from typing import Type, Union, Optional
+from typing import Optional, Type, Union
 
 from openlineage.client.transport.noop import NoopConfig, NoopTransport
 from openlineage.client.transport.transport import Config, Transport, TransportFactory
 from openlineage.client.utils import try_import_from_string
-
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ class DefaultTransportFactory(TransportFactory):
         if http:
             return http
         # If there is no HTTP transport, log events to console
-        from openlineage.client.transport.console import ConsoleTransport, ConsoleConfig
+        from openlineage.client.transport.console import ConsoleConfig, ConsoleTransport
         log.warning("Couldn't initialize transport; will print events to console.")
         return ConsoleTransport(ConsoleConfig())
 
@@ -116,8 +115,11 @@ class DefaultTransportFactory(TransportFactory):
 
     @staticmethod
     def _try_http_from_env_config() -> Optional[Transport]:
-        from openlineage.client.transport.http import HttpTransport, HttpConfig, \
-            create_token_provider
+        from openlineage.client.transport.http import (
+            HttpConfig,
+            HttpTransport,
+            create_token_provider,
+        )
         # backwards compatibility: create Transport from
         # OPENLINEAGE_URL and OPENLINEAGE_API_KEY
         if 'OPENLINEAGE_URL' not in os.environ:

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import TYPE_CHECKING, Dict, Optional
 from urllib.parse import urljoin
 
 import attr
-
-from typing import Optional, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from requests import Session

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -5,10 +5,9 @@ import logging
 from typing import Dict
 
 import attr
-
 from openlineage.client.run import RunEvent
 from openlineage.client.serde import Serde
-from openlineage.client.transport.transport import Transport, Config
+from openlineage.client.transport.transport import Config, Transport
 from openlineage.client.utils import get_only_specified_fields
 
 log = logging.getLogger(__name__)

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -4,8 +4,7 @@
 import logging
 
 from openlineage.client.run import RunEvent
-from openlineage.client.transport.transport import Transport, Config
-
+from openlineage.client.transport.transport import Config, Transport
 
 log = logging.getLogger(__name__)
 

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -3,7 +3,6 @@
 
 from openlineage.client.run import RunEvent
 
-
 """
 To implement custom Transport implement Config and Transport classes.
 

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -1,13 +1,13 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import inspect
-from typing import Type, List
+import logging
+from typing import List, Type
+from warnings import warn
 
 import attr
-import importlib
-from warnings import warn
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+select = [
+    "F",
+    "E",
+    "W",
+    "I001"
+]
+target-version = "py37"
+ignore-init-module-imports = true
+src = ["openlineage", "tests"]
+namespace-packages = ["openlineage/client"]

--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -15,8 +15,5 @@ replace = version="{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[flake8]
-max-line-length = 99
-
 [mypy]
 ignore_missing_imports = True

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -5,7 +5,7 @@
 #
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages, setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -22,7 +22,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "flake8",
+        "ruff",
         "requests",
         "pyyaml",
         "mypy>=0.9.6",

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -4,9 +4,8 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from openlineage.client.client import OpenLineageClient
-from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.run import Job, Run, RunEvent, RunState
 
 
 def test_client_fails_with_wrong_event_type():

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -3,14 +3,13 @@
 
 import json
 import os
-from typing import Optional, List
+from typing import List, Optional
 
 import attr
 import pytest
-
+from openlineage.client import facet, run, set_producer
 from openlineage.client.run import RunState
 from openlineage.client.serde import Serde
-from openlineage.client import run, facet, set_producer
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -1,19 +1,28 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import copy
-
+import json
 from unittest.mock import MagicMock
 
 from openlineage.client.client import OpenLineageClient
-from openlineage.client.facet import SymlinksDatasetFacet, SymlinksDatasetFacetIdentifiers, \
-    StorageDatasetFacet, OwnershipJobFacet, OwnershipJobFacetOwners, DatasetVersionDatasetFacet, \
-    LifecycleStateChangeDatasetFacet, LifecycleStateChangeDatasetFacetPreviousIdentifier, \
-    LifecycleStateChange, OwnershipDatasetFacetOwners, OwnershipDatasetFacet, \
-    ColumnLineageDatasetFacet, ColumnLineageDatasetFacetFieldsAdditional, \
-    ColumnLineageDatasetFacetFieldsAdditionalInputFields
-from openlineage.client.run import RunEvent, RunState, Run, Job, Dataset
+from openlineage.client.facet import (
+    ColumnLineageDatasetFacet,
+    ColumnLineageDatasetFacetFieldsAdditional,
+    ColumnLineageDatasetFacetFieldsAdditionalInputFields,
+    DatasetVersionDatasetFacet,
+    LifecycleStateChange,
+    LifecycleStateChangeDatasetFacet,
+    LifecycleStateChangeDatasetFacetPreviousIdentifier,
+    OwnershipDatasetFacet,
+    OwnershipDatasetFacetOwners,
+    OwnershipJobFacet,
+    OwnershipJobFacetOwners,
+    StorageDatasetFacet,
+    SymlinksDatasetFacet,
+    SymlinksDatasetFacetIdentifiers,
+)
+from openlineage.client.run import Dataset, Job, Run, RunEvent, RunState
 
 openlineage_event = {
     "eventType": "START",

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -5,10 +5,14 @@ import os
 from unittest.mock import patch
 
 from openlineage.client import OpenLineageClient
-from openlineage.client.transport import DefaultTransportFactory, \
-    get_default_factory, KafkaTransport
+from openlineage.client.transport import (
+    DefaultTransportFactory,
+    KafkaTransport,
+    get_default_factory,
+)
 from openlineage.client.transport.http import HttpTransport
 from openlineage.client.transport.noop import NoopTransport
+
 from tests.transport import AccumulatingTransport, FakeTransport
 
 current_path = os.path.join(os.getcwd(), "tests")

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -5,12 +5,11 @@ import datetime
 import uuid
 from unittest.mock import patch
 
-from requests import Session
-
 from openlineage.client import OpenLineageClient
-from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
 from openlineage.client.transport.http import HttpConfig, HttpTransport
+from requests import Session
 
 
 def test_http_loads_full_config():

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -6,11 +6,10 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-
 from openlineage.client import OpenLineageClient
-from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
-from openlineage.client.transport.kafka import KafkaTransport, KafkaConfig
+from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 
 
 def test_kafka_loads_full_config():

--- a/client/python/tests/transport.py
+++ b/client/python/tests/transport.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client.run import RunEvent
-from openlineage.client.transport import Transport, Config, register_transport
+from openlineage.client.transport import Config, Transport, register_transport
 
 
 class AccumulatingTransport(Transport):

--- a/integration/airflow/openlineage/airflow/__init__.py
+++ b/integration/airflow/openlineage/airflow/__init__.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-
-from pkg_resources import parse_version
-from airflow.version import version as AIRFLOW_VERSION
-from openlineage.airflow.version import __version__
 import logging
+
+from openlineage.airflow.version import __version__
+from pkg_resources import parse_version
+
+from airflow.version import version as AIRFLOW_VERSION
 
 __author__ = """OpenLineage"""
 
@@ -19,4 +21,5 @@ if parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"):     # type: ignore
     )
 
 from airflow.models import DAG
+
 __all__ = ["DAG", "__version__"]

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -1,30 +1,28 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import logging
+import os
 import uuid
-from typing import Optional, Dict, Type, TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Type
 
-from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
+import requests.exceptions
 from openlineage.airflow.extractors import TaskMetadata
-
+from openlineage.airflow.utils import DagUtils, redact_with_exclusions
+from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
 from openlineage.client import OpenLineageClient, OpenLineageClientOptions, set_producer
 from openlineage.client.facet import (
+    BaseFacet,
     DocumentationJobFacet,
+    ErrorMessageRunFacet,
+    NominalTimeRunFacet,
     OwnershipJobFacet,
     OwnershipJobFacetOwners,
-    SourceCodeLocationJobFacet,
-    NominalTimeRunFacet,
     ParentRunFacet,
-    BaseFacet,
-    ErrorMessageRunFacet,
     ProcessingEngineRunFacet,
+    SourceCodeLocationJobFacet,
 )
-from openlineage.airflow.utils import redact_with_exclusions, DagUtils
-from openlineage.client.run import RunEvent, RunState, Run, Job
-import requests.exceptions
-
+from openlineage.client.run import Job, Run, RunEvent, RunState
 
 if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun

--- a/integration/airflow/openlineage/airflow/extractors/__init__.py
+++ b/integration/airflow/openlineage/airflow/extractors/__init__.py
@@ -1,8 +1,8 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from openlineage.airflow.extractors.extractors import Extractors
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.extractors.extractors import Extractors
 from openlineage.airflow.extractors.manager import ExtractorManager
 
 __all__ = [Extractors, BaseExtractor, TaskMetadata, ExtractorManager]

--- a/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
@@ -9,7 +9,7 @@ from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 from openlineage.client.facet import SqlJobFacet
 from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbColumn, DbTableSchema
-from openlineage.common.sql import DbTableMeta, parse, SqlMeta
+from openlineage.common.sql import DbTableMeta, SqlMeta, parse
 
 
 class AthenaExtractor(BaseExtractor):

--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -1,16 +1,15 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import attr
-from abc import ABC, abstractmethod
-
-from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 import json
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from openlineage.client.run import Dataset
-from typing import List, Dict, Optional
-from openlineage.client.facet import BaseFacet
+import attr
 from openlineage.airflow.utils import LoggingMixin, get_job_name
+from openlineage.client.facet import BaseFacet
+from openlineage.client.run import Dataset
 
 
 @attr.s

--- a/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.airflow.facets import UnknownOperatorAttributeRunFacet, UnknownOperatorInstance

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -2,16 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import traceback
-from typing import Optional, List
+from typing import List, Optional
 
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.utils import get_job_name, try_import_from_string
 from openlineage.client.facet import SqlJobFacet
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider, BigQueryErrorRunFacet
-
-from openlineage.airflow.extractors.base import (
-    BaseExtractor,
-    TaskMetadata
-)
-from openlineage.airflow.utils import get_job_name, try_import_from_string
 
 _BIGQUERY_CONN_URL = 'bigquery'
 

--- a/integration/airflow/openlineage/airflow/extractors/converters.py
+++ b/integration/airflow/openlineage/airflow/extractors/converters.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client.run import Dataset
+
 from airflow.lineage.entities import Table
 
 

--- a/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
@@ -3,12 +3,11 @@
 
 import logging
 from contextlib import closing
-from typing import Optional, TYPE_CHECKING, List, Tuple, Dict, Iterator
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
-from openlineage.common.dataset import Source, Dataset
-from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
-
 
 if TYPE_CHECKING:
     from airflow.hooks.base import BaseHook

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-
-from typing import Type, Optional
+from typing import Optional, Type
 
 from openlineage.airflow.extractors.base import BaseExtractor, DefaultExtractor
-from openlineage.airflow.utils import import_from_string, try_import_from_string
 from openlineage.airflow.extractors.sql_check_extractors import get_check_extractors
 from openlineage.airflow.extractors.sql_execute_query import (
-    sql_extractors,
     get_sql_execute_query_extractor,
+    sql_extractors,
 )
+from openlineage.airflow.utils import import_from_string, try_import_from_string
 
 _extractors = list(
     filter(

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -1,10 +1,9 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, List
+from typing import List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-
 
 # Great Expectations is optional dependency.
 try:

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Type, List
+from typing import List, Optional, Type
 
-from openlineage.airflow.extractors import TaskMetadata, BaseExtractor, Extractors
+from openlineage.airflow.extractors import BaseExtractor, Extractors, TaskMetadata
 from openlineage.airflow.facets import UnknownOperatorAttributeRunFacet, UnknownOperatorInstance
 from openlineage.airflow.utils import get_job_name, get_operator_class
 

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -4,8 +4,8 @@
 from typing import List
 from urllib.parse import urlparse
 
-from openlineage.airflow.utils import try_import_from_string
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+from openlineage.airflow.utils import try_import_from_string
 
 
 class MySqlExtractor(SqlExtractor):

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -4,8 +4,8 @@
 from typing import List
 from urllib.parse import urlparse
 
-from openlineage.airflow.utils import try_import_from_string
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+from openlineage.airflow.utils import try_import_from_string
 
 
 class PostgresExtractor(SqlExtractor):

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -1,9 +1,9 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import inspect
-from typing import Optional, List, Callable, Dict
+import os
+from typing import Callable, Dict, List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.airflow.facets import UnknownOperatorAttributeRunFacet, UnknownOperatorInstance

--- a/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
@@ -1,13 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, List
-
-from openlineage.client.facet import SqlJobFacet
-from openlineage.common.provider.redshift_data import RedshiftDataDatasetsProvider
+from typing import List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.airflow.utils import get_job_name
+from openlineage.client.facet import SqlJobFacet
+from openlineage.common.provider.redshift_data import RedshiftDataDatasetsProvider
 from openlineage.common.sql import SqlMeta, parse
 
 

--- a/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
@@ -1,9 +1,10 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, TYPE_CHECKING
-from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+from typing import TYPE_CHECKING, List
+
 import boto3
+from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
 if TYPE_CHECKING:
     from airflow.hooks.base import BaseHook

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, List
+from typing import List, Optional
 from urllib.parse import urlparse
+
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.run import Dataset
 

--- a/integration/airflow/openlineage/airflow/extractors/sagemaker_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sagemaker_extractors.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, List
+from typing import List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.run import Dataset

--- a/integration/airflow/openlineage/airflow/extractors/sftp_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sftp_extractor.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import socket
-from typing import Optional, List
+from typing import List, Optional
 
 import paramiko
-
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Dataset, Source
+
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.providers.sftp.operators.sftp import SFTPOperation
 

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Dict
+from typing import Dict, List
 
 from openlineage.airflow.extractors.dbapi_utils import execute_query_on_hook
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor

--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -1,16 +1,16 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, List, Optional, Dict
 from collections import defaultdict
+from typing import Any, Dict, List, Optional
 
 from openlineage.airflow.extractors.base import TaskMetadata
-from openlineage.client.facet import BaseFacet
 from openlineage.client.facet import (
-    DataQualityMetricsInputDatasetFacet,
+    Assertion,
+    BaseFacet,
     ColumnMetric,
     DataQualityAssertionsDatasetFacet,
-    Assertion
+    DataQualityMetricsInputDatasetFacet,
 )
 
 

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -1,32 +1,32 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, TYPE_CHECKING, Dict, Tuple, Callable, Iterable, Union
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.airflow.extractors.dbapi_utils import (
-    get_table_schemas,
+    TablesHierarchy,
     create_information_schema_query,
-    TablesHierarchy
+    get_table_schemas,
 )
 from openlineage.airflow.utils import get_connection
-from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.facet import (
     BaseFacet,
-    SqlJobFacet,
     ColumnLineageDatasetFacet,
     ColumnLineageDatasetFacetFieldsAdditional,
     ColumnLineageDatasetFacetFieldsAdditionalInputFields,
     ExtractionError,
-    ExtractionErrorRunFacet
+    ExtractionErrorRunFacet,
+    SqlJobFacet,
 )
-from openlineage.common.sql import SqlMeta, parse, DbTableMeta
 from openlineage.common.dataset import Dataset, Source
-from abc import abstractmethod
+from openlineage.common.sql import DbTableMeta, SqlMeta, parse
 
 if TYPE_CHECKING:
-    from airflow.models import Connection
     from airflow.hooks.base import BaseHook
+    from airflow.models import Connection
 
 
 class SqlExtractor(BaseExtractor):

--- a/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
@@ -4,8 +4,8 @@
 from typing import List
 from urllib.parse import urlparse
 
-from openlineage.airflow.utils import try_import_from_string
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+from openlineage.airflow.utils import try_import_from_string
 
 
 class TrinoExtractor(SqlExtractor):

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -1,14 +1,14 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Dict
+from typing import Dict, List
 
 import attr
-from airflow.version import version as AIRFLOW_VERSION
-from openlineage.client.facet import BaseFacet
-
 from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
+from openlineage.client.facet import BaseFacet
 from openlineage.client.utils import RedactMixin
+
+from airflow.version import version as AIRFLOW_VERSION
 
 
 @attr.s

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -6,25 +6,26 @@ import logging
 import threading
 import uuid
 from concurrent.futures import Executor, ThreadPoolExecutor
-from typing import TYPE_CHECKING, Optional, Callable, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import attr
-from airflow.listeners import hookimpl
-
 from openlineage.airflow.adapter import OpenLineageAdapter
 from openlineage.airflow.extractors import ExtractorManager
 from openlineage.airflow.utils import (
     DagUtils,
-    get_dagrun_start_end,
-    get_task_location,
-    get_job_name,
-    get_custom_facets,
     get_airflow_run_facet,
+    get_custom_facets,
+    get_dagrun_start_end,
+    get_job_name,
+    get_task_location,
 )
 
+from airflow.listeners import hookimpl
+
 if TYPE_CHECKING:
-    from airflow.models import TaskInstance, BaseOperator, MappedOperator, DagRun
     from sqlalchemy.orm import Session
+
+    from airflow.models import BaseOperator, DagRun, MappedOperator, TaskInstance
 
 
 @attr.s(frozen=True)

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+
 from openlineage.airflow.utils import JobIdMapping, openlineage_job_name
 
 _JOB_NAMESPACE = os.getenv('OPENLINEAGE_NAMESPACE', 'default')

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -3,13 +3,12 @@
 
 import os
 
-from airflow.plugins_manager import AirflowPlugin
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
-
-
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+from pkg_resources import parse_version
+
+from airflow.plugins_manager import AirflowPlugin
+from airflow.version import version as AIRFLOW_VERSION
 
 
 def _is_disabled():

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -7,25 +7,24 @@ import json
 import logging
 import os
 import subprocess
-import attr
-from typing import TYPE_CHECKING, Type, Dict, Any, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from uuid import uuid4
-from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
-from typing import Optional
-from airflow.models import DAG as AIRFLOW_DAG
 
+import attr
 from openlineage.airflow.facets import (
     AirflowMappedTaskRunFacet,
-    AirflowVersionRunFacet,
     AirflowRunArgsRunFacet,
-    AirflowRunFacet
+    AirflowRunFacet,
+    AirflowVersionRunFacet,
 )
 from openlineage.client.utils import RedactMixin
 from pendulum import from_timestamp
 
+from airflow.models import DAG as AIRFLOW_DAG
 
 if TYPE_CHECKING:
-    from airflow.models import Connection, BaseOperator, TaskInstance, DagRun, DAG
+    from airflow.models import DAG, BaseOperator, Connection, DagRun, TaskInstance
 
 
 log = logging.getLogger(__name__)

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -6,9 +6,10 @@ import time
 import uuid
 from typing import Optional
 
+from pkg_resources import parse_version
+
 from airflow.lineage.backend import LineageBackend
 from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
 
 
 class Backend:
@@ -33,8 +34,14 @@ class Backend:
         Send_lineage ignores manually provided inlets and outlets. The data collection mechanism
         is automatic, and bases on the passed context.
         """
-        from openlineage.airflow.utils import DagUtils, get_custom_facets, \
-            get_job_name, get_task_location, get_airflow_run_facet, get_dagrun_start_end
+        from openlineage.airflow.utils import (
+            DagUtils,
+            get_airflow_run_facet,
+            get_custom_facets,
+            get_dagrun_start_end,
+            get_job_name,
+            get_task_location,
+        )
         dag = context['dag']
         dagrun = context['dag_run']
         task_instance = context['task_instance']

--- a/integration/airflow/pyproject.toml
+++ b/integration/airflow/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+select = [
+    "F",
+    "E",
+    "W",
+    "I001"
+]
+target-version = "py37"
+ignore-init-module-imports = true
+src = ["openlineage", "tests"]
+namespace-packages = ["openlineage/airflow"]

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -15,9 +15,6 @@ replace = __version__ = "{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[flake8]
-max-line-length = 99
-
 [tool:pytest]
 addopts = -p no:warnings
 
@@ -47,7 +44,7 @@ deps = -r dev-requirements.txt
 	airflow-2.4.3: apache-airflow==2.4.3
 	airflow-2.5.0: apache-airflow==2.5.0
 whitelist_externals = bash
-commands = flake8 --extend-exclude tests/integration,scripts/
+commands = ruff . --no-update-check
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}
 	python -m pytest --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -5,7 +5,7 @@
 #
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages, setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -24,12 +24,11 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "flake8",
-        "mypy>=0.9.6",
+        "ruff",
         "SQLAlchemy",       # must be set to 1.3.* for airflow tests compatibility
         "Flask-SQLAlchemy",  # must be set to 2.4.* for airflow tests compatibility
         "pandas-gbq==0.14.1",       # must be set to 0.14.* for airflow tests compatibility
-        "snowflake-connector-python"
+        "snowflake-connector-python",
     ],
     "airflow": [
         "apache-airflow-providers-postgres>=2.0.0",

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -5,10 +5,11 @@ import logging
 import os
 
 import pytest
-
-from pkg_resources import parse_version
-from airflow.version import version as AIRFLOW_VERSION
 from mock import patch
+from pkg_resources import parse_version
+
+from airflow.version import version as AIRFLOW_VERSION
+
 log = logging.getLogger(__name__)
 
 collect_ignore = []
@@ -46,8 +47,8 @@ def dagbag():
     os.environ['AIRFLOW__CORE__SQL_ALCHEMY_CONN'] = 'sqlite://'
     os.environ['MARQUEZ_NAMESPACE'] = 'test-marquez'
 
-    from airflow import settings
     import airflow.utils.db as db_utils
+    from airflow import settings
     db_utils.resetdb(settings.RBAC)
     from airflow.models import DagBag
     dagbag = DagBag(include_examples=False)

--- a/integration/airflow/tests/extractors/test_base.py
+++ b/integration/airflow/tests/extractors/test_base.py
@@ -1,9 +1,11 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from airflow.models import Connection
+from urllib.parse import parse_qs, urlparse
+
 from openlineage.airflow.extractors.base import BaseExtractor
-from urllib.parse import urlparse, parse_qs
+
+from airflow.models import Connection
 
 AIRFLOW_CONN_ID = "test_db"
 AIRFLOW_CONN_URI = "postgres://localhost:5432/testdb"

--- a/integration/airflow/tests/extractors/test_bash_extractor.py
+++ b/integration/airflow/tests/extractors/test_bash_extractor.py
@@ -4,11 +4,11 @@
 import os
 from unittest.mock import patch
 
-from airflow.operators.bash_operator import BashOperator
-
 from openlineage.airflow.extractors.bash_extractor import BashExtractor
 from openlineage.airflow.extractors.example_dag import bash_task
 from openlineage.client.facet import SourceCodeJobFacet
+
+from airflow.operators.bash_operator import BashOperator
 
 
 def test_extract_operator_bash_command_disables_without_env():

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -9,19 +9,22 @@ import uuid
 from datetime import datetime
 
 import mock
-from pkg_resources import parse_version
 import pytz
-from airflow.utils import timezone
-from airflow.models import TaskInstance, DAG
-from airflow.utils.state import State
-from airflow.version import version as AIRFLOW_VERSION
-
 from openlineage.airflow.extractors.bigquery_extractor import BigQueryExtractor
 from openlineage.airflow.utils import try_import_from_string
-from openlineage.client.facet import OutputStatisticsOutputDatasetFacet, ExternalQueryRunFacet
-from openlineage.common.provider.bigquery import BigQueryJobRunFacet, \
-    BigQueryStatisticsDatasetFacet, BigQueryErrorRunFacet
+from openlineage.client.facet import ExternalQueryRunFacet, OutputStatisticsOutputDatasetFacet
+from openlineage.common.provider.bigquery import (
+    BigQueryErrorRunFacet,
+    BigQueryJobRunFacet,
+    BigQueryStatisticsDatasetFacet,
+)
 from openlineage.common.utils import get_from_nullable_chain
+from pkg_resources import parse_version
+
+from airflow.models import DAG, TaskInstance
+from airflow.utils import timezone
+from airflow.utils.state import State
+from airflow.version import version as AIRFLOW_VERSION
 
 log = logging.getLogger(__name__)
 

--- a/integration/airflow/tests/extractors/test_converters.py
+++ b/integration/airflow/tests/extractors/test_converters.py
@@ -3,6 +3,7 @@
 
 def test_table_to_dataset_conversion():
     from openlineage.airflow.extractors.converters import convert_to_dataset
+
     from airflow.lineage.entities import Table
     t = Table(
         database="db",

--- a/integration/airflow/tests/extractors/test_dbapi_utils.py
+++ b/integration/airflow/tests/extractors/test_dbapi_utils.py
@@ -4,10 +4,10 @@
 from unittest.mock import MagicMock
 
 from openlineage.airflow.extractors.dbapi_utils import (
-    get_table_schemas,
     create_filter_clauses,
+    get_table_schemas,
 )
-from openlineage.common.dataset import Source, Dataset
+from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
 

--- a/integration/airflow/tests/extractors/test_default_extractor.py
+++ b/integration/airflow/tests/extractors/test_default_extractor.py
@@ -2,22 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any
-
-from airflow.models import BaseOperator
-from airflow.operators.python import PythonOperator
 from unittest import mock
-import attr
 
+import attr
 from openlineage.airflow.extractors import Extractors
 from openlineage.airflow.extractors.base import (
-    OperatorLineage,
     DefaultExtractor,
+    OperatorLineage,
     TaskMetadata,
 )
 from openlineage.airflow.extractors.python_extractor import PythonExtractor
-from openlineage.client.facet import ParentRunFacet, SqlJobFacet, BaseFacet
+from openlineage.client.facet import BaseFacet, ParentRunFacet, SqlJobFacet
 from openlineage.client.run import Dataset
 
+from airflow.models import BaseOperator
+from airflow.operators.python import PythonOperator
 
 INPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
 OUTPUTS = [Dataset(namespace="database://host:port", name="inputtable")]

--- a/integration/airflow/tests/extractors/test_extractor_manager.py
+++ b/integration/airflow/tests/extractors/test_extractor_manager.py
@@ -1,12 +1,13 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional, List
+from typing import Any, List, Optional
 from unittest.mock import MagicMock
-from airflow.models import BaseOperator
 
-from openlineage.airflow.extractors import ExtractorManager, BaseExtractor, TaskMetadata
+from openlineage.airflow.extractors import BaseExtractor, ExtractorManager, TaskMetadata
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+
+from airflow.models import BaseOperator
 
 
 class FakeOperator(BaseOperator):
@@ -72,8 +73,9 @@ def test_adding_extractors_to_manager():
 
 
 def test_extracting_inlets_and_outlets():
-    from airflow.lineage.entities import Table
     from openlineage.client.run import Dataset
+
+    from airflow.lineage.entities import Table
 
     metadata = TaskMetadata(name="fake-name", job_facets={})
     inlets = [Dataset(namespace="c1", name="d1.t0", facets={}),
@@ -90,8 +92,9 @@ def test_extracting_inlets_and_outlets():
 
 
 def test_extraction_from_inlets_and_outlets_without_extractor():
-    from airflow.lineage.entities import Table
     from openlineage.client.run import Dataset
+
+    from airflow.lineage.entities import Table
 
     dagrun = MagicMock()
 
@@ -112,8 +115,9 @@ def test_extraction_from_inlets_and_outlets_without_extractor():
 
 
 def test_extraction_from_inlets_and_outlets_ignores_unhandled_types():
-    from airflow.lineage.entities import Table, File
     from openlineage.client.run import Dataset
+
+    from airflow.lineage.entities import File, Table
 
     dagrun = MagicMock()
 
@@ -132,8 +136,9 @@ def test_extraction_from_inlets_and_outlets_ignores_unhandled_types():
 
 
 def test_fake_extractor_extracts_from_inlets_and_outlets():
-    from airflow.lineage.entities import Table
     from openlineage.client.run import Dataset
+
+    from airflow.lineage.entities import Table
 
     dagrun = MagicMock()
 
@@ -161,8 +166,9 @@ def test_fake_extractor_extracts_from_inlets_and_outlets():
 
 
 def test_fake_extractor_extracts_and_discards_inlets_and_outlets():
-    from airflow.lineage.entities import Table
     from openlineage.client.run import Dataset
+
+    from airflow.lineage.entities import Table
 
     dagrun = MagicMock()
 

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import pytest
 from typing import List, Optional
 from unittest.mock import patch
+
+import pytest
+from openlineage.airflow.extractors import BaseExtractor, Extractors, TaskMetadata
+from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+
 from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection
-
-from openlineage.airflow.extractors import Extractors, BaseExtractor, TaskMetadata
-from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
 
 class FakeExtractor(BaseExtractor):

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -4,19 +4,16 @@
 from unittest import mock
 
 import pytest
+from openlineage.airflow.extractors.mysql_extractor import MySqlExtractor
+from openlineage.airflow.utils import get_connection, try_import_from_string
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+
+from airflow import DAG
 from airflow.models import Connection
 from airflow.utils.dates import days_ago
-from airflow import DAG
 from airflow.utils.session import create_session
-
-from openlineage.airflow.utils import get_connection, try_import_from_string
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset, Field
-from openlineage.airflow.extractors.mysql_extractor import MySqlExtractor
 
 MySqlOperator = try_import_from_string("airflow.providers.mysql.operators.mysql.MySqlOperator")
 MySqlHook = try_import_from_string("airflow.providers.mysql.hooks.mysql.MySqlHook")

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -4,19 +4,16 @@
 from unittest import mock
 
 import pytest
+from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
+from openlineage.airflow.utils import get_connection, try_import_from_string
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+
+from airflow import DAG
 from airflow.models import Connection
 from airflow.utils.dates import days_ago
-from airflow import DAG
 from airflow.utils.session import create_session
-
-from openlineage.airflow.utils import get_connection, try_import_from_string
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset, Field
-from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 
 PostgresOperator = try_import_from_string(
     "airflow.providers.postgres.operators.postgres.PostgresOperator"

--- a/integration/airflow/tests/extractors/test_python_extractor.py
+++ b/integration/airflow/tests/extractors/test_python_extractor.py
@@ -5,11 +5,11 @@ import inspect
 import os
 from unittest.mock import patch
 
-from airflow.operators.python_operator import PythonOperator
-
 from openlineage.airflow.extractors.example_dag import python_task_getcwd
 from openlineage.airflow.extractors.python_extractor import PythonExtractor
 from openlineage.client.facet import SourceCodeJobFacet
+
+from airflow.operators.python_operator import PythonOperator
 
 
 def callable():

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -1,29 +1,27 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import random
-from unittest import mock
-from mock import PropertyMock
-
-from airflow.models import TaskInstance, DAG
-from airflow.utils.state import State
-from datetime import datetime
-import pytz
-import uuid
 import json
 import logging
+import random
 import unittest
+import uuid
+from datetime import datetime
+from unittest import mock
 
-from pkg_resources import parse_version
-from airflow.utils import timezone
-from airflow.version import version as AIRFLOW_VERSION
-from openlineage.common.models import DbTableSchema, DbColumn
-from openlineage.common.sql import DbTableMeta
-
+import pytz
+from mock import PropertyMock
 from openlineage.airflow.extractors.redshift_data_extractor import RedshiftDataExtractor
-from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
 from openlineage.client.facet import ErrorMessageRunFacet, OutputStatisticsOutputDatasetFacet
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+from pkg_resources import parse_version
 
+from airflow.models import DAG, TaskInstance
+from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
+from airflow.utils import timezone
+from airflow.utils.state import State
+from airflow.version import version as AIRFLOW_VERSION
 
 CONN_ID = "food_delivery_db"
 CONN_URI = (

--- a/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
@@ -2,21 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
-from airflow.models import Connection
-from airflow.utils.dates import days_ago
-from airflow import DAG
-from airflow.utils.session import create_session
-from urllib.parse import urlparse, parse_qs
-
-from openlineage.airflow.utils import get_connection
-from openlineage.common.models import DbTableSchema, DbColumn
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset, Field
 from openlineage.airflow.extractors.redshift_sql_extractor import RedshiftSQLExtractor
-from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
+from openlineage.airflow.utils import get_connection
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
 
+from airflow import DAG
+from airflow.models import Connection
+from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.session import create_session
 
 CONN_ID = "food_delivery_db"
 CONN_URI = (

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -4,15 +4,17 @@
 import logging
 import unittest
 from unittest import TestCase
-from airflow.models import DAG
-from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator, S3FileTransformOperator
-from airflow.utils import timezone
+
 from openlineage.airflow.extractors.base import TaskMetadata
 from openlineage.airflow.extractors.s3_extractor import (
     S3CopyObjectExtractor,
-    S3FileTransformExtractor
+    S3FileTransformExtractor,
 )
 from openlineage.client.run import Dataset
+
+from airflow.models import DAG
+from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator, S3FileTransformOperator
+from airflow.utils import timezone
 
 log = logging.getLogger(__name__)
 

--- a/integration/airflow/tests/extractors/test_sagemaker_extractors.py
+++ b/integration/airflow/tests/extractors/test_sagemaker_extractors.py
@@ -2,27 +2,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import unittest
-from unittest import mock, TestCase
 import random
+import unittest
+from datetime import datetime
+from unittest import TestCase, mock
+
 import pytz
 from openlineage.airflow.extractors.sagemaker_extractors import (
     SageMakerProcessingExtractor,
     SageMakerTrainingExtractor,
-    SageMakerTransformExtractor
+    SageMakerTransformExtractor,
 )
+from pkg_resources import parse_version
 
+from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerProcessingOperator,
     SageMakerTrainingOperator,
-    SageMakerTransformOperator
+    SageMakerTransformOperator,
 )
-
-from datetime import datetime
-from airflow.models import TaskInstance, DAG
-from airflow.utils.state import State
 from airflow.utils import timezone
-from pkg_resources import parse_version
+from airflow.utils.state import State
 from airflow.version import version as AIRFLOW_VERSION
 
 log = logging.getLogger(__name__)

--- a/integration/airflow/tests/extractors/test_sftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_sftp_extractor.py
@@ -1,24 +1,22 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import paramiko
-import pytest
 import socket
-
-from pkg_resources import parse_version
 from unittest import mock
 
-from airflow.models import Connection, DAG
+import paramiko
+import pytest
+from openlineage.airflow.extractors.sftp_extractor import SFTPExtractor
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.common.dataset import Dataset, Source
+from pkg_resources import parse_version
+
+from airflow.models import DAG, Connection
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.providers.sftp.operators.sftp import SFTPOperation
 from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers_manager import ProvidersManager
 from airflow.utils import timezone
-
-from openlineage.airflow.extractors.sftp_extractor import SFTPExtractor
-from openlineage.airflow.utils import try_import_from_string
-from openlineage.common.dataset import Source, Dataset
-
 
 SFTP_PROVIDER_VERSION = parse_version(
     ProvidersManager().providers["apache-airflow-providers-sftp"].version

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -2,20 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
-from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
-from airflow.models import Connection
-from airflow import DAG
-from airflow.utils.dates import days_ago
-
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset, Field
 from openlineage.airflow.extractors.snowflake_extractor import SnowflakeExtractor
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+
+from airflow import DAG
+from airflow.models import Connection
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from airflow.utils.dates import days_ago
 
 CONN_ID = 'food_delivery_db'
 CONN_URI = 'snowflake://snowflake.example/db-schema?account=test_account&database=FOOD_DELIVERY&region=us-east&warehouse=snow-warehouse&secret=hideit'  # noqa

--- a/integration/airflow/tests/extractors/test_sql_check_extractors.py
+++ b/integration/airflow/tests/extractors/test_sql_check_extractors.py
@@ -4,7 +4,6 @@
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor
 from openlineage.airflow.extractors.sql_check_extractors import get_check_extractors
 
-
 COLUMN_CHECK_MAPPING = {
     "X": {
         "null_check": {

--- a/integration/airflow/tests/extractors/test_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_sql_extractor.py
@@ -1,8 +1,8 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from openlineage.common.sql import DbTableMeta
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
+from openlineage.common.sql import DbTableMeta
 
 
 def normalize_name_lower(name: str) -> str:

--- a/integration/airflow/tests/extractors/test_trino_extractor.py
+++ b/integration/airflow/tests/extractors/test_trino_extractor.py
@@ -1,22 +1,18 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 from unittest import mock
 
+import pytest
+from openlineage.airflow.extractors.trino_extractor import TrinoExtractor
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
+
+from airflow import DAG
 from airflow.models import Connection
 from airflow.utils.dates import days_ago
-from airflow import DAG
-
-from openlineage.airflow.utils import try_import_from_string
-from openlineage.common.models import (
-    DbTableSchema,
-    DbColumn
-)
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset, Field
-from openlineage.airflow.extractors.trino_extractor import TrinoExtractor
 
 TrinoOperator = try_import_from_string(
     "airflow.providers.trino.operators.trino.TrinoOperator"

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from time import sleep
-from typing import Union, Optional, List
+from typing import List, Optional, Union
 
 from openlineage.airflow.extractors import TaskMetadata
 from openlineage.airflow.extractors.base import BaseExtractor
@@ -11,8 +11,8 @@ from openlineage.client.run import Dataset
 
 class HangingExtractor(BaseExtractor):
     """
-    Custom extractor that hangs for 30 seconds. The listener module should terminate the thread that executes
-    this extractor after waiting for the timeout to complete.
+    Custom extractor that hangs for 30 seconds. The listener module should terminate
+    the thread that executes this extractor after waiting for the timeout to complete.
     """
     @classmethod
     def get_operator_classnames(cls) -> List[str]:

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
@@ -4,19 +4,20 @@
 import os
 from typing import Any
 
+from openlineage.client import set_producer
+from pkg_resources import parse_version
+
+from airflow import DAG
 from airflow.models import BaseOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
+from airflow.version import version as AIRFLOW_VERSION
 
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
-from airflow import DAG
 
 # Exercise the extractor only for Airflow 2.3.0+
-# This is to test the thread handling in the Airflow listener. The thread should be shutdown after 2 seconds, even
-# if the extractor is hanging
+# This is to test the thread handling in the Airflow listener.
+# The thread should be shutdown after 2 seconds, even if the extractor is hanging
 if parse_version(AIRFLOW_VERSION) > parse_version("2.3.0"):
     os.environ["OPENLINEAGE_EXTRACTOR_CustomOperator"] = 'hanging_extractor.HangingExtractor'
 

--- a/integration/airflow/tests/integration/failures/airflow/dags/run_test_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/run_test_dag.py
@@ -1,11 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
+from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
-from airflow import DAG
 
 _PRODUCER = "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
 set_producer(_PRODUCER)

--- a/integration/airflow/tests/integration/failures/airflow/dags/wait_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/wait_dag.py
@@ -1,12 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
+from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
-from airflow import DAG
-
 
 _PRODUCER = "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
 set_producer(_PRODUCER)

--- a/integration/airflow/tests/integration/server/app.py
+++ b/integration/airflow/tests/integration/server/app.py
@@ -1,15 +1,15 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
+import sqlite3
 import sys
 import time
 
-from flask import Flask, request, g, jsonify
 from dateutil.parser import parse
-import sqlite3
-import json
+from flask import Flask, g, jsonify, request
 
 app = Flask(__name__)
 

--- a/integration/airflow/tests/integration/test_failure.py
+++ b/integration/airflow/tests/integration/test_failure.py
@@ -3,15 +3,14 @@
 
 import logging
 import sys
+import time
+import unittest
 
 import psycopg2
-import time
+import pytest
 import requests
 from requests.auth import HTTPBasicAuth
 from retrying import retry
-import pytest
-import unittest
-
 
 logging.basicConfig(
     format="[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s",
@@ -55,6 +54,7 @@ def wait_for_dag(dag_id):
         raise Exception('Retry!')
     return True
 
+
 @pytest.fixture(scope="module", autouse=True)
 def airflow_db_conn():
     yield setup_db()
@@ -71,6 +71,7 @@ def setup_db():
     )
     airflow_db_conn.autocommit = True
 
+
 @pytest.mark.parametrize("dag_id", ["wait_dag", "test_dag", "hanging_extractor_dag"])
 def test_failure(dag_id):
     trigger_dag(dag_id)
@@ -78,7 +79,11 @@ def test_failure(dag_id):
 
 
 def trigger_dag(dag_id):
-    r = requests.post(f"http://airflow:8080/api/v1/dags/{dag_id}/dagRuns", auth=HTTPBasicAuth('airflow', 'airflow'), json={})
+    r = requests.post(
+        f"http://airflow:8080/api/v1/dags/{dag_id}/dagRuns",
+        auth=HTTPBasicAuth('airflow', 'airflow'),
+        json={}
+    )
     r.raise_for_status()
 
 

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -5,17 +5,16 @@ import json
 import logging
 import os
 import sys
+import time
+import unittest
 from typing import List
 
-from pkg_resources import parse_version
-
 import psycopg2
-import time
-import requests
-from retrying import retry
 import pytest
-import unittest
+import requests
 from openlineage.common.test import match, setup_jinja
+from pkg_resources import parse_version
+from retrying import retry
 
 env = setup_jinja()
 
@@ -39,9 +38,8 @@ except:  # noqa
 SNOWFLAKE_AIRFLOW_TEST_VERSION = os.environ.get("SNOWFLAKE_AIRFLOW_TEST_VERSION", "2.2.4")
 
 
-IS_AIRFLOW_VERSION_ENOUGH = lambda x: parse_version(
-    os.environ.get("AIRFLOW_VERSION", "0.0.0")
-) >= parse_version(x)
+def IS_AIRFLOW_VERSION_ENOUGH(x):
+    return parse_version(os.environ.get("AIRFLOW_VERSION", "0.0.0")) >= parse_version(x)
 
 
 params = [

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
+
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 
 LOGGING_CONFIG = deepcopy(DEFAULT_LOGGING_CONFIG)

--- a/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-
 from urllib.parse import urlparse
+
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.client import set_producer
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.utils.dates import days_ago
 
-from openlineage.airflow.utils import try_import_from_string
-from openlineage.client import set_producer
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 AthenaOperator = try_import_from_string(

--- a/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
@@ -4,12 +4,13 @@
 import os
 import time
 
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.google.cloud.operators.bigquery import BigQueryExecuteQueryOperator
 from airflow.utils.dates import days_ago
 
-from openlineage.client import set_producer
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 
@@ -85,7 +86,7 @@ t4 = BigQueryExecuteQueryOperator(
         order_placed_on,
         COUNT(*) AS orders_placed
     FROM airflow_integration.{PREFIX}top_delivery_times
-    GROUP BY order_placed_on;''',
+    GROUP BY order_placed_on;''',  # noqa: E501
     use_legacy_sql=False,
     dag=dag
 )

--- a/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor.py
@@ -1,11 +1,11 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Union, Optional, List
+from typing import List, Optional, Union
 
-from openlineage.client.run import Dataset
 from openlineage.airflow.extractors import TaskMetadata
 from openlineage.airflow.extractors.base import BaseExtractor
+from openlineage.client.run import Dataset
 
 
 class CustomExtractor(BaseExtractor):

--- a/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor_dag.py
@@ -3,10 +3,12 @@
 
 import os
 from typing import Any
+
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.models import BaseOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
 
 os.environ["OPENLINEAGE_EXTRACTOR_CustomOperator"] = 'custom_extractor.CustomExtractor'
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")

--- a/integration/airflow/tests/integration/tests/airflow/dags/dag_event_order.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dag_event_order.py
@@ -1,12 +1,11 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from airflow import DAG
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
 from openlineage.client import set_producer
 
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
 
 _PRODUCER="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
 set_producer(_PRODUCER)

--- a/integration/airflow/tests/integration/tests/airflow/dags/dbt_bigquery.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dbt_bigquery.py
@@ -6,8 +6,6 @@ import os
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
-from airflow.utils.session import create_session
-
 
 PLUGIN_MACRO = "{{ macros.OpenLineagePlugin.lineage_parent_id(run_id, task) }}"
 
@@ -34,7 +32,7 @@ dag = DAG(
 t1 = BashOperator(
     task_id='dbt_seed',
     dag=dag,
-    bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt seed --full-refresh --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",
+    bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt seed --full-refresh --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",  # noqa: E501
     env={
         **os.environ,
         "OPENLINEAGE_PARENT_ID": PLUGIN_MACRO,
@@ -45,7 +43,7 @@ t1 = BashOperator(
 t2 = BashOperator(
     task_id='dbt_run',
     dag=dag,
-    bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt-ol run --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",
+    bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt-ol run --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",  # noqa: E501
     env={
         **os.environ,
         "OPENLINEAGE_PARENT_ID": PLUGIN_MACRO,

--- a/integration/airflow/tests/integration/tests/airflow/dags/dbt_snowflake.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dbt_snowflake.py
@@ -1,13 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import os
+
+from openlineage.airflow.utils import JobIdMapping
 
 from airflow.operators.bash_operator import BashOperator
 from airflow.utils.dates import days_ago
-
-from openlineage.airflow.utils import JobIdMapping
 
 try:
     from airflow.utils.db import create_session
@@ -52,7 +51,7 @@ if AIRFLOW_VERSION == os.environ.get("SNOWFLAKE_AIRFLOW_TEST_VERSION", "2.3.4"):
     t1 = BashOperator(
         task_id='dbt_seed',
         dag=dag,
-        bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt seed --full-refresh --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",
+        bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt seed --full-refresh --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR} && deactivate",  # noqa: E501
         env={
             **os.environ,
             "OPENLINEAGE_PARENT_ID": "{{ lineage_parent_id(run_id, task) }}",
@@ -63,7 +62,7 @@ if AIRFLOW_VERSION == os.environ.get("SNOWFLAKE_AIRFLOW_TEST_VERSION", "2.3.4"):
     t2 = BashOperator(
         task_id='dbt_run',
         dag=dag,
-        bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt-ol run --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR}",
+        bash_command=f"source /opt/airflow/dbt_venv/bin/activate && dbt-ol run --project-dir={PROJECT_DIR} --profiles-dir={PROFILE_DIR}",  # noqa: E501
         env={
             **os.environ,
             "OPENLINEAGE_PARENT_ID": "{{ lineage_parent_id(run_id, task) }}",

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -3,15 +3,14 @@
 
 from typing import Any
 
-from airflow import DAG
-from airflow.models import BaseOperator
-from airflow.utils.dates import days_ago
 import attr
-
 from openlineage.airflow.extractors.base import OperatorLineage
 from openlineage.client.facet import BaseFacet, ParentRunFacet, SqlJobFacet
 from openlineage.client.run import Dataset
 
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.utils.dates import days_ago
 
 INPUTS = [Dataset(namespace="database://host:port", name="inputtable")]
 OUTPUTS = [Dataset(namespace="database://host:port", name="inputtable")]

--- a/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
@@ -5,9 +5,8 @@ from datetime import datetime
 
 from airflow import DAG, XComArg
 from airflow.decorators import task
-from airflow.operators.python import PythonOperator
 from airflow.operators.bash import BashOperator
-
+from airflow.operators.python import PythonOperator
 
 with DAG(
     dag_id="mapped_dag", start_date=datetime(2020, 4, 7), schedule_interval="@once"

--- a/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
@@ -5,13 +5,13 @@ import datetime
 import os
 import uuid
 
+from openlineage.client import OpenLineageClient, set_producer
+from openlineage.client.run import Job, Run, RunEvent, RunState
+
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer, OpenLineageClient
-from openlineage.client.run import RunEvent, Run, Job, RunState
-
 
 _PRODUCER="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
@@ -1,12 +1,13 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
-from airflow import DAG
-from airflow.version import version as AIRFLOW_VERSION
-from airflow.providers.postgres.operators.postgres import PostgresOperator
-from airflow.utils.dates import days_ago
-
 from openlineage.client import set_producer
 from pkg_resources import parse_version
+
+from airflow import DAG
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.utils.dates import days_ago
+from airflow.version import version as AIRFLOW_VERSION
+
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/greatexpectations_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/greatexpectations_dag.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from great_expectations_provider.operators.great_expectations import GreatExpectationsOperator
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
+
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
@@ -1,11 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.providers.mysql.operators.mysql import MySqlOperator
 from airflow.utils.dates import days_ago
 
-from openlineage.client import set_producer
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -1,13 +1,14 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from airflow import DAG
-from airflow.version import version as AIRFLOW_VERSION
-from airflow.providers.postgres.operators.postgres import PostgresOperator
-from airflow.utils.dates import days_ago
-
 from openlineage.client import set_producer
 from pkg_resources import parse_version
+
+from airflow import DAG
+from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.utils.dates import days_ago
+from airflow.version import version as AIRFLOW_VERSION
+
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
@@ -5,7 +5,6 @@ from airflow import DAG
 from airflow.providers.amazon.aws.operators.s3 import S3CopyObjectOperator
 from airflow.utils.dates import days_ago
 
-
 with DAG(dag_id="s3copy_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
     S3CopyObjectOperator(
         task_id="s3copy_task",

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
@@ -5,7 +5,6 @@ from airflow import DAG
 from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
 from airflow.utils.dates import days_ago
 
-
 with DAG(dag_id="s3transform_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
     S3FileTransformOperator(
         task_id="s3transform_task",

--- a/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.models import BaseOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.log.secrets_masker import mask_secret
 
-from openlineage.client import set_producer
-
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 
 class SecretsOperator(BaseOperator):
-    """This shouldn't have extractor - we're testing if we'll see password in UnknownSourceAttribute"""
+    """This shouldn't have extractor - testing if we'll see password in UnknownSourceAttribute"""
     template_fields = ['password']
 
     def __init__(self, password, **kwargs):

--- a/integration/airflow/tests/integration/tests/airflow/dags/sftp_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/sftp_dag.py
@@ -5,7 +5,6 @@ from airflow import DAG
 from airflow.providers.sftp.operators.sftp import SFTPOperator
 from airflow.utils.dates import days_ago
 
-
 with DAG(dag_id="sftp_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
     SFTPOperator(
         task_id="sftp_task",

--- a/integration/airflow/tests/integration/tests/airflow/dags/snowflake_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/snowflake_dag.py
@@ -1,11 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from airflow.utils.dates import days_ago
 
-from openlineage.client import set_producer
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 
@@ -30,7 +31,7 @@ CONNECTION = "snowflake_conn"
 t1 = SnowflakeOperator(
     task_id='snowflake_if_not_exists',
     snowflake_conn_id=CONNECTION,
-    sql=f'''
+    sql='''
     CREATE TABLE IF NOT EXISTS test_orders (
       ord   NUMBER,
       str   STRING,
@@ -42,7 +43,7 @@ t1 = SnowflakeOperator(
 t2 = SnowflakeOperator(
     task_id='snowflake_insert',
     snowflake_conn_id=CONNECTION,
-    sql=f'''
+    sql='''
     INSERT INTO test_orders (ord, str, num) VALUES
     (1, 'b', 15),
     (2, 'a', 21),
@@ -54,7 +55,7 @@ t2 = SnowflakeOperator(
 t3 = SnowflakeOperator(
     task_id='snowflake_truncate',
     snowflake_conn_id=CONNECTION,
-    sql=f"TRUNCATE TABLE test_orders;",
+    sql="TRUNCATE TABLE test_orders;",
     dag=dag
 )
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/source_extractor_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/source_extractor_dag.py
@@ -1,12 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
-from openlineage.client import set_producer
-
 
 _PRODUCER="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow"
 set_producer(_PRODUCER)

--- a/integration/airflow/tests/integration/tests/airflow/dags/task_group_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/task_group_dag.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from airflow.decorators import dag, task, task_group
 
+from airflow.decorators import dag, task, task_group
 from airflow.utils.dates import days_ago
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/trino_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/trino_orders_popular_day_of_week.py
@@ -1,11 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from openlineage.client import set_producer
+
 from airflow import DAG
 from airflow.providers.trino.operators.trino import TrinoOperator
 from airflow.utils.dates import days_ago
 
-from openlineage.client import set_producer
 set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow")
 
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/unknown_operator_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/unknown_operator_dag.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any
+
 from airflow import DAG
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 from airflow.utils.dates import days_ago
+from airflow.utils.decorators import apply_defaults
 
 
 class TestUnknownDummyOperator(BaseOperator):

--- a/integration/airflow/tests/log_config.py
+++ b/integration/airflow/tests/log_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
+
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 
 LOGGING_CONFIG = deepcopy(DEFAULT_LOGGING_CONFIG)

--- a/integration/airflow/tests/test_dags/test_dummy_dag.py
+++ b/integration/airflow/tests/test_dags/test_dummy_dag.py
@@ -4,8 +4,8 @@
 import logging
 from datetime import datetime
 
-from airflow.operators.dummy import DummyOperator
 from airflow import DAG
+from airflow.operators.dummy import DummyOperator
 
 log = logging.getLogger(__name__)
 

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -1,17 +1,18 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from airflow.models import BaseOperator
-from airflow.models import TaskInstance, DAG
-from airflow.utils.dates import days_ago
-import pandas as pd
 import uuid
 from unittest.mock import patch
-from airflow.utils.state import State
+
+import pandas as pd
+
 from airflow.listeners.events import (
     register_task_instance_state_events,
     unregister_task_instance_state_events,
 )
+from airflow.models import DAG, BaseOperator, TaskInstance
+from airflow.utils.dates import days_ago
+from airflow.utils.state import State
 
 
 class TemplateOperator(BaseOperator):

--- a/integration/airflow/tests/test_location.py
+++ b/integration/airflow/tests/test_location.py
@@ -7,9 +7,10 @@ import sys
 from unittest.mock import patch
 
 import pytest
+from openlineage.airflow.utils import get_location
+
 from tests.mocks.git_mock import execute_git_mock
 
-from openlineage.airflow.utils import get_location
 log = logging.getLogger(__name__)
 
 

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -1,36 +1,36 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import json
-import uuid
-import pytest
-
-import pendulum
 import datetime
-from airflow.models import DAG as AIRFLOW_DAG, DagModel
-from airflow.utils.dates import days_ago
-from airflow.utils.state import State
-from airflow.operators.dummy import DummyOperator
-from airflow.version import version as AIRFLOW_VERSION
-from pkg_resources import parse_version
-
-from openlineage.airflow.utils import (
-    url_to_https,
-    get_location,
-    get_connection,
-    to_json_encodable,
-    DagUtils,
-    SafeStrDict,
-    _is_name_redactable,
-    redact_with_exclusions,
-    InfoJsonEncodable,
-    get_dagrun_start_end,
-)
-from openlineage.client.utils import RedactMixin
-import attr
+import json
+import os
+import uuid
 from json import JSONEncoder
 
+import attr
+import pendulum
+import pytest
+from openlineage.airflow.utils import (
+    DagUtils,
+    InfoJsonEncodable,
+    SafeStrDict,
+    _is_name_redactable,
+    get_connection,
+    get_dagrun_start_end,
+    get_location,
+    redact_with_exclusions,
+    to_json_encodable,
+    url_to_https,
+)
+from openlineage.client.utils import RedactMixin
+from pkg_resources import parse_version
+
+from airflow.models import DAG as AIRFLOW_DAG
+from airflow.models import DagModel
+from airflow.operators.dummy import DummyOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.state import State
+from airflow.version import version as AIRFLOW_VERSION
 
 AIRFLOW_CONN_ID = 'test_db'
 AIRFLOW_CONN_URI = 'postgres://localhost:5432/testdb'

--- a/integration/common/openlineage/common/dataset.py
+++ b/integration/common/openlineage/common/dataset.py
@@ -1,13 +1,19 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
-from openlineage.common.models import DbTableSchema, DbColumn
-from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, \
-    DocumentationDatasetFacet, SchemaDatasetFacet, SchemaField
-from openlineage.client.run import Dataset as OpenLineageDataset, InputDataset, OutputDataset
+from openlineage.client.facet import (
+    BaseFacet,
+    DataSourceDatasetFacet,
+    DocumentationDatasetFacet,
+    SchemaDatasetFacet,
+    SchemaField,
+)
+from openlineage.client.run import Dataset as OpenLineageDataset
+from openlineage.client.run import InputDataset, OutputDataset
 from openlineage.client.utils import RedactMixin
+from openlineage.common.models import DbColumn, DbTableSchema
 
 
 class Source(RedactMixin):

--- a/integration/common/openlineage/common/models.py
+++ b/integration/common/openlineage/common/models.py
@@ -1,7 +1,8 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
+
 from openlineage.client.utils import RedactMixin
 
 if TYPE_CHECKING:

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -4,16 +4,19 @@
 import json
 import logging
 import traceback
-import attr
-from typing import Tuple, Optional, Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+import attr
+from openlineage.client.facet import (
+    BaseFacet,
+    ExternalQueryRunFacet,
+    OutputStatisticsOutputDatasetFacet,
+)
 from openlineage.common.dataset import Dataset, Source
-from openlineage.common.models import DbTableSchema, DbColumn
+from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.sql import DbTableMeta
 from openlineage.common.utils import get_from_nullable_chain
-from openlineage.client.facet import BaseFacet, OutputStatisticsOutputDatasetFacet, \
-    ExternalQueryRunFacet
 
 _BIGQUERY_CONN_URL = 'bigquery'
 

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -8,23 +8,25 @@ import logging
 import os
 import uuid
 from enum import Enum
-from typing import Dict, List, Optional, Tuple, TypeVar, Any
+from typing import Any, Dict, List, Optional, Tuple, TypeVar
 
 import attr
 import yaml
 from jinja2 import Environment, Undefined
-from openlineage.client.facet import (Assertion, BaseFacet,
-                                      DataQualityAssertionsDatasetFacet,
-                                      DataSourceDatasetFacet,
-                                      OutputStatisticsOutputDatasetFacet,
-                                      ParentRunFacet, SchemaDatasetFacet,
-                                      SchemaField, SqlJobFacet)
-from openlineage.client.run import (Dataset, Job, OutputDataset, Run, RunEvent,
-                                    RunState)
-
+from openlineage.client.facet import (
+    Assertion,
+    BaseFacet,
+    DataQualityAssertionsDatasetFacet,
+    DataSourceDatasetFacet,
+    OutputStatisticsOutputDatasetFacet,
+    ParentRunFacet,
+    SchemaDatasetFacet,
+    SchemaField,
+    SqlJobFacet,
+)
+from openlineage.client.run import Dataset, Job, OutputDataset, Run, RunEvent, RunState
 from openlineage.common.schema import GITHUB_LOCATION
-from openlineage.common.utils import (get_from_multiple_chains,
-                                      get_from_nullable_chain)
+from openlineage.common.utils import get_from_multiple_chains, get_from_nullable_chain
 
 
 class Adapter(Enum):

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -6,51 +6,51 @@ import logging
 import os
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional, List, Union, Dict
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 
-from great_expectations.checkpoint import ValidationAction
-from great_expectations.core import ExpectationSuiteValidationResult
-from great_expectations.data_context.types.resource_identifiers import (
-    ValidationResultIdentifier,
-)
-from great_expectations.dataset import (
-    SqlAlchemyDataset,
-    PandasDataset,
-    Dataset as GEDataset,
-)
-from great_expectations.execution_engine import (
-    SqlAlchemyExecutionEngine,
-    PandasExecutionEngine,
-)
-from great_expectations.execution_engine.sqlalchemy_batch_data import (
-    SqlAlchemyBatchData,
-)
-from great_expectations.validator.validator import Validator
-
 from openlineage.client import OpenLineageClient, OpenLineageClientOptions
 from openlineage.client.facet import (
-    ParentRunFacet,
-    DocumentationJobFacet,
-    SourceCodeLocationJobFacet,
-    DataQualityMetricsInputDatasetFacet,
     ColumnMetric,
+    DataQualityMetricsInputDatasetFacet,
+    DocumentationJobFacet,
+    ParentRunFacet,
+    SourceCodeLocationJobFacet,
 )
-from openlineage.client.run import RunEvent, RunState, Run, Job
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
-from openlineage.common.dataset import Dataset, Source, Field
+from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.dataset import Dataset as OLDataset
 from openlineage.common.provider.great_expectations.facets import (
     GreatExpectationsAssertionsDatasetFacet,
     GreatExpectationsRunFacet,
 )
 from openlineage.common.provider.great_expectations.results import (
-    EXPECTATIONS_PARSERS,
     COLUMN_EXPECTATIONS_PARSER,
+    EXPECTATIONS_PARSERS,
     GreatExpectationsAssertion,
 )
 from openlineage.common.sql import parse
+
+from great_expectations.checkpoint import ValidationAction
+from great_expectations.core import ExpectationSuiteValidationResult
+from great_expectations.data_context.types.resource_identifiers import (
+    ValidationResultIdentifier,
+)
+from great_expectations.dataset import Dataset as GEDataset
+from great_expectations.dataset import (
+    PandasDataset,
+    SqlAlchemyDataset,
+)
+from great_expectations.execution_engine import (
+    PandasExecutionEngine,
+    SqlAlchemyExecutionEngine,
+)
+from great_expectations.execution_engine.sqlalchemy_batch_data import (
+    SqlAlchemyBatchData,
+)
+from great_expectations.validator.validator import Validator
 
 # There is no guarantee that SqlAlchemy is available with Great Expectations.
 # Especially, it could be used only with Pandas datasets, in which case

--- a/integration/common/openlineage/common/provider/great_expectations/facets.py
+++ b/integration/common/openlineage/common/provider/great_expectations/facets.py
@@ -1,15 +1,15 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 
 import attr
-from great_expectations.core import IDDict
-from great_expectations.core.batch import BatchMarkers, BatchDefinition
-from great_expectations.core.id_dict import BatchSpec, BatchKwargs
 from openlineage.client.facet import BaseFacet
-
 from openlineage.common.provider.great_expectations.results import GreatExpectationsAssertion
+
+from great_expectations.core import IDDict
+from great_expectations.core.batch import BatchDefinition, BatchMarkers
+from great_expectations.core.id_dict import BatchKwargs, BatchSpec
 
 
 @attr.s

--- a/integration/common/openlineage/common/provider/great_expectations/results.py
+++ b/integration/common/openlineage/common/provider/great_expectations/results.py
@@ -1,12 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import attr
-from great_expectations.core import ExpectationValidationResult
-
 from openlineage.common.utils import get_from_nullable_chain
+
+from great_expectations.core import ExpectationValidationResult
 
 
 @attr.s

--- a/integration/common/openlineage/common/provider/redshift_data.py
+++ b/integration/common/openlineage/common/provider/redshift_data.py
@@ -2,20 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import traceback
+from typing import Any, Dict, List, Optional
+
 import attr
-
-from typing import Any, Optional, Dict, List
 import botocore
-
-from openlineage.common.dataset import Dataset, Source
-from openlineage.common.models import DbTableSchema, DbColumn
-from openlineage.common.sql import DbTableMeta
 from openlineage.client.facet import (
     BaseFacet,
     ErrorMessageRunFacet,
     OutputStatisticsOutputDatasetFacet,
 )
-import traceback
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta
 
 
 @attr.s

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -2,18 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
-from openlineage_sql import (  # noqa: F401
-    parse as parse_sql,  # noqa: F401
-    SqlMeta,  # noqa: F401
-    DbTableMeta,  # noqa: F401
+from openlineage_sql import (
     ColumnLineage,  # noqa: F401
     ColumnMeta,  # noqa: F401
+    DbTableMeta,  # noqa: F401
     ExtractionError,  # noqa: F401
-    provider  # noqa: F401
-)  # noqa: F401
-
+    SqlMeta,  # noqa: F401
+    provider,  # noqa: F401
+)
+from openlineage_sql import parse as parse_sql  # noqa: F401  # noqa: F401
 
 log = logging.getLogger(__name__)
 

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -1,15 +1,15 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import logging
 import json
+import logging
+import os
 import uuid
-from dateutil.parser import parse
-from jinja2 import Environment
 from typing import Any, Optional
 from urllib.parse import urlparse
 
+from dateutil.parser import parse
+from jinja2 import Environment
 
 log = logging.getLogger(__name__)
 

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 def get_from_nullable_chain(source: Any, chain: List[str]) -> Optional[Any]:

--- a/integration/common/pyproject.toml
+++ b/integration/common/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+select = [
+    "F",
+    "E",
+    "W",
+    "I001"
+]
+target-version = "py37"
+ignore-init-module-imports = true
+src = ["openlineage", "tests"]
+namespace-packages = ["openlineage/common"]

--- a/integration/common/script/match.py
+++ b/integration/common/script/match.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+
 from openlineage.common.test import match
 
 

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -36,7 +36,7 @@ deps = ../../client/python
 	-e .[dev]
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
-commands = flake8
+commands = ruff . --no-update-check
 	python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
 	pytest --cov=openlineage --junitxml=test-results/junit.xml tests/
 	coverage xml

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -46,7 +46,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "flake8",
+        "ruff",
         "pandas",
         "jinja2",
         "python-dateutil",

--- a/integration/common/tests/bigquery/test_bigquery.py
+++ b/integration/common/tests/bigquery/test_bigquery.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import MagicMock
 
 from openlineage.client.facet import ExternalQueryRunFacet
-from openlineage.common.dataset import Dataset, Source, Field
+from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider, BigQueryJobRunFacet
 
 

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -2,18 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import textwrap
 from enum import Enum
 from unittest import mock
 
 import attr
 import pytest
-
-from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata, DbtRunContext
 from openlineage.client import set_producer
+from openlineage.common.provider.dbt import DbtArtifactProcessor, DbtRunContext, ParentRunMetadata
 from openlineage.common.test import match
-
-import os
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -10,33 +10,34 @@ from unittest.mock import patch
 
 import pandas
 import pytest
-from ruamel import yaml
-from great_expectations.core import (
-  ExpectationSuiteValidationResult,
-  ExpectationValidationResult,
-  ExpectationConfiguration, RunIdentifier,
-)
-from great_expectations.data_context.types.resource_identifiers import (
-  ExpectationSuiteIdentifier, ValidationResultIdentifier,
-)
-from great_expectations.core.expectation_suite import ExpectationSuite
-from great_expectations.checkpoint.checkpoint import (
-  Checkpoint,
-)
-from great_expectations.data_context import BaseDataContext
-from great_expectations.data_context.types.base import (
-  DataContextConfig,
-  FilesystemStoreBackendDefaults,
-)
-from great_expectations.dataset import SqlAlchemyDataset, PandasDataset
 from openlineage.client.facet import SchemaField
+from openlineage.common.provider.great_expectations import OpenLineageValidationAction
+from openlineage.common.provider.great_expectations.results import (
+    GreatExpectationsAssertion,
+)
+from ruamel import yaml
 from sqlalchemy import create_engine
 
-from openlineage.common.provider.great_expectations import \
-  OpenLineageValidationAction
-from openlineage.common.provider.great_expectations.results import (
-  GreatExpectationsAssertion,
+from great_expectations.checkpoint.checkpoint import (
+    Checkpoint,
 )
+from great_expectations.core import (
+    ExpectationConfiguration,
+    ExpectationSuiteValidationResult,
+    ExpectationValidationResult,
+    RunIdentifier,
+)
+from great_expectations.core.expectation_suite import ExpectationSuite
+from great_expectations.data_context import BaseDataContext
+from great_expectations.data_context.types.base import (
+    DataContextConfig,
+    FilesystemStoreBackendDefaults,
+)
+from great_expectations.data_context.types.resource_identifiers import (
+    ExpectationSuiteIdentifier,
+    ValidationResultIdentifier,
+)
+from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
 
 current_env = os.environ
 

--- a/integration/common/tests/redshift_data/test_redshift_data.py
+++ b/integration/common/tests/redshift_data/test_redshift_data.py
@@ -4,10 +4,10 @@
 import json
 from unittest.mock import MagicMock
 
-from openlineage.common.sql import DbTableMeta
-from openlineage.common.models import DbTableSchema, DbColumn
-from openlineage.common.dataset import Source, Dataset, Field
+from openlineage.common.dataset import Dataset, Field, Source
+from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.provider.redshift_data import RedshiftDataDatasetsProvider
+from openlineage.common.sql import DbTableMeta
 
 REDSHIFT_DATABASE = "dev"
 REDSHIFT_DATABASE_USER = "admin"

--- a/integration/common/tests/sql/test_column.py
+++ b/integration/common/tests/sql/test_column.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from openlineage.common.sql import parse, ColumnLineage, ColumnMeta, DbTableMeta
+from openlineage.common.sql import ColumnLineage, ColumnMeta, DbTableMeta, parse
 
 
 def test_column_level_lineage():

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -4,7 +4,7 @@
 import logging
 
 import pytest
-from openlineage.common.sql import parse, DbTableMeta, provider, ExtractionError
+from openlineage.common.sql import DbTableMeta, ExtractionError, parse, provider
 
 log = logging.getLogger(__name__)
 

--- a/integration/common/tests/sql/test_tpcds.py
+++ b/integration/common/tests/sql/test_tpcds.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from openlineage.common.sql import parse, DbTableMeta
+from openlineage.common.sql import DbTableMeta, parse
 
 
 def test_tpcds_cte_query():

--- a/integration/common/tests/test_dataset.py
+++ b/integration/common/tests/test_dataset.py
@@ -4,9 +4,9 @@
 import pytest
 from openlineage.client.facet import DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
 from openlineage.client.run import Dataset as OpenLineageDataset
+from openlineage.common.dataset import Dataset, Source
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
-from openlineage.common.dataset import Source, Dataset
 
 
 @pytest.fixture

--- a/integration/dagster/openlineage/dagster/adapter.py
+++ b/integration/dagster/openlineage/dagster/adapter.py
@@ -3,14 +3,12 @@
 
 import logging
 import os
-from typing import Optional
-from typing import Dict
+from typing import Dict, Optional
 
 from openlineage.client import OpenLineageClient, set_producer
 from openlineage.client.constants import DEFAULT_NAMESPACE_NAME
 from openlineage.client.facet import ParentRunFacet
-from openlineage.client.run import RunEvent, RunState, Run, Job
-
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
 from openlineage.dagster.utils import make_step_job_name, to_utc_iso_8601
 

--- a/integration/dagster/openlineage/dagster/cursor.py
+++ b/integration/dagster/openlineage/dagster/cursor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
 import attr
 import cattr

--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -2,22 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Dict
-
-from dagster import (   # type: ignore
-    DagsterEventType,
-    sensor,
-    SensorDefinition,
-    SensorEvaluationContext,
-    SkipReason
-)
-
-from dagster.core.definitions.sensor_definition import DEFAULT_SENSOR_DAEMON_INTERVAL
-from dagster.core.events import PIPELINE_EVENTS, STEP_EVENTS
+from typing import Dict, Optional
 
 from openlineage.dagster.adapter import OpenLineageAdapter
 from openlineage.dagster.cursor import OpenLineageCursor, RunningPipeline, RunningStep
-from openlineage.dagster.utils import make_step_run_id, get_event_log_records, get_repository_name
+from openlineage.dagster.utils import get_event_log_records, get_repository_name, make_step_run_id
+
+from dagster import (  # type: ignore
+    DagsterEventType,
+    SensorDefinition,
+    SensorEvaluationContext,
+    SkipReason,
+    sensor,
+)
+from dagster.core.definitions.sensor_definition import DEFAULT_SENSOR_DAEMON_INTERVAL
+from dagster.core.events import PIPELINE_EVENTS, STEP_EVENTS
 
 _ADAPTER = OpenLineageAdapter()
 

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -7,7 +7,6 @@ from typing import Iterable, Optional
 
 from dagster import DagsterInstance, EventLogRecord, EventRecordsFilter  # type: ignore
 
-
 NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 

--- a/integration/dagster/pyproject.toml
+++ b/integration/dagster/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+select = [
+    "F",
+    "E",
+    "W",
+    "I001"
+]
+target-version = "py37"
+ignore-init-module-imports = true
+src = ["openlineage", "tests"]
+namespace-packages = ["openlineage/dagster"]

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -5,7 +5,7 @@
 #
 # -*- coding: utf-8 -*-
 # import setuptools
-from setuptools import setup, find_namespace_packages
+from setuptools import find_namespace_packages, setup
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -26,7 +26,7 @@ extras_require = {
     "tests": [
         "pytest",
         "pytest-cov",
-        "flake8",
+        "ruff",
         "mypy>=0.9.6"
     ],
 }

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -5,19 +5,19 @@ import time
 import uuid
 from typing import Optional
 
-from dagster import DagsterEventType, EventLogRecord, EventLogEntry, DagsterEvent, PipelineRun
+from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
+from pkg_resources import parse_version
+
+from dagster import DagsterEvent, DagsterEventType, EventLogEntry, EventLogRecord, PipelineRun
 from dagster.core.code_pointer import FileCodePointer
 from dagster.core.definitions.reconstructable import ReconstructableRepository
-from dagster.core.execution.plan.objects import StepSuccessData, StepFailureData
+from dagster.core.execution.plan.objects import StepFailureData, StepSuccessData
 from dagster.core.host_representation import (
     ExternalPipelineOrigin,
     ExternalRepositoryOrigin,
-    InProcessRepositoryLocationOrigin
+    InProcessRepositoryLocationOrigin,
 )
 from dagster.version import __version__ as DAGSTER_VERSION
-from pkg_resources import parse_version
-
-from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
 
 PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/" \
            f"{OPENLINEAGE_DAGSTER_VERSION}/integration/dagster"

--- a/integration/dagster/tests/test_adapter_pipeline.py
+++ b/integration/dagster/tests/test_adapter_pipeline.py
@@ -6,9 +6,9 @@ import uuid
 from unittest.mock import patch
 
 from openlineage.client.constants import DEFAULT_NAMESPACE_NAME
-from openlineage.client.run import RunEvent, RunState, Run, Job
-
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.dagster.adapter import OpenLineageAdapter
+
 from .conftest import PRODUCER
 
 

--- a/integration/dagster/tests/test_adapter_step.py
+++ b/integration/dagster/tests/test_adapter_step.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 
 from openlineage.client.constants import DEFAULT_NAMESPACE_NAME
 from openlineage.client.facet import ParentRunFacet
-from openlineage.client.run import RunEvent, RunState, Run, Job
-
+from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.dagster.adapter import OpenLineageAdapter
+
 from .conftest import PRODUCER
 
 

--- a/integration/dagster/tests/test_sensor_cursor.py
+++ b/integration/dagster/tests/test_sensor_cursor.py
@@ -1,14 +1,16 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import json
+import os
 import uuid
 from unittest.mock import patch
 
-from dagster import SensorDefinition, build_sensor_context, DagsterEventType
-from dagster.core.test_utils import instance_for_test
 from openlineage.dagster.cursor import OpenLineageCursor, RunningPipeline, RunningStep
+
+from dagster import DagsterEventType, SensorDefinition, build_sensor_context
+from dagster.core.test_utils import instance_for_test
+
 from .conftest import make_test_event_log_record
 
 

--- a/integration/dagster/tests/test_sensor_evaluation.py
+++ b/integration/dagster/tests/test_sensor_evaluation.py
@@ -5,12 +5,20 @@ import tempfile
 import time
 import uuid
 from unittest import mock
-from unittest.mock import patch, call
-
-from dagster import job, op, execute_pipeline, reconstructable, build_sensor_context, DagsterEventType  # noqa: E501
-from dagster.core.test_utils import instance_for_test
+from unittest.mock import call, patch
 
 from openlineage.dagster.sensor import openlineage_sensor
+
+from dagster import (  # noqa: E501
+    DagsterEventType,
+    build_sensor_context,
+    execute_pipeline,
+    job,
+    op,
+    reconstructable,
+)
+from dagster.core.test_utils import instance_for_test
+
 from .conftest import make_test_event_log_record
 
 

--- a/integration/dagster/tests/test_utils.py
+++ b/integration/dagster/tests/test_utils.py
@@ -4,10 +4,16 @@
 import uuid
 from unittest.mock import patch
 
+from openlineage.dagster.utils import (
+    get_event_log_records,
+    get_repository_name,
+    make_step_job_name,
+    make_step_run_id,
+    to_utc_iso_8601,
+)
+
 from dagster import EventRecordsFilter
 
-from openlineage.dagster.utils import make_step_run_id, to_utc_iso_8601, make_step_job_name, \
-    get_repository_name, get_event_log_records
 from .conftest import make_pipeline_run_with_external_pipeline_origin
 
 

--- a/integration/dbt/pyproject.toml
+++ b/integration/dbt/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 100
+select = [
+    "F",
+    "E",
+    "W",
+    "I001"
+]
+target-version = "py37"
+ignore-init-module-imports = true
+src = ["openlineage", "tests"]
+namespace-packages = ["openlineage/common"]

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -13,7 +13,7 @@ with open("README.md") as readme_file:
 __version__ = "0.20.0"
 
 requirements = [
-    f"tqdm>=4.62.0",
+    "tqdm>=4.62.0",
     f"openlineage-integration-common[dbt]=={__version__}",
 ]
 
@@ -23,7 +23,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "flake8",
+        "ruff"
         "mypy>=0.9.6",
         "python-dateutil"
     ],

--- a/integration/sql/iface-py/pyproject.toml
+++ b/integration/sql/iface-py/pyproject.toml
@@ -10,4 +10,3 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-


### PR DESCRIPTION
Similar to Airflow, move to `ruff` package that bundles several linters and formatters in one fast binary. 
This PR also includes changes made by first run of this application.
 
Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>