### PR TITLE
CI: remove codecov from tox required packages.

### DIFF
--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -37,7 +37,6 @@ install_command = python -m pip install {opts} --find-links target/wheels/ \
 deps = -r dev-requirements.txt
 	pytest
 	mypy>=0.9.6
-	codecov>=1.4.0
 	airflow-2.1.4: apache-airflow==2.1.4
 	airflow-2.2.4: apache-airflow==2.2.4
 	airflow-2.3.4: apache-airflow==2.3.4


### PR DESCRIPTION
### Problem

codecov couldn't be found in pypi while running tox tests. That is related to this [announcement](https://about.codecov.io/blog/message-regarding-the-pypi-package/). The package was not needed anyway, `pytest-cov` is used instead.

### Solution

Remove `codecov` from `setup.cfg` in Airflow integration.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project