### PR TITLE
iceberg: bump version, rename table, give Iceberg 1 second to update metadata before dropping table.

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -60,7 +60,7 @@ ext {
 
     versionsMap = [
             "3.3": ["module": "spark33", "scala": "2.12", "delta": "2.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.3_2.12:0.14.0"],
-            "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2", "iceberg": "iceberg-spark-runtime-3.2_2.12:0.13.0"],
+            "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2", "iceberg": "iceberg-spark-runtime-3.2_2.12:0.14.0"],
             "3.1": ["module": "spark3",  "scala": "2.12", "delta": "1.0.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.1", "iceberg": "iceberg-spark-runtime-3.1_2.12:0.13.0"],
             "2.4": ["module": "spark2",  "scala": "2.11", "delta": "NA",    "gcs": "hadoop2-2.2.9", "snowflake": "2.9.3-spark_2.4",  "iceberg": "NA"]
     ]

--- a/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
@@ -8,7 +8,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.drop_table_test",
+      "name": "/tmp/iceberg/default.iceberg_drop_table_test",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -21,7 +21,7 @@
           "identifiers": [
             {
               "namespace": "/tmp/iceberg",
-              "name": "default.drop_table_test",
+              "name": "default.iceberg_drop_table_test",
               "type": "TABLE"
             }
           ]

--- a/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
@@ -8,7 +8,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.drop_table_test",
+      "name": "/tmp/iceberg/default.iceberg_drop_table_test",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -21,7 +21,7 @@
           "identifiers": [
             {
               "namespace": "/tmp/iceberg",
-              "name": "default.drop_table_test",
+              "name": "default.iceberg_drop_table_test",
               "type": "TABLE"
             }
           ]

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -244,11 +244,13 @@ public class SparkIcebergIntegrationTest {
   }
 
   @Test
-  void testDrop() {
-    clearTables("drop_table_test");
-    spark.sql("CREATE TABLE drop_table_test (a string, b string) USING iceberg");
-    spark.sql("INSERT INTO drop_table_test VALUES ('a', 'b')");
-    spark.sql("DROP TABLE drop_table_test");
+  void testDrop() throws InterruptedException {
+    String tableName = "iceberg_drop_table_test";
+    clearTables(tableName);
+    spark.sql(String.format("CREATE TABLE %s (a string, b string) USING iceberg", tableName));
+    spark.sql(String.format("INSERT INTO %s VALUES ('a', 'b')", tableName));
+    Thread.sleep(1000);
+    spark.sql("DROP TABLE " + tableName);
 
     verifyEvents(
         mockServer, "pysparkV2DropTableStartEvent.json", "pysparkV2DropTableCompleteEvent.json");


### PR DESCRIPTION
This fixes flaky Iceberg test. It passed 3 times without failure on CI.
Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
