### PR TITLE
dbt: make `compiled_code` optional.

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -395,9 +395,13 @@ class DbtArtifactProcessor:
                 + (".build.run" if self.command == 'build' else "")
 
             if self.manifest_version >= 7:
-                sql = output_node['compiled_code']
+                sql = output_node.get('compiled_code', None)
             else:
                 sql = output_node['compiled_sql']
+
+            job_facets = {}
+            if sql:
+                job_facets['sql'] = SqlJobFacet(sql)
 
             events.add(self.to_openlineage_events(
                 run['status'],
@@ -407,9 +411,7 @@ class DbtArtifactProcessor:
                 Job(
                     namespace=self.job_namespace,
                     name=job_name,
-                    facets={
-                        'sql': SqlJobFacet(sql)
-                    }
+                    facets=job_facets
                 ),
                 [self.node_to_dataset(node, has_facets=True) for node in inputs],
                 self.node_to_output_dataset(

--- a/integration/common/tests/dbt/postgres/result.json
+++ b/integration/common/tests/dbt/postgres/result.json
@@ -209,14 +209,7 @@
 	},
 	"job": {
 		"namespace": "job-namespace",
-		"name": "postgres.public.jaffle_shop.customers",
-		"facets": {
-			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
-				"query": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final"
-			}
-		}
+		"name": "postgres.public.jaffle_shop.customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{
@@ -692,14 +685,7 @@
 	},
 	"job": {
 		"namespace": "job-namespace",
-		"name": "postgres.public.jaffle_shop.customers",
-		"facets": {
-			"sql": {
-				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-				"_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/SqlJobFacet",
-				"query": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final"
-			}
-		}
+		"name": "postgres.public.jaffle_shop.customers"
 	},
 	"producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 	"inputs": [{

--- a/integration/common/tests/dbt/postgres/target/manifest.json
+++ b/integration/common/tests/dbt/postgres/target/manifest.json
@@ -154,7 +154,6 @@
 				"materialized": "table"
 			},
 			"created_at": 1670976638.457581,
-			"compiled_code": "with\n  customers as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_customers\"\n\n  ),\n\n  orders as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_orders\"\n\n  ),\n\n  payments as (\n\n    select *\n    from \"postgres\".\"public\".\"stg_payments\"\n\n  ),\n\n  customer_orders as (\n\n    select\n      customer_id,\n      min(order_date) as first_order,\n      max(order_date) as most_recent_order,\n      count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n  ),\n\n  customer_payments as (\n\n    select\n      orders.customer_id,\n      sum(amount) as total_amount\n\n    from payments\n\n    left join orders on payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n  ),\n\n  final as (\n\n    select\n      customers.customer_id,\n      customers.first_name,\n      customers.last_name,\n      customer_orders.first_order,\n      customer_orders.most_recent_order,\n      customer_orders.number_of_orders,\n      customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments on customers.customer_id = customer_payments.customer_id\n\n  )\n\nselect\n  *\nfrom final",
 			"extra_ctes_injected": true,
 			"extra_ctes": [],
 			"relation_name": "\"postgres\".\"public\".\"customers\""


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Closes: #1550 

### Solution

make `compiled_code` optional for manifest > v7.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project