### PR TITLE
airflow: update OL macros to be usable in Airflow 2+

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -217,7 +217,7 @@ t1 = DataProcPySparkOperator(
     job_name=job_name,
     dataproc_pyspark_properties={
         'spark.driver.extraJavaOptions':
-            f"-javaagent:{jar}={os.environ.get('OPENLINEAGE_URL')}/api/v1/namespaces/{os.getenv('OPENLINEAGE_NAMESPACE', 'default')}/jobs/{job_name}/runs/{{{{macros.OpenLineagePlugin.lineage_run_id(run_id, task)}}}}?api_key={os.environ.get('OPENLINEAGE_API_KEY')}"
+            f"-javaagent:{jar}={os.environ.get('OPENLINEAGE_URL')}/api/v1/namespaces/{os.getenv('OPENLINEAGE_NAMESPACE', 'default')}/jobs/{job_name}/runs/{{{{macros.OpenLineagePlugin.lineage_run_id(task, task_instance)}}}}?api_key={os.environ.get('OPENLINEAGE_API_KEY')}"
         dag=dag)
 ```
 

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -74,7 +74,8 @@ class OpenLineageAdapter:
             uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}")
         )
 
-    def build_task_instance_run_id(self, task_id, execution_date, try_number):
+    @staticmethod
+    def build_task_instance_run_id(task_id, execution_date, try_number):
         return str(
             uuid.uuid3(
                 uuid.NAMESPACE_URL,

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -97,7 +97,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
             return
         parent_run_id = adapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
-        task_uuid = adapter.build_task_instance_run_id(
+        task_uuid = OpenLineageAdapter.build_task_instance_run_id(
             task.task_id, task_instance.execution_date, task_instance.try_number
         )
 
@@ -136,7 +136,7 @@ def on_task_instance_success(previous_state, task_instance: "TaskInstance", sess
 
     dagrun = task_instance.dag_run
 
-    task_uuid = adapter.build_task_instance_run_id(
+    task_uuid = OpenLineageAdapter.build_task_instance_run_id(
         task.task_id, task_instance.execution_date, task_instance.try_number - 1
     )
 
@@ -161,7 +161,7 @@ def on_task_instance_failed(previous_state, task_instance: "TaskInstance", sessi
 
     dagrun = task_instance.dag_run
 
-    task_uuid = adapter.build_task_instance_run_id(
+    task_uuid = OpenLineageAdapter.build_task_instance_run_id(
         task.task_id, task_instance.execution_date, task_instance.try_number - 1
     )
 

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -34,6 +34,7 @@ class Backend:
         Send_lineage ignores manually provided inlets and outlets. The data collection mechanism
         is automatic, and bases on the passed context.
         """
+        from openlineage.airflow.adapter import OpenLineageAdapter
         from openlineage.airflow.utils import (
             DagUtils,
             get_airflow_run_facet,
@@ -57,7 +58,7 @@ class Backend:
             task_instance=task_instance
         )
 
-        task_uuid = self.adapter.build_task_instance_run_id(
+        task_uuid = OpenLineageAdapter.build_task_instance_run_id(
             operator.task_id, task_instance.execution_date, task_instance.try_number
         )
         start, end = get_dagrun_start_end(dagrun, dag)

--- a/integration/airflow/tests/integration/tests/airflow/dags/dbt_bigquery.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dbt_bigquery.py
@@ -7,7 +7,7 @@ from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 
-PLUGIN_MACRO = "{{ macros.OpenLineagePlugin.lineage_parent_id(run_id, task) }}"
+PLUGIN_MACRO = "{{ macros.OpenLineagePlugin.lineage_parent_id(run_id, task, task_instance) }}"
 
 
 PROJECT_DIR = "/opt/data/dbt/testproject"


### PR DESCRIPTION
Remove JobIdMapping.

### Problem

OL macros no longer make sense for Airflow 2+.

Closes: #1530 

### Solution

Update macros to use `OpenLineadeAdapter`'s method to generate deterministic run uuid.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project