### PR TITLE
clients: debug logging of event is done only in base client class, not transports

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -39,6 +39,10 @@ public final class OpenLineageClient {
    * @param runEvent The run event to emit.
    */
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "OpenLineageClient will emit lineage event: {}", OpenLineageClientUtils.toJson(runEvent));
+    }
     transport.emit(runEvent);
   }
 

--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
@@ -17,6 +17,7 @@ public final class ConsoleTransport extends Transport {
 
   @Override
   public void emit(OpenLineage.RunEvent runEvent) {
+    // if DEBUG loglevel is enabled, this will double-log even due to OpenLineageClient also logging
     log.info(OpenLineageClientUtils.toJson(runEvent));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -100,7 +100,7 @@ public final class HttpTransport extends Transport implements Closeable {
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     final String eventAsJson = OpenLineageClientUtils.toJson(runEvent);
-    log.debug("POST {}: {}", uri, eventAsJson);
+    log.debug("POST event on URL {}", uri);
     try {
       final HttpPost request = new HttpPost();
       request.setURI(uri);

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -34,7 +34,6 @@ public final class KafkaTransport extends Transport {
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     final String eventAsJson = OpenLineageClientUtils.toJson(runEvent);
-    log.debug("Received lineage event: {}", eventAsJson);
     final ProducerRecord<String, String> record =
         new ProducerRecord<>(topicName, localServerId, eventAsJson);
     try {

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -62,7 +62,6 @@ public class KinesisTransport extends Transport {
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     final String eventAsJson = OpenLineageClientUtils.toJson(runEvent);
-    log.debug("Received lineage event: {}", eventAsJson);
     ListenableFuture<UserRecordResult> future =
         this.producer.addUserRecord(
             new UserRecord(

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -6,6 +6,7 @@ import typing
 from typing import Optional
 
 import attr
+from openlineage.client.serde import Serde
 
 if typing.TYPE_CHECKING:
     from requests import Session
@@ -67,6 +68,10 @@ class OpenLineageClient:
         if not self.transport:
             log.error("Tried to emit OpenLineage event, but transport is not configured.")
         else:
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug(
+                    f"OpenLineageClient will emit event {Serde.to_json(event).encode('utf-8')}"
+                )
             self.transport.emit(event)
 
     @classmethod

--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -21,4 +21,5 @@ class ConsoleTransport(Transport):
         self.log.debug("Constructing openlineage client to send events to console or logs")
 
     def emit(self, event: RunEvent):
+        # If logging is set to DEBUG, this will also log event in client.py
         self.log.info(Serde.to_json(event))

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -117,8 +117,6 @@ class HttpTransport(Transport):
 
     def emit(self, event: RunEvent):
         event = Serde.to_json(event)
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(f"Sending openlineage event {event}")
         resp = self.session.post(
             urljoin(self.url, self.endpoint),
             event,

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -56,4 +56,4 @@ class KafkaTransport(Transport):
     def emit(self, event: RunEvent):
         self.producer.produce(topic=self.topic, value=Serde.to_json(event).encode('utf-8'))
         if self.flush:
-            self.producer.flush(timeout=2)
+            self.producer.flush(timeout=5)


### PR DESCRIPTION
This way we can ensure that `DEBUG` loglevel on properly configured loggers will always log the OL event, regardless of chosen transport.

This has the effect of double-logging when choosing `ConsoleTransport` with `DEBUG` loglevel, but I don't think it's a concern - `ConsoleTransport` is ment for debugging purposes only. 

Closes: https://github.com/OpenLineage/OpenLineage/issues/1625

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>