### PR TITLE
Make OPENLINEAGE_DISABLED case insensitive

### DIFF
--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -28,7 +28,7 @@ class DefaultTransportFactory(TransportFactory):
         self.transports[type] = clazz
 
     def create(self) -> Transport:
-        if os.environ.get("OPENLINEAGE_DISABLED", False) in [True, "true", "True"]:
+        if os.getenv("OPENLINEAGE_DISABLED", "").lower() == "true":
             return NoopTransport(NoopConfig())
 
         if 'yaml' in sys.modules:

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -12,7 +12,7 @@ from airflow.version import version as AIRFLOW_VERSION
 
 
 def _is_disabled():
-    return os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]
+    return os.getenv("OPENLINEAGE_DISABLED", "").lower() == "true"
 
 
 if parse_version(AIRFLOW_VERSION) \

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -104,7 +104,7 @@ class OpenLineageBackend(LineageBackend):
         if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
             return
         # Make this method a noop if OPENLINEAGE_DISABLED is set to true
-        if os.getenv("OPENLINEAGE_DISABLED", None) in [True, 'true', "True"]:
+        if os.getenv("OPENLINEAGE_DISABLED", "").lower() == "true":
             return
         if not cls.backend:
             cls.backend = Backend()


### PR DESCRIPTION
### Problem

It can be surprising that OPENLINEAGE_DISABLED is case sensitive.

Closes: #1704

### Solution

In the python client and Airflow plugin, check OPENLINEAGE_DISABLED in a case insensitive way.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project