### PR TITLE
[SPARK] modify dataset path with regex

### DIFF
--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -92,15 +92,16 @@ The following parameters can be specified in the Spark configuration:
 Parameters configuring the Spark integration
 
 
-| Parameter                                | Definition                                                                                                                                          | Example                             |
-------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------
-| spark.openlineage.transport.type         | The transport type used for event emit, default type is `console`                                                                                   | http                                |
-| spark.openlineage.namespace              | The default namespace to be applied for any jobs submitted                                                                                          | MyNamespace                         |
-| spark.openlineage.parentJobName          | The job name to be used for the parent job facet                                                                                                    | ParentJobName                       |
-| spark.openlineage.parentRunId            | The RunId of the parent job that initiated this Spark job                                                                                           | xxxx-xxxx-xxxx-xxxx                 |
-| spark.openlineage.appName                | Custom value overwriting Spark app name in events                                                                                                   | AppName                             |
-| spark.openlineage.facets.disabled        | List of facets to disable, enclosed in `[]` (required from 0.21.x) and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`) | \[spark_unknown;spark.logicalPlan\] |
-| spark.openlineage.capturedProperties     | comma separated list of properties to be captured in spark properties facet (default `spark.master`, `spark.app.name`)                              | "spark.example1,spark.example2"     |
+| Parameter                                    | Definition                                                                                                                                                                          | Example                         |
+----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------
+| spark.openlineage.transport.type             | The transport type used for event emit, default type is `console`                                                                                                                   | http                            |
+| spark.openlineage.namespace                  | The default namespace to be applied for any jobs submitted                                                                                                                          | MyNamespace                     |
+| spark.openlineage.parentJobName              | The job name to be used for the parent job facet                                                                                                                                    | ParentJobName                   |
+| spark.openlineage.parentRunId                | The RunId of the parent job that initiated this Spark job                                                                                                                           | xxxx-xxxx-xxxx-xxxx             |
+| spark.openlineage.appName                    | Custom value overwriting Spark app name in events                                                                                                                                   | AppName                         |
+| spark.openlineage.facets.disabled            | List of facets to disable, enclosed in `[]` (required from 0.21.x) and separated by `;`, default is `[spark_unknown;]` (currently must contain `;`)                                 | \[spark_unknown;spark.logicalPlan\] |
+| spark.openlineage.capturedProperties         | comma separated list of properties to be captured in spark properties facet (default `spark.master`, `spark.app.name`)                                                              | "spark.example1,spark.example2" |
+| spark.openlineage.dataset.removePath.pattern | Java regular expression that removes `?<remove>` named group from dataset path. Can be used to last path subdirectories from paths like `s3://my-whatever-path/year=2023/month=04` | `(.*)(?<remove>\/.*\/.*)`     |
 
 
 ### HTTP

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -69,19 +69,12 @@ public class DeltaHandler implements CatalogHandler {
     }
 
     // Delta uses spark2 catalog when location isn't specified.
-
-    String a = catalog.loadTable(identifier).properties().get("location");
-    String b =
-        location.orElse(
-            Optional.ofNullable(catalog.loadTable(identifier).properties().get("location"))
-                .orElse("dupa"));
     Path path =
         new Path(
             location.orElseGet(
                 () ->
                     Optional.ofNullable(catalog.loadTable(identifier).properties().get("location"))
                         .orElseGet(() -> getDefaultTablePath(session, identifier))));
-    log.info(path.toString());
     DatasetIdentifier di = PathUtils.fromPath(path, "file");
     return di.withSymlink(
         identifier.toString(),


### PR DESCRIPTION
### Problem

It is a common use case to write Spark output datasets with a path like:
```
s3://my-whatever-path/year=2023/month=04/day=24
```
while we would like to have the dataset identified as `s3://my-whatever-path`. 

Closes: #1794

### Solution

Spark configuration parameter `spark.openlineage.dataset.removePath.pattern ` is introduced.
It contains Java regular expression that removes `?<remove>` named group from dataset path. 
This can be used to last path subdirectories from paths like `s3://my-whatever-path/year=2023/month=04` with a pattern ``(.*)(?<remove>\/.*\/.*)``

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project