### PR TITLE
sql: add linux-aarch64 native library to Java SQL parser

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -363,17 +363,22 @@ jobs:
           destination: sql-artifacts
 
   compile-integration-sql-java-linux:
-    working_directory: ~/openlineage/integration/sql/iface-java
-    docker:
-      - image: cimg/openjdk:8.0
-    resource_class: medium
+    parameters:
+      image:
+        type: string
+      resource_class:
+        type: string
+    working_directory: ~/openlineage/integration/sql
+    machine:
+      image: ubuntu-2004:current
+    resource_class: << parameters.resource_class >>
     steps:
       - *checkout_project_root
-      - run: bash script/compile.sh
+      - run: docker run -it -v $PWD:/code << parameters.image >> bash -c 'cd /code/iface-java && bash script/compile.sh'
       - persist_to_workspace:
-          root: ../
+          root: ./
           paths:
-            - target/debug/libopenlineage_sql_java.so
+            - target/debug/*.so
 
   compile-integration-sql-java-macos:
     working_directory: ~/openlineage/integration/sql/iface-java
@@ -764,6 +769,27 @@ workflows:
     # Only trigger CI job on release (=X.Y.Z) with possible (rcX)
     jobs:
       - compile-integration-sql-java-linux:
+          matrix:
+            alias: compile-integration-sql-java-linux-x86
+            parameters:
+              image: [
+                "quay.io/pypa/manylinux2014_x86_64",
+              ]
+              resource_class: [ "medium" ]
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+          context: release
+      - compile-integration-sql-java-linux:
+          matrix:
+            alias: compile-integration-sql-java-linux-arm
+            parameters:
+              image: [
+                "quay.io/pypa/manylinux2014_aarch64",
+              ]
+              resource_class: [ "arm.medium" ]
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
@@ -866,7 +892,8 @@ workflows:
             branches:
               ignore: /.*/
           requires:
-            - compile-integration-sql-java-linux
+            - compile-integration-sql-java-linux-x86
+            - compile-integration-sql-java-linux-arm
             - compile-integration-sql-java-macos
       - build-integration-sql:
           matrix:

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -2,11 +2,27 @@ workflows:
   openlineage-java:
     jobs:
       - build-client-java
-      - compile-integration-sql-java-linux
+      - compile-integration-sql-java-linux:
+          matrix:
+            alias: compile-integration-sql-java-linux-x86
+            parameters:
+              image: [
+                "quay.io/pypa/manylinux2014_x86_64",
+              ]
+              resource_class: [ "medium" ]
+      - compile-integration-sql-java-linux:
+          matrix:
+            alias: compile-integration-sql-java-linux-arm
+            parameters:
+              image: [
+                "quay.io/pypa/manylinux2014_aarch64",
+              ]
+              resource_class: [ "arm.medium" ]
       - compile-integration-sql-java-macos
       - build-integration-sql-java:
           requires:
-            - compile-integration-sql-java-linux
+            - compile-integration-sql-java-linux-arm
+            - compile-integration-sql-java-linux-x86
             - compile-integration-sql-java-macos
       - publish-snapshot-client-java:
           filters:

--- a/integration/sql/iface-java/script/build.sh
+++ b/integration/sql/iface-java/script/build.sh
@@ -16,8 +16,11 @@ SCRIPTS=$ROOT/script
 mkdir -p $RESOURCES
 
 # Native lib should be compiled at this point by compile.sh
-if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java.so" ]]; then
-    cp $ROOT/../target/debug/libopenlineage_sql_java.so $RESOURCES
+if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java_x86_64.so" ]]; then
+    cp $ROOT/../target/debug/libopenlineage_sql_java_x86_64.so $RESOURCES
+fi
+if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java_aarch64.so" ]]; then
+    cp $ROOT/../target/debug/libopenlineage_sql_java_aarch64.so $RESOURCES
 fi
 if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java.dylib" ]]; then
     cp $ROOT/../target/debug/libopenlineage_sql_java.dylib $RESOURCES
@@ -33,7 +36,7 @@ fi
 
 # Run a simple integration test
 printf "\n------ Running smoke test ------\n"
