### PR TITLE
Airflow: make extractor for async operators work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.20.4...HEAD)
+### Changed
+* Airflow: make extractors for async operators work. Send deterministic Run UUID for Airflow runs [`#1601`](https://github.com/OpenLineage/OpenLineage/pull/1601) [@JDarDagran](https://github.com/JDarDagran)
 
 ## [0.20.4](https://github.com/OpenLineage/OpenLineage/compare/0.19.2...0.20.4) - 2023-2-7
 

--- a/integration/airflow/tests/integration/requests/failing/async.json
+++ b/integration/airflow/tests/integration/requests/failing/async.json
@@ -1,0 +1,72 @@
+[{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "name": "async_dag.timedelta_sensor",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow": {
+                "dag": {
+                    "dag_id": "async_dag",
+                    "timetable": {}
+                },
+                "dagRun": {
+                    "dag_id": "async_dag"
+                },
+                "task": {
+                },
+                "taskInstance": {
+                    "try_number": 1
+                }
+            }
+        }
+    }
+},
+{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "name": "async_dag.failing_sensor",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow": {
+                "dag": {
+                    "dag_id": "async_dag",
+                    "timetable": {}
+                },
+                "dagRun": {
+                    "dag_id": "async_dag"
+                },
+                "task": {
+                },
+                "taskInstance": {
+                    "try_number": 1
+                }
+            }
+        }
+    }
+},
+{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "name": "async_dag.timedelta_sensor",
+        "namespace": "food_delivery"
+    },
+    "outputs": []
+},
+{
+    "eventType": "FAIL",
+    "inputs": [],
+    "job": {
+        "name": "async_dag.failing_sensor",
+        "namespace": "food_delivery"
+    },
+    "outputs": []
+}]

--- a/integration/airflow/tests/integration/tests/airflow/dags/async_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/async_dag.py
@@ -1,0 +1,27 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from datetime import timedelta
+
+from airflow.decorators import dag
+from airflow.sensors.time_delta import TimeDeltaSensorAsync
+from airflow.utils.dates import days_ago
+
+
+class TimeDeltaCustomAsync(TimeDeltaSensorAsync):
+    def execute_complete(self, context, event=None):
+        print(context, event)
+        # fail on purpose
+        raise Exception
+
+@dag(
+    schedule_interval="@once",
+    start_date=days_ago(7),
+    catchup=False,
+)
+def async_dag():
+    working_operator = TimeDeltaSensorAsync(task_id='timedelta_sensor', delta=timedelta(seconds=10))
+    failing_operator = TimeDeltaCustomAsync(task_id='failing_sensor', delta=timedelta(seconds=10))
+    working_operator >> failing_operator
+    
+
+async_dag = async_dag()

--- a/integration/airflow/tests/integration/tests/docker-compose-dev.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose-dev.yml
@@ -6,8 +6,6 @@ x-dev-mounts: &dev-mounts
 
 services:
   integration:
-    volumes:
-      - ../:/app
     entrypoint: /bin/bash
     tty: true
 

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -106,6 +106,7 @@ services:
     depends_on:
       - airflow_scheduler
       - airflow_worker
+      - airflow_triggerer
       - backend
     entrypoint: ["/wait-for-it.sh", "backend:5000", "--", "python", '-m', 'pytest', 'test_integration.py']
 
@@ -116,6 +117,22 @@ services:
       - app_net
     healthcheck:
       test: [ "CMD-SHELL", 'airflow jobs check --job-type SchedulerJob --hostname "$${HOSTNAME}"' ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow_init:
+        condition: service_completed_successfully
+
+  airflow_triggerer:
+    <<: *airflow-base
+    command: triggerer
+    networks:
+      - app_net
+    healthcheck:
+      test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Add triggerer and async dag.
Use deterministic run id in Airflow integration.
Skip sending START event on deferred task.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

Check for duplicates in Airflow integration test.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Async operators previously sent at least 2 START events - one per regular start of the task, the following when task was run back from deferred state. Each succeeding event also had different generated run UUID which was breaking behaviour.

### Solution

Check if actual execution of task comes from deferred state with a simple `ti.next_method is not None` and send event only for the very first execution.
Set run UUID to deterministic task instance UUID (introduced in #1413)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] You've updated the [`CHANGELOG.md`](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md) with details about your change under the "Unreleased" section (_if relevant, depending on the change, this may not be necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project