### PR TITLE
sql: add support for snowflake TRANSIENT keyword, bump sqlparser dependency

### DIFF
--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -266,7 +266,7 @@ def test_parse_bugged_cte():
             WHERE count > 1000 OR balance > 100000;
     """
     assert parse(sql).errors == [
-        ExtractionError(0, "Expected AS, found: (", sql)
+        ExtractionError(0, "Expected ), found: user_id", sql)
     ]
 
 

--- a/integration/sql/impl/tests/table_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_cte.rs
@@ -45,13 +45,12 @@ fn parse_bugged_cte() {
         FROM sum_trans
         WHERE count > 1000 OR balance > 100000;";
     let meta = parse_sql(sql, &PostgreSqlDialect {}, None).unwrap();
-
     assert_eq!(meta.errors.len(), 1);
     assert_eq!(
         meta.errors.get(0).unwrap(),
         &ExtractionError {
             index: 0,
-            message: "Expected AS, found: (".to_string(),
+            message: "Expected ), found: user_id".to_string(),
             origin_statement: sql.to_string(),
         }
     );


### PR DESCRIPTION
This PR mainly updates `sqlparser-rs` dependency - the keyword support happened there. 
The only changes happening here are due to internal `sqlparser-rs` changes. 

I will update `sqlp-release` branch to `snowflake/add-transient-keyword` and revert this change. This PR has this changed to not break build on other branches.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>