### PR TITLE
fix one node plans with LogicalRelation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     *Collect column lineage from Spark logical plans that contain cached datasets.*
 * Collect complete event for really quick Spark jobs. [`#1650`](https://github.com/OpenLineage/OpenLineage/pull/1650) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
     *Improve collecting OpenLineage events on SQL complete in case of quick operations.*
+* Spark: fix input/outputs for one node `LogicalRelation` plans.[`#1668`](https://github.com/OpenLineage/OpenLineage/pull/1668) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *For simple queries like "select * from my_db.my_table" that do not write output, Spark plan contained just a single node,
+  which was wrongly treated as both input and output dataset.*
 
 ## [0.20.6](https://github.com/OpenLineage/OpenLineage/compare/0.20.4...0.20.6) - 2023-2-10
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
@@ -1,0 +1,85 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import scala.collection.immutable.HashMap;
+
+@ExtendWith(SparkAgentTestExtension.class)
+public class LogicalRelationBuilderTest {
+
+  StructType structTypeSchema =
+      new StructType(
+          new StructField[] {
+            new StructField("a", IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+            new StructField("b", IntegerType$.MODULE$, false, new Metadata(new HashMap<>()))
+          });
+
+  @Test
+  void logicalRelationOnlyPlanHasNoOutput(SparkSession spark)
+      throws InterruptedException, TimeoutException {
+    spark
+        .createDataFrame(Arrays.asList(new GenericRow(new Object[] {1, 2})), structTypeSchema)
+        .write()
+        .saveAsTable("temp");
+    spark.sql("select * from temp").collect();
+
+    // wait for event processing to complete
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
+        ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(1))
+        .emit(lineageEvent.capture());
+    List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
+
+    assertThat(events.get(events.size() - 1).getOutputs()).isEmpty();
+  }
+
+  @Test
+  void logicalRelationPlanHasInputAndOutput(SparkSession spark)
+      throws InterruptedException, TimeoutException {
+    spark
+        .createDataFrame(Arrays.asList(new GenericRow(new Object[] {1, 2})), structTypeSchema)
+        .write()
+        .saveAsTable("temp");
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    spark.sql("select * from temp").write().saveAsTable("output_table");
+
+    StaticExecutionContextFactory.waitForExecutionEnd();
+
+    ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
+        ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(1))
+        .emit(lineageEvent.capture());
+    List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
+
+    assertThat(events.get(events.size() - 1).getInputs().get(0).getName()).endsWith("temp");
+    assertThat(events.get(events.size() - 1).getOutputs()).hasSize(1);
+
+    // verify only output table is contained within outputs
+    assertThat(events.get(events.size() - 1).getOutputs().get(0).getName())
+        .endsWith("output_table");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -43,7 +43,7 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
   private final UnknownEntryFacetListener unknownEntryFacetListener =
       UnknownEntryFacetListener.getInstance();
 
-  private final boolean searchDependencies;
+  protected final boolean searchDependencies;
 
   public AbstractQueryPlanDatasetBuilder(OpenLineageContext context, boolean searchDependencies) {
     this.context = context;


### PR DESCRIPTION
### Problem

Queries `select * from my_db.my_table` result in a SparkPlan with a single tree node being `LogicalRelation`. Dataset Builder treats the same node as input and output relation. 

Closes: #1653

### Solution

 * Write test reproducing it,
 * Fix it.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project