### PR TITLE
draft: generating Python client models from OL spec

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -67,7 +67,7 @@ jobs:
   build-client-java:
     working_directory: ~/openlineage/client/java
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - *checkout_project_root
       - restore_cache:

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -19,6 +19,12 @@ plugins {
     id "pmd"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 pmd {
     consoleOutput = true
     toolVersion = "6.46.0"

--- a/client/java/generator/build.gradle
+++ b/client/java/generator/build.gradle
@@ -9,6 +9,8 @@
 plugins {
     // Apply the Java Gradle plugin development plugin to add support for developing Gradle plugins
     id 'java'
+    id("io.freefair.lombok") version "8.0.1"
+    id 'com.diffplug.spotless' version '6.13.0'
 }
 
 repositories {
@@ -24,3 +26,18 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
 }
 
+spotless {
+    def disallowWildcardImports = {
+        String text = it
+        def regex = ~/import .*\.\*;/
+        def m = regex.matcher(text)
+        if (m.find()) {
+            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
+        }
+    }
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+        custom 'disallowWildcardImports', disallowWildcardImports
+    }
+}

--- a/client/java/generator/build.gradle
+++ b/client/java/generator/build.gradle
@@ -13,6 +13,12 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -163,7 +163,7 @@ public class Generator {
       }
 
       try (PrintWriter printWriter = new PrintWriter(pythonOutput)) {
-        new PythonGenerator(typeResolver, containerToID).generate(printWriter);
+        new PythonGenerator(typeResolver, new HashMap<>()).generate(printWriter);
       }
 
     } catch (RuntimeException e) {

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -12,18 +12,6 @@ import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URI;
-import java.net.URL;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -41,7 +29,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-
 import com.squareup.javapoet.TypeVariableName;
 import io.openlineage.client.TypeResolver.ArrayResolvedType;
 import io.openlineage.client.TypeResolver.ObjectResolvedType;
@@ -49,11 +36,19 @@ import io.openlineage.client.TypeResolver.PrimitiveResolvedType;
 import io.openlineage.client.TypeResolver.ResolvedField;
 import io.openlineage.client.TypeResolver.ResolvedType;
 import io.openlineage.client.TypeResolver.ResolvedTypeVisitor;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URL;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
-
-/**
- * Generates a JavaClass with all the types as inner classes
- */
+/** Generates a JavaClass with all the types as inner classes */
 public class JavaPoetGenerator {
 
   private final TypeResolver typeResolver;
@@ -63,7 +58,12 @@ public class JavaPoetGenerator {
   private final boolean server;
   private final String containerClass;
 
-  public JavaPoetGenerator(TypeResolver typeResolver, String containerPackage, String containerClassName, boolean server, Map<String, URL> containerToID) {
+  public JavaPoetGenerator(
+      TypeResolver typeResolver,
+      String containerPackage,
+      String containerClassName,
+      boolean server,
+      Map<String, URL> containerToID) {
     this.typeResolver = typeResolver;
     this.containerPackage = containerPackage;
     this.containerClassName = containerClassName;
@@ -77,25 +77,26 @@ public class JavaPoetGenerator {
 
   public void generate(PrintWriter printWriter) throws IOException {
 
-    TypeSpec.Builder containerTypeBuilder = TypeSpec.classBuilder(containerClassName)
-        .addModifiers(PUBLIC, FINAL);
+    TypeSpec.Builder containerTypeBuilder =
+        TypeSpec.classBuilder(containerClassName).addModifiers(PUBLIC, FINAL);
 
     if (!server) {
-      containerTypeBuilder.addField(FieldSpec.builder(ClassName.get(URI.class), "producer", PRIVATE, FINAL).build());
-      containerTypeBuilder.addMethod(MethodSpec.constructorBuilder()
-          .addModifiers(PUBLIC)
-          .addParameter(
-              ParameterSpec.builder(ClassName.get(URI.class), "producer").build()
-              )
-          .addCode("this.producer = producer;\n")
-          .build());
+      containerTypeBuilder.addField(
+          FieldSpec.builder(ClassName.get(URI.class), "producer", PRIVATE, FINAL).build());
+      containerTypeBuilder.addMethod(
+          MethodSpec.constructorBuilder()
+              .addModifiers(PUBLIC)
+              .addParameter(ParameterSpec.builder(ClassName.get(URI.class), "producer").build())
+              .addCode("this.producer = producer;\n")
+              .build());
     }
 
-    TypeSpec.Builder builderInterfaceBuilder = TypeSpec.interfaceBuilder("Builder")
+    TypeSpec.Builder builderInterfaceBuilder =
+        TypeSpec.interfaceBuilder("Builder")
             .addModifiers(STATIC, PUBLIC)
             .addTypeVariable(TypeVariableName.get("T"));
-    builderInterfaceBuilder.addMethod(MethodSpec
-            .methodBuilder("build")
+    builderInterfaceBuilder.addMethod(
+        MethodSpec.methodBuilder("build")
             .addJavadoc("@return the constructed type")
             .returns(TypeVariableName.get("T"))
             .addModifiers(PUBLIC, ABSTRACT)
@@ -106,8 +107,7 @@ public class JavaPoetGenerator {
     generateTypes(containerTypeBuilder);
     TypeSpec openLineage = containerTypeBuilder.build();
 
-    JavaFile javaFile = JavaFile.builder(containerPackage, openLineage)
-        .build();
+    JavaFile javaFile = JavaFile.builder(containerPackage, openLineage).build();
 
     javaFile.writeTo(printWriter);
   }
@@ -132,13 +132,14 @@ public class JavaPoetGenerator {
 
         containerTypeBuilder.addType(modelClassSpec);
 
-        if (! server) {
+        if (!server) {
           containerTypeBuilder.addMethod(factoryModelMethodUnderContainer(type));
-          containerTypeBuilder.addMethod(MethodSpec.methodBuilder("new" + type.getName() + "Builder")
-              .addModifiers(PUBLIC)
-              .returns(ClassName.get(containerClass, type.getName() + "Builder"))
-              .addCode("return new $N();", type.getName() + "Builder")
-              .build());
+          containerTypeBuilder.addMethod(
+              MethodSpec.methodBuilder("new" + type.getName() + "Builder")
+                  .addModifiers(PUBLIC)
+                  .returns(ClassName.get(containerClass, type.getName() + "Builder"))
+                  .addCode("return new $N();", type.getName() + "Builder")
+                  .build());
           containerTypeBuilder.addType(builderClassSpec);
         }
       }
@@ -160,50 +161,58 @@ public class JavaPoetGenerator {
         String schemaURL = containerToID.get(type.getContainer()) + "#/$defs/" + type.getName();
         constructor.addCode("this.$N = URI.create($S);\n", f.getName(), schemaURL);
       } else {
-        constructor.addJavadoc("@param $N $N\n", f.getName(), f.getDescription() == null ? "the " + f.getName() : f.getDescription());
+        constructor.addJavadoc(
+            "@param $N $N\n",
+            f.getName(),
+            f.getDescription() == null ? "the " + f.getName() : f.getDescription());
         constructor.addParameter(
             ParameterSpec.builder(getTypeName(f.getType()), f.getName())
-                .addAnnotation(AnnotationSpec.builder(JsonProperty.class).addMember("value", "$S", f.getName()).build())
+                .addAnnotation(
+                    AnnotationSpec.builder(JsonProperty.class)
+                        .addMember("value", "$S", f.getName())
+                        .build())
                 .build());
         constructor.addCode("this.$N = $N;\n", f.getName(), f.getName());
       }
     }
     if (type.hasAdditionalProperties()) {
-      constructor.addCode(CodeBlock.builder().addStatement("this.$N = new $T<>()", "additionalProperties", LinkedHashMap.class).build());
+      constructor.addCode(
+          CodeBlock.builder()
+              .addStatement("this.$N = new $T<>()", "additionalProperties", LinkedHashMap.class)
+              .build());
     }
     return constructor.build();
   }
 
   private TypeSpec modelClass(ObjectResolvedType type) {
-    TypeSpec.Builder modelClassBuilder = TypeSpec.classBuilder(type.getName())
-        .addModifiers(STATIC, PUBLIC);
+    TypeSpec.Builder modelClassBuilder =
+        TypeSpec.classBuilder(type.getName()).addModifiers(STATIC, PUBLIC);
     if (!server) {
-      modelClassBuilder.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-          .addMember("as", CodeBlock.of(type.getName() + ".class"))
-          .build());
+      modelClassBuilder.addAnnotation(
+          AnnotationSpec.builder(JsonDeserialize.class)
+              .addMember("as", CodeBlock.of(type.getName() + ".class"))
+              .build());
     }
     for (ObjectResolvedType parent : type.getParents()) {
-      modelClassBuilder.addSuperinterface(ClassName.get(containerPackage, parent.getContainer(), parent.getName()));
+      modelClassBuilder.addSuperinterface(
+          ClassName.get(containerPackage, parent.getContainer(), parent.getName()));
     }
-    //adds possibility to extend CustomFacet
+    // adds possibility to extend CustomFacet
     if (!type.getName().equals("CustomFacet")) {
       modelClassBuilder.addModifiers(FINAL);
     }
 
-    com.squareup.javapoet.AnnotationSpec.Builder jsonPropertyOrder = AnnotationSpec.builder(JsonPropertyOrder.class);
+    com.squareup.javapoet.AnnotationSpec.Builder jsonPropertyOrder =
+        AnnotationSpec.builder(JsonPropertyOrder.class);
     for (ResolvedField f : type.getProperties()) {
       if (f.getType() instanceof TypeResolver.EnumResolvedType) {
-        modelClassBuilder.addType(enumClass((TypeResolver.EnumResolvedType)f.getType()));
+        modelClassBuilder.addType(enumClass((TypeResolver.EnumResolvedType) f.getType()));
       }
 
       modelClassBuilder.addField(getTypeName(f.getType()), f.getName(), PRIVATE, FINAL);
-      Builder getterBuilder = getter(f)
-          .addModifiers(PUBLIC)
-          .addCode("return $N;", f.getName());
+      Builder getterBuilder = getter(f).addModifiers(PUBLIC).addCode("return $N;", f.getName());
 
-      type
-          .getParents()
-          .stream()
+      type.getParents().stream()
           .flatMap(t -> t.getProperties().stream())
           .filter(t -> t.getName().equals(f.getName()))
           .findAny()
@@ -211,31 +220,33 @@ public class JavaPoetGenerator {
       modelClassBuilder.addMethod(getterBuilder.build());
 
       jsonPropertyOrder.addMember("value", "$S", f.getName());
-
     }
 
     if (type.hasAdditionalProperties()) {
       String fieldName = "additionalProperties";
-      TypeName additionalPropertiesValueType = type.getAdditionalPropertiesType() == null ? ClassName.get(Object.class) : getTypeName(type.getAdditionalPropertiesType());
-      TypeName additionalPropertiesType = ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
-      MethodSpec.Builder methodBuilder = MethodSpec
-          .methodBuilder("get" + titleCase(fieldName))
-          .addJavadoc("@return additional properties")
-          .returns(additionalPropertiesType)
-          .addModifiers(PUBLIC)
-          .addCode("return $N;", fieldName)
-          .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build());
-      type
-          .getParents()
-          .stream()
+      TypeName additionalPropertiesValueType =
+          type.getAdditionalPropertiesType() == null
+              ? ClassName.get(Object.class)
+              : getTypeName(type.getAdditionalPropertiesType());
+      TypeName additionalPropertiesType =
+          ParameterizedTypeName.get(
+              ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
+      MethodSpec.Builder methodBuilder =
+          MethodSpec.methodBuilder("get" + titleCase(fieldName))
+              .addJavadoc("@return additional properties")
+              .returns(additionalPropertiesType)
+              .addModifiers(PUBLIC)
+              .addCode("return $N;", fieldName)
+              .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build());
+      type.getParents().stream()
           .findAny()
           .ifPresent(rf -> methodBuilder.addAnnotation(Override.class));
       modelClassBuilder.addMethod(methodBuilder.build());
 
-      modelClassBuilder.addMethod(MethodSpec
-        .methodBuilder("with" + titleCase(fieldName))
-        .addJavadoc("Get object with additional properties")
-        .build());
+      modelClassBuilder.addMethod(
+          MethodSpec.methodBuilder("with" + titleCase(fieldName))
+              .addJavadoc("Get object with additional properties")
+              .build());
       modelClassBuilder.addField(
           FieldSpec.builder(additionalPropertiesType, fieldName, PRIVATE, FINAL)
               .addAnnotation(JsonAnySetter.class)
@@ -248,61 +259,74 @@ public class JavaPoetGenerator {
   }
 
   private TypeSpec enumClass(TypeResolver.EnumResolvedType type) {
-    TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(type.getName())
-        .addModifiers(PUBLIC);
+    TypeSpec.Builder enumBuilder = TypeSpec.enumBuilder(type.getName()).addModifiers(PUBLIC);
     type.getValues().forEach(v -> enumBuilder.addEnumConstant(v));
     return enumBuilder.build();
   }
 
   private TypeSpec builderClass(ObjectResolvedType type) {
-    TypeSpec.Builder builderClassBuilder = TypeSpec.classBuilder(type.getName() + "Builder")
-        .addModifiers(PUBLIC, FINAL)
-        .addSuperinterface(ParameterizedTypeName.get(ClassName.get(containerPackage, containerClassName, "Builder"),
-                getTypeName(type)));
+    TypeSpec.Builder builderClassBuilder =
+        TypeSpec.classBuilder(type.getName() + "Builder")
+            .addModifiers(PUBLIC, FINAL)
+            .addSuperinterface(
+                ParameterizedTypeName.get(
+                    ClassName.get(containerPackage, containerClassName, "Builder"),
+                    getTypeName(type)));
 
-    boolean producerFiledExist = type.getProperties().stream()
-        .anyMatch(this::isAProducerField);
+    boolean producerFiledExist = type.getProperties().stream().anyMatch(this::isAProducerField);
     if (!producerFiledExist) builderClassBuilder.addModifiers(STATIC);
 
-    type.getProperties().stream().filter(f -> !isASchemaUrlField(f)).forEach(f -> {
-      if (!(isAProducerField(f))) {
-        builderClassBuilder.addField(getTypeName(f.getType()), f.getName(), PRIVATE);
-        builderClassBuilder.addMethod(
-            MethodSpec
-                .methodBuilder(f.getName())
-                .addParameter(getTypeName(f.getType()), f.getName())
-                .addJavadoc("@param $N $N\n", f.getName(), f.getDescription() == null ? "the " + f.getName() : f.getDescription())
-                .addModifiers(PUBLIC)
-                .returns(ClassName.get(containerPackage, containerClassName, type.getName() + "Builder"))
-                .addJavadoc("@return this\n")
-                .addCode("this.$N = $N;\n", f.getName(), f.getName())
-                .addCode("return this;")
-                .build());
-      }
-    });
+    type.getProperties().stream()
+        .filter(f -> !isASchemaUrlField(f))
+        .forEach(
+            f -> {
+              if (!(isAProducerField(f))) {
+                builderClassBuilder.addField(getTypeName(f.getType()), f.getName(), PRIVATE);
+                builderClassBuilder.addMethod(
+                    MethodSpec.methodBuilder(f.getName())
+                        .addParameter(getTypeName(f.getType()), f.getName())
+                        .addJavadoc(
+                            "@param $N $N\n",
+                            f.getName(),
+                            f.getDescription() == null ? "the " + f.getName() : f.getDescription())
+                        .addModifiers(PUBLIC)
+                        .returns(
+                            ClassName.get(
+                                containerPackage, containerClassName, type.getName() + "Builder"))
+                        .addJavadoc("@return this\n")
+                        .addCode("this.$N = $N;\n", f.getName(), f.getName())
+                        .addCode("return this;")
+                        .build());
+              }
+            });
     if (type.hasAdditionalProperties()) {
       String fieldName = "additionalProperties";
-      TypeName additionalPropertiesValueType = type.getAdditionalPropertiesType() == null ? ClassName.get(Object.class) : getTypeName(type.getAdditionalPropertiesType());
-      TypeName additionalPropertiesType = ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
-
+      TypeName additionalPropertiesValueType =
+          type.getAdditionalPropertiesType() == null
+              ? ClassName.get(Object.class)
+              : getTypeName(type.getAdditionalPropertiesType());
+      TypeName additionalPropertiesType =
+          ParameterizedTypeName.get(
+              ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
 
       builderClassBuilder.addField(
           FieldSpec.builder(additionalPropertiesType, fieldName, PRIVATE, FINAL)
               .initializer("new $T<>()", LinkedHashMap.class)
               .build());
-      builderClassBuilder.addMethod(MethodSpec
-          .methodBuilder("put")
-          .addJavadoc("add additional properties\n")
-          .addModifiers(PUBLIC)
-          .returns(ClassName.get(containerPackage, containerClassName, type.getName() + "Builder"))
-          .addParameter(TypeName.get(String.class), "key")
-          .addJavadoc("@param key the additional property name\n")
-          .addParameter(additionalPropertiesValueType, "value")
-          .addJavadoc("@param value the additional property value\n")
-          .addCode("this.$N.put(key, value);", fieldName)
-          .addCode("return this;", fieldName)
-          .addJavadoc("@return this\n")
-          .build());
+      builderClassBuilder.addMethod(
+          MethodSpec.methodBuilder("put")
+              .addJavadoc("add additional properties\n")
+              .addModifiers(PUBLIC)
+              .returns(
+                  ClassName.get(containerPackage, containerClassName, type.getName() + "Builder"))
+              .addParameter(TypeName.get(String.class), "key")
+              .addJavadoc("@param key the additional property name\n")
+              .addParameter(additionalPropertiesValueType, "value")
+              .addJavadoc("@param value the additional property value\n")
+              .addCode("this.$N.put(key, value);", fieldName)
+              .addCode("return this;", fieldName)
+              .addJavadoc("@return this\n")
+              .build());
     }
 
     Builder build = builderBuildMethod(type);
@@ -312,22 +336,25 @@ public class JavaPoetGenerator {
 
   private Builder builderBuildMethod(ObjectResolvedType type) {
     List<CodeBlock> builderParams = new ArrayList<>();
-    type.getProperties().stream().filter(f -> !isASchemaUrlField(f)).forEach(f -> {
-      if (isAProducerField(f)) {
-        builderParams.add(CodeBlock.of(containerClassName + ".this.producer"));
-      } else {
-        builderParams.add(CodeBlock.of("$N", f.getName()));
-      }
-    });
+    type.getProperties().stream()
+        .filter(f -> !isASchemaUrlField(f))
+        .forEach(
+            f -> {
+              if (isAProducerField(f)) {
+                builderParams.add(CodeBlock.of(containerClassName + ".this.producer"));
+              } else {
+                builderParams.add(CodeBlock.of("$N", f.getName()));
+              }
+            });
 
-    Builder build = MethodSpec
-        .methodBuilder("build")
-        .addModifiers(PUBLIC)
-        .addAnnotation(Override.class)
-        .returns(getTypeName(type))
-        .addCode("$N __result = new $N(", type.getName(), type.getName())
-        .addCode(CodeBlock.join(builderParams, ", "))
-        .addCode(");\n");
+    Builder build =
+        MethodSpec.methodBuilder("build")
+            .addModifiers(PUBLIC)
+            .addAnnotation(Override.class)
+            .returns(getTypeName(type))
+            .addCode("$N __result = new $N(", type.getName(), type.getName())
+            .addCode(CodeBlock.join(builderParams, ", "))
+            .addCode(");\n");
 
     if (type.hasAdditionalProperties()) {
       build.addCode("__result.getAdditionalProperties().putAll(additionalProperties);\n");
@@ -337,21 +364,29 @@ public class JavaPoetGenerator {
   }
 
   private MethodSpec factoryModelMethodUnderContainer(ObjectResolvedType type) {
-    Builder factory = MethodSpec.methodBuilder("new" + type.getName())
-        .addModifiers(PUBLIC)
-        .returns(getTypeName(type));
+    Builder factory =
+        MethodSpec.methodBuilder("new" + type.getName())
+            .addModifiers(PUBLIC)
+            .returns(getTypeName(type));
 
     List<CodeBlock> factoryParams = new ArrayList<>();
 
-    type.getProperties().stream().filter(f -> !isASchemaUrlField(f)).forEach(f -> {
-      if (isAProducerField(f)) {
-        factoryParams.add(CodeBlock.of("this.producer"));
-      } else {
-        factory.addParameter(ParameterSpec.builder(getTypeName(f.getType()), f.getName()).build());
-        factory.addJavadoc("@param $N $N\n", f.getName(), f.getDescription() == null ? "the " + f.getName() : f.getDescription());
-        factoryParams.add(CodeBlock.of("$N", f.getName()));
-      }
-    });
+    type.getProperties().stream()
+        .filter(f -> !isASchemaUrlField(f))
+        .forEach(
+            f -> {
+              if (isAProducerField(f)) {
+                factoryParams.add(CodeBlock.of("this.producer"));
+              } else {
+                factory.addParameter(
+                    ParameterSpec.builder(getTypeName(f.getType()), f.getName()).build());
+                factory.addJavadoc(
+                    "@param $N $N\n",
+                    f.getName(),
+                    f.getDescription() == null ? "the " + f.getName() : f.getDescription());
+                factoryParams.add(CodeBlock.of("$N", f.getName()));
+              }
+            });
     factory.addJavadoc("@return $N", type.getName());
     factory.addCode("return new $N(", type.getName());
     factory.addCode(CodeBlock.join(factoryParams, ", "));
@@ -368,27 +403,26 @@ public class JavaPoetGenerator {
   }
 
   private void generateInterface(TypeSpec.Builder containerTypeBuilder, ObjectResolvedType type) {
-    TypeSpec.Builder interfaceBuilder = TypeSpec.interfaceBuilder(type.getName())
-        .addModifiers(STATIC, PUBLIC);
+    TypeSpec.Builder interfaceBuilder =
+        TypeSpec.interfaceBuilder(type.getName()).addModifiers(STATIC, PUBLIC);
 
     generateDefaultImplementation(containerTypeBuilder, type, interfaceBuilder);
 
     for (ResolvedField f : type.getProperties()) {
-      MethodSpec getter = getter(f)
-          .addModifiers(ABSTRACT, PUBLIC)
-          .build();
+      MethodSpec getter = getter(f).addModifiers(ABSTRACT, PUBLIC).build();
       interfaceBuilder.addMethod(getter);
     }
     if (type.hasAdditionalProperties()) {
       String fieldName = "additionalProperties";
       TypeName additionalPropertiesValueType = getAdditionalPropertiesValueType(type);
-      TypeName additionalPropertiesType = getAdditionalPropertiesType(additionalPropertiesValueType);
-      interfaceBuilder.addMethod(MethodSpec
-          .methodBuilder("get" + titleCase(fieldName))
-          .addJavadoc("@return additional properties")
-          .returns(additionalPropertiesType)
-          .addModifiers(PUBLIC, ABSTRACT)
-          .build());
+      TypeName additionalPropertiesType =
+          getAdditionalPropertiesType(additionalPropertiesValueType);
+      interfaceBuilder.addMethod(
+          MethodSpec.methodBuilder("get" + titleCase(fieldName))
+              .addJavadoc("@return additional properties")
+              .returns(additionalPropertiesType)
+              .addModifiers(PUBLIC, ABSTRACT)
+              .build());
     }
     TypeSpec intrfc = interfaceBuilder.build();
 
@@ -404,16 +438,17 @@ public class JavaPoetGenerator {
     ///////////////////////////////////////////
     if (type.getName().endsWith("Facet") && !type.getName().equals("BaseFacet")) {
       // adding the annotation to the interface to have a default implementation
-      interfaceBuilder.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-          .addMember("as", CodeBlock.of("Default" + type.getName() + ".class"))
-          .build());
+      interfaceBuilder.addAnnotation(
+          AnnotationSpec.builder(JsonDeserialize.class)
+              .addMember("as", CodeBlock.of("Default" + type.getName() + ".class"))
+              .build());
 
-      TypeSpec.Builder classBuilder = TypeSpec.classBuilder("Default" + type.getName())
-          .addModifiers(STATIC, PUBLIC);
-      classBuilder.addSuperinterface(ClassName.get(containerPackage, containerClassName, type.getName()));
+      TypeSpec.Builder classBuilder =
+          TypeSpec.classBuilder("Default" + type.getName()).addModifiers(STATIC, PUBLIC);
+      classBuilder.addSuperinterface(
+          ClassName.get(containerPackage, containerClassName, type.getName()));
 
-      MethodSpec.Builder constructor = MethodSpec.constructorBuilder()
-          .addModifiers(PUBLIC);
+      MethodSpec.Builder constructor = MethodSpec.constructorBuilder().addModifiers(PUBLIC);
       constructor.addAnnotation(JsonCreator.class);
       List<String> fieldNames = new ArrayList<String>();
       for (ResolvedField f : type.getProperties()) {
@@ -424,11 +459,12 @@ public class JavaPoetGenerator {
         } else {
           addConstructorParameter(constructor, f);
         }
-        MethodSpec getter = getter(f)
-            .addModifiers(PUBLIC)
-            .addCode("return $N;", f.getName())
-            .addAnnotation(Override.class)
-            .build();
+        MethodSpec getter =
+            getter(f)
+                .addModifiers(PUBLIC)
+                .addCode("return $N;", f.getName())
+                .addAnnotation(Override.class)
+                .build();
         classBuilder.addMethod(getter);
       }
 
@@ -439,22 +475,29 @@ public class JavaPoetGenerator {
       classBuilder.addMethod(constructor.build());
       containerTypeBuilder.addType(classBuilder.build());
 
-
-      Builder factory = MethodSpec.methodBuilder("new" + type.getName())
-          .addModifiers(PUBLIC)
-          .returns(getTypeName(type));
+      Builder factory =
+          MethodSpec.methodBuilder("new" + type.getName())
+              .addModifiers(PUBLIC)
+              .returns(getTypeName(type));
 
       List<CodeBlock> factoryParams = new ArrayList<>();
 
-      type.getProperties().stream().filter(f -> !isASchemaUrlField(f)).forEach(f -> {
-        if (isAProducerField(f)) {
-          factoryParams.add(CodeBlock.of("this.producer"));
-        } else {
-          factory.addParameter(ParameterSpec.builder(getTypeName(f.getType()), f.getName()).build());
-          factory.addJavadoc("@param $N $N\n", f.getName(), f.getDescription() == null ? "the " + f.getName() : f.getDescription());
-          factoryParams.add(CodeBlock.of("$N", f.getName()));
-        }
-      });
+      type.getProperties().stream()
+          .filter(f -> !isASchemaUrlField(f))
+          .forEach(
+              f -> {
+                if (isAProducerField(f)) {
+                  factoryParams.add(CodeBlock.of("this.producer"));
+                } else {
+                  factory.addParameter(
+                      ParameterSpec.builder(getTypeName(f.getType()), f.getName()).build());
+                  factory.addJavadoc(
+                      "@param $N $N\n",
+                      f.getName(),
+                      f.getDescription() == null ? "the " + f.getName() : f.getDescription());
+                  factoryParams.add(CodeBlock.of("$N", f.getName()));
+                }
+              });
       factory.addJavadoc("@return $N", type.getName());
       factory.addCode("return new $N(", "Default" + type.getName());
       factory.addCode(CodeBlock.join(factoryParams, ", "));
@@ -464,23 +507,31 @@ public class JavaPoetGenerator {
     ///////////////////////////////
   }
 
-  private void addParameterFromField(MethodSpec.Builder factory, ResolvedField f, AnnotationSpec annotationSpec) {
-    com.squareup.javapoet.ParameterSpec.Builder paramSpecBuilder = ParameterSpec.builder(getTypeName(f.getType()), f.getName());
+  private void addParameterFromField(
+      MethodSpec.Builder factory, ResolvedField f, AnnotationSpec annotationSpec) {
+    com.squareup.javapoet.ParameterSpec.Builder paramSpecBuilder =
+        ParameterSpec.builder(getTypeName(f.getType()), f.getName());
     if (annotationSpec != null) {
       paramSpecBuilder.addAnnotation(annotationSpec);
     }
     factory.addParameter(paramSpecBuilder.build());
 
-    factory.addJavadoc("@param $N $N\n", f.getName(), f.getDescription() == null ? "the " + f.getName() : f.getDescription());
+    factory.addJavadoc(
+        "@param $N $N\n",
+        f.getName(),
+        f.getDescription() == null ? "the " + f.getName() : f.getDescription());
   }
 
   private ParameterizedTypeName getAdditionalPropertiesType(
       TypeName additionalPropertiesValueType) {
-    return ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
+    return ParameterizedTypeName.get(
+        ClassName.get(Map.class), ClassName.get(String.class), additionalPropertiesValueType);
   }
 
   private TypeName getAdditionalPropertiesValueType(ObjectResolvedType type) {
-    return type.getAdditionalPropertiesType() == null ? ClassName.get(Object.class) : getTypeName(type.getAdditionalPropertiesType());
+    return type.getAdditionalPropertiesType() == null
+        ? ClassName.get(Object.class)
+        : getTypeName(type.getAdditionalPropertiesType());
   }
 
   private void addAdditionalProperties(
@@ -488,25 +539,31 @@ public class JavaPoetGenerator {
     String fieldName = "additionalProperties";
     TypeName additionalPropertiesValueType = getAdditionalPropertiesValueType(type);
     TypeName additionalPropertiesType = getAdditionalPropertiesType(additionalPropertiesValueType);
-    classBuilder.addMethod(MethodSpec
-        .methodBuilder("get" + titleCase(fieldName))
-        .addJavadoc("@return additional properties")
-        .returns(additionalPropertiesType)
-        .addModifiers(PUBLIC)
-        .addCode("return $N;", fieldName)
-        .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build())
-        .addAnnotation(Override.class)
-        .build());
+    classBuilder.addMethod(
+        MethodSpec.methodBuilder("get" + titleCase(fieldName))
+            .addJavadoc("@return additional properties")
+            .returns(additionalPropertiesType)
+            .addModifiers(PUBLIC)
+            .addCode("return $N;", fieldName)
+            .addAnnotation(AnnotationSpec.builder(JsonAnyGetter.class).build())
+            .addAnnotation(Override.class)
+            .build());
     classBuilder.addField(
         FieldSpec.builder(additionalPropertiesType, fieldName, PRIVATE, FINAL)
-        .addAnnotation(JsonAnySetter.class)
-        .build());
+            .addAnnotation(JsonAnySetter.class)
+            .build());
 
-    constructor.addCode(CodeBlock.builder().addStatement("this.$N = new $T<>()", fieldName, LinkedHashMap.class).build());
+    constructor.addCode(
+        CodeBlock.builder()
+            .addStatement("this.$N = new $T<>()", fieldName, LinkedHashMap.class)
+            .build());
   }
 
   private void addConstructorParameter(MethodSpec.Builder constructor, ResolvedField f) {
-    addParameterFromField(constructor, f, AnnotationSpec.builder(JsonProperty.class).addMember("value", "$S", f.getName()).build());
+    addParameterFromField(
+        constructor,
+        f,
+        AnnotationSpec.builder(JsonProperty.class).addMember("value", "$S", f.getName()).build());
     constructor.addCode("this.$N = $N;\n", f.getName(), f.getName());
   }
 
@@ -517,59 +574,60 @@ public class JavaPoetGenerator {
   }
 
   private Builder getter(ResolvedField f) {
-    Builder builder = MethodSpec
-        .methodBuilder("get" + titleCase(f.getName()))
-        .returns(getTypeName(f.getType()));
+    Builder builder =
+        MethodSpec.methodBuilder("get" + titleCase(f.getName())).returns(getTypeName(f.getType()));
     if (f.getDescription() != null) {
       builder.addJavadoc("@return $N", f.getDescription());
     }
     return builder;
   }
 
-
   public TypeName getTypeName(ResolvedType type) {
-    return type.accept(new ResolvedTypeVisitor<TypeName>() {
+    return type.accept(
+        new ResolvedTypeVisitor<TypeName>() {
 
-      @Override
-      public TypeName visit(PrimitiveResolvedType primitiveType) {
-        if (primitiveType.getName().equals("integer")) {
-          return ClassName.get(Long.class);
-        } else if (primitiveType.getName().equals("number")) {
-          return ClassName.get(Double.class);
-        } else if (primitiveType.getName().equals("boolean")) {
-          return ClassName.get(Boolean.class);
-        } else if (primitiveType.getName().equals("string")) {
-          if (primitiveType.getFormat() != null) {
-            String format = primitiveType.getFormat();
-            if (format.equals("uri")) {
-              return ClassName.get(URI.class);
-            } else if (format.equals("date-time")) {
-              return ClassName.get(ZonedDateTime.class);
-            } else if (format.equals("uuid")) {
-              return ClassName.get(UUID.class);
-            } else {
-              throw new RuntimeException("Unknown format: " + primitiveType.getFormat());
+          @Override
+          public TypeName visit(PrimitiveResolvedType primitiveType) {
+            if (primitiveType.getName().equals("integer")) {
+              return ClassName.get(Long.class);
+            } else if (primitiveType.getName().equals("number")) {
+              return ClassName.get(Double.class);
+            } else if (primitiveType.getName().equals("boolean")) {
+              return ClassName.get(Boolean.class);
+            } else if (primitiveType.getName().equals("string")) {
+              if (primitiveType.getFormat() != null) {
+                String format = primitiveType.getFormat();
+                if (format.equals("uri")) {
+                  return ClassName.get(URI.class);
+                } else if (format.equals("date-time")) {
+                  return ClassName.get(ZonedDateTime.class);
+                } else if (format.equals("uuid")) {
+                  return ClassName.get(UUID.class);
+                } else {
+                  throw new RuntimeException("Unknown format: " + primitiveType.getFormat());
+                }
+              }
+              return ClassName.get(String.class);
             }
+            throw new RuntimeException("Unknown primitive: " + primitiveType.getName());
           }
-          return ClassName.get(String.class);
-        }
-        throw new RuntimeException("Unknown primitive: " + primitiveType.getName());
-      }
 
-      @Override
-      public TypeName visit(ObjectResolvedType objectType) {
-        return ClassName.get(containerClass, objectType.getName());
-      }
+          @Override
+          public TypeName visit(ObjectResolvedType objectType) {
+            return ClassName.get(containerClass, objectType.getName());
+          }
 
-      @Override
-      public TypeName visit(ArrayResolvedType arrayType) {
-        return ParameterizedTypeName.get(ClassName.get(List.class), getTypeName(arrayType.getItems()));
-      }
+          @Override
+          public TypeName visit(ArrayResolvedType arrayType) {
+            return ParameterizedTypeName.get(
+                ClassName.get(List.class), getTypeName(arrayType.getItems()));
+          }
 
-      @Override
-      public TypeName visit(TypeResolver.EnumResolvedType enumType) {
-         return ClassName.get(containerClass, enumType.getParentName() + "." + enumType.getName());
-      }
-    });
+          @Override
+          public TypeName visit(TypeResolver.EnumResolvedType enumType) {
+            return ClassName.get(
+                containerClass, enumType.getParentName() + "." + enumType.getName());
+          }
+        });
   }
 }

--- a/client/java/generator/src/main/java/io/openlineage/client/PythonGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/PythonGenerator.java
@@ -5,19 +5,13 @@ import io.openlineage.client.python.DecoratorSpec;
 import io.openlineage.client.python.FieldSpec;
 import io.openlineage.client.python.PythonFile;
 import io.openlineage.client.python.TypeRef;
-
-import java.io.Console;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -29,7 +23,7 @@ public class PythonGenerator {
     PythonFile file = new PythonFile();
 
     file.requirements.add(TypeRef.builder().name("attrs").build());
-    file.requirements.add(TypeRef.builder().name("datetime").build());
+    file.requirements.add(TypeRef.builder().name("List").module("typing").build());
 
     Collection<TypeResolver.ObjectResolvedType> types = typeResolver.getTypes();
 
@@ -68,18 +62,17 @@ public class PythonGenerator {
       }
 
       builder.parent(TypeRef.builder().name(parent.getName()).isInternal(true).build());
-      for (TypeResolver.ResolvedField field: parent.getProperties()) {
+      for (TypeResolver.ResolvedField field : parent.getProperties()) {
         parentFields.add(field.getName());
       }
     }
-
 
     for (TypeResolver.ResolvedField field : type.getProperties()) {
       FieldSpec.FieldSpecBuilder fieldSpecBuilder = FieldSpec.builder();
       TypeRef typeRef = getTypeRef(field.getType());
 
       if (parentFields.contains(field.getName())) {
-//        System.out.printf("%s contains %s\n", parentFields, field.getName());
+        System.out.printf("%s contains %s\n", parentFields, field.getName());
         continue;
       }
 
@@ -89,8 +82,7 @@ public class PythonGenerator {
           if (!arrayRef.isPrimitive() && !arrayRef.isInternal()) {
             builder.requirement(arrayRef);
           }
-        }
-        else {
+        } else {
           builder.requirement(typeRef);
         }
       }
@@ -103,10 +95,11 @@ public class PythonGenerator {
 
     ClassSpec clazz = builder.build();
     if (clazz.fields.isEmpty()) {
-//      System.out.printf("%s %s\n", clazz.getName(), Arrays.toString(clazz.getParents().toArray()));
+      //      System.out.printf("%s %s\n", clazz.getName(),
+      // Arrays.toString(clazz.getParents().toArray()));
       if (parentClass.isPresent()) {
         parentClassMapping.put(clazz.getTypeRef(), parentClass.get().getTypeRef());
-        return Optional.empty();
+        return parentClass;
       }
       parentClassMapping.put(clazz.getTypeRef(), null);
       return Optional.empty();

--- a/client/java/generator/src/main/java/io/openlineage/client/PythonGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/PythonGenerator.java
@@ -1,0 +1,143 @@
+package io.openlineage.client;
+
+import io.openlineage.client.python.ClassSpec;
+import io.openlineage.client.python.DecoratorSpec;
+import io.openlineage.client.python.FieldSpec;
+import io.openlineage.client.python.PythonFile;
+import io.openlineage.client.python.TypeRef;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class PythonGenerator {
+  private final TypeResolver typeResolver;
+  private final Map<String, URL> containerToID;
+
+  public void generate(PrintWriter printWriter) throws IOException {
+    PythonFile file = new PythonFile();
+
+    file.requirements.add(TypeRef.builder().name("attrs").build());
+    file.requirements.add(TypeRef.builder().name("datetime").build());
+
+    Collection<TypeResolver.ObjectResolvedType> types = typeResolver.getTypes();
+
+    for (TypeResolver.ObjectResolvedType type : types) {
+      if (type.getName().length() == 0) {
+        // we're generating types that have name (through ref)
+        continue;
+      }
+
+      // Add enums
+      for (TypeResolver.ResolvedField field : type.getProperties()) {
+        if (field.getType() instanceof TypeResolver.EnumResolvedType) {
+          ClassSpec enumClazz = buildEnum((TypeResolver.EnumResolvedType) field.getType());
+          file.addClass(enumClazz);
+        }
+      }
+
+      ClassSpec clazz = buildClass(type);
+      file.addClass(clazz);
+    }
+    printWriter.print(file.dump(0));
+  }
+
+  ClassSpec buildClass(TypeResolver.ObjectResolvedType type) {
+    ClassSpec.ClassSpecBuilder builder = ClassSpec.builder();
+    builder.name(type.getName());
+
+    for (TypeResolver.ObjectResolvedType parent : type.getParents()) {
+      //      TODO: remove parent properties
+      //      parent.getProperties();
+      builder.parent(TypeRef.builder().name(parent.getName()).isInternal(true).build());
+    }
+    for (TypeResolver.ResolvedField field : type.getProperties()) {
+      FieldSpec.FieldSpecBuilder fieldSpecBuilder = FieldSpec.builder();
+      TypeRef typeRef = getTypeRef(field.getType());
+
+      if (!typeRef.isPrimitive()) {
+        builder.requirement(typeRef);
+      }
+      fieldSpecBuilder.name(field.getName());
+      fieldSpecBuilder.type(typeRef);
+      builder.field(fieldSpecBuilder.build());
+    }
+
+    builder.decorator(DecoratorSpec.builder().name("attrs.define").build());
+
+    return builder.build();
+  }
+
+  ClassSpec buildEnum(TypeResolver.EnumResolvedType type) {
+    ClassSpec.ClassSpecBuilder builder = ClassSpec.builder();
+    builder.name(type.getName());
+    builder.isEnum(true);
+    builder.parent(TypeRef.builder().name("Enum").module("enum").build());
+    builder.requirement(TypeRef.builder().name("Enum").module("enum").build());
+
+    for (String value : type.getValues()) {
+      FieldSpec.FieldSpecBuilder fieldSpecBuilder = FieldSpec.builder();
+      fieldSpecBuilder.name(value);
+      fieldSpecBuilder.defaultValue(String.format("\"%s\"", value.toUpperCase()));
+      builder.field(fieldSpecBuilder.build());
+    }
+    return builder.build();
+  }
+
+  public TypeRef getTypeRef(TypeResolver.ResolvedType type) {
+    return type.accept(
+        new TypeResolver.ResolvedTypeVisitor<TypeRef>() {
+          @Override
+          public TypeRef visit(TypeResolver.PrimitiveResolvedType primitiveType) {
+            if (primitiveType.getName().equals("integer")) {
+              return TypeRef.INT;
+            } else if (primitiveType.getName().equals("number")) {
+              return TypeRef.FLOAT;
+            } else if (primitiveType.getName().equals("boolean")) {
+              return TypeRef.BOOL;
+            } else if (primitiveType.getName().equals("string")) {
+              if (primitiveType.getFormat() != null) {
+                String format = primitiveType.getFormat();
+                switch (format) {
+                  case "uri":
+                  case "uuid":
+                    return TypeRef.STR; // todo?
+                  case "date-time":
+                    return TypeRef.DATETIME; // real classname? move to typedef?
+                  default:
+                    throw new RuntimeException("Unknown format: " + primitiveType.getFormat());
+                }
+              }
+              return TypeRef.STR;
+            }
+            throw new RuntimeException("Unknown primitive: " + primitiveType.getName());
+          }
+
+          @Override
+          public TypeRef visit(TypeResolver.ObjectResolvedType objectType) {
+            return TypeRef.builder()
+                .name(objectType.getName())
+                .isPrimitive(false)
+                .isInternal(true)
+                .build();
+          }
+
+          @Override
+          public TypeRef visit(TypeResolver.ArrayResolvedType arrayType) {
+            return TypeRef.builder()
+                .name(String.format("List[%s]", (visit(arrayType.getItems()).getName())))
+                .isPrimitive(true)  // TODO fix by subclassing;
+                .isInternal(false)  // TODO fix by subclassing;
+                .build();
+          }
+
+          @Override
+          public TypeRef visit(TypeResolver.EnumResolvedType enumType) {
+            return TypeRef.builder().name(enumType.getName()).isInternal(false).build();
+          }
+        });
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
@@ -140,11 +140,13 @@ public class SchemaParser {
 
     default boolean isObject() {
       return false;
-    };
+    }
+    ;
 
     default ObjectType asObject() {
       return (ObjectType) this;
-    };
+    }
+    ;
   }
 
   static class RefType implements Type {
@@ -421,7 +423,8 @@ public class SchemaParser {
 
     public boolean isObject() {
       return true;
-    };
+    }
+    ;
 
     @Override
     public <T> T accept(TypeVisitor<T> visitor) {

--- a/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
@@ -1,0 +1,86 @@
+package io.openlineage.client.python;
+
+import static io.openlineage.client.python.Utils.nestString;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+
+@Getter
+@Builder
+public class ClassSpec implements Dump {
+  public String name;
+
+  @Singular public List<TypeRef> parents;
+  @Singular public List<FieldSpec> fields;
+  @Singular public List<MethodSpec> methods;
+  @Singular public List<DecoratorSpec> decorators;
+
+  @Singular public Set<TypeRef> requirements;
+
+  public boolean isEnum;
+
+  public List<TypeRef> getTypeDependencies() {
+    if (isEnum) {
+      return Collections.emptyList();
+    }
+    List<TypeRef> typeRefs = new ArrayList<>();
+    for (FieldSpec field : fields) {
+      if (!field.type.isPrimitive && field.type.isInternal) {
+        typeRefs.add(field.type);
+      }
+    }
+    for (TypeRef parent: parents) {
+      if(!parent.isPrimitive && parent.isInternal) {
+        typeRefs.add(parent);
+      }
+    }
+    return typeRefs;
+  }
+
+  public TypeRef getTypeRef() {
+    // TODO: module? sameFile?
+    return new TypeRef(name, null, false, false, true);
+  }
+
+  public String dump(int nestLevel) {
+    StringBuilder content = new StringBuilder();
+
+    for (DecoratorSpec decorator : decorators) {
+      content.append(decorator.dump(nestLevel));
+      content.append("\n");
+    }
+
+    StringBuilder parentString = new StringBuilder();
+    if (!parents.isEmpty()) {
+      parentString.append("(");
+      ListIterator<TypeRef> listIterator = parents.listIterator();
+      while (listIterator.hasNext()) {
+        parentString.append(listIterator.next().getName());
+        if (listIterator.hasNext()) {
+          parentString.append(",");
+        }
+      }
+      parentString.append(")");
+    }
+
+    content.append(nestString(String.format("class %s%s:\n", name, parentString), nestLevel));
+
+    for (FieldSpec field : fields) {
+      content.append(field.dump(nestLevel + 1));
+      content.append("\n");
+    }
+
+    for (MethodSpec method : methods) {
+      content.append(method.dump(nestLevel + 1));
+      content.append("\n");
+    }
+
+    return content.toString();
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import lombok.Singular;
 
 @Getter
 @Builder
-public class ClassSpec implements Dump {
+public class ClassSpec {
   public String name;
 
   @Singular public List<TypeRef> parents;
@@ -45,10 +46,10 @@ public class ClassSpec implements Dump {
 
   public TypeRef getTypeRef() {
     // TODO: module? sameFile?
-    return new TypeRef(name, null, false, false, true);
+    return TypeRef.builder().name(name).isInternal(true).build();
   }
 
-  public String dump(int nestLevel) {
+  public String dump(int nestLevel, Map<TypeRef, TypeRef> parentClassMapping) {
     StringBuilder content = new StringBuilder();
 
     for (DecoratorSpec decorator : decorators) {
@@ -61,7 +62,15 @@ public class ClassSpec implements Dump {
       parentString.append("(");
       ListIterator<TypeRef> listIterator = parents.listIterator();
       while (listIterator.hasNext()) {
-        parentString.append(listIterator.next().getName());
+        TypeRef parent = listIterator.next();
+        if (parentClassMapping.containsKey(parent)) {
+          parent = parentClassMapping.get(parent);
+          if (parent == null || parent.isPrimitive()) {
+            continue;
+          }
+        }
+
+        parentString.append(parent.getName());
         if (listIterator.hasNext()) {
           parentString.append(",");
         }

--- a/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/ClassSpec.java
@@ -32,12 +32,18 @@ public class ClassSpec {
     }
     List<TypeRef> typeRefs = new ArrayList<>();
     for (FieldSpec field : fields) {
+      if (field.type.arrayRef != null) {
+        if (!field.type.arrayRef.isPrimitive && field.type.arrayRef.isInternal) {
+          typeRefs.add(field.type.arrayRef);
+        }
+      }
+
       if (!field.type.isPrimitive && field.type.isInternal) {
         typeRefs.add(field.type);
       }
     }
-    for (TypeRef parent: parents) {
-      if(!parent.isPrimitive && parent.isInternal) {
+    for (TypeRef parent : parents) {
+      if (!parent.isPrimitive && parent.isInternal) {
         typeRefs.add(parent);
       }
     }
@@ -81,12 +87,12 @@ public class ClassSpec {
     content.append(nestString(String.format("class %s%s:\n", name, parentString), nestLevel));
 
     for (FieldSpec field : fields) {
-      content.append(field.dump(nestLevel + 1));
+      content.append(field.dump(nestLevel + 1, parentClassMapping));
       content.append("\n");
     }
 
     for (MethodSpec method : methods) {
-      content.append(method.dump(nestLevel + 1));
+      content.append(method.dump(nestLevel + 1, parentClassMapping));
       content.append("\n");
     }
 

--- a/client/java/generator/src/main/java/io/openlineage/client/python/DecoratorSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/DecoratorSpec.java
@@ -1,0 +1,12 @@
+package io.openlineage.client.python;
+
+import lombok.Builder;
+
+@Builder
+public class DecoratorSpec {
+  public String name;
+
+  public String dump(int nestLevel) {
+    return String.format("@%s", name);
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/Dump.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/Dump.java
@@ -1,0 +1,5 @@
+package io.openlineage.client.python;
+
+public interface Dump {
+  String dump(int nextLevel);
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/FieldSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/FieldSpec.java
@@ -2,21 +2,30 @@ package io.openlineage.client.python;
 
 import static io.openlineage.client.python.Utils.nestString;
 
+import java.util.Map;
 import lombok.Builder;
 
 @Builder
-public class FieldSpec implements Dump {
+public class FieldSpec {
   public TypeRef type;
   public String name;
   public String defaultValue;
 
-  @Override
-  public String dump(int nestLevel) {
+  public String dump(int nestLevel, Map<TypeRef, TypeRef> parentClassMapping) {
     String resultType = "";
     String resultValue = "";
 
     if (type != null) {
-      resultType = String.format(": %s", type.getName());
+      if (parentClassMapping.containsKey(type)) {
+        TypeRef parent = parentClassMapping.get(type);
+        if (parent != null) {
+          resultType = String.format(": %s", parent.getName());
+        } else {
+          resultType = ": dict";
+        }
+      } else {
+        resultType = String.format(": %s", type.getName());
+      }
     }
 
     if (defaultValue != null) {

--- a/client/java/generator/src/main/java/io/openlineage/client/python/FieldSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/FieldSpec.java
@@ -1,0 +1,27 @@
+package io.openlineage.client.python;
+
+import static io.openlineage.client.python.Utils.nestString;
+
+import lombok.Builder;
+
+@Builder
+public class FieldSpec implements Dump {
+  public TypeRef type;
+  public String name;
+  public String defaultValue;
+
+  @Override
+  public String dump(int nestLevel) {
+    String resultType = "";
+    String resultValue = "";
+
+    if (type != null) {
+      resultType = String.format(": %s", type.getName());
+    }
+
+    if (defaultValue != null) {
+      resultValue = String.format(" = %s", defaultValue);
+    }
+    return nestString(String.format("%s%s%s", name, resultType, resultValue), nestLevel);
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/MethodSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/MethodSpec.java
@@ -1,0 +1,34 @@
+package io.openlineage.client.python;
+
+import static io.openlineage.client.python.Utils.nestString;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+
+@Getter
+@Builder
+public class MethodSpec implements Dump {
+  public String code;
+  @Singular public List<ParameterSpec> params;
+  public String name;
+  public String codeBlock;
+
+  @Override
+  public String dump(int nextLevel) {
+    StringBuilder content = new StringBuilder();
+    StringBuilder paramsList = new StringBuilder();
+    boolean isFirst = true;
+    for (ParameterSpec param : params) {
+      if (isFirst) {
+        isFirst = false;
+      } else {
+        paramsList.append(",");
+      }
+      paramsList.append(param.dump(0));
+    }
+    content.append(nestString(String.format("def %s(%s):", name, paramsList), 0));
+    return content.toString();
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/MethodSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/MethodSpec.java
@@ -3,20 +3,20 @@ package io.openlineage.client.python;
 import static io.openlineage.client.python.Utils.nestString;
 
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
 
 @Getter
 @Builder
-public class MethodSpec implements Dump {
+public class MethodSpec {
   public String code;
   @Singular public List<ParameterSpec> params;
   public String name;
   public String codeBlock;
 
-  @Override
-  public String dump(int nextLevel) {
+  public String dump(int nextLevel, Map<TypeRef, TypeRef> parentClassMapping) {
     StringBuilder content = new StringBuilder();
     StringBuilder paramsList = new StringBuilder();
     boolean isFirst = true;

--- a/client/java/generator/src/main/java/io/openlineage/client/python/ParameterSpec.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/ParameterSpec.java
@@ -1,0 +1,11 @@
+package io.openlineage.client.python;
+
+public class ParameterSpec implements Dump {
+  public String type;
+  public String name;
+
+  @Override
+  public String dump(int nextLevel) {
+    return String.format("%s %s", type, name);
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/PythonFile.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/PythonFile.java
@@ -1,10 +1,5 @@
 package io.openlineage.client.python;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,21 +7,20 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class PythonFile {
 
   public Set<TypeRef> requirements = new HashSet<>();
   public Map<TypeRef, ClassSpec> dumpables = new HashMap<>();
   public Map<TypeRef, Set<TypeRef>> dumpableDependencies = new HashMap<>();
+
   public void addClass(ClassSpec clazz) {
     if (clazz.getName().equals("BaseFacet")) {
       System.out.printf("BaseFacet Reqs: %s\n", Arrays.toString(clazz.requirements.toArray()));
-      System.out.printf("BaseFacet Type Deps: %s\n", Arrays.toString(clazz.getTypeDependencies().toArray()));
-
+      System.out.printf(
+          "BaseFacet Type Deps: %s\n", Arrays.toString(clazz.getTypeDependencies().toArray()));
     }
     dumpables.put(clazz.getTypeRef(), clazz);
     requirements.addAll(clazz.requirements);
@@ -34,16 +28,20 @@ public class PythonFile {
   }
 
   public String dump(int nestLevel, Map<TypeRef, TypeRef> parentClassMapping) {
-    int addJustSome = 50;
+    int addJustSome = 9999;
 
-    System.out.printf("%s\n", Arrays.toString(requirements.stream().map(TypeRef::getName).toArray()));
-    System.out.printf("%s\n", Arrays.toString(parentClassMapping.keySet().stream().map(TypeRef::getName).toArray()));
-    System.out.printf("%s\n", Arrays.toString(dumpables.keySet().stream().map(TypeRef::getName).toArray()));
+    System.out.printf(
+        "%s\n", Arrays.toString(requirements.stream().map(TypeRef::getName).toArray()));
+    System.out.printf(
+        "%s\n",
+        Arrays.toString(parentClassMapping.keySet().stream().map(TypeRef::getName).toArray()));
+    System.out.printf(
+        "%s\n", Arrays.toString(dumpables.keySet().stream().map(TypeRef::getName).toArray()));
 
     // Remove dead reqs and create queue
-    for (TypeRef deadRef: parentClassMapping.keySet()) {
+    for (TypeRef deadRef : parentClassMapping.keySet()) {
       System.out.printf("Dead ref class: %s\n", deadRef.getName());
-      for(TypeRef dumpable: dumpableDependencies.keySet()) {
+      for (TypeRef dumpable : dumpableDependencies.keySet()) {
         Set<TypeRef> typeRefs = dumpableDependencies.get(dumpable);
         if (!typeRefs.contains(deadRef)) {
           continue;
@@ -51,7 +49,8 @@ public class PythonFile {
         System.out.printf("\tRemoving ref in class %s\n", dumpable.getName());
         typeRefs.remove(deadRef);
         if (parentClassMapping.get(deadRef) != null) {
-          System.out.printf("\t\tAdding ref to parent %s\n", parentClassMapping.get(deadRef).getName());
+          System.out.printf(
+              "\t\tAdding ref to parent %s\n", parentClassMapping.get(deadRef).getName());
           typeRefs.add(parentClassMapping.get(deadRef));
         }
         dumpableDependencies.put(dumpable, typeRefs);
@@ -63,13 +62,13 @@ public class PythonFile {
     Queue<TypeRef> classes = new ArrayDeque<>(dumpables.keySet());
     while (!classes.isEmpty()) {
       TypeRef classRef = classes.poll();
-//      System.out.printf("Class: %s ", classRef.getName());
-//      System.out.printf(
-//          "remaining deps: %s\n",
-//          dumpableDependencies.get(classRef).stream()
-//            .filter(Objects::nonNull)
-//            .map(TypeRef::getName)
-//            .collect(Collectors.toList()));
+      //      System.out.printf("Class: %s ", classRef.getName());
+      //      System.out.printf(
+      //          "remaining deps: %s\n",
+      //          dumpableDependencies.get(classRef).stream()
+      //            .filter(Objects::nonNull)
+      //            .map(TypeRef::getName)
+      //            .collect(Collectors.toList()));
       System.out.flush();
       if (dumpableDependencies.get(classRef).isEmpty()) {
         ClassSpec clazz = dumpables.get(classRef);
@@ -79,11 +78,12 @@ public class PythonFile {
           typeRefs.remove(clazz.getTypeRef());
           dumpableDependencies.put(type, typeRefs);
         }
-//        System.out.printf("Dumped class %s\n", classRef.getName());
-//        System.out.flush();
+        //        System.out.printf("Dumped class %s\n", classRef.getName());
+        //        System.out.flush();
       } else {
         if (parentClassMapping.containsKey(classRef)) {
-//          System.out.printf("Not requeueing class: %s - parentClassMapping\n", classRef.getName());
+          //          System.out.printf("Not requeueing class: %s - parentClassMapping\n",
+          // classRef.getName());
           ClassSpec clazz = dumpables.get(classRef);
           for (TypeRef type : dumpableDependencies.keySet()) {
             Set<TypeRef> typeRefs = dumpableDependencies.get(type);
@@ -97,7 +97,11 @@ public class PythonFile {
           System.out.printf("Not requeueing class: %s - is a req\n", classRef.getName());
           continue;
         }
-        System.out.printf("Requeueing class: %s - has reqs\n", classRef.getName());
+        System.out.printf(
+            "Requeueing class: %s - has reqs %s\n",
+            classRef.getName(),
+            Arrays.toString(
+                dumpableDependencies.get(classRef).stream().map(TypeRef::getName).toArray()));
         System.out.flush();
 
         if (addJustSome > 0) {
@@ -115,9 +119,9 @@ public class PythonFile {
 
       if (requirement.getModule() == null) {
         content.append(String.format("import %s", requirement.getName()));
-      }
-      else {
-        content.append(String.format("from %s import %s", requirement.getModule(), requirement.getName()));
+      } else {
+        content.append(
+            String.format("from %s import %s", requirement.getModule(), requirement.getName()));
       }
       content.append("\n");
     }

--- a/client/java/generator/src/main/java/io/openlineage/client/python/PythonFile.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/PythonFile.java
@@ -1,0 +1,91 @@
+package io.openlineage.client.python;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PythonFile implements Dump {
+
+  public Set<TypeRef> requirements = new HashSet<>();
+  public Map<String, ClassSpec> dumpables = new HashMap<>();
+  public Map<String, Set<TypeRef>> dumpableDependencies = new HashMap<>();
+
+  public void dumpToFile(Path path) {
+    try {
+      Files.write(path, dump(0).getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void addClass(ClassSpec clazz) {
+    dumpables.put(clazz.name, clazz);
+    requirements.addAll(clazz.requirements);
+    dumpableDependencies.put(clazz.name, new HashSet<>(clazz.getTypeDependencies()));
+  }
+
+  public String dump(int nestLevel) {
+
+    // Naive toposort this
+    List<Dump> sortedDumpables = new ArrayList<>();
+    Queue<String> classes = new ArrayDeque<>(dumpables.keySet());
+    while (!classes.isEmpty()) {
+      String className = classes.poll();
+      System.out.printf("Class: %s ", className);
+      System.out.printf(
+          "remaining deps: %s\n",
+          dumpableDependencies.get(className).stream()
+              .map(TypeRef::getName)
+              .collect(Collectors.toList()));
+      System.out.flush();
+      if (dumpableDependencies.get(className).isEmpty()) {
+        ClassSpec clazz = dumpables.get(className);
+        sortedDumpables.add(dumpables.get(className));
+        for (String key : dumpableDependencies.keySet()) {
+          Set<TypeRef> typeRefs = dumpableDependencies.get(key);
+          typeRefs.remove(clazz.getTypeRef());
+          dumpableDependencies.put(key, typeRefs);
+        }
+        System.out.flush();
+      } else {
+        if (!requirements.contains(className)) {
+          System.out.printf("Not adding class: %s\n", className);
+          System.out.flush();
+          classes.add(className);
+        }
+      }
+    }
+
+    StringBuilder content = new StringBuilder();
+    for (TypeRef requirement : requirements) {
+      if (requirement.isPrimitive || requirement.isInternal) {
+        continue;
+      }
+
+      if (requirement.getModule() == null) {
+        content.append(String.format("import %s", requirement.getName()));
+      }
+      else {
+        content.append(String.format("from %s import %s", requirement.getModule(), requirement.getName()));
+      }
+      content.append("\n");
+    }
+    content.append("\n\n");
+
+    for (Dump dumpable : sortedDumpables) {
+      content.append(dumpable.dump(nestLevel));
+      content.append("\n\n");
+    }
+    return content.toString();
+  }
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/TypeRef.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/TypeRef.java
@@ -1,0 +1,33 @@
+package io.openlineage.client.python;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class TypeRef {
+  public static TypeRef INT = TypeRef.builder().name("int").isPrimitive(true).build();
+  public static TypeRef STR = TypeRef.builder().name("str").isPrimitive(true).build();
+  public static TypeRef FLOAT = TypeRef.builder().name("float").isPrimitive(true).build();
+  public static TypeRef BOOL = TypeRef.builder().name("bool").isPrimitive(true).build();
+  public static TypeRef DATETIME =
+      TypeRef.builder()
+          .name("datetime")
+          .module("datetime")
+          .isPrimitive(false)
+          .isInternal(false)
+          .build();
+
+  @NonNull String name;
+  String module;
+  boolean sameFile;
+  boolean isPrimitive;
+  boolean isInternal;
+}

--- a/client/java/generator/src/main/java/io/openlineage/client/python/TypeRef.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/TypeRef.java
@@ -30,4 +30,8 @@ public class TypeRef {
   boolean sameFile;
   boolean isPrimitive;
   boolean isInternal;
+
+  TypeRef arrayRef;
+  TypeRef keyRef;
+  TypeRef valueRef;
 }

--- a/client/java/generator/src/main/java/io/openlineage/client/python/Utils.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/python/Utils.java
@@ -1,0 +1,7 @@
+package io.openlineage.client.python;
+
+public class Utils {
+  public static String nestString(String content, int nestLevel) {
+    return new String(new char[nestLevel * 4]).replace('\0', ' ') + content;
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/OpenLineage.py
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineage.py
@@ -1,0 +1,337 @@
+import EventType
+from enum import Enum
+from datetime import datetime
+from typing import List
+import LifecycleStateChange
+import attrs
+
+
+@attrs.define
+class SchemaDatasetFacetFields:
+    name: str
+    type: str
+    description: str
+
+
+@attrs.define
+class DataQualityAssertionsDatasetFacetAssertions:
+    assertion: str
+    success: bool
+    column: str
+
+
+@attrs.define
+class ParentRunFacetRun:
+    runId: str
+
+
+@attrs.define
+class ExtractionErrorRunFacetErrors:
+    errorMessage: str
+    stackTrace: str
+    task: str
+    taskNumber: int
+
+
+@attrs.define
+class ParentRunFacetJob:
+    namespace: str
+    name: str
+
+
+@attrs.define
+class LifecycleStateChangeDatasetFacetPreviousIdentifier:
+    name: str
+    namespace: str
+
+
+@attrs.define
+class SymlinksDatasetFacetIdentifiers:
+    namespace: str
+    name: str
+    type: str
+
+
+class EventType(Enum):
+    START = "START"
+    RUNNING = "RUNNING"
+    COMPLETE = "COMPLETE"
+    ABORT = "ABORT"
+    FAIL = "FAIL"
+    OTHER = "OTHER"
+
+
+@attrs.define
+class ColumnLineageDatasetFacetFieldsAdditionalInputFields:
+    namespace: str
+    name: str
+    field: str
+
+
+@attrs.define
+class BaseFacet:
+    _producer: str
+    _schemaURL: str
+
+
+@attrs.define
+class DataQualityMetricsInputDatasetFacetColumnMetricsAdditional:
+    nullCount: int
+    distinctCount: int
+    sum: float
+    count: float
+    min: float
+    max: float
+    quantiles: dict
+
+
+class LifecycleStateChange(Enum):
+    ALTER = "ALTER"
+    CREATE = "CREATE"
+    DROP = "DROP"
+    OVERWRITE = "OVERWRITE"
+    RENAME = "RENAME"
+    TRUNCATE = "TRUNCATE"
+
+
+@attrs.define
+class OwnershipJobFacetOwners:
+    name: str
+    type: str
+
+
+@attrs.define
+class ExtractionErrorRunFacet(BaseFacet):
+    totalTasks: int
+    failedTasks: int
+    errors: List[ExtractionErrorRunFacetErrors]
+
+
+@attrs.define
+class SymlinksDatasetFacet(BaseFacet):
+    identifiers: List[SymlinksDatasetFacetIdentifiers]
+
+
+@attrs.define
+class OwnershipDatasetFacetOwners:
+    name: str
+    type: str
+
+
+@attrs.define
+class DataQualityMetricsInputDatasetFacet(BaseFacet):
+    rowCount: int
+    bytes: int
+    columnMetrics: dict
+
+
+@attrs.define
+class OwnershipJobFacet(BaseFacet):
+    owners: List[OwnershipJobFacetOwners]
+
+
+@attrs.define
+class SchemaDatasetFacet(BaseFacet):
+    fields: List[SchemaDatasetFacetFields]
+
+
+@attrs.define
+class ColumnLineageDatasetFacetFieldsAdditional:
+    inputFields: List[ColumnLineageDatasetFacetFieldsAdditionalInputFields]
+    transformationDescription: str
+    transformationType: str
+
+
+@attrs.define
+class DatasetVersionDatasetFacet(BaseFacet):
+    datasetVersion: str
+
+
+@attrs.define
+class SourceCodeJobFacet(BaseFacet):
+    language: str
+    sourceCode: str
+
+
+@attrs.define
+class LifecycleStateChangeDatasetFacet(BaseFacet):
+    lifecycleStateChange: LifecycleStateChange
+    previousIdentifier: LifecycleStateChangeDatasetFacetPreviousIdentifier
+
+
+@attrs.define
+class ColumnLineageDatasetFacet(BaseFacet):
+    fields: dict
+
+
+@attrs.define
+class OwnershipDatasetFacet(BaseFacet):
+    owners: List[OwnershipDatasetFacetOwners]
+
+
+@attrs.define
+class DataQualityAssertionsDatasetFacet(BaseFacet):
+    assertions: List[DataQualityAssertionsDatasetFacetAssertions]
+
+
+@attrs.define
+class SourceCodeLocationJobFacet(BaseFacet):
+    type: str
+    url: str
+    repoUrl: str
+    path: str
+    version: str
+    tag: str
+    branch: str
+
+
+@attrs.define
+class ProcessingEngineRunFacet(BaseFacet):
+    version: str
+    name: str
+    openlineageAdapterVersion: str
+
+
+@attrs.define
+class ErrorMessageRunFacet(BaseFacet):
+    message: str
+    programmingLanguage: str
+    stackTrace: str
+
+
+@attrs.define
+class DatasourceDatasetFacet(BaseFacet):
+    name: str
+    uri: str
+
+
+@attrs.define
+class DocumentationDatasetFacet(BaseFacet):
+    description: str
+
+
+@attrs.define
+class ParentRunFacet(BaseFacet):
+    run: ParentRunFacetRun
+    job: ParentRunFacetJob
+
+
+@attrs.define
+class SQLJobFacet(BaseFacet):
+    query: str
+
+
+@attrs.define
+class ExternalQueryRunFacet(BaseFacet):
+    externalQueryId: str
+    source: str
+
+
+@attrs.define
+class DocumentationJobFacet(BaseFacet):
+    description: str
+
+
+@attrs.define
+class NominalTimeRunFacet(BaseFacet):
+    nominalStartTime: datetime
+    nominalEndTime: datetime
+
+
+@attrs.define
+class StorageDatasetFacet(BaseFacet):
+    storageLayer: str
+    fileFormat: str
+
+
+@attrs.define
+class OutputStatisticsOutputDatasetFacet(BaseFacet):
+    rowCount: int
+    size: int
+
+
+@attrs.define
+class JobFacets:
+    sourceCode: SourceCodeJobFacet
+    ownership: OwnershipJobFacet
+    sql: SQLJobFacet
+    sourceCodeLocation: SourceCodeLocationJobFacet
+    documentation: DocumentationJobFacet
+
+
+@attrs.define
+class RunFacets:
+    errorMessage: ErrorMessageRunFacet
+    externalQuery: ExternalQueryRunFacet
+    extractionError: ExtractionErrorRunFacet
+    parent: ParentRunFacet
+    nominalTime: NominalTimeRunFacet
+    processing_engine: ProcessingEngineRunFacet
+
+
+@attrs.define
+class Run:
+    runId: str
+    facets: RunFacets
+
+
+@attrs.define
+class InputDatasetInputFacets:
+    dataQualityAssertions: DataQualityAssertionsDatasetFacet
+    dataQualityMetrics: DataQualityMetricsInputDatasetFacet
+
+
+@attrs.define
+class Job:
+    namespace: str
+    name: str
+    facets: JobFacets
+
+
+@attrs.define
+class DatasetFacets:
+    documentation: DocumentationDatasetFacet
+    dataSource: DatasourceDatasetFacet
+    version: DatasetVersionDatasetFacet
+    schema: SchemaDatasetFacet
+    ownership: OwnershipDatasetFacet
+    storage: StorageDatasetFacet
+    columnLineage: ColumnLineageDatasetFacet
+    symlinks: SymlinksDatasetFacet
+    lifecycleStateChange: LifecycleStateChangeDatasetFacet
+
+
+@attrs.define
+class OutputDatasetOutputFacets:
+    outputStatistics: OutputStatisticsOutputDatasetFacet
+
+
+@attrs.define
+class Dataset:
+    namespace: str
+    name: str
+    facets: DatasetFacets
+
+
+@attrs.define
+class OutputDataset(Dataset):
+    outputFacets: OutputDatasetOutputFacets
+
+
+@attrs.define
+class InputDataset(Dataset):
+    inputFacets: InputDatasetInputFacets
+
+
+@attrs.define
+class RunEvent:
+    eventType: EventType
+    eventTime: datetime
+    run: Run
+    job: Job
+    inputs: List[InputDataset]
+    outputs: List[OutputDataset]
+    producer: str
+    schemaURL: str
+
+


### PR DESCRIPTION
We want to make adding new facets or changing spec as automatic as possible. This means we want to use automatic code generation for Python client - just as we do for Java one. 

This is a draft for such generator, with example generated file attached just for visibility now.

The idea is to provide full compatibility with current models by sharing wrappers for primary interface as much as needed. This part isn't done yet 