### PR TITLE
Add dbt seed to list of dbt-ol events

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -244,14 +244,14 @@ class DbtArtifactProcessor:
 
         context = DbtRunContext(manifest, run_result, catalog)
 
-        if self.command not in ['run', 'build', 'test']:
+        if self.command not in ['run', 'build', 'test', 'seed']:
             raise ValueError(
                 f"Not recognized run command "
-                f"{self.command} - should be run, test or build"
+                f"{self.command} - should be run, test, seed or build"
             )
 
         events = DbtEvents()
-        if self.command in ['run', 'build']:
+        if self.command in ['run', 'build', 'seed']:
             events += self.parse_execution(context, nodes)
         if self.command in ['test', 'build']:
             events += self.parse_test(context, nodes)

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -145,7 +145,7 @@ def main():
     )
     process.wait()
 
-    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test', 'build']:
+    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test', 'build', 'seed']:
         return
 
     # If run_result has modification time before dbt command


### PR DESCRIPTION
### Problem

when running `dbt-ol test` against an event seed, the following failure occurs:

```text
[2023-02-22, 12:12:23 MST] {subprocess.py:93} INFO - ValueError: Model node connected to test {'test_metadata': {'name': 'not_null', 'kwargs': {'column_name': 'converted_at', 'model': "{{ get_where_subquery(ref('customer_conversions')) }}"}, 'namespace': None}, 'database': 'sandbox', 'schema': 'dbt_test__audit', 'name': 'not_null_customer_conversions_converted_at', 'resource_type': 'test', 'package_name': 'acme', 'path': 'not_null_customer_conversions_converted_at.sql', 'original_file_path': 'data/schema.yml', 'unique_id': 'test.acme.not_null_customer_conversions_converted_at.49026a132e', 'fqn': ['acme', 'not_null_customer_conversions_converted_at'], 'alias': 'not_null_customer_conversions_converted_at', 'checksum': {'name': 'none', 'checksum': ''}, 'config': {'enabled': True, 'alias': None, 'schema': 'dbt_test__audit', 'database': None, 'tags': [], 'meta': {}, 'materialized': 'test', 'severity': 'ERROR', 'store_failures': None, 'where': None, 'limit': None, 'fail_calc': 'count(*)', 'warn_if': '!= 0', 'error_if': '!= 0'}, 'tags': [], 'description': '', 'columns': {}, 'meta': {}, 'docs': {'show': True, 'node_color': None}, 'patch_path': None, 'build_path': 'target/run/acme/data/schema.yml/not_null_customer_conversions_converted_at.sql', 'deferred': False, 'unrendered_config': {}, 'created_at': 1677092937.6026092, 'relation_name': None, 'raw_code': '{{ test_not_null(**_dbt_generic_test_kwargs) }}', 'language': 'sql', 'refs': [['customer_conversions']], 'sources': [], 'metrics': [], 'depends_on': {'macros': ['macro.dbt.test_not_null', 'macro.dbt.get_where_subquery', 'macro.dbt_snowflake.set_query_tag', 'macro.dbt.materialization_test_default', 'macro.dbt_snowflake.unset_query_tag'], 'nodes': ['seed.acme.customer_conversions']}, 'compiled_path': 'target/compiled/acme/data/schema.yml/not_null_customer_conversions_converted_at.sql', 'compiled': True, 'compiled_code': '\n    \n    \n\n\n\nselect converted_at\nfrom sandbox.chronek.customer_conversions\nwhere converted_at is null\n\n\n', 'extra_ctes_injected': True, 'extra_ctes': [], 'column_name': 'converted_at', 'file_key_name': 'seeds.customer_conversions'} not found
```

Closes: #1648 

### Solution

Pretty simple fix, just added `seed` to the list of events in the `/common` and `/provider` directories for `dbt-ol`. 
