### PR TITLE
ci: airflow: save docker logs after failed `docker-compose run`.

### DIFF
--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -37,8 +37,25 @@ export DBT_DATASET_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")_d
 # just a hack to have same docker-compose for dev and CI env
 export PWD='.'
 
+# Bring down any existing containers and volumes
 docker-compose -f tests/docker-compose.yml down -v
+
+# Build the images
 docker-compose -f tests/docker-compose.yml build
+
+# Run the integration tests
+set +e
 docker-compose -f tests/docker-compose.yml run integration
-docker-compose -f tests/docker-compose.yml logs > tests/airflow/logs/docker.log
-docker-compose -f tests/docker-compose.yml down
+exit_code=$?
+set -e
+
+# Save the container logs to a file, if the integration test failed
+if [ $exit_code -ne 0 ]; then
+  docker-compose -f tests/docker-compose.yml logs > tests/airflow/logs/docker.log
+fi
+
+# Bring down the containers and volumes
+docker-compose -f tests/docker-compose.yml down -v
+
+# Exit with the exit code of the integration test
+exit $exit_code

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -23,6 +23,7 @@ levels = {
     "great_expectations": "INFO",
     "airflow.lineage": "DEBUG",
     "airflow.processor_manager": "WARNING",
+    "airflow.models.dagrun": "DEBUG",
     "botocore": "INFO",
 }
 


### PR DESCRIPTION
### Problem

When `docker-compose run` fails docker logs are not saved. It's more difficult to find some root causes because of that.

### Solution

Use `set +e` flag in the script.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project