### PR TITLE
dbt: render actual profile only in profiles.yml

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -225,7 +225,7 @@ class DbtArtifactProcessor:
                 raise KeyError(f'profile not found in {self.project}')
 
         profile = self.load_yaml_with_jinja(
-            os.path.join(profile_dir, 'profiles.yml')
+            os.path.join(profile_dir, 'profiles.yml'), include_section=[self.profile_name]
         )[self.profile_name]
 
         if not self.target:
@@ -330,22 +330,38 @@ class DbtArtifactProcessor:
         env.globals["env_var"] = DbtArtifactProcessor.env_var
         return env
 
-    def load_yaml_with_jinja(self, path: str) -> Dict:
+    def load_yaml_with_jinja(
+        self, path: str, include_section: Optional[List[Optional[str]]] = None
+    ) -> Dict:
         loaded = self.load_yaml(path)
         if not self.jinja_environment:
             self.jinja_environment = self.setup_jinja()
-        return self.render_values_jinja(environment=self.jinja_environment, value=loaded)
+        return self.render_values_jinja(
+            environment=self.jinja_environment,
+            value=loaded,
+            include_section=include_section,
+        )
 
     @classmethod
-    def render_values_jinja(cls, environment: Environment, value: T) -> T:
+    def render_values_jinja(
+        cls,
+        environment: Environment,
+        value: T,
+        include_section: Optional[List[Optional[str]]] = None,
+    ) -> T:
         """
         Traverses passed dictionary and render any string value using jinja.
         Returns copy of the dict with parsed values.
         """
+        include_section = include_section or []
         if isinstance(value, dict):
             parsed_dict = {}
             for key, val in value.items():
-                parsed_dict[key] = cls.render_values_jinja(environment, val)
+                if include_section and key != include_section[0]:
+                    continue
+                parsed_dict[key] = cls.render_values_jinja(
+                    environment, val, include_section=include_section[1:]
+                )
             return parsed_dict      # type: ignore
         elif isinstance(value, list):
             parsed_list = []

--- a/integration/common/tests/dbt/env_vars/profiles.yml
+++ b/integration/common/tests/dbt/env_vars/profiles.yml
@@ -9,3 +9,14 @@ redshift:
             user: "{{ env_var('USER_NAME') }}"
             pass: "{{ env_var('PASSWORD') }}"
             schema: "{{ env_var('SCHEMA') }}"
+redshift_missing:
+    target: prod
+    outputs:
+        prod:
+            type: redshift
+            host: "{{ env_var('HOST2') }}"
+            port: "{{ env_var('PORT') | as_number }}"
+            dbname: "{{ env_var('DB_NAME') }}"
+            user: "{{ env_var('USER_NAME') }}"
+            pass: "{{ env_var('PASSWORD') }}"
+            schema: "{{ env_var('SCHEMA') }}"

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -165,6 +165,25 @@ def test_jinja_undefined_method_with_args(jinja_env):
     text = "# {{ does_not_exist(some_arg.subarg.subarg2) }}"
     assert text == DbtArtifactProcessor.render_values_jinja(jinja_env, text)
 
+@mock.patch.dict(os.environ, {"PORT": "1111"})
+def test_jinja_include_section(jinja_env):
+    object = {
+        "proper_one": "{{ env_var('PORT') }}",
+        "to_ignore": "{{ env_var('FAKE_VAR') }}",
+    }
+
+    parsed = DbtArtifactProcessor.render_values_jinja(
+        jinja_env, object, include_section=["proper_one"]
+    )
+
+    assert parsed == {"proper_one": "1111"}
+
+    with pytest.raises(Exception):
+        DbtArtifactProcessor.render_values_jinja(
+            jinja_env, object, include_section=[]
+        )
+
+
 
 def test_jinja_multiline(jinja_env):
     os.environ['PORT_REDSHIFT'] = "13"


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Fix mypy issue.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

dbt integration attempts to render whole `profiles.yml` file even if other profiles are not used. It should follow similar practice as in dbt-core - fetch and render only needed profile.

Closes: #1589 

### Solution

Add `include_section` argument for jinja render method to include only one profile if needed.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project