### PR TITLE
[INTEGRATION][AIRFLOW] Add new extractor for FTPFileTransmitOperator

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -114,6 +114,7 @@ suited to extract metadata from a particular operator (or operators).
 * `TrinoOperator`
 * `GreatExpectationsOperator`
 * `SFTPOperator`
+* `FTPFileTransmitOperator`
 * `PythonOperator`
 * `RedshiftDataOperator`, `RedshiftSQLOperator`
 * `SageMakerProcessingOperator`, `SageMakerProcessingOperatorAsync`

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -53,6 +53,9 @@ _extractors = list(
                 'openlineage.airflow.extractors.sftp_extractor.SFTPExtractor'
             ),
             try_import_from_string(
+                'openlineage.airflow.extractors.ftp_extractor.FTPExtractor'
+            ),
+            try_import_from_string(
                 'openlineage.airflow.extractors.sagemaker_extractors.SageMakerProcessingExtractor'
             ),
             try_import_from_string(
@@ -88,6 +91,7 @@ _check_providers = {
     "TrinoExtractor": "trino",
     "AthenaExtractor": "aws",
     "SFTPExtractor": ["sftp", "ssh"],
+    "FTPExtractor": "ftp",
 }
 
 

--- a/integration/airflow/openlineage/airflow/extractors/ftp_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/ftp_extractor.py
@@ -1,0 +1,77 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import socket
+from ftplib import FTP_PORT
+from typing import List, Optional
+
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.common.dataset import Dataset, Source
+
+FTPOperation = try_import_from_string("airflow.providers.ftp.operators.ftp.FTPOperation")
+
+
+class FTPExtractor(BaseExtractor):
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        return ["FTPFileTransmitOperator"]
+
+    def extract(self) -> Optional[TaskMetadata]:
+        scheme = "file"
+
+        local_host = socket.gethostname()
+        try:
+            local_host = socket.gethostbyname(local_host)
+        except Exception as e:
+            self.log.warning(
+                f"Failed to resolve local hostname. Using the hostname got by socket.gethostbyname() without resolution. {e}",  # noqa: E501
+                exc_info=True
+            )
+
+        conn = self.operator.hook.get_conn()
+        remote_host = conn.host
+        remote_port = conn.port
+
+        if isinstance(self.operator.local_filepath, str):
+            local_filepath = [self.operator.local_filepath]
+        else:
+            local_filepath = self.operator.local_filepath
+        if isinstance(self.operator.remote_filepath, str):
+            remote_filepath = [self.operator.remote_filepath]
+        else:
+            remote_filepath = self.operator.remote_filepath
+
+        local_datasets = [
+            Dataset(source=self._get_source(scheme, local_host, None, path), name=path)
+            for path in local_filepath
+        ]
+        remote_datasets = [
+            Dataset(source=self._get_source(scheme, remote_host, remote_port, path), name=path)
+            for path in remote_filepath
+        ]
+
+        if self.operator.operation.lower() == FTPOperation.GET:
+            inputs = remote_datasets
+            outputs = local_datasets
+        else:
+            inputs = local_datasets
+            outputs = remote_datasets
+
+        return TaskMetadata(
+            name=f"{self.operator.dag_id}.{self.operator.task_id}",
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in outputs],
+            run_facets={},
+            job_facets={},
+        )
+
+    def _get_source(self, scheme, host, port, path) -> Source:
+        port = port or FTP_PORT
+        authority = f"{host}:{port}"
+        return Source(
+            scheme=scheme,
+            authority=authority,
+            connection_url=f"{scheme}://{authority}{path}"
+        )

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -39,6 +39,7 @@ extras_require = {
         "apache-airflow-providers-amazon>=3.1.1",
         "apache-airflow-providers-sftp>=2.1.1",
         "apache-airflow-providers-ssh>=2.1.0",
+        "apache-airflow-providers-ftp>=3.3.0",
         "airflow-provider-great-expectations==0.1.5",
         "great-expectations<=0.15.23",
         "protobuf==3.20.*",

--- a/integration/airflow/tests/extractors/test_ftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_ftp_extractor.py
@@ -1,0 +1,100 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import socket
+from unittest import mock
+
+import pytest
+from openlineage.airflow.extractors.ftp_extractor import FTPExtractor
+from openlineage.airflow.utils import try_import_from_string
+from openlineage.common.dataset import Dataset, Source
+
+from airflow.models import DAG, Connection
+from airflow.utils import timezone
+
+FTPOperator = try_import_from_string("airflow.providers.ftp.operators.ftp.FTPFileTransmitOperator")
+FTPOperation = try_import_from_string("airflow.providers.ftp.operators.ftp.FTPOperation")
+
+SCHEME = "file"
+
+LOCAL_FILEPATH = "/path/to/local"
+LOCAL_HOST = socket.gethostbyname(socket.gethostname())
+LOCAL_PORT = 21
+LOCAL_AUTHORITY = f"{LOCAL_HOST}:{LOCAL_PORT}"
+LOCAL_SOURCE = Source(
+    scheme=SCHEME, authority=LOCAL_AUTHORITY,
+    connection_url=f"{SCHEME}://{LOCAL_AUTHORITY}{LOCAL_FILEPATH}"
+)
+LOCAL_DATASET = [Dataset(source=LOCAL_SOURCE, name=LOCAL_FILEPATH).to_openlineage_dataset()]
+
+REMOTE_FILEPATH = "/path/to/remote"
+REMOTE_HOST = "remotehost"
+REMOTE_PORT = 21
+REMOTE_AUTHORITY = f"{REMOTE_HOST}:{REMOTE_PORT}"
+REMOTE_SOURCE = Source(
+    scheme=SCHEME, authority=REMOTE_AUTHORITY,
+    connection_url=f"{SCHEME}://{REMOTE_AUTHORITY}{REMOTE_FILEPATH}"
+)
+REMOTE_DATASET = [Dataset(source=REMOTE_SOURCE, name=REMOTE_FILEPATH).to_openlineage_dataset()]
+
+CONN_ID = "ftp_default"
+CONN = Connection(
+    conn_id=CONN_ID,
+    conn_type='ftp',
+    host=REMOTE_HOST,
+    port=REMOTE_PORT,
+)
+
+
+@pytest.mark.skipif(
+    FTPOperator is None,
+    reason="FTPFileTransmitOperator is only available since apache-airflow-providers-ftp 3.3.0+."
+)
+@mock.patch('airflow.providers.ftp.hooks.ftp.FTPHook.get_conn', spec=Connection)
+def test_extract_get(get_conn):
+    get_conn.return_value = CONN
+
+    dag_id = "ftp_dag"
+    task_id = "ftp_task"
+
+    task = FTPOperator(
+        task_id=task_id,
+        ftp_conn_id=CONN_ID,
+        dag=DAG(dag_id),
+        start_date=timezone.utcnow(),
+        local_filepath=LOCAL_FILEPATH,
+        remote_filepath=REMOTE_FILEPATH,
+        operation=FTPOperation.GET,
+    )
+    task_metadata = FTPExtractor(task).extract()
+
+    assert task_metadata.name == f"{dag_id}.{task_id}"
+    assert task_metadata.inputs == REMOTE_DATASET
+    assert task_metadata.outputs == LOCAL_DATASET
+
+
+@pytest.mark.skipif(
+    FTPOperator is None,
+    reason="FTPFileTransmitOperator is only available since apache-airflow-providers-ftp 3.3.0+."
+)
+@mock.patch('airflow.providers.ftp.hooks.ftp.FTPHook.get_conn', spec=Connection)
+def test_extract_put(get_conn):
+    get_conn.return_value = CONN
+
+    dag_id = "ftp_dag"
+    task_id = "ftp_task"
+
+    task = FTPOperator(
+        task_id=task_id,
+        ftp_conn_id=CONN_ID,
+        dag=DAG(dag_id),
+        start_date=timezone.utcnow(),
+        local_filepath=LOCAL_FILEPATH,
+        remote_filepath=REMOTE_FILEPATH,
+        operation=FTPOperation.PUT,
+    )
+    task_metadata = FTPExtractor(task).extract()
+
+    assert task_metadata.name == f"{dag_id}.{task_id}"
+    assert task_metadata.inputs == LOCAL_DATASET
+    assert task_metadata.outputs == REMOTE_DATASET

--- a/integration/airflow/tests/integration/requests/ftp.json
+++ b/integration/airflow/tests/integration/requests/ftp.json
@@ -1,0 +1,68 @@
+[{
+    "eventType": "START",
+    "inputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "file://172.16.238.100:21",
+                    "uri": "file://172.16.238.100:21/opt/airflow/airflow.cfg"
+                }
+            },
+            "name": "/opt/airflow/airflow.cfg",
+            "namespace": "file://172.16.238.100:21"
+        }
+    ],
+    "job": {
+        "name": "ftp_dag.ftp_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "file://pure-ftpd:21",
+                    "uri": "file://pure-ftpd:21/airflow.cfg"
+                }
+            },
+            "name": "/airflow.cfg",
+            "namespace": "file://pure-ftpd:21"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+},
+{
+    "eventType": "COMPLETE",
+    "inputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "file://172.16.238.100:21",
+                    "uri": "file://172.16.238.100:21/opt/airflow/airflow.cfg"
+                }
+            },
+            "name": "/opt/airflow/airflow.cfg",
+            "namespace": "file://172.16.238.100:21"
+        }
+    ],
+    "job": {
+        "name": "ftp_dag.ftp_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": [
+        {
+            "facets": {
+                "dataSource": {
+                    "name": "file://pure-ftpd:21",
+                    "uri": "file://pure-ftpd:21/airflow.cfg"
+                }
+            },
+            "name": "/airflow.cfg",
+            "namespace": "file://pure-ftpd:21"
+        }
+    ],
+    "run": {
+        "facets": {}
+    }
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -158,6 +158,13 @@ params = [
     ),
     ("sftp_dag", "requests/sftp.json"),
     pytest.param(
+        "ftp_dag",
+        "requests/ftp.json",
+        marks=pytest.mark.skipif(
+            not IS_AIRFLOW_VERSION_ENOUGH("2.5.0"), reason="Airflow < 2.5.0"
+        ),
+    ),
+    pytest.param(
         "s3copy_dag",
         "requests/s3copy.json",
         marks=pytest.mark.skipif(

--- a/integration/airflow/tests/integration/tests/airflow/dags/ftp_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/ftp_dag.py
@@ -1,0 +1,14 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from airflow import DAG
+from airflow.providers.ftp.operators.ftp import FTPFileTransmitOperator
+from airflow.utils.dates import days_ago
+
+with DAG(dag_id="ftp_dag", start_date=days_ago(7), schedule_interval="@once") as dag:
+    FTPFileTransmitOperator(
+        task_id="ftp_task",
+        ftp_conn_id="ftp_conn",
+        local_filepath="/opt/airflow/airflow.cfg",
+        remote_filepath="/airflow.cfg",
+    )

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -54,6 +54,7 @@ x-airflow-base: &airflow-base
     AIRFLOW_CONN_AWS_CONN: "aws://"
     AIRFLOW_CONN_AWS_LOCAL_CONN: "aws://?aws_access_key_id=k&aws_secret_access_key=v&endpoint_url=http%3A%2F%2Flocalstack%3A4566"
     AIRFLOW_CONN_SFTP_CONN: sftp://airflow:airflow@openssh-server:2222
+    AIRFLOW_CONN_FTP_CONN: ftp://airflow:airflow@pure-ftpd:21
   volumes:
       - ./airflow/config/log_config.py:/opt/airflow/config/log_config.py
       - $PWD/airflow/logs:/opt/airflow/logs
@@ -76,6 +77,8 @@ x-airflow-base: &airflow-base
       condition: service_healthy
     localstack:
       condition: service_healthy
+    pure-ftpd:
+      condition: service_started
 
 services:
   integration:
@@ -296,6 +299,19 @@ services:
       interval: 5s
       timeout: 30s
       retries: 50
+
+  pure-ftpd:
+    image: stilliard/pure-ftpd
+    networks:
+      - app_net
+    expose:
+      - 21
+    environment:
+      PUBLICHOST: localhost
+      FTP_USER_NAME: airflow
+      FTP_USER_PASS: airflow
+      FTP_USER_HOME: /home/airflow
+    restart: always
 
 networks:
   app_net:


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

Some legacy systems still use FTP for file transmission, but OL currently doesn't provide an extractor for FTPFileTransmitOperator natively.

### Solution

This PR adds a new extractor for FTPFileTransmitOperator.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project