### PR TITLE
[SPARK] fix null pointer in JobMetricsHolder

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
@@ -33,16 +33,25 @@ public class JobMetricsHolder {
   JobMetricsHolder() {}
 
   public void addJobStages(int jobId, Set<Integer> stages) {
-    jobStages.put(jobId, stages);
+    if (stages != null) {
+      jobStages.put(jobId, stages);
+    }
   }
 
   public void addMetrics(int stage, TaskMetrics taskMetrics) {
-    stageMetrics.put(stage, taskMetrics);
+    if (taskMetrics != null) {
+      stageMetrics.put(stage, taskMetrics);
+    }
   }
 
   public Map<Metric, Number> pollMetrics(int jobId) {
     return Optional.ofNullable(jobStages.remove(jobId))
-        .map(stages -> stages.stream().map(stageMetrics::remove).collect(Collectors.toList()))
+        .map(
+            stages ->
+                stages.stream()
+                    .map(stageMetrics::remove)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()))
         .filter(l -> !l.isEmpty())
         .map(this::mapOutputMetrics)
         .orElse(Collections.emptyMap());

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -92,6 +92,23 @@ class JobMetricsHolderTest {
     assertThat(jobMetrics).isEmpty();
   }
 
+  @Test
+  void testAddMetricsWhenNull() {
+    JobMetricsHolder underTest = new JobMetricsHolder();
+    underTest.addMetrics(1, null);
+    underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
+
+    assertThat(underTest.pollMetrics(0)).isEmpty();
+  }
+
+  @Test
+  void testAddJobStagesWhenNull() {
+    JobMetricsHolder underTest = new JobMetricsHolder();
+    underTest.addJobStages(0, null);
+
+    assertThat(underTest.pollMetrics(0)).isEmpty();
+  }
+
   private TaskMetrics outputTaskMetrics(int bytes, int records) {
     TaskMetrics taskMetrics = new TaskMetrics();
     taskMetrics.outputMetrics()._bytesWritten().add(bytes);


### PR DESCRIPTION
### Problem

According to [docs](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ConcurrentHashMap.html#put(K,%20V)),
Java's `ConcurrentHashMap` throws NPE when value put is `null` which is happening `JobMetricsHolder`. 

Closes: #1784

### Solution

Add null check before running `put`. Write a unit test to verify the behaviour is correct. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project