### PR TITLE
CI: Add commit ID to BIGQUERY_PREFIX environment variable.

### DIFF
--- a/integration/airflow/scripts/run-dev-airflow.sh
+++ b/integration/airflow/scripts/run-dev-airflow.sh
@@ -55,6 +55,13 @@ function compose_up() {
   export DBT_DATASET_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")_dbt
   export DAGS_ARE_PAUSED_AT_CREATION=True
 
+  # Add commit ID to the BIGQUERY_PREFIX variable
+  # to avoid concurrent table update issue
+  COMMIT_ID=$(git rev-parse HEAD 2>/dev/null)
+  if [[ -n "${COMMIT_ID}" ]]; then
+    BIGQUERY_PREFIX="${BIGQUERY_PREFIX}_${COMMIT_ID}"
+  fi
+
   if [[ "$(id -u)" == "0" ]]; then
     set_write_permissions
     export AIRFLOW_UID=50000

--- a/integration/airflow/tests/integration/docker/up.sh
+++ b/integration/airflow/tests/integration/docker/up.sh
@@ -37,6 +37,13 @@ export DBT_DATASET_PREFIX=$(echo "$AIRFLOW_VERSION" | tr "-" "_" | tr "." "_")_d
 # just a hack to have same docker-compose for dev and CI env
 export PWD='.'
 
+# Add commit ID to the BIGQUERY_PREFIX variable
+# to avoid concurrent table update issue
+COMMIT_ID=$(git rev-parse HEAD 2>/dev/null)
+if [[ -n "${COMMIT_ID}" ]]; then
+  BIGQUERY_PREFIX="${BIGQUERY_PREFIX}_${COMMIT_ID}"
+fi
+
 # Bring down any existing containers and volumes
 docker-compose -f tests/docker-compose.yml down -v
 


### PR DESCRIPTION
### Problem

If two CI workflows ran at the same time BigQuery integration test DAG, it caused in some rare cases concurrent update to the same table. That is not allowed in BigQuery and caused failures in integration tests.

### Solution

Add commit ID to `BIGQUERY_PREFIX`.

#### One-line summary:

CI: add commit ID to BIGQUERY_PREFIX environment variable.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project