### PR TITLE
Fix openjdk image to use 11.0 instead of 11

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -228,7 +228,7 @@ jobs:
   release-integration-flink:
     working_directory: ~/openlineage/integration/flink
     docker:
-      - image: cimg/openjdk:11
+      - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
       - restore_cache:
@@ -250,7 +250,7 @@ jobs:
   publish-snapshot-integration-flink:
     working_directory: ~/openlineage/integration/flink
     docker:
-      - image: cimg/openjdk:11
+      - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
       - restore_cache:


### PR DESCRIPTION


Signed-off-by: Harel Shein <harel.shein@gmail.com>

### Problem

OpenLineage release is failing

### Solution

Fix openjdk image to use 11.0 instead of 11 (which doesn't exist in dockerhub)

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project