### PR TITLE
added support for deprecated config

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -85,6 +85,12 @@ public class ArgumentParser {
               replaceConfigEntry(conf, SPARK_CONF_HTTP_URL, c, "spark.openlineage.host");
             });
 
+    findSparkConfigKey(conf, "spark.openlineage.url")
+        .ifPresent(
+            c -> {
+              replaceConfigEntry(conf, SPARK_CONF_HTTP_URL, c, "spark.openlineage.url");
+            });
+
     findSparkConfigKey(conf, "spark.openlineage.timeout")
         .ifPresent(
             c -> {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -104,7 +104,7 @@ class ArgumentParserTest {
   void testDeprecatedConfig() {
     SparkConf sparkConf =
         new SparkConf()
-            .set("spark.openlineage.host", URL)
+            .set("spark.openlineage.url", URL)
             .set("spark.openlineage.version", "1")
             .set("spark.openlineage.apiKey", API_KEY)
             .set("spark.openlineage.timeout", "5000")


### PR DESCRIPTION
Signed-off-by: Tomasz Nazarewicz <tomasz.nazarewicz@getindata.com>

### Problem

`spark.openlineage.url` (deprecated config that still should work) was not mapped to new config name

Closes: #1585 

### Solution

mapping between `spark.openlineage.url` and `spark.openlineage.transport.url` was created, currently `spark.openlineage.url` and `spark.openlineage.host` map to `spark.openlineage.transport.url`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project