### PR TITLE
fix several spark/bigquery related issues

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -95,10 +95,17 @@ public class ArgumentParser {
     findSparkConfigKey(conf, "spark.openlineage.version")
         .ifPresent(
             c -> {
+              String apiVersion;
+              try {
+                int version = Integer.parseInt(c);
+                apiVersion = String.format("v%d", version);
+              } catch (NumberFormatException ex) {
+                apiVersion = c;
+              }
               replaceConfigEntry(
                   conf,
                   UrlParser.SPARK_CONF_API_ENDPOINT,
-                  String.format("api/v%s/lineage", c),
+                  String.format("api/%s/lineage", apiVersion),
                   "spark.openlineage.version");
             });
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -192,9 +192,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   public static Optional<ExecutionContext> getExecutionContext(int jobId, long executionId) {
     Optional<ExecutionContext> executionContext = getSparkSQLExecutionContext(executionId);
-    if (executionContext.isPresent()) {
-      rddExecutionRegistry.put(jobId, executionContext.get());
-    }
+    executionContext.ifPresent(context -> rddExecutionRegistry.put(jobId, context));
     return executionContext;
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -323,7 +323,7 @@ class OpenLineageRunEventBuilder {
                 log.debug("Physical plan executed {}", qe.executedPlan().toJSON());
               }
             });
-    log.info(
+    log.debug(
         "Visiting query plan {} with input dataset builders {}",
         openLineageContext.getQueryExecution(),
         inputDatasetBuilders);
@@ -391,7 +391,7 @@ class OpenLineageRunEventBuilder {
   }
 
   private List<OutputDataset> buildOutputDatasets(List<Object> nodes) {
-    log.info(
+    log.debug(
         "Visiting query plan {} with output dataset builders {}",
         openLineageContext.getQueryExecution(),
         outputDatasetBuilders);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
@@ -31,4 +31,13 @@ public class ReflectionUtils {
       return Optional.empty();
     }
   }
+
+  public static Optional<Object> tryExecuteMethod(
+      Object object, String methodName, Object... args) {
+    try {
+      return Optional.of(MethodUtils.invokeMethod(object, methodName, args));
+    } catch (Exception exception) {
+      return Optional.empty();
+    }
+  }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/QueryPlanVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/QueryPlanVisitor.java
@@ -98,7 +98,7 @@ public abstract class QueryPlanVisitor<T extends LogicalPlan, D extends OpenLine
       Type arg = typeArgs[0];
       boolean isAssignable = ((Class) arg).isAssignableFrom(x.getClass());
       if (isAssignable) {
-        logger.info("Matched {} to logical plan {}", this, x);
+        logger.debug("Matched {} to logical plan {}", this, x);
       }
       return isAssignable;
     }


### PR DESCRIPTION
- fix assumption that version is always number
- add support for `HadoopMapReduceWriteConfigUtil`, instead of only `HadoopMapRedWriteConfigUtil`
- access `BigQueryUtil` and `getTableId` using reflection, which supports all BigQuery versions, with dependencies or not
- log full serialized LogicalPlan on `debug`