### PR TITLE
Adjust tqdm logging in dbt-ol.

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -116,16 +116,22 @@ def main():
 
     # Always emit "wrapping event" around dbt run. This indicates start of dbt execution, since
     # both the start and complete events for dbt models won't get emitted until end of execution.
-    dbt_run_event = dbt_run_event_start(
+    start_event = dbt_run_event_start(
         job_name=f"dbt-run-{processor.project['name']}",
         job_namespace=job_namespace,
         parent_run_metadata=parent_run_metadata
     )
     dbt_run_metadata = ParentRunMetadata(
-        run_id=dbt_run_event.run.runId,
-        job_name=dbt_run_event.job.name,
-        job_namespace=dbt_run_event.job.namespace
+        run_id=start_event.run.runId,
+        job_name=start_event.job.name,
+        job_namespace=start_event.job.namespace
     )
+
+    # Failed start event emit should not stop dbt command from running.
+    try:
+        client.emit(start_event)
+    except Exception as e:
+        logger.warning("OpenLineage client failed to emit start event. Exception: %s", e)
 
     # Set parent run metadata to use it as parent run facet
     processor.dbt_run_metadata = dbt_run_metadata
@@ -156,15 +162,21 @@ def main():
 
     events = processor.parse().events()
 
-    for event in tqdm(events, desc="Emitting OpenLineage events"):
-        client.emit(event)
-
-    client.emit(dbt_run_event_end(
+    end_event = dbt_run_event_end(
         run_id=dbt_run_metadata.run_id,
         job_namespace=dbt_run_metadata.job_namespace,
         job_name=dbt_run_metadata.job_name,
         parent_run_metadata=parent_run_metadata
-    ))
+    )
+
+    for event in tqdm(
+        events + [end_event],
+        desc="Emitting OpenLineage events",
+        initial=1,
+        total=len(events) + 2,
+    ):
+        client.emit(event)
+
     logger.info(f"Emitted {len(events) + 2} openlineage events")
 
 


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Fix ruff issues in gcs extractor.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Run integration-common unit tests when modyfing integration-dbt.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

`dbt-ol` logged wrong number of events emitted with `tqdm`. Also it did not emit START event for parent run.

Closes: #1481 

### Solution

Emit start event. Adjust `tqdm` to show correct number of iterations.


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project