### PR TITLE
Throw UnsupportedDbtCommand when finding unsupported entry in `args.which`.

### DIFF
--- a/integration/common/openlineage/common/provider/dbt.py
+++ b/integration/common/openlineage/common/provider/dbt.py
@@ -53,6 +53,8 @@ class SparkConnectionMethod(Enum):
     def methods():
         return [x.value for x in SparkConnectionMethod]
 
+class UnsupportedDbtCommand(Exception):
+    pass
 
 class SkipUndefined(Undefined):
     def __getattr__(self, name):
@@ -245,7 +247,7 @@ class DbtArtifactProcessor:
         context = DbtRunContext(manifest, run_result, catalog)
 
         if self.command not in ['run', 'build', 'test', 'seed']:
-            raise ValueError(
+            raise UnsupportedDbtCommand(
                 f"Not recognized run command "
                 f"{self.command} - should be run, test, seed or build"
             )

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -4,19 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import subprocess
 import sys
 import time
-import os
 import uuid
+from datetime import datetime, timezone
 from typing import Optional
 
-from tqdm import tqdm
-from datetime import datetime, timezone
-
-from openlineage.client.run import RunEvent, RunState, Run, Job
 from openlineage.client.client import OpenLineageClient
-from openlineage.common.provider.dbt import DbtArtifactProcessor, ParentRunMetadata
+from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.common.provider.dbt import (
+    DbtArtifactProcessor,
+    ParentRunMetadata,
+    UnsupportedDbtCommand,
+)
+from tqdm import tqdm
 
 __version__ = "0.22.0"
 
@@ -72,6 +75,20 @@ def dbt_run_event_end(
         parent=parent_run_metadata
     )
 
+def dbt_run_event_failed(
+    run_id: str,
+    job_namespace: str,
+    job_name: str,
+    parent_run_metadata: Optional[ParentRunMetadata]
+) -> RunEvent:
+    return dbt_run_event(
+        state=RunState.FAIL,
+        job_namespace=job_namespace,
+        job_name=job_name,
+        run_id=run_id,
+        parent=parent_run_metadata
+    )
+
 
 logger = logging.getLogger("dbtol")
 logger.setLevel("INFO")
@@ -80,9 +97,9 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 
 def main():
     logger.info(f"Running OpenLineage dbt wrapper version {__version__}")
-    logger.info(f"This wrapper will send OpenLineage events at the end of dbt execution.")
+    logger.info("This wrapper will send OpenLineage events at the end of dbt execution.")
 
-    args = sys.argv[2:]
+    args = sys.argv[1:]
     target = parse_single_arg(args, ['-t', '--target'])
     project_dir = parse_single_arg(args, ['--project-dir'], default='./')
     profile_name = parse_single_arg(args, ['--profile'])
@@ -143,10 +160,7 @@ def main():
         stdout=sys.stdout,
         stderr=sys.stderr
     )
-    process.wait()
-
-    if len(sys.argv) < 2 or sys.argv[1] not in ['run', 'test', 'build', 'seed']:
-        return
+    return_code = process.wait()
 
     # If run_result has modification time before dbt command
     # or does not exist, do not emit dbt events.
@@ -160,17 +174,30 @@ def main():
                     f"did not find run_result file ({processor.run_result_path})")
         return
 
-    events = processor.parse().events()
+    try:
+        events = processor.parse().events()
+    except UnsupportedDbtCommand as e:
+        # log exception message
+        logger.info(e)
+        events = []
 
-    end_event = dbt_run_event_end(
-        run_id=dbt_run_metadata.run_id,
-        job_namespace=dbt_run_metadata.job_namespace,
-        job_name=dbt_run_metadata.job_name,
-        parent_run_metadata=parent_run_metadata
-    )
+    if return_code == 0:
+        last_event = dbt_run_event_end(
+            run_id=dbt_run_metadata.run_id,
+            job_namespace=dbt_run_metadata.job_namespace,
+            job_name=dbt_run_metadata.job_name,
+            parent_run_metadata=parent_run_metadata
+        )
+    else:
+        last_event = dbt_run_event_failed(
+            run_id=dbt_run_metadata.run_id,
+            job_namespace=dbt_run_metadata.job_namespace,
+            job_name=dbt_run_metadata.job_name,
+            parent_run_metadata=parent_run_metadata
+        )
 
     for event in tqdm(
-        events + [end_event],
+        events + [last_event],
         desc="Emitting OpenLineage events",
         initial=1,
         total=len(events) + 2,


### PR DESCRIPTION

Adjust `dbt-ol` script to scan all arguments and rely on `UnsupportedDbtCommand` exception.

### Problem

DBT integration checks for actual DBT command in two ways - by scanning `sys.argv[2:]` and from `run_results.json` file. First is more difficult to handle different combinations of parameter positions.

Closes: #1716 

### Solution

This PR changes detecting DBT command only to read from `run_results.json`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project