### PR TITLE
fix column lineage for cached datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.20.6...HEAD)
 
+### Fixed
+* Column lineage extraction in Spark supports caching. [`#1634`](https://github.com/OpenLineage/OpenLineage/pull/1634) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Collect column lineage from Spark logical plans that contain cached datasets.*
+
 ## [0.20.6](https://github.com/OpenLineage/OpenLineage/compare/0.20.4...0.20.6) - 2023-2-10
 
 ### Added

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/UrlParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/UrlParser.java
@@ -100,7 +100,6 @@ public class UrlParser {
     if (check) {
       return Optional.of(elements[index + 1]);
     } else {
-      log.warn("missing " + name + " in " + Arrays.toString(elements) + " at " + index);
       return Optional.empty();
     }
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -6,10 +6,17 @@
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.columnar.InMemoryRelation;
 
 /**
  * Utility functions for detecting column level lineage within {@link
@@ -29,9 +36,8 @@ public class ColumnLevelLineageUtils {
     ColumnLevelLineageBuilder builder = new ColumnLevelLineageBuilder(schemaFacet, context);
     LogicalPlan plan = context.getQueryExecution().get().optimizedPlan();
 
-    ExpressionDependencyCollector.collect(plan, builder);
+    collectInputsAndExpressionDependencies(context, plan, builder);
     OutputFieldsCollector.collect(plan, builder);
-    InputFieldsCollector.collect(context, plan, builder);
 
     OpenLineage.ColumnLineageDatasetFacetBuilder facetBuilder =
         context.getOpenLineage().newColumnLineageDatasetFacetBuilder();
@@ -43,6 +49,41 @@ public class ColumnLevelLineageUtils {
       return Optional.empty();
     } else {
       return Optional.of(facetBuilder.build());
+    }
+  }
+
+  private static void collectInputsAndExpressionDependencies(
+      OpenLineageContext context, LogicalPlan plan, ColumnLevelLineageBuilder builder) {
+    ExpressionDependencyCollector.collect(plan, builder);
+    InputFieldsCollector.collect(context, plan, builder);
+
+    // iterate children plans and see if they contain dataset caching
+    if (plan.children() != null) {
+      plan.foreach(
+          node -> {
+            if (node instanceof InMemoryRelation) {
+              PlanUtils3.getLogicalPlanOf(context, (InMemoryRelation) node)
+                  .ifPresent(
+                      cachedPlan -> {
+                        // run self for the cached plan
+                        collectInputsAndExpressionDependencies(context, cachedPlan, builder);
+
+                        // map outputs of cachedPlan onto inputs of InMemoryRelation
+                        Map<String, ExprId> idMap =
+                            ScalaConversionUtils.<Attribute>fromSeq(node.output()).stream()
+                                .collect(Collectors.toMap(Attribute::name, Attribute::exprId));
+
+                        OutputFieldsCollector.getOutputExpressionsFromTree(cachedPlan).stream()
+                            .filter(namedExpression -> idMap.containsKey(namedExpression.name()))
+                            .forEach(
+                                namedExpression ->
+                                    builder.addDependency(
+                                        namedExpression.exprId(),
+                                        idMap.get(namedExpression.name())));
+                      });
+            }
+            return scala.runtime.BoxedUnit.UNIT;
+          });
     }
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LeafNode;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.UnaryNode;
 import org.apache.spark.sql.execution.LogicalRDD;
+import org.apache.spark.sql.execution.columnar.InMemoryRelation;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
@@ -90,6 +91,10 @@ class InputFieldsCollector {
       return extractDatasetIdentifier(relation);
     } else if (node instanceof LogicalRDD) {
       return extractDatasetIdentifier((LogicalRDD) node);
+    } else if (node instanceof InMemoryRelation) {
+      // implemented in
+      // io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageUtils.collectInputsAndExpressionDependencies
+      // requires merging multiple LogicalPlans
     } else if (node instanceof LeafNode) {
       log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());
     }


### PR DESCRIPTION
### Problem

Column level lineage is not collected if a Spark plan contains InMemoryRelations, which means if there are some datasets cached. 

Closes: #1628

### Solution

 * Detect `InMemorRelations`, extract logical plans that lead to them
 * be able to merge expression dependencies of those plans  

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project