### PR TITLE
ci: fix broken release

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -145,6 +145,8 @@ jobs:
           keys:
             - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
             - v1-release-client-java-{{ .Branch }}
+      - attach_workspace:
+          at: ~/.m2/repository/io/openlineage/
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
@@ -826,6 +828,7 @@ workflows:
           context: release
           requires:
             - release-client-java
+            - build-integration-sql-java
       - release-integration-sql-java:
           filters:
             tags:
@@ -834,7 +837,9 @@ workflows:
               ignore: /.*/
           context: release
           requires:
-            - build-integration-sql-java
+            - compile-integration-sql-java-linux-x86
+            - compile-integration-sql-java-linux-arm
+            - compile-integration-sql-java-macos
       - release-integration-flink:
           filters:
             tags:

--- a/integration/sql/iface-java/script/build.sh
+++ b/integration/sql/iface-java/script/build.sh
@@ -32,7 +32,7 @@ $ROOT/gradlew clean getDependencies
 ./$SCRIPTS/generate_jni_header.sh
 
 # Install to maven
-$ROOT/gradlew --info -x javadoc publishToMavenLocal
+$ROOT/gradlew --info -x javadoc -x sign publishToMavenLocal
 
 # Package into jar
 $ROOT/gradlew shadowJar


### PR DESCRIPTION
1. There was needless `publishToMavenLocal` in java-sql build that made gradle try to sign artifact, as it's configured to do on non-`-SNAPSHOT` builds.
2. Spark release now is linked to java parser.