### PR TITLE
add bot for automating changelog updates

### DIFF
--- a/.github/changelog-ci-config.yml
+++ b/.github/changelog-ci-config.yml
@@ -1,0 +1,20 @@
+changelog_type: 'pull_request'
+header_prefix: 'Version:'
+commit_changelog: true
+comment_changelog: false
+include_unlabeled_changes: true
+unlabeled_group_title: 'Unlabeled Changes'
+pull_request_title_regex: '^update changelog|prepare changelog'
+version_regex: '.*'
+exclude_labels:
+  - bot
+  - dependabot
+  - dependencies
+  - ci
+  - documentation
+  - dev/ops
+  - proposal
+group_config:
+  - title: Fixed
+    labels:
+      - bug

--- a/.github/changelog-ci-config.yml
+++ b/.github/changelog-ci-config.yml
@@ -4,7 +4,7 @@ comment_changelog: false
 include_unlabeled_changes: true
 unlabeled_group_title: 'Unlabeled Changes'
 pull_request_title_regex: '^update changelog|prepare changelog'
-version_regex: '.*'
+version_regex: '([0-9]{1,2})+[.]+([0-9]{1,2})+[.]+([0-9]{1,2})'
 exclude_labels:
   - bot
   - dependabot

--- a/.github/changelog-ci-config.yml
+++ b/.github/changelog-ci-config.yml
@@ -1,5 +1,4 @@
 changelog_type: 'pull_request'
-header_prefix: 'Version:'
 commit_changelog: true
 comment_changelog: false
 include_unlabeled_changes: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,7 @@ If you're contributing a new integration, please specify the scope of the integr
 - [ ] Your changes are accompanied by tests (_if relevant_)
 - [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
 - [ ] You've updated any relevant documentation (_if relevant_)
+- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
 - [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
 - [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,6 @@ If you're contributing a new integration, please specify the scope of the integr
 - [ ] Your changes are accompanied by tests (_if relevant_)
 - [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
 - [ ] You've updated any relevant documentation (_if relevant_)
-- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
 - [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
 - [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)
 

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -1,0 +1,20 @@
+name: Changelog CI
+
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Changelog CI
+        uses: saadmk11/changelog-ci@v1.1.1
+        with:
+          changelog_filename: CHANGELOG.md
+          config_file: .github/changelog-ci-config.yml
+          committer_username: 'github-actions[bot]'
+          committer_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

### Problem

Requiring contributors to update the changelog adds an unnecessary additional commit to every pull request. 

Closes: #1579 

### Solution

This adds a GitHub Action that makes creation of the changelog partly automatic. When a PR is opened with a title starting with 'prepare changelog' or 'update changelog,' a commit is added to the PR that adds the title and URL of every PR merged since the most recent release to CHANGELOG.md, except any types we want to exclude (e.g., 'CI' or 'documentation'). Exclusions are easy to configure via our existing labels. 

This also replaces the changelog update item in the PR template checklist with one about adding a one-liner for the changelog. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project