### PR TITLE
[SPARK] LogicalPlanSerializer

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -259,7 +259,11 @@ shadowJar {
     relocate 'org.apache.commons.beanutils', 'io.openlineage.spark.shaded.org.apache.commons.beanutils'
     relocate 'org.apache.http', 'io.openlineage.spark.shaded.org.apache.http'
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
-    relocate 'com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson'
+    relocate('com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson') {
+        exclude 'com.fasterxml.jackson.annotation.JsonIgnore'
+        exclude 'com.fasterxml.jackson.annotation.JsonIgnoreProperties'
+        exclude 'com.fasterxml.jackson.annotation.JsonIgnoreType'
+    }
     manifest {
         attributes(
                 'Created-By': "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -5,61 +5,117 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.ClassIntrospector;
-import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.databind.introspect.ClassIntrospector.MixInResolver;
 import com.google.common.collect.ImmutableMap;
-import java.util.List;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Map;
-import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.MethodUtils;
 import org.apache.spark.Partition;
 import org.apache.spark.api.python.PythonRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.SQLExecutionRDD;
-import org.apache.spark.sql.sources.BaseRelation;
-import scala.PartialFunction;
-import scala.runtime.AbstractPartialFunction;
 
 /**
  * {@link LogicalPlan} serializer which serialize {@link LogicalPlan} to JSON string. This
  * serializer relies on Jackson's {@link com.fasterxml.jackson.module.scala.DefaultScalaModule},
- * which is scala-version specific. Currently, we depend on the Scala 2.11 version of the jar,
- * making this code incompatible with Spark 3 or other other Spark installations compiled with Scala
- * 2.12 or higher. In such cases, we'll fail to load the Jackson module, but will continue to
- * attempt serialization of the {@link LogicalPlan}. If serialization fails, the exception message
- * and stacktrace will be reported.
+ * which is scala-version specific. That is why we need to use Jackson library available within
+ * Spark and not shaded one included within openlineage-java. This poses some limitations as logical
+ * plan serialization relies on mixIns and annotations, however annotations class are relocated and
+ * cannot be replaced with dynamic proxy classes. The major limitation of this approach is that we
+ * cannot use JsonTypeInfo annotation to enrich jsons with class names within the plan.
  */
 @Slf4j
 class LogicalPlanSerializer {
   private static final int MAX_SERIALIZED_PLAN_LENGTH =
       50000; // 50K UTF-8 chars should be ~200KB + some extra bytes added during json encoding
-  private final ObjectMapper mapper;
+  private final Object objectMapper;
+
+  /** relocate plugin rewrites by default all occurences of com.fasterxml.jackson */
+  private static final String UNSHADED_JACKSON_PACKAGE = "com.".trim() + "fasterxml.jackson";
 
   public LogicalPlanSerializer() {
-    mapper = new ObjectMapper();
-    try {
-      mapper.registerModule(
-          (Module)
-              Class.forName("com.fasterxml.jackson.module.scala.DefaultScalaModule$")
-                  .getDeclaredField("MODULE$")
-                  .get(null));
-    } catch (Exception t) {
-      log.warn("Can't register jackson scala module for serializing LogicalPlan");
-    }
+    // we need to use non-relocated Spark's ObjectMapper to serialize logical plan
+    objectMapper = getObjectMapper();
 
-    mapper.setMixInResolver(new LogicalPlanMixinResolver());
+    try {
+      /**
+       * We want to use LogicalPlanMixinResolver to add some extra Jackson annotations on how a plan
+       * should be serialized. This can be achieved by running: `objectMapper.setMixInResolver(new
+       * LogicalPlanMixinResolver)` However, this won't work as we want to use non-shaded original
+       * ObjectMapper and LogicalPlanMixinResolver available in this class will be relocated to
+       * other package. The issue can be solved by creating dynamic proxy class which will implement
+       * non-shaded MixInResolver and its methods will call shaded LogicalPlanMixinResolver methods.
+       * This allows merging together non-shaded and shaded Jackson classes.
+       */
+      Class clazz =
+          Class.forName(
+              UNSHADED_JACKSON_PACKAGE + ".databind.introspect.ClassIntrospector$MixInResolver");
+
+      Object resolver =
+          Proxy.newProxyInstance(
+              clazz.getClassLoader(),
+              new Class[] {clazz},
+              new InvocationHandler() {
+                LogicalPlanMixinResolver resolver = new LogicalPlanMixinResolver();
+
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                  return MethodUtils.invokeMethod(resolver, method.getName(), args);
+                }
+              });
+
+      MethodUtils.invokeMethod(
+          objectMapper,
+          "registerModule",
+          Class.forName(UNSHADED_JACKSON_PACKAGE + ".module.scala.DefaultScalaModule$")
+              .getDeclaredField("MODULE$")
+              .get(null));
+
+      MethodUtils.invokeMethod(objectMapper, "setMixInResolver", resolver);
+    } catch (Exception | Error t) {
+      log.warn("Can't register jackson scala module for serializing LogicalPlan", t);
+    }
+  }
+
+  private Object getObjectMapper() {
+    try {
+      return Class.forName(UNSHADED_JACKSON_PACKAGE + ".databind.ObjectMapper")
+          .getConstructor()
+          .newInstance();
+    } catch (Exception e) {
+      log.warn("Couldn't instantiate ObjectMapper", e);
+
+      // didn't work. Let's get shaded one
+      return new ObjectMapper();
+    }
+  }
+
+  private String writeValueAsString(LogicalPlan x) {
+    try {
+      return (String) MethodUtils.invokeMethod(objectMapper, "writeValueAsString", x);
+    } catch (Exception e) {
+      log.warn("Unable to writeValueAsString", e);
+      return "";
+    }
+  }
+
+  private String writeValueAsString(String x) {
+    try {
+      return (String) MethodUtils.invokeMethod(objectMapper, "writeValueAsString", x);
+    } catch (Exception e) {
+      log.warn("Unable to writeValueAsString", e);
+      return "";
+    }
   }
 
   /**
@@ -69,37 +125,22 @@ class LogicalPlanSerializer {
    * @return
    */
   public String serialize(LogicalPlan x) {
-    try {
-      String serializedPlan = mapper.writeValueAsString(x);
-      if (serializedPlan.length() > MAX_SERIALIZED_PLAN_LENGTH) {
-        // entry is too long, we slice a substring it and send as String field
-        serializedPlan =
-            mapper.writeValueAsString(serializedPlan.substring(0, MAX_SERIALIZED_PLAN_LENGTH));
-      }
-      return serializedPlan;
-    } catch (Exception e) {
-      try {
-        return mapper.writeValueAsString(
-            "Unable to serialize logical plan due to: " + e.getMessage());
-      } catch (JsonProcessingException ex) {
-        return "\"Unable to serialize error message\"";
-      }
+    String serializedPlan = writeValueAsString(x);
+    if (serializedPlan.length() > MAX_SERIALIZED_PLAN_LENGTH) {
+      // entry is too long, we slice a substring it and send as String field
+      serializedPlan = writeValueAsString(serializedPlan.substring(0, MAX_SERIALIZED_PLAN_LENGTH));
     }
+    return serializedPlan;
   }
 
   @JsonIgnoreType
   public static class IgnoredType {}
-
-  @JsonTypeInfo(use = Id.CLASS)
-  @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
-  public static class TypeInfoMixin {}
 
   /**
    * 'canonicalized' field is ignored due to recursive call and {@link StackOverflowError} 'child'
    * and 'containsChild' fields ignored cause we don't need them for the root node in {@link
    * LogicalPlan} and leaf nodes don't have child nodes in {@link LogicalPlan}
    */
-  @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
   @JsonIgnoreProperties({
     "child",
     "containsChild",
@@ -114,15 +155,12 @@ class LogicalPlanSerializer {
   @JsonIgnoreProperties({"sqlConfigs", "sqlConfExecutorSide"})
   public static class SqlConfigMixin {}
 
-  @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
   public static class PythonRDDMixin {
     @SuppressWarnings("PMD")
     @JsonIgnore
     private PythonRDDMixin asJavaRDD;
   }
 
-  @JsonTypeInfo(use = Id.CLASS)
-  @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
   public static class RDDMixin {
     @SuppressWarnings("PMD")
     @JsonIgnore
@@ -139,27 +177,7 @@ class LogicalPlanSerializer {
     }
   }
 
-  static class PolymorficMixIn extends AbstractPartialFunction<Class, Class> {
-    private Class target;
-    private Class mixin;
-
-    public PolymorficMixIn(Class target, Class mixin) {
-      this.target = target;
-      this.mixin = mixin;
-    }
-
-    @Override
-    public boolean isDefinedAt(Class x) {
-      return target.isAssignableFrom(x);
-    }
-
-    @Override
-    public Class apply(Class clazz) {
-      return mixin;
-    }
-  }
-
-  static class LogicalPlanMixinResolver implements ClassIntrospector.MixInResolver {
+  static class LogicalPlanMixinResolver implements MixInResolver {
     private static Map<Class, Class> concreteMixin;
 
     static {
@@ -170,30 +188,20 @@ class LogicalPlanSerializer {
               .put(RDD.class, RDDMixin.class)
               .put(SQLExecutionRDD.class, SqlConfigMixin.class)
               .put(FunctionRegistry.class, IgnoredType.class);
+
       try {
-        Class<?> c = PolymorficMixIn.class.getClassLoader().loadClass("java.lang.Module");
+        Class<?> c = ChildMixIn.class.getClassLoader().loadClass("java.lang.Module");
         builder.put(c, IgnoredType.class);
       } catch (Exception e) {
         // ignore
       }
+
       concreteMixin = builder.build();
     }
 
-    private static List<PartialFunction<Class, Class>> polymorficMixIn =
-        ImmutableList.of(
-            new PolymorficMixIn(LogicalPlan.class, TypeInfoMixin.class),
-            new PolymorficMixIn(BaseRelation.class, TypeInfoMixin.class));
-
     @Override
     public Class<?> findMixInClassFor(Class<?> cls) {
-      Supplier<Class> defaultMixin =
-          () ->
-              polymorficMixIn.stream()
-                  .filter(fun -> fun.isDefinedAt(cls))
-                  .findFirst()
-                  .map(f -> f.apply(cls))
-                  .orElse(ChildMixIn.class);
-      return concreteMixin.getOrDefault(cls, defaultMixin.get());
+      return concreteMixin.getOrDefault(cls, ChildMixIn.class);
     }
 
     @Override

--- a/integration/spark/shared/src/test/resources/test_data/serde/aggregate-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/aggregate-node.json
@@ -1,5 +1,4 @@
 {
-  "@class": "org.apache.spark.sql.catalyst.plans.logical.Aggregate",
   "groupingExpressions": [],
   "aggregateExpressions": [],
   "allAttributes": {

--- a/integration/spark/shared/src/test/resources/test_data/serde/bigqueryrelation-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/bigqueryrelation-node.json
@@ -1,7 +1,5 @@
 {
-  "@class":"org.apache.spark.sql.execution.datasources.LogicalRelation",
   "relation":{
-    "@class":"com.google.cloud.spark.bigquery.BigQueryRelation",
     "tableId": {
       "dataset":"dataset",
       "table":"test"

--- a/integration/spark/shared/src/test/resources/test_data/serde/hadoopfsrelation-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/hadoopfsrelation-node.json
@@ -1,7 +1,5 @@
 {
-  "@class": "org.apache.spark.sql.execution.datasources.LogicalRelation",
   "relation": {
-    "@class": "org.apache.spark.sql.execution.datasources.HadoopFsRelation",
     "location": {
       "table": {
         "identifier": {

--- a/integration/spark/shared/src/test/resources/test_data/serde/insertintods-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/insertintods-node.json
@@ -1,10 +1,6 @@
 {
-  "@class":"org.apache.spark.sql.execution.datasources.InsertIntoDataSourceCommand",
   "logicalRelation":{
-    "@class":"org.apache.spark.sql.execution.datasources.LogicalRelation",
     "relation":{
-      "@class":"com.google.cloud.spark.bigquery.BigQueryRelation",
-      "id": 3,
       "tableName": "dataset.test",
       "tableId": {
           "dataset":"dataset",

--- a/integration/spark/shared/src/test/resources/test_data/serde/insertintofs-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/insertintofs-node.json
@@ -1,5 +1,4 @@
 {
-  "@class": "org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand",
   "outputPath": {
     "root": false,
     "uriPathAbsolute": true,
@@ -35,9 +34,7 @@
   "fileFormat": {},
   "options": {},
   "query": {
-    "@class": "org.apache.spark.sql.execution.datasources.LogicalRelation",
     "relation": {
-      "@class": "org.apache.spark.sql.execution.datasources.HadoopFsRelation",
       "location": {
         "table": {
           "identifier": {

--- a/integration/spark/shared/src/test/resources/test_data/serde/logicalrelation-node.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/logicalrelation-node.json
@@ -1,7 +1,5 @@
 {
-  "@class": "org.apache.spark.sql.execution.datasources.LogicalRelation",
   "relation": {
-    "@class": "org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation",
     "parts": [],
     "jdbcOptions": {
       "asProperties": {


### PR DESCRIPTION
### Problem

`LogicalPlanSerializer` does not serialize `LogicalPlans`

Closes: #1714

### Solution

Almost a year ago we decided to shade Jackson dependency introduced with openlineage-client, however it does not contain `ScalaModule` which is necessary to serialize Scala objects. We could not include it, as this has to be set per Scala version within Spark runtime. As a result `LogicalPlan` has to serialised by a Jackson attached to Spark application. As a solution, `LogicalPlanSerializer` makes use of reflection and dynamic proxy classes to make use of the non-shaded Jackson classes. This allows creating proper `ObjectMapper` and implementing required `MixedIn`s. However, this is not sufficient for `@JSON...` annotations, which get relocated during shading.

After the fix, behaviour of the feature will be slightly different that before it got broken a long time ago: class names won't be serialised and I could not find a way to fix it. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project