### PR TITLE
Introduce new output visitors: AlterTableAddPartitionCommandVisitor and AlterTableSetLocationCommandVisitor

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
@@ -1,0 +1,95 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+import scala.collection.immutable.Map;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class AlterTableAddPartitionCommandVisitorTest {
+
+  private static final String TABLE_5 = "table5";
+  SparkSession session;
+  AlterTableAddPartitionCommandVisitor visitor;
+  String database;
+
+  @AfterEach
+  public void afterEach() {
+    dropTables();
+  }
+
+  private void dropTables() {
+    session
+        .sessionState()
+        .catalog()
+        .dropTable(new TableIdentifier(TABLE_5, Option.apply(database)), true, true);
+  }
+
+  @BeforeEach
+  public void setup() {
+
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .config("spark.sql.catalogImplementation", "hive")
+            .enableHiveSupport()
+            .master("local")
+            .getOrCreate();
+
+    dropTables();
+    session.sql("CREATE TABLE `table5` (col2 varchar(31)) PARTITIONED BY (\n" +
+        "  `col1` string)\n" +
+        "STORED AS PARQUET");
+    visitor = new AlterTableAddPartitionCommandVisitor(SparkAgentTestExtension.newContext(session));
+  }
+
+  @Test
+  void testAlterTableAddPartition() {
+
+    scala.collection.immutable.Map<String, String> params =
+        scala.collection.immutable.Map$.MODULE$
+            .<String, String>newBuilder()
+            .$plus$eq(Tuple2.apply("col1", "aaa"))
+            .result();
+
+    Seq<Tuple2<Map<String, String>, Option<String>>> partitionSpecsAndLocs =
+        Seq$.MODULE$.<Tuple2<Map<String, String>, Option<String>>>newBuilder().$plus$eq(Tuple2.apply(params, Option.apply("file:///tmp/dir"))).result();
+
+    AlterTableAddPartitionCommand command =
+        new AlterTableAddPartitionCommand(
+            new TableIdentifier(TABLE_5, Option.apply("default")),
+            partitionSpecsAndLocs,
+            false);
+
+    command.run(session);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+    assertEquals(2, datasets.get(0).getFacets().getSchema().getFields().size());
+    assertEquals("default.table5", datasets.get(0).getFacets().getSymlinks().getIdentifiers().get(0).getName());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/table5")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
@@ -5,8 +5,12 @@
 
 package io.openlineage.spark.agent.lifecycle.plan;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.execution.command.AlterTableSetLocationCommand;
@@ -21,11 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
 import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 @ExtendWith(SparkAgentTestExtension.class)
 class AlterTableSetLocationCommandVisitorTest {
@@ -59,8 +58,8 @@ class AlterTableSetLocationCommandVisitorTest {
 
     StructType schema =
         new StructType(
-            new StructField[]{
-                new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            new StructField[] {
+              new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
 
     session.catalog().createTable(TABLE_1, "csv", schema, Map$.MODULE$.empty());
@@ -81,7 +80,9 @@ class AlterTableSetLocationCommandVisitorTest {
     assertThat(visitor.isDefinedAt(command)).isTrue();
     List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
     assertEquals(1, datasets.get(0).getFacets().getSchema().getFields().size());
-    assertEquals("default.table1", datasets.get(0).getFacets().getSymlinks().getIdentifiers().get(0).getName());
+    assertEquals(
+        "default.table1",
+        datasets.get(0).getFacets().getSymlinks().getIdentifiers().get(0).getName());
     assertThat(datasets)
         .singleElement()
         .hasFieldOrPropertyWithValue("name", "/tmp/dir")

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
@@ -1,0 +1,90 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.execution.command.AlterTableSetLocationCommand;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.Option;
+import scala.collection.Map$;
+import scala.collection.immutable.HashMap;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class AlterTableSetLocationCommandVisitorTest {
+
+  private static final String TABLE_1 = "table1";
+  SparkSession session;
+  AlterTableSetLocationCommandVisitor visitor;
+  String database;
+
+  @AfterEach
+  public void afterEach() {
+    dropTables();
+  }
+
+  private void dropTables() {
+    session
+        .sessionState()
+        .catalog()
+        .dropTable(new TableIdentifier(TABLE_1, Option.apply(database)), true, true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    session =
+        SparkSession.builder()
+            .config("spark.sql.warehouse.dir", "/tmp/warehouse")
+            .master("local")
+            .getOrCreate();
+
+    dropTables();
+
+    StructType schema =
+        new StructType(
+            new StructField[]{
+                new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+            });
+
+    session.catalog().createTable(TABLE_1, "csv", schema, Map$.MODULE$.empty());
+    database = session.catalog().currentDatabase();
+    visitor = new AlterTableSetLocationCommandVisitor(SparkAgentTestExtension.newContext(session));
+  }
+
+  @Test
+  void testAlterTableSetLocation() {
+    AlterTableSetLocationCommand command =
+        new AlterTableSetLocationCommand(
+            new TableIdentifier(TABLE_1, Option.apply(database)),
+            Option.empty(),
+            "file:///tmp/dir");
+
+    command.run(session);
+
+    assertThat(visitor.isDefinedAt(command)).isTrue();
+    List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+    assertEquals(1, datasets.get(0).getFacets().getSchema().getFields().size());
+    assertEquals("default.table1", datasets.get(0).getFacets().getSymlinks().getIdentifiers().get(0).getName());
+    assertThat(datasets)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/tmp/dir")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -9,7 +9,9 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.Dataset;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.lifecycle.plan.AlterTableAddColumnsCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.AlterTableAddPartitionCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.AlterTableRenameCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.AlterTableSetLocationCommandVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeInputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.CreateDataSourceTableAsSelectCommandVisitor;
@@ -120,6 +122,8 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(new CreateTableCommandVisitor(context));
     list.add(new DropTableCommandVisitor(context));
     list.add(new TruncateTableCommandVisitor(context));
+    list.add(new AlterTableSetLocationCommandVisitor(context));
+    list.add(new AlterTableAddPartitionCommandVisitor(context));
     return list;
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -36,6 +36,7 @@ public class AlterTableAddPartitionCommandVisitor
 
     CatalogTable catalogTable = tableOption.get();
 
+    // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
             .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -1,0 +1,43 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+public class AlterTableAddPartitionCommandVisitor
+    extends QueryPlanVisitor<AlterTableAddPartitionCommand, OpenLineage.OutputDataset> {
+
+  public AlterTableAddPartitionCommandVisitor(OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    Optional<CatalogTable> tableOption = catalogTableFor(((AlterTableAddPartitionCommand) x).tableName());
+
+    if (!tableOption.isPresent()) {
+      return Collections.emptyList();
+    }
+
+    CatalogTable catalogTable = tableOption.get();
+
+    return Collections.singletonList(
+        outputDataset()
+            .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -9,14 +9,13 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.AlterTableAddPartitionCommand;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 public class AlterTableAddPartitionCommandVisitor
@@ -28,7 +27,8 @@ public class AlterTableAddPartitionCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    Optional<CatalogTable> tableOption = catalogTableFor(((AlterTableAddPartitionCommand) x).tableName());
+    Optional<CatalogTable> tableOption =
+        catalogTableFor(((AlterTableAddPartitionCommand) x).tableName());
 
     if (!tableOption.isPresent()) {
       return Collections.emptyList();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -36,6 +36,7 @@ public class AlterTableSetLocationCommandVisitor
 
     CatalogTable catalogTable = tableOption.get();
 
+    // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
             .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -1,0 +1,43 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.command.AlterTableSetLocationCommand;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+public class AlterTableSetLocationCommandVisitor
+    extends QueryPlanVisitor<AlterTableSetLocationCommand, OpenLineage.OutputDataset> {
+
+  public AlterTableSetLocationCommandVisitor(OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    Optional<CatalogTable> tableOption = catalogTableFor(((AlterTableSetLocationCommand) x).tableName());
+
+    if (!tableOption.isPresent()) {
+      return Collections.emptyList();
+    }
+
+    CatalogTable catalogTable = tableOption.get();
+
+    return Collections.singletonList(
+        outputDataset()
+            .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -9,14 +9,13 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.AlterTableSetLocationCommand;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 public class AlterTableSetLocationCommandVisitor
@@ -28,7 +27,8 @@ public class AlterTableSetLocationCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
-    Optional<CatalogTable> tableOption = catalogTableFor(((AlterTableSetLocationCommand) x).tableName());
+    Optional<CatalogTable> tableOption =
+        catalogTableFor(((AlterTableSetLocationCommand) x).tableName());
 
     if (!tableOption.isPresent()) {
       return Collections.emptyList();

--- a/integration/spark/supported-commands.md
+++ b/integration/spark/supported-commands.md
@@ -13,10 +13,11 @@ The page lists Spark commands which are supported by OpenLineage.
 | InsertIntoHiveTable                     | &check;                | `INSERT INTO t1 SELECT * from t2` <br/>when table created with `using HIVE`       |
 | OptimizedCreateHiveTableAsSelectCommand | &check;                | `CREATE TABLE t STORED AS PARQUET LOCATION '...' `<br/>`AS SELECT a, b FROM temp` |
 | AlterTableChangeColumnCommand           | &cross;                | irrelevant as only column comment changes are allowed in Spark                    |
-| AlterTableAddPartitionCommand           | &cross;                | not implemented                                                                   |
+| AlterTableAddPartitionCommand           | &cross;                | `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`                               |
 | AlterTableRenamePartitionCommand        | &cross;                | not implemented                                                                   |
 | AlterTableDropPartitionCommand          | &cross;                | not implemented                                                                   |
 | AlterTableRecoverPartitionsCommand      | &cross;                | not implemented                                                                   |
+| AlterTableSetLocationCommand            | &cross;                | `ALTER TABLE t SET LOCATION '...'`                                                |
 | Generate                                | &cross;                |                                                                                   |
 | ReturnAnswer                            | &cross;                |                                                                                   |
 | SaveAsHiveFile                          | &cross;                |                                                                                   |

--- a/integration/spark/supported-commands.md
+++ b/integration/spark/supported-commands.md
@@ -2,25 +2,25 @@
 
 The page lists Spark commands which are supported by OpenLineage.
 
-| Command                                 | Output visitor support | Example SQL / Notes                                                                                      |
-|-----------------------------------------|------------------------|----------------------------------------------------------------------------------------------------------|
-| AlterTableAddColumnsCommand             | &check;                | `ALTER TABLE t ADD COLUMNS (a string, b string)`                                                         |
-| AlterTableRenameCommand                 | &check;                | `ALTER TABLE t1 RENAME TO t2`                                                                            |
-| AppendData                              | &check;                |                                                                                                          |                                                                                                                                                                                                                                                                                                |
-| CreateHiveTableAsSelectCommand          | &check;                | `CREATE TABLE t USING hive LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                               |
-| InsertIntoDataSourceDirCommand          | &check;                | `INSERT OVERWRITE DIRECTORY '...' USING PARQUET SELECT * from t`                                         |
-| InsertIntoHiveDirCommand                | &check;                | `INSERT OVERWRITE DIRECTORY '...' SELECT * from t`                                                       |
-| InsertIntoHiveTable                     | &check;                | `INSERT INTO t1 SELECT * from t2` <br/>when table created with `using HIVE`                              |
-| OptimizedCreateHiveTableAsSelectCommand | &check;                | `CREATE TABLE t STORED AS PARQUET LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                        |
-| AlterTableChangeColumnCommand           | &cross;                | irrelevant as only column comment changes are allowed in Spark                                           |
-| AlterTableAddPartitionCommand           | &check;                | `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`. Generated datasets exclude partition/location info. |
-| AlterTableRenamePartitionCommand        | &cross;                | not implemented                                                                                          |
-| AlterTableDropPartitionCommand          | &cross;                | not implemented                                                                                          |
-| AlterTableRecoverPartitionsCommand      | &cross;                | not implemented                                                                                          |
-| AlterTableSetLocationCommand            | &check;                | `ALTER TABLE t SET LOCATION '...'`. Generated datasets exclude partition/location info.                  |
-| Generate                                | &cross;                |                                                                                                          |
-| ReturnAnswer                            | &cross;                |                                                                                                          |
-| SaveAsHiveFile                          | &cross;                |                                                                                                          |
+| Command                                 | Output visitor support | Example SQL / Notes                                                                                                |
+|-----------------------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------|
+| AlterTableAddColumnsCommand             | &check;                | `ALTER TABLE t ADD COLUMNS (a string, b string)`                                                                   |
+| AlterTableRenameCommand                 | &check;                | `ALTER TABLE t1 RENAME TO t2`                                                                                      |
+| AppendData                              | &check;                |                                                                                                                    |                                                                                                                                                                                                                                                                                                |
+| CreateHiveTableAsSelectCommand          | &check;                | `CREATE TABLE t USING hive LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                                         |
+| InsertIntoDataSourceDirCommand          | &check;                | `INSERT OVERWRITE DIRECTORY '...' USING PARQUET SELECT * from t`                                                   |
+| InsertIntoHiveDirCommand                | &check;                | `INSERT OVERWRITE DIRECTORY '...' SELECT * from t`                                                                 |
+| InsertIntoHiveTable                     | &check;                | `INSERT INTO t1 SELECT * from t2` <br/>when table created with `using HIVE`                                        |
+| OptimizedCreateHiveTableAsSelectCommand | &check;                | `CREATE TABLE t STORED AS PARQUET LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                                  |
+| AlterTableChangeColumnCommand           | &cross;                | irrelevant as only column comment changes are allowed in Spark                                                     |
+| AlterTableAddPartitionCommand           | &check;                | `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`. <br/> Generated datasets exclude partition and location info. |
+| AlterTableRenamePartitionCommand        | &cross;                | not implemented                                                                                                    |
+| AlterTableDropPartitionCommand          | &cross;                | not implemented                                                                                                    |
+| AlterTableRecoverPartitionsCommand      | &cross;                | not implemented                                                                                                    |
+| AlterTableSetLocationCommand            | &check;                | `ALTER TABLE t SET LOCATION '...'`. <br/> Generated datasets exclude partition and location info.                  |
+| Generate                                | &cross;                |                                                                                                                    |
+| ReturnAnswer                            | &cross;                |                                                                                                                    |
+| SaveAsHiveFile                          | &cross;                |                                                                                                                    |
 
 
 ## V2 commands 

--- a/integration/spark/supported-commands.md
+++ b/integration/spark/supported-commands.md
@@ -2,25 +2,25 @@
 
 The page lists Spark commands which are supported by OpenLineage.
 
-| Command                                 | Output visitor support | Example SQL / Notes                                                               |
-|-----------------------------------------|------------------------|-----------------------------------------------------------------------------------|
-| AlterTableAddColumnsCommand             | &check;                | `ALTER TABLE t ADD COLUMNS (a string, b string)`                                  |
-| AlterTableRenameCommand                 | &check;                | `ALTER TABLE t1 RENAME TO t2`                                                     |
-| AppendData                              | &check;                |                                                                                   |                                                                                                                                                                                                                                                                                                |
-| CreateHiveTableAsSelectCommand          | &check;                | `CREATE TABLE t USING hive LOCATION '...' `<br/>`AS SELECT a, b FROM temp`        |
-| InsertIntoDataSourceDirCommand          | &check;                | `INSERT OVERWRITE DIRECTORY '...' USING PARQUET SELECT * from t`                  |
-| InsertIntoHiveDirCommand                | &check;                | `INSERT OVERWRITE DIRECTORY '...' SELECT * from t`                                |
-| InsertIntoHiveTable                     | &check;                | `INSERT INTO t1 SELECT * from t2` <br/>when table created with `using HIVE`       |
-| OptimizedCreateHiveTableAsSelectCommand | &check;                | `CREATE TABLE t STORED AS PARQUET LOCATION '...' `<br/>`AS SELECT a, b FROM temp` |
-| AlterTableChangeColumnCommand           | &cross;                | irrelevant as only column comment changes are allowed in Spark                    |
-| AlterTableAddPartitionCommand           | &cross;                | `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`                               |
-| AlterTableRenamePartitionCommand        | &cross;                | not implemented                                                                   |
-| AlterTableDropPartitionCommand          | &cross;                | not implemented                                                                   |
-| AlterTableRecoverPartitionsCommand      | &cross;                | not implemented                                                                   |
-| AlterTableSetLocationCommand            | &cross;                | `ALTER TABLE t SET LOCATION '...'`                                                |
-| Generate                                | &cross;                |                                                                                   |
-| ReturnAnswer                            | &cross;                |                                                                                   |
-| SaveAsHiveFile                          | &cross;                |                                                                                   |
+| Command                                 | Output visitor support | Example SQL / Notes                                                                                      |
+|-----------------------------------------|------------------------|----------------------------------------------------------------------------------------------------------|
+| AlterTableAddColumnsCommand             | &check;                | `ALTER TABLE t ADD COLUMNS (a string, b string)`                                                         |
+| AlterTableRenameCommand                 | &check;                | `ALTER TABLE t1 RENAME TO t2`                                                                            |
+| AppendData                              | &check;                |                                                                                                          |                                                                                                                                                                                                                                                                                                |
+| CreateHiveTableAsSelectCommand          | &check;                | `CREATE TABLE t USING hive LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                               |
+| InsertIntoDataSourceDirCommand          | &check;                | `INSERT OVERWRITE DIRECTORY '...' USING PARQUET SELECT * from t`                                         |
+| InsertIntoHiveDirCommand                | &check;                | `INSERT OVERWRITE DIRECTORY '...' SELECT * from t`                                                       |
+| InsertIntoHiveTable                     | &check;                | `INSERT INTO t1 SELECT * from t2` <br/>when table created with `using HIVE`                              |
+| OptimizedCreateHiveTableAsSelectCommand | &check;                | `CREATE TABLE t STORED AS PARQUET LOCATION '...' `<br/>`AS SELECT a, b FROM temp`                        |
+| AlterTableChangeColumnCommand           | &cross;                | irrelevant as only column comment changes are allowed in Spark                                           |
+| AlterTableAddPartitionCommand           | &check;                | `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`. Generated datasets exclude partition/location info. |
+| AlterTableRenamePartitionCommand        | &cross;                | not implemented                                                                                          |
+| AlterTableDropPartitionCommand          | &cross;                | not implemented                                                                                          |
+| AlterTableRecoverPartitionsCommand      | &cross;                | not implemented                                                                                          |
+| AlterTableSetLocationCommand            | &check;                | `ALTER TABLE t SET LOCATION '...'`. Generated datasets exclude partition/location info.                  |
+| Generate                                | &cross;                |                                                                                                          |
+| ReturnAnswer                            | &cross;                |                                                                                                          |
+| SaveAsHiveFile                          | &cross;                |                                                                                                          |
 
 
 ## V2 commands 


### PR DESCRIPTION
### Problem

Introduce new output visitors:
**AlterTableAddPartitionCommandVisitor** - extracts tables from spark command 'AlterTableAddPartitionCommand'. Example sql: `ALTER TABLE t ADD IF NOT EXISTS PARTITION (a='b')`
**AlterTableSetLocationCommandVisitor** - extracts table names from spark command 'AlterTableSetLocationCommand'. Example sql: `ALTER TABLE t SET LOCATION '...'`


### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modifcation(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project