### PR TITLE
Fix file existence check in build script for openlineage-sql-java

### DIFF
--- a/integration/sql/iface-java/script/build.sh
+++ b/integration/sql/iface-java/script/build.sh
@@ -19,7 +19,7 @@ mkdir -p $RESOURCES
 if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java.so" ]]; then
     cp $ROOT/../target/debug/libopenlineage_sql_java.so $RESOURCES
 fi
-if [[ "$ROOT/../target/debug/libopenlineage_sql_java.dylib" ]]; then
+if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java.dylib" ]]; then
     cp $ROOT/../target/debug/libopenlineage_sql_java.dylib $RESOURCES
 fi
 


### PR DESCRIPTION
Signed-off-by: Kengo Seki <sekikn@apache.org>

### Problem

integration/sql/iface-java/script/build.sh doesn't seem to work if that library is compiled only for Linux. For example:

```
$ cd integration/sql/iface-java
$ script/compile.sh
$ script/build.sh 
cp: cannot stat 'script/../../target/debug/libopenlineage_sql_java.dylib': No such file or directory
```

### Solution

This PR fixes file existence check in that script as expected.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project