### PR TITLE
Add Hive as default catalog in Trino Extractor

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
@@ -32,7 +32,7 @@ class TrinoExtractor(SqlExtractor):
         return "trino"
 
     def _get_database(self) -> str:
-        return self.conn.extra_dejson["catalog"]
+        return self.conn.extra_dejson.get("catalog", "hive")
 
     def _get_authority(self) -> str:
         if self.conn.host and self.conn.port:


### PR DESCRIPTION
The catalog connection parameter is optional in Airflow, despite apparently being needed to actually connect. Airflow handles this in the TrinoHook by making Hive the default catalog. The same functionality is applied here to remove a bug where a missing catalog in the Airflow connection woudl break the extractor.

Closes: #1554 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project