### PR TITLE
Airflow: Remove explicit `pass` from several `extract_on_complete` methods.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
@@ -40,6 +40,3 @@ class GCSToGCSExtractor(BaseExtractor):
             inputs=input_objects,
             outputs=[output_object],
         )
-
-    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        pass

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -31,9 +31,6 @@ class GreatExpectationsExtractorImpl(BaseExtractor):
     def extract(self) -> Optional[TaskMetadata]:
         return None
 
-    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        return None
-
 
 if _has_great_expectations:
     GreatExpectationsExtractor = GreatExpectationsExtractorImpl

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -41,9 +41,6 @@ class S3CopyObjectExtractor(BaseExtractor):
             outputs=[output_object],
         )
 
-    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        pass
-
 
 class S3FileTransformExtractor(BaseExtractor):
     @classmethod

--- a/integration/airflow/tests/integration/requests/gcs.json
+++ b/integration/airflow/tests/integration/requests/gcs.json
@@ -21,12 +21,22 @@
     }
 },{
     "eventType" : "COMPLETE",
-    "inputs" : [],
+    "inputs" : [
+        {
+            "name" : "{{ env_var('GOOGLE_CLOUD_STORAGE_SOURCE_URI') }}",
+            "namespace" : "{{ env_var('GOOGLE_CLOUD_STORAGE_SOURCE_URI') | url_scheme_authority }}"
+        }
+    ],
     "job" : {
         "facets": {},
         "name" : "gcs_dag.gcs_task"
     },
-    "outputs" : [],
+    "outputs" : [
+        {
+            "name" : "{{ env_var('GOOGLE_CLOUD_STORAGE_DESTINATION_URI') }}",
+            "namespace" : "{{ env_var('GOOGLE_CLOUD_STORAGE_DESTINATION_URI') | url_scheme_authority }}"
+        }
+    ],
     "run" : {
         "facets" : {}
     }

--- a/integration/airflow/tests/integration/requests/s3copy.json
+++ b/integration/airflow/tests/integration/requests/s3copy.json
@@ -21,12 +21,22 @@
     }
 },{
     "eventType": "COMPLETE",
-    "inputs": [],
+    "inputs": [
+        {
+            "name": "testfile",
+            "namespace": "s3://testbucket"
+        }
+    ],
     "job": {
         "facets": {},
         "name": "s3copy_dag.s3copy_task"
     },
-    "outputs": [],
+    "outputs": [
+        {
+            "name": "testfile2",
+            "namespace": "s3://testbucket"
+        }
+    ],
     "run": {
         "facets": {}
     }


### PR DESCRIPTION
### Problem

Possibly closes: #1726 

### Solution

Remove explicit `pass` from 3 extractors' `extract_on_complete` methods.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project