### PR TITLE
spark: remove url parameters for jdbc namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.21.1...HEAD)
 
+### Changed
+* **Spark: remove url parameters for jdbc namespaces** [`#1708`](https://github.com/OpenLineage/OpenLineage/pull/1708) by [@tnazarew](https://github.com/tnazarew)    
+  *Make namespace value from event conform to naming convention specified in* [Naming.md](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md)
+
+
 ## [0.21.1](https://github.com/OpenLineage/OpenLineage/compare/0.20.6...0.21.1) - 2023-3-2
 ### Added
 * **Clients: add `DEBUG` logging of events to transports** [`#1633`](https://github.com/OpenLineage/OpenLineage/pull/1633) by [@mobuchowski](https://github.com/mobuchowski)  

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -24,6 +24,7 @@ public class JdbcUtils {
   public static String sanitizeJdbcUrl(String jdbcUrl) {
     String jdbcUrlCroppedPrefix = jdbcUrl.substring(5);
     return jdbcUrlCroppedPrefix
+        .replaceFirst("^jdbc:", "")
         .replaceFirst("^postgresql:", "postgres:")
         .replaceAll(PlanUtils.SLASH_DELIMITER_USER_PASSWORD_REGEX, "@")
         .replaceAll(PlanUtils.COLON_DELIMITER_USER_PASSWORD_REGEX, "$1")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -26,7 +26,8 @@ public class JdbcUtils {
     return jdbcUrlCroppedPrefix
         .replaceAll(PlanUtils.SLASH_DELIMITER_USER_PASSWORD_REGEX, "@")
         .replaceAll(PlanUtils.COLON_DELIMITER_USER_PASSWORD_REGEX, "$1")
-        .replaceAll("(?<=[?,;&:)=])\\(?(?i)(?:user|username|password)=[^;&,)]+(?:[;&;)]|$)", "");
+        .replaceAll("(?<=[?,;&:)=])\\(?(?i)(?:user|username|password)=[^;&,)]+(?:[;&;)]|$)", "")
+        .replaceAll("\\?.+$", "");
   }
 
   public static Optional<SqlMeta> extractQueryFromSpark(JDBCRelation relation) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -24,6 +24,7 @@ public class JdbcUtils {
   public static String sanitizeJdbcUrl(String jdbcUrl) {
     String jdbcUrlCroppedPrefix = jdbcUrl.substring(5);
     return jdbcUrlCroppedPrefix
+        .replaceFirst("^postgresql:", "postgres:")
         .replaceAll(PlanUtils.SLASH_DELIMITER_USER_PASSWORD_REGEX, "@")
         .replaceAll(PlanUtils.COLON_DELIMITER_USER_PASSWORD_REGEX, "$1")
         .replaceAll("(?<=[?,;&:)=])\\(?(?i)(?:user|username|password)=[^;&,)]+(?:[;&;)]|$)", "")

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.postgresql.Driver;
 import scala.Option;
@@ -69,10 +68,10 @@ class LogicalRelationDatasetBuilderTest {
 
   @ParameterizedTest
   @CsvSource({
-          "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432/sparkdata",
-          "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata",
-          "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl",
-          "jdbc:mysql://localhost/sparkdata,mysql://localhost/sparkdata"
+    "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432/sparkdata",
+    "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata",
+    "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl",
+    "jdbc:mysql://localhost/sparkdata,mysql://localhost/sparkdata"
   })
   void testApply(String connectionUri, String targetUri) {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -43,6 +43,7 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.postgresql.Driver;
@@ -67,16 +68,14 @@ class LogicalRelationDatasetBuilderTest {
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {
-        "postgresql://postgreshost:5432/sparkdata",
-        "jdbc:oracle:oci8:@sparkdata",
-        "jdbc:oracle:thin@sparkdata:1521:orcl",
-        "mysql://localhost/sparkdata"
-      })
-  void testApply(String connectionUri) {
+  @CsvSource({
+          "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432/sparkdata",
+          "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata",
+          "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl",
+          "jdbc:mysql://localhost/sparkdata,mysql://localhost/sparkdata"
+  })
+  void testApply(String connectionUri, String targetUri) {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
-    String jdbcUrl = "jdbc:" + connectionUri;
     String sparkTableName = "my_spark_table";
     JDBCRelation relation =
         new JDBCRelation(
@@ -84,7 +83,7 @@ class LogicalRelationDatasetBuilderTest {
                 new StructField[] {new StructField("name", StringType$.MODULE$, false, null)}),
             new Partition[] {},
             new JDBCOptions(
-                jdbcUrl,
+                connectionUri,
                 sparkTableName,
                 Map$.MODULE$
                     .<String, String>newBuilder()
@@ -124,10 +123,10 @@ class LogicalRelationDatasetBuilderTest {
         visitor.apply(new SparkListenerJobStart(1, 1, Seq$.MODULE$.empty(), null));
     assertEquals(1, datasets.size());
     OutputDataset ds = datasets.get(0);
-    assertEquals(connectionUri, ds.getNamespace());
+    assertEquals(targetUri, ds.getNamespace());
     assertEquals(sparkTableName, ds.getName());
-    assertEquals(URI.create(connectionUri), ds.getFacets().getDataSource().getUri());
-    assertEquals(connectionUri, ds.getFacets().getDataSource().getName());
+    assertEquals(URI.create(targetUri), ds.getFacets().getDataSource().getUri());
+    assertEquals(targetUri, ds.getFacets().getDataSource().getName());
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -57,14 +57,14 @@ class PlanUtilsTest {
             "db2://[2001:DB8:0:0:8:800:200C:417A]:5021/test:"),
         Arguments.of(
             "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
-            "postgresql://localhost/test"),
+            "postgres://localhost/test"),
         Arguments.of(
             "jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true",
-            "postgresql://localhost:5432/test"),
+            "postgres://localhost:5432/test"),
         Arguments.of(
             "jdbc:postgresql://192.168.1.1:5432/test?user=fred&password=secret&ssl=true",
-            "postgresql://192.168.1.1:5432/test"),
-        Arguments.of("jdbc:postgresql://192.168.1.1:5432", "postgresql://192.168.1.1:5432"),
+            "postgres://192.168.1.1:5432/test"),
+        Arguments.of("jdbc:postgresql://192.168.1.1:5432", "postgres://192.168.1.1:5432"),
         Arguments.of(
             "jdbc:oracle:thin:us%2Ar/p%40%24%24w0rd@some.host:1521:orcl",
             "oracle:thin:@some.host:1521:orcl"),

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -56,21 +56,21 @@ class PlanUtilsTest {
             "jdbc:db2://[2001:DB8:0:0:8:800:200C:417A]:5021/test:user=dba%20adm;password=db%40dm;",
             "db2://[2001:DB8:0:0:8:800:200C:417A]:5021/test:"),
         Arguments.of(
-            "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
-            "postgresql://localhost/test?ssl=true"),
+            "jdbc:postgresql://localhost/test",
+            "postgresql://localhost/test"),
         Arguments.of(
-            "jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true",
-            "postgresql://localhost:5432/test?ssl=true"),
+            "jdbc:postgresql://localhost:5432/test",
+            "postgresql://localhost:5432/test"),
         Arguments.of(
-            "jdbc:postgresql://192.168.1.1:5432/test?user=fred&password=secret&ssl=true",
-            "postgresql://192.168.1.1:5432/test?ssl=true"),
+            "jdbc:postgresql://192.168.1.1:5432/test",
+            "postgresql://192.168.1.1:5432/test"),
         Arguments.of("jdbc:postgresql://192.168.1.1:5432", "postgresql://192.168.1.1:5432"),
         Arguments.of(
             "jdbc:oracle:thin:us%2Ar/p%40%24%24w0rd@some.host:1521:orcl",
             "oracle:thin:@some.host:1521:orcl"),
         Arguments.of(
-            "jdbc:oracle:thin:@10.253.102.122:1521:dg01?key=value",
-            "oracle:thin:@10.253.102.122:1521:dg01?key=value"),
+            "jdbc:oracle:thin:@10.253.102.122:1521:dg01",
+            "oracle:thin:@10.253.102.122:1521:dg01"),
         Arguments.of(
             "jdbc:oracle:thin:user/password@some.host:1521:orcl",
             "oracle:thin:@some.host:1521:orcl"),
@@ -88,8 +88,8 @@ class PlanUtilsTest {
             "jdbc:oracle:thin:@//localhost:1521/serviceName",
             "oracle:thin:@//localhost:1521/serviceName"),
         Arguments.of(
-            "jdbc:oracle:thin:@dbname_high?TNS_ADMIN=/Users/test/wallet_dbname",
-            "oracle:thin:@dbname_high?TNS_ADMIN=/Users/test/wallet_dbname"),
+            "jdbc:oracle:thin:@dbname_high",
+            "oracle:thin:@dbname_high"),
         Arguments.of(
             "jdbc:mysql://10.253.102.122:1521/dbname;key=value",
             "mysql://10.253.102.122:1521/dbname;key=value"),
@@ -100,8 +100,8 @@ class PlanUtilsTest {
         Arguments.of(
             "jdbc:mysql://username:pwd@host.name.com/dbname", "mysql://host.name.com/dbname"),
         Arguments.of(
-            "jdbc:mysql://username:pwd@host.name.com/dbname?key=value;key2=value2",
-            "mysql://host.name.com/dbname?key=value;key2=value2"),
+            "jdbc:mysql://username:pwd@host.name.com/dbname",
+            "mysql://host.name.com/dbname"),
         Arguments.of(
             "jdbc:mysql://username:pwd@myhost1:1111,username:pwd@myhost2:2222/db",
             "mysql://myhost1:1111,myhost2:2222/db"),

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -56,20 +56,20 @@ class PlanUtilsTest {
             "jdbc:db2://[2001:DB8:0:0:8:800:200C:417A]:5021/test:user=dba%20adm;password=db%40dm;",
             "db2://[2001:DB8:0:0:8:800:200C:417A]:5021/test:"),
         Arguments.of(
-            "jdbc:postgresql://localhost/test",
+            "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
             "postgresql://localhost/test"),
         Arguments.of(
-            "jdbc:postgresql://localhost:5432/test",
+            "jdbc:postgresql://localhost:5432/test?user=fred&password=secret&ssl=true",
             "postgresql://localhost:5432/test"),
         Arguments.of(
-            "jdbc:postgresql://192.168.1.1:5432/test",
+            "jdbc:postgresql://192.168.1.1:5432/test?user=fred&password=secret&ssl=true",
             "postgresql://192.168.1.1:5432/test"),
         Arguments.of("jdbc:postgresql://192.168.1.1:5432", "postgresql://192.168.1.1:5432"),
         Arguments.of(
             "jdbc:oracle:thin:us%2Ar/p%40%24%24w0rd@some.host:1521:orcl",
             "oracle:thin:@some.host:1521:orcl"),
         Arguments.of(
-            "jdbc:oracle:thin:@10.253.102.122:1521:dg01",
+            "jdbc:oracle:thin:@10.253.102.122:1521:dg01?key=value",
             "oracle:thin:@10.253.102.122:1521:dg01"),
         Arguments.of(
             "jdbc:oracle:thin:user/password@some.host:1521:orcl",
@@ -88,7 +88,7 @@ class PlanUtilsTest {
             "jdbc:oracle:thin:@//localhost:1521/serviceName",
             "oracle:thin:@//localhost:1521/serviceName"),
         Arguments.of(
-            "jdbc:oracle:thin:@dbname_high",
+            "jdbc:oracle:thin:@dbname_high?TNS_ADMIN=/Users/test/wallet_dbname",
             "oracle:thin:@dbname_high"),
         Arguments.of(
             "jdbc:mysql://10.253.102.122:1521/dbname;key=value",
@@ -100,7 +100,7 @@ class PlanUtilsTest {
         Arguments.of(
             "jdbc:mysql://username:pwd@host.name.com/dbname", "mysql://host.name.com/dbname"),
         Arguments.of(
-            "jdbc:mysql://username:pwd@host.name.com/dbname",
+            "jdbc:mysql://username:pwd@host.name.com/dbname?key=value;key2=value2",
             "mysql://host.name.com/dbname"),
         Arguments.of(
             "jdbc:mysql://username:pwd@myhost1:1111,username:pwd@myhost2:2222/db",

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -39,6 +39,6 @@ class JdbcHandlerTest {
             new HashMap<>());
 
     assertEquals("database.schema.table", datasetIdentifier.getName());
-    assertEquals("postgresql://postgreshost:5432", datasetIdentifier.getNamespace());
+    assertEquals("postgres://postgreshost:5432", datasetIdentifier.getNamespace());
   }
 }


### PR DESCRIPTION
### Problem

currently we use `url` as namespace for jdbc connection, it can cause failure when url contains parametes

Closes: #1699 

### Solution

add removing parameters from url before assigning its value to namespace

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project