### PR TITLE
airflow fix: Disable plugin if OPENLINEAGE_URL is missing

### DIFF
--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -12,8 +12,9 @@ from airflow.version import version as AIRFLOW_VERSION
 
 
 def _is_disabled():
-    return os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]
-
+    return "OPENLINEAGE_URL" not in os.getenv or os.getenv(
+        "OPENLINEAGE_DISABLED", None
+    ) in [True, "true", "True"]
 
 if parse_version(AIRFLOW_VERSION) \
         < parse_version("2.3.0.dev0") or _is_disabled():      # type: ignore

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -104,7 +104,8 @@ class OpenLineageBackend(LineageBackend):
         if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
             return
         # Make this method a noop if OPENLINEAGE_DISABLED is set to true
-        if os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:
+        # or OPENEDLINEAGE_URL is not set
+        if "OPENLINEAGE_URL" not in os.getenv or os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:
             return
         if not cls.backend:
             cls.backend = Backend()


### PR DESCRIPTION
### Problem

Airflow task runs can be impacted by the OL plugin, even if `OPENLINEAGE_URL` is not set. It is particularly frustrating if a user has OL installed but not configured.

### Solution

It seems reasonable to disable the OL plugin if the url isn't set.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project