### PR TITLE
spec: add TagDatasetFacet

### DIFF
--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -398,3 +398,19 @@ class ExtractionErrorRunFacet(BaseFacet):
     @staticmethod
     def _get_schema() -> str:
         return SCHEMA_URI + "#/definitions/ExtractionErrorRunFacet"
+
+
+@attr.s
+class Tag:
+    key: str = attr.ib()
+    value: Optional[str] = attr.ib(default=None)
+    field: Optional[str] = attr.ib(default=None)
+
+
+@attr.s
+class TagDatasetFacet(BaseFacet):
+    tags: List[Tag] = attr.ib()
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/TagDatasetFacet"

--- a/spec/facets/TagDatasetFacet.json
+++ b/spec/facets/TagDatasetFacet.json
@@ -1,0 +1,47 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$id" : "https://openlineage.io/spec/facets/1-0-0/TagDatasetFacet.json",
+  "$defs" : {
+    "TagDatasetFacet" : {
+      "allOf" : [ {
+        "$ref" : "https://openlineage.io/spec/1-0-2/OpenLineage.json#/$defs/DatasetFacet"
+      }, {
+        "type" : "object",
+        "properties" : {
+          "tags" : {
+            "description" : "Tags specified on this table",
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "key" : {
+                  "description" : "The name of this tag.",
+                  "type" : "string",
+                  "example" : "key1"
+                },
+                "value" : {
+                  "description" : "The value of this tag.",
+                  "type" : "string",
+                  "example" : "true"
+                },
+                "field" : {
+                  "description" : "Column in this dataset that this tag applies to.",
+                  "type" : "string",
+                  "example": "email"
+                }
+              },
+              "required" : [ "key" ]
+            }
+          }
+        }
+      } ],
+      "type" : "object"
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "tag" : {
+      "$ref" : "#/$defs/TagDatasetFacet"
+    }
+  }
+}


### PR DESCRIPTION
Main motivation for this facet is [Snowflake object tagging mechanism.](https://github.com/OpenLineage/OpenLineage/issues/1160)

But, we want to have standardized, general mechanism to capture tags from different systems - and enable OL Consumers to do thing like propagation - show all datasets (or columns) that use some PII tagged columns.

Initial idea was to just have key-value dictionary of tags, but we want to capture column level tags too. One idea is to add separate facet for that. In contrast, this one adds `column` field. If the column field is filled, that means tag is ment for that column only. If it's empty, it means the tag concerns whole table.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
