### PR TITLE
ci: fix ruff version

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -311,7 +311,7 @@ jobs:
       - *checkout_project_root
       - attach_workspace:
           at: .
-      - run: pip install tox==3.27.1 ruff
+      - run: pip install tox==3.27.1
       - run: tox
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
@@ -457,7 +457,7 @@ jobs:
     <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: pip install ruff
+      - run: pip install ruff==0.0.250
       - run: ruff . --no-update-check
       - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "ruff",
+        "ruff==0.0.250",
         "requests",
         "pyyaml",
         "mypy>=0.9.6",

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -24,7 +24,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "ruff",
+        "ruff==0.0.250",
         "SQLAlchemy",       # must be set to 1.3.* for airflow tests compatibility
         "Flask-SQLAlchemy",  # must be set to 2.4.* for airflow tests compatibility
         "pandas-gbq==0.14.1",       # must be set to 0.14.* for airflow tests compatibility

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "ruff",
+        "ruff==0.0.250",
         "pandas",
         "jinja2",
         "python-dateutil",

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -26,7 +26,7 @@ extras_require = {
     "tests": [
         "pytest",
         "pytest-cov",
-        "ruff",
+        "ruff==0.0.250",
         "mypy>=0.9.6",
         "sqlalchemy<2.0.0"
     ],

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -23,7 +23,7 @@ extras_require = {
         "pytest",
         "pytest-cov",
         "mock",
-        "ruff"
+        "ruff==0.0.250"
         "mypy>=0.9.6",
         "python-dateutil"
     ],


### PR DESCRIPTION
New ruff version adds checks that aren't in older brew version, so it's hard to fix them easily.