### PR TITLE
python: create client from dictionary.

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -77,3 +77,7 @@ class OpenLineageClient:
     @classmethod
     def from_environment(cls):
         return cls(transport=get_default_factory().create())
+
+    @classmethod
+    def from_dict(cls, config: dict):
+        return cls(transport=get_default_factory().create(config=config))

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Dict, Optional
 from urllib.parse import urljoin
 
@@ -29,7 +30,14 @@ class TokenProvider:
 
 class ApiKeyTokenProvider(TokenProvider):
     def __init__(self, config: Dict):
-        self.api_key = config['api_key']
+        try:
+            self.api_key = config["api_key"]
+            warnings.warn(
+                "'api_key' option is deprecated, please use 'apiKey'",
+                DeprecationWarning,
+            )
+        except KeyError:
+            self.api_key = config["apiKey"]
 
     def get_bearer(self) -> Optional[str]:
         return f"Bearer {self.api_key}"

--- a/client/python/tests/config/http.yml
+++ b/client/python/tests/config/http.yml
@@ -1,0 +1,7 @@
+transport:
+  type: http
+  url: http://localhost:5050
+  endpoint: api/v1/lineage
+  auth:
+    type: api_key
+    apiKey: random_token

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -79,6 +79,29 @@ def test_factory_registers_transports_from_yaml_config():
     transport = factory.create()
     assert isinstance(transport, FakeTransport)
 
+@patch.dict(os.environ, {"OPENLINEAGE_CONFIG": "tests/config/http.yml"})
+def test_factory_configures_http_transport_from_yaml_config():
+    factory = get_default_factory()
+    transport = factory.create()
+    assert isinstance(transport, HttpTransport)
+
+
+def test_factory_registers_from_dict():
+    factory = DefaultTransportFactory()
+    factory.register_transport(
+        "fake",
+        clazz="tests.transport.FakeTransport"
+    )
+    factory.register_transport(
+        "accumulating",
+        clazz="tests.transport.AccumulatingTransport"
+    )
+    config = {
+        "type": "accumulating"
+    }
+    transport = factory.create(config=config)
+    assert isinstance(transport, AccumulatingTransport)
+
 
 def test_automatically_registers_http_kafka():
     factory = get_default_factory()


### PR DESCRIPTION
Deprecate `api_key` in transport options.

### Problem

OpenLineage Python client does not allow creating it from dictionary. Only environment variables / YAML file is accepted.

### Solution

Add `from_dict` classmethod.

This PR also unifies `api_key` in http YAML config into `apiKey` which is consistent with Java-related configs. `api_key` now warns about deprecation of this option.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project