### PR TITLE
common/sql: Provide public interface for openlineage_sql package.

### DIFF
--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 def parse(
     sql: Union[List[str], str],
     dialect: Optional[str] = None,
-    default_schema: Optional[str] = None
+    default_schema: Optional[str] = None,
 ) -> Optional[SqlMeta]:
     if isinstance(sql, str):
         sql = [sql]

--- a/integration/sql/iface-py/openlineage_sql.pyi
+++ b/integration/sql/iface-py/openlineage_sql.pyi
@@ -1,0 +1,62 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Definition of the public interface for openlineage_sql
+"""
+
+class DbTableMeta:
+    """
+    Represents a table in a database.
+    """
+
+    qualified_name: str
+    database: str | None
+    schema: str | None
+    name: str
+    def __init__(self, name: str) -> None: ...
+
+class ColumnMeta:
+    """
+    Represents a table in a database.
+    """
+
+    origin: DbTableMeta | None
+    name: str
+    def __init__(self, name: str, origin: DbTableMeta | None) -> None: ...
+
+class ColumnLineage:
+    """
+    Represents column lineage.
+    """
+
+    descendant: ColumnMeta
+    lineage: list[ColumnMeta]
+    def __init__(self, descendant: ColumnMeta, lineage: list[ColumnMeta]) -> None: ...
+
+class ExtractionError:
+    """
+    Represents an error during parsing of a SQL statement.
+    """
+
+    index: int
+    message: str
+    origin_statement: str
+
+class SqlMeta:
+    """
+    Contains metadata about a SQL statement:
+        - in & out table metadata
+        - column lineage metadata
+        - potential parsing errors
+    """
+
+    in_tables: list[DbTableMeta]
+    out_tables: list[DbTableMeta]
+    column_lineage: list[ColumnLineage]
+    errors: list[ExtractionError]
+
+def parse(
+    sql: list[str], dialect: str | None = None, default_schema: str | None = None
+) -> SqlMeta: ...
+def provider() -> str: ...


### PR DESCRIPTION
### Problem

`openlineage_sql` has no typing hints.

### Solution

Provide `.pyi` public interface file. More information [here](https://pyo3.rs/v0.17.3/python_typing_hints.html)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project