### PR TITLE
great expectations, airflow: follow snowflake dataset naming rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 ### Fixed
 * DBT: fix `dbt-ol test` output [`#1542`](https://github.com/OpenLineage/OpenLineage/pull/1542) [@JDarDagran](https://github.com/JDarDagran)  
     *Edits the docs for consistency.*
+* Harmonized Snowflake naming schemes across all Python integrations [#PR num](https://github.com/OpenLineage/OpenLineage/pull/1) [@mobuchowski](https://github.com/mobuchowski)  
+  *This fixes a bug where same dataset would be represented by different name/namespace across different integrations.*
+
 ### Changed
+* Use ruff tool instead of flake8 [`#1526`](https://github.com/OpenLineage/OpenLineage/pull/1288) [@mobuchowski](https://github.com/mobuchowski)  
+  *All Python code pieces are now formatted by ruff tool, that combines functionality of a lot of other tools in one package*
 * Docs: edit spec READMEs [`#1528`](https://github.com/OpenLineage/OpenLineage/pull/1528) [@merobi-hub](https://github.com/merobi-hub)  
     *Edits the docs for consistency.*
 

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -5,7 +5,6 @@ import importlib
 import inspect
 import logging
 from typing import List, Type
-from warnings import warn
 
 import attr
 
@@ -18,14 +17,14 @@ def import_from_string(path: str):
         module = importlib.import_module(module_path)
         return getattr(module, target)
     except Exception as e:
+        log.warning(e)
         raise ImportError(f"Failed to import {path}") from e
 
 
 def try_import_from_string(path: str):
     try:
         return import_from_string(path)
-    except ImportError as e:
-        warn(e.msg)
+    except ImportError:
         return None
 
 

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, List
+from urllib.parse import urlparse
 
 from openlineage.airflow.extractors.dbapi_utils import execute_query_on_hook
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor
 from openlineage.client.facet import BaseFacet, ExternalQueryRunFacet
+from openlineage.common.provider.snowflake import fix_snowflake_sqlalchemy_uri
 
 
 class SnowflakeExtractor(SqlExtractor):
@@ -47,11 +49,8 @@ class SnowflakeExtractor(SqlExtractor):
         ) or self.conn.extra_dejson.get("database", "")
 
     def _get_authority(self) -> str:
-        if hasattr(self.operator, "account") and self.operator.account is not None:
-            return self.operator.account
-        return self.conn.extra_dejson.get(
-            "extra__snowflake__account", ""
-        ) or self.conn.extra_dejson.get("account", "")
+        uri = fix_snowflake_sqlalchemy_uri(self.hook.get_uri())
+        return urlparse(uri).hostname
 
     def _get_hook(self):
         if hasattr(self.operator, "get_db_hook"):

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -463,14 +463,14 @@ def import_from_string(path: str):
         module = importlib.import_module(module_path)
         return getattr(module, target)
     except Exception as e:
+        log.warning(e)
         raise ImportError(f"Failed to import {path}") from e
 
 
 def try_import_from_string(path: str):
     try:
         return import_from_string(path)
-    except ImportError as e:
-        log.info(e.msg)  # type: ignore
+    except ImportError:
         return None
 
 

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -30,7 +30,7 @@ skipsdist = True
 [testenv]
 usedevelop = True
 install_command = python -m pip install {opts} --find-links target/wheels/ \
-	--find-links ../sql/target/wheels \
+	--find-links ../sql/iface-py/target/wheels \
 	--use-deprecated=legacy-resolver \
 	--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-{env:AIRFLOW_VERSION}/constraints-3.7.txt \
 	{packages}

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -89,6 +89,7 @@ TASK = SnowflakeOperator(
 def mock_get_hook(operator):
     mocked = mock.MagicMock()
     mocked.return_value.conn_name_attr = 'snowflake_conn_id'
+    mocked.return_value.get_uri.return_value = "snowflake://user:pass@xy123456/db/schema"
     if hasattr(operator, 'get_db_hook'):
         operator.get_db_hook = mocked
     else:

--- a/integration/airflow/tests/integration/data/dbt/profiles/profiles.yml
+++ b/integration/airflow/tests/integration/data/dbt/profiles/profiles.yml
@@ -16,7 +16,7 @@ snowflake:
     outputs:
         prod:
           type: snowflake
-          account: "{{ env_var('SNOWFLAKE_ACCOUNT_ID') }}.us-east-1"
+          account: "{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower  }}.us-east-1"
           user: "{{ env_var('SNOWFLAKE_USER') }}"
           password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
           role: OPENLINEAGE

--- a/integration/airflow/tests/integration/requests/dbt_snowflake.json
+++ b/integration/airflow/tests/integration/requests/dbt_snowflake.json
@@ -12,7 +12,7 @@
             {
                 "facets": {},
                 "name": "SANDBOX.money_received",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]
@@ -29,8 +29,8 @@
         "outputs": [
             {
                 "facets": {},
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') }}.money_send",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower  }}.money_send",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]
@@ -41,12 +41,12 @@
             {
                 "facets": {},
                 "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID' )}}.us-east-1.money_received",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
             },
             {
                 "facets": {},
                 "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID' )}}.us-east-1.money_send",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
             }
         ],
         "job": {
@@ -58,7 +58,7 @@
             {
                 "facets": {},
                 "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID' )}}.us-east-1.balance",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]
@@ -87,8 +87,8 @@
             {
                 "facets": {
                     "dataSource": {
-                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
-                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
+                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
                     },
                     "schema": {
                         "fields": [
@@ -104,8 +104,8 @@
                         ]
                     }
                 },
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1.money_received",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.money_received",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]
@@ -134,8 +134,8 @@
             {
                 "facets": {
                     "dataSource": {
-                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
-                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
+                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
                     },
                     "schema": {
                         "fields": [
@@ -151,8 +151,8 @@
                         ]
                     }
                 },
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1.money_send",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.money_send",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]
@@ -171,8 +171,8 @@
             {
                 "facets": {
                     "dataSource": {
-                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
-                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
+                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
                     },
                     "schema": {
                         "fields": [
@@ -188,14 +188,14 @@
                         ]
                     }
                 },
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1.money_received",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.money_received",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
             },
             {
                 "facets": {
                     "dataSource": {
-                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
-                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
+                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
                     },
                     "schema": {
                         "fields": [
@@ -211,8 +211,8 @@
                         ]
                     }
                 },
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1.money_send",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.money_send",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
             }
         ],
         "job": {
@@ -228,8 +228,8 @@
             {
                 "facets": {
                     "dataSource": {
-                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
-                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1"
+                        "name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
+                        "uri": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws"
                     },
                     "schema": {
                         "fields": [
@@ -245,8 +245,8 @@
                         ]
                     }
                 },
-                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1.balance",
-                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID')}}.us-east-1",
+                "name": "SANDBOX.{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.balance",
+                "namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower }}.us-east-1.aws",
                 "outputFacets": {}
             }
         ]

--- a/integration/airflow/tests/integration/requests/snowflake.json
+++ b/integration/airflow/tests/integration/requests/snowflake.json
@@ -13,7 +13,7 @@
 	"outputs": [{
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') }}",
+				"name": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower  }}.us-east-1.aws",
 				"uri": "{{ any(result) }}"
 			},
 			"schema": {
@@ -30,7 +30,7 @@
 			}
 		},
 		"name": "SANDBOX.OPENLINEAGE.TEST_ORDERS",
-		"namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') }}"
+		"namespace": "snowflake://{{ env_var('SNOWFLAKE_ACCOUNT_ID') | lower  }}.us-east-1.aws"
 	}],
 	"run": {
 		"facets": {

--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -25,6 +25,7 @@ from openlineage.client.facet import (
     SqlJobFacet,
 )
 from openlineage.client.run import Dataset, Job, OutputDataset, Run, RunEvent, RunState
+from openlineage.common.provider.snowflake import fix_account_name
 from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.utils import get_from_multiple_chains, get_from_nullable_chain
 
@@ -689,7 +690,7 @@ class DbtArtifactProcessor:
     def extract_namespace(self, profile: Dict) -> str:
         """Extract namespace from profile's type"""
         if self.adapter_type == Adapter.SNOWFLAKE:
-            return f"snowflake://{profile['account']}"
+            return f"snowflake://{fix_account_name(profile['account'])}"
         elif self.adapter_type == Adapter.BIGQUERY:
             return "bigquery"
         elif self.adapter_type == Adapter.REDSHIFT:

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -31,6 +31,7 @@ from openlineage.common.provider.great_expectations.results import (
     EXPECTATIONS_PARSERS,
     GreatExpectationsAssertion,
 )
+from openlineage.common.provider.snowflake import fix_snowflake_sqlalchemy_uri
 from openlineage.common.sql import parse
 
 from great_expectations.checkpoint import ValidationAction
@@ -389,6 +390,13 @@ class OpenLineageValidationAction(ValidationAction):
         if isinstance(engine, Connection):
             engine = engine.engine
         datasource_url = engine.url
+
+        if engine.dialect.name.lower() == "snowflake":
+            if engine.connection_string:
+                datasource_url = engine.connection_string
+            else:
+                datasource_url = engine.url
+            datasource_url = fix_snowflake_sqlalchemy_uri(datasource_url)
 
         # bug in sql parser doesn't strip ` character from bigquery tables
         if table_name.endswith("`") or table_name.startswith("`"):

--- a/integration/common/openlineage/common/provider/snowflake.py
+++ b/integration/common/openlineage/common/provider/snowflake.py
@@ -1,0 +1,41 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from urllib.parse import urlparse, urlunparse
+
+
+def fix_account_name(name: str) -> str:
+    spl = name.split('.')
+    if len(spl) == 1:
+        account = spl[0]
+        region, cloud = 'us-west-1', 'aws'
+    elif len(spl) == 2:
+        account, region = spl
+        cloud = 'aws'
+    else:
+        account, region, cloud = spl
+    return f"{account}.{region}.{cloud}"
+
+
+def fix_snowflake_sqlalchemy_uri(uri: str) -> str:
+    """Snowflake sqlalchemy connection URI has following structure:
+        'snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>'
+        We want to canonicalize account identifier. It can have two forms:
+        - newer, in form of <organization>-<id>. In this case we want to do nothing.
+        - older, composed of <id>-<region>-<cloud> where region and cloud can be
+          optional in some cases.If <cloud> is omitted, it's AWS.
+          If region and cloud are omitted, it's AWS us-west-1
+    """
+
+    parts = urlparse(uri)
+
+    hostname = parts.hostname
+    if not hostname:
+        return uri
+
+    # old account identifier like xy123456
+    if '.' in hostname or not any(word in hostname for word in ['-', '_']):
+        hostname = fix_account_name(hostname)
+    # else - its new hostname, just return it
+    return urlunparse(
+        (parts.scheme, hostname, parts.path, parts.params, parts.query, parts.fragment)
+    )

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -31,7 +31,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = python -m pip install {opts} --find-links target/wheels/ --find-links ../sql/target/wheels {packages}
+install_command = python -m pip install {opts} --find-links target/wheels/ --find-links ../sql/iface-py/target/wheels {packages}
 deps = ../../client/python
 	-e .[dev]
 	dbt-1.0: dbt-core>=1.0,<1.3

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -11,7 +11,7 @@
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders"
 	}]
 }, {
@@ -27,7 +27,7 @@
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments"
 	}]
 }, {
@@ -43,7 +43,7 @@
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_customers"
 	}]
 }, {
@@ -58,14 +58,14 @@
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders"
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments"
 	}],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.orders"
 	}]
 }, {
@@ -80,17 +80,17 @@
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_customers"
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders"
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments"
 	}],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.customers"
 	}]
 }, {
@@ -121,12 +121,12 @@
 	},
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -169,12 +169,12 @@
 	},
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -219,12 +219,12 @@
 	},
 	"inputs": [],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -260,12 +260,12 @@
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -278,12 +278,12 @@
 			}
 		}
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -297,12 +297,12 @@
 		}
 	}],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.orders",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -362,12 +362,12 @@
 		}
 	},
 	"inputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_customers",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -377,12 +377,12 @@
 			}
 		}
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_orders",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -395,12 +395,12 @@
 			}
 		}
 	}, {
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.stg_payments",
 		"facets": {
 			"dataSource": {
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"fields": [{
@@ -414,14 +414,14 @@
 		}
 	}],
 	"outputs": [{
-		"namespace": "snowflake://ASDF1234.eu-central-1",
+		"namespace": "snowflake://ASDF1234.eu-central-1.aws",
 		"name": "DEMO_DB.public.customers",
 		"facets": {
 			"dataSource": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/DataSourceDatasetFacet",
-				"name": "snowflake://ASDF1234.eu-central-1",
-				"uri": "snowflake://ASDF1234.eu-central-1"
+				"name": "snowflake://ASDF1234.eu-central-1.aws",
+				"uri": "snowflake://ASDF1234.eu-central-1.aws"
 			},
 			"schema": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/test_snowflake.py
+++ b/integration/common/tests/test_snowflake.py
@@ -1,0 +1,21 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from openlineage.common.provider.snowflake import fix_snowflake_sqlalchemy_uri
+
+
+@pytest.mark.parametrize("source,target", [
+    ("snowflake://user:pass@xy123456.us-east-1.aws/database/schema",
+        "snowflake://xy123456.us-east-1.aws/database/schema"),
+    ("snowflake://xy123456/database/schema", "snowflake://xy123456.us-west-1.aws/database/schema"),
+    ("snowflake://xy12345.ap-southeast-1/database/schema",
+        "snowflake://xy12345.ap-southeast-1.aws/database/schema"),
+    ("snowflake://user:pass@xy12345.south-central-us.azure/database/schema",
+        "snowflake://xy12345.south-central-us.azure/database/schema"),
+    ("snowflake://user:pass@xy12345.us-east4.gcp/database/schema",
+        "snowflake://xy12345.us-east4.gcp/database/schema"),
+    ("snowflake://user:pass@organization-account/database/schema",
+        "snowflake://organization-account/database/schema")
+])
+def test_snowflake_sqlite_account_urls(source, target):
+    assert fix_snowflake_sqlalchemy_uri(source) == target

--- a/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
+++ b/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
@@ -135,6 +135,28 @@ class OpenLineageSqlTest {
   }
 
   @Test
+  void columnLevelLineageCte() {
+      SqlMeta output = OpenLineageSql.parse(Collections.singletonList("" +
+        "WITH cte1 AS (\n" +
+        "    SELECT col1, col2\n" +
+        "    FROM table1\n" +
+        "    WHERE col1 = 'value1'\n" +
+        "), cte2 AS (\n" +
+        "    SELECT col3, col4\n" +
+        "    FROM table2\n" +
+        "    WHERE col2 = 'value2'\n" +
+        ")\n" +
+        "SELECT cte1.col1, cte2.col3\n" +
+        "FROM cte1\n" +
+        "JOIN cte2 ON cte1.col2 = cte2.col4\n")).get();
+      assertEquals(
+        Arrays.asList(
+            columnLineage("col1", "table1", "col1"),
+            columnLineage("col3", "table2", "col3")),
+        output.columnLineage());
+  }
+
+  @Test
   void returnedError() {
     SqlMeta output = OpenLineageSql.parse(Collections.singletonList("NOT A STATEMENT")).get();
     assertEquals(1, output.errors().size());


### PR DESCRIPTION
Normalize Snowflake dataset and datasource naming rules among dbt/airflow/great expectations.

Canonicalize old snowflake account paths around making them all full size with account, region and cloud names.

Closes: https://github.com/OpenLineage/OpenLineage/issues/1195

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