-EXPECTED="{{\"inTables\": [table1], \"outTables\": [], \"columnLineage\": [], \"errors\": []}}"
+EXPECTED="{\"inTables\": [\"table1\"], \"outTables\": [], \"columnLineage\": [], \"errors\": []}"
 OUTPUT=$(./src/test/integration/run_test.sh "SELECT * FROM table1;")
 if [ "$OUTPUT" = "$EXPECTED" ]; then
     printf "\n${GREEN}Smoke Test Passed!${NC}\n"

--- a/integration/sql/iface-java/script/compile.sh
+++ b/integration/sql/iface-java/script/compile.sh
@@ -17,8 +17,10 @@ JAVA_SRC=$SRC/java/io/openlineage/sql
 RESOURCES=$ROOT/src/main/resources/io/openlineage/sql
 SCRIPTS=$ROOT/script
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    NATIVE_LIB_NAME=libopenlineage_sql_java.so
+if [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "x86_64" ]]; then
+    NATIVE_LIB_NAME=libopenlineage_sql_java_x86_64.so
+elif [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "aarch64" ]]; then
+    NATIVE_LIB_NAME=libopenlineage_sql_java_aarch64.so
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java.dylib
 else
@@ -29,3 +31,6 @@ fi
 rm -rf build/libs/*
 cd $ROOT/..
 cargo build -p openlineage_sql_java
+
+shopt -s extglob
+mv target/debug/libopenlineage_sql_java*(*.so|*.dylib) target/debug/$NATIVE_LIB_NAME

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnLineage.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnLineage.java
@@ -29,7 +29,7 @@ public class ColumnLineage {
   @Override
   public String toString() {
     return String.format(
-        "{{\"descendant\": %s, \"lineage\": %s}}",
+        "{\"descendant\": %s, \"lineage\": %s}",
         descendant.toString(), Arrays.toString(lineage.toArray()));
   }
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnMeta.java
@@ -28,7 +28,7 @@ public class ColumnMeta {
   @Override
   public String toString() {
     return String.format(
-        "{{\"origin\": %s, \"name\": %s}}", origin != null ? origin.toString() : "unknown", name);
+        "{\"origin\": %s, \"name\": \"%s\"}", origin.isPresent() ? origin.get().toString() : "\"unknown\"", name);
   }
 
   @Override

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
@@ -32,7 +32,7 @@ public class DbTableMeta {
 
   public String qualifiedName() {
     return String.format(
-        "%s%s%s", database != null ? database + "." : "", schema != null ? schema + "." : "", name);
+        "\"%s%s%s\"", database != null ? database + "." : "", schema != null ? schema + "." : "", name);
   }
 
   @Override

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
@@ -73,8 +73,10 @@ public final class OpenLineageSql {
     String libName = "libopenlineage_sql_java";
     if (SystemUtils.IS_OS_MAC_OSX) {
       libName += ".dylib";
-    } else if (SystemUtils.IS_OS_LINUX) {
-      libName += ".so";
+    } else if (SystemUtils.IS_OS_LINUX && SystemUtils.OS_ARCH.equals("aarch64")) {
+      libName += "_aarch64.so";
+    } else if (SystemUtils.IS_OS_LINUX && SystemUtils.OS_ARCH.equals("amd64")) {
+      libName += "_x86_64.so";
     } else {
       loadError = Optional.of("Cannot link native library: unsupported OS");
     }

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
@@ -45,7 +45,7 @@ public class SqlMeta {
   @Override
   public String toString() {
     return String.format(
-        "{{\"inTables\": %s, \"outTables\": %s, \"columnLineage\": %s, \"errors\": %s}}",
+        "{\"inTables\": %s, \"outTables\": %s, \"columnLineage\": %s, \"errors\": %s}",
         Arrays.toString(inTables.toArray()),
         Arrays.toString(outTables.toArray()),
         Arrays.toString(columnLineage.toArray()),


### PR DESCRIPTION
Java SQL parser interface had only linux-x64 and MacOS universal binary variants. This PR adds linux-arm version of native library.