### PR TITLE
Spark/fix input dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.23.0...HEAD)
 
+### Added
+* **Spark: support dataset name modification using regex** [`#1796`](https://github.com/OpenLineage/OpenLineage/pull/1796) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+    * It is a common scenario to write Spark output datasets with a location path ending with `/year=2023/month=04`. The introduced Spark parameter `spark.openlineage.dataset.removePath.pattern` allows removing certain elements from a path by a regex pattern provided.
+
+### Fixed
+* **Spark: catch exception when trying to obtain details of non-existing table.** [`#1798`](https://github.com/OpenLineage/OpenLineage/pull/1798) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+    * This mostly happens when getting table details on START event while the table is still not created. 
+
 ## [0.23.0](https://github.com/OpenLineage/OpenLineage/compare/0.22.0...0.23.0) - 2023-4-20
 ### Added
 * **SQL: parser improvements to support: `copy into`, `create stage`, `pivot`** [`#1742`](https://github.com/OpenLineage/OpenLineage/pull/1742) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/spark/app/integrations/container/pysparkDeltaCTASStart.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaCTASStart.json
@@ -1,0 +1,9 @@
+{
+  "eventType": "START",
+  "inputs": [],
+  "job": {
+    "name": "delta_integration_test.atomic_create_table_as_select",
+    "namespace": "delta-namespace"
+  },
+  "run": {}
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
@@ -131,6 +131,7 @@ public class SparkDeltaIntegrationTest {
     dataset.createOrReplaceTempView("temp");
     spark.sql("CREATE TABLE tbl USING delta LOCATION '/tmp/delta/tbl' AS SELECT * FROM temp");
 
+    verifyEvents(mockServer, "pysparkDeltaCTASStart.json");
     verifyEvents(mockServer, "pysparkDeltaCTASComplete.json");
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -79,6 +80,12 @@ public class PlanUtils3 {
     } catch (UnsupportedCatalogException ex) {
       log.error(String.format("Catalog %s is unsupported", ex.getMessage()), ex);
       return Optional.empty();
+    } catch (Exception e) {
+      if (e instanceof NoSuchTableException) {
+        // probably trying to obtain table details on START event while table does not exist
+        return Optional.empty();
+      }
+      throw e;
     }
   }
 


### PR DESCRIPTION
### Problem

Spark integration is trying to include output dataset's details on START event. This may lead to errors in case of creating tables as the table does not exist on `START`. This did not break lineage mechanics, although caused the following entry in logs: 

```
org.apache.spark.sql.catalyst.analysis.NoSuchTableException: Table or view 'tbl' not found in database 'default'
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.requireTableExists(SessionCatalog.scala:226)
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableRawMetadata(SessionCatalog.scala:514)
	at org.apache.spark.sql.catalyst.catalog.SessionCatalog.getTableMetadata(SessionCatalog.scala:500)
	at org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog.loadTable(V2SessionCatalog.scala:66)
	at org.apache.spark.sql.connector.catalog.DelegatingCatalogExtension.loadTable(DelegatingCatalogExtension.java:66)
	at org.apache.spark.sql.delta.catalog.DeltaCatalog.loadTable(DeltaCatalog.scala:169)
	at io.openlineage.spark3.agent.lifecycle.plan.catalog.DeltaHandler.getDatasetIdentifier(DeltaHandler.java:73)
	at io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3.lambda$getDatasetIdentifier$2(CatalogUtils3.java:65)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findAny(ReferencePipeline.java:536)
	at io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3.getDatasetIdentifier(CatalogUtils3.java:67)
	at io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3.getDatasetIdentifier(CatalogUtils3.java:48)
	at io.openlineage.spark3.agent.utils.PlanUtils3.getDatasetIdentifier(PlanUtils3.java:78)
	at io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder.apply(CreateReplaceDatasetBuilder.java:143)
	at io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder.lambda$apply$1(CreateReplaceDatasetBuilder.java:86)
	at java.util.Optional.map(Optional.java:215)
```

Potentially, this was related to #1747 

### Solution

Catch `NoSuchTableException` and prevent an error with a stack trace being printed.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project