### PR TITLE
JDBC query handling fixes

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -34,7 +34,7 @@ public class JdbcUtils {
 
   public static Optional<SqlMeta> extractQueryFromSpark(JDBCRelation relation) {
     String tableOrQuery = relation.jdbcOptions().tableOrQuery();
-    if (!tableOrQuery.contains(") SPARK_GEN_SUBQ_")) {
+    if (!tableOrQuery.trim().startsWith("(")) {
       return Optional.of(
           new SqlMeta(
               Collections.singletonList(new DbTableMeta(null, null, tableOrQuery)),
@@ -42,9 +42,7 @@ public class JdbcUtils {
               Collections.emptyList(),
               Collections.emptyList()));
     } else {
-      String query =
-          tableOrQuery.replaceFirst("\\(", "").replaceAll("\\) SPARK_GEN_SUBQ_[0-9]+", "");
-
+      String query = tableOrQuery.substring(0, tableOrQuery.lastIndexOf(")")).replaceFirst("\\(", "").replaceAll("`", "");
       SqlMeta sqlMeta = OpenLineageSql.parse(Collections.singletonList(query)).get();
 
       if (!sqlMeta.errors().isEmpty()) { // error return nothing

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -42,7 +42,11 @@ public class JdbcUtils {
               Collections.emptyList(),
               Collections.emptyList()));
     } else {
-      String query = tableOrQuery.substring(0, tableOrQuery.lastIndexOf(")")).replaceFirst("\\(", "").replaceAll("`", "");
+      String query =
+          tableOrQuery
+              .substring(0, tableOrQuery.lastIndexOf(")"))
+              .replaceFirst("\\(", "")
+              .replaceAll("`", "");
       SqlMeta sqlMeta = OpenLineageSql.parse(Collections.singletonList(query)).get();
 
       if (!sqlMeta.errors().isEmpty()) { // error return nothing

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -30,17 +30,21 @@ public class JdbcRelationHandlerTest {
   JDBCOptions jdbcOptions = mock(JDBCOptions.class);
   String jdbcQuery =
       "(select js1.k, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) SPARK_GEN_SUBQ_0";
-  String jdbcTableSubQuery =
-      "(select `js1`.`k`, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) as table1";
+  String jdbcDbTableAsSubQuery =
+      "(select js1.k, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) as table1";
+  String mysqlQuery =
+      "(select `js1`.`k`, CONCAT(js1.j1, js2.j2) as j from `jdbc_source1` js1 join `jdbc_source2` js2 on js1.k = js2.k) as table1";
   String jdbcTable = "tablename";
   String invalidJdbc = "(test) SPARK_GEN_SUBQ_0";
   String url = "postgresql://localhost:5432/test";
+  String mysqlUrl = "mysql://localhost:3306/test";
   StructType schema =
       new StructType().add("k", DataTypes.IntegerType).add("j", DataTypes.StringType);
 
   @BeforeEach
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
+    when(jdbcOptions.url()).thenReturn("jdbc:" + url);
     when(relation.schema()).thenReturn(schema);
     jdbcRelationHandler = new JdbcRelationHandler(datasetFactory);
   }
@@ -69,8 +73,8 @@ public class JdbcRelationHandlerTest {
   }
 
   @Test
-  void testHandlingJdbcTableAsSubQuery() {
-    when(jdbcOptions.tableOrQuery()).thenReturn(jdbcTableSubQuery);
+  void testHandlingJdbcDbTableAsSubQuery() {
+    when(jdbcOptions.tableOrQuery()).thenReturn(jdbcDbTableAsSubQuery);
     StructType schema1 =
         new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
     StructType schema2 = new StructType().add("j2", DataTypes.StringType);
@@ -79,6 +83,20 @@ public class JdbcRelationHandlerTest {
 
     verify(datasetFactory, times(1)).getDataset("jdbc_source1", url, schema1);
     verify(datasetFactory, times(1)).getDataset("jdbc_source2", url, schema2);
+  }
+
+  @Test
+  void testMysqlDialect() {
+    when(jdbcOptions.tableOrQuery()).thenReturn(mysqlQuery);
+    when(jdbcOptions.url()).thenReturn("jdbc:" + mysqlUrl);
+    StructType schema1 =
+        new StructType().add("k", DataTypes.IntegerType).add("j1", DataTypes.StringType);
+    StructType schema2 = new StructType().add("j2", DataTypes.StringType);
+
+    jdbcRelationHandler.getDatasets(relation, mysqlUrl);
+
+    verify(datasetFactory, times(1)).getDataset("jdbc_source1", mysqlUrl, schema1);
+    verify(datasetFactory, times(1)).getDataset("jdbc_source2", mysqlUrl, schema2);
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -47,7 +47,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   String jdbcQuery =
       "(select js1.k, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) SPARK_GEN_SUBQ_0";
   String invalidJdbcQuery = "(INVALID) SPARK_GEN_SUBQ_0";
-  String url = "postgresql://localhost:5432/test";
+  String url = "jdbc:postgresql://localhost:5432/test";
   Map<ColumnMeta, ExprId> mockMap = new HashMap<>();
 
   @BeforeEach
@@ -58,7 +58,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   @Test
   void testInputCollection() {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcQuery);
-    when(jdbcOptions.url()).thenReturn("jdbc:" + url);
+    when(jdbcOptions.url()).thenReturn(url);
     doAnswer(
             invocation -> mockMap.putIfAbsent(invocation.getArgument(0), invocation.getArgument(1)))
         .when(builder)
@@ -77,7 +77,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   @Test
   void testInvalidQuery() {
     when(jdbcOptions.tableOrQuery()).thenReturn(invalidJdbcQuery);
-    when(jdbcOptions.url()).thenReturn("jdbc:" + url);
+    when(jdbcOptions.url()).thenReturn(url);
 
     JdbcColumnLineageCollector.extractExpressionsFromJDBC(
         relation, builder, Arrays.asList(expression1, expression2));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -47,6 +47,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   String jdbcQuery =
       "(select js1.k, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) SPARK_GEN_SUBQ_0";
   String invalidJdbcQuery = "(INVALID) SPARK_GEN_SUBQ_0";
+  String url = "postgresql://localhost:5432/test";
   Map<ColumnMeta, ExprId> mockMap = new HashMap<>();
 
   @BeforeEach
@@ -57,6 +58,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   @Test
   void testInputCollection() {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcQuery);
+    when(jdbcOptions.url()).thenReturn("jdbc:" + url);
     doAnswer(
             invocation -> mockMap.putIfAbsent(invocation.getArgument(0), invocation.getArgument(1)))
         .when(builder)
@@ -75,6 +77,7 @@ public class JdbcColumnLineageExpressionCollectorTest {
   @Test
   void testInvalidQuery() {
     when(jdbcOptions.tableOrQuery()).thenReturn(invalidJdbcQuery);
+    when(jdbcOptions.url()).thenReturn("jdbc:" + url);
 
     JdbcColumnLineageCollector.extractExpressionsFromJDBC(
         relation, builder, Arrays.asList(expression1, expression2));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
@@ -33,6 +33,7 @@ public class JdbcColumnLineageInputCollectorTest {
   String invalidJdbcQuery = "(INVALID) SPARK_GEN_SUBQ_0";
   DatasetIdentifier datasetIdentifier1 = new DatasetIdentifier("jdbc_source1", "jdbc");
   DatasetIdentifier datasetIdentifier2 = new DatasetIdentifier("jdbc_source2", "jdbc");
+  String url = "jdbc:postgresql://localhost:5432/test";
 
   static ExprId exprId1 = ExprId.apply(1);
   static ExprId exprId2 = ExprId.apply(2);
@@ -58,6 +59,7 @@ public class JdbcColumnLineageInputCollectorTest {
   @Test
   void testInputCollection() {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcQuery);
+    when(jdbcOptions.url()).thenReturn(url);
     when(builder.getMapping(any(ColumnMeta.class)))
         .thenAnswer(invocation -> mockMap.get(invocation.getArgument(0)));
 
@@ -72,6 +74,7 @@ public class JdbcColumnLineageInputCollectorTest {
   @Test
   void testInvalidQuery() {
     when(jdbcOptions.tableOrQuery()).thenReturn(invalidJdbcQuery);
+    when(jdbcOptions.url()).thenReturn(url);
 
     JdbcColumnLineageCollector.extractExternalInputs(
         relation, builder, Arrays.asList(datasetIdentifier1, datasetIdentifier2));


### PR DESCRIPTION
This PR solves 2 issues that are currently not supported in spark JDBC query handling:
1. JDBC query with "dbtable" option containing a subquery such as: "(select * from t) as table1" - should be handled the same was as using "query" option.
2. Pass the dialect to the sql parser, to support special db functionalities such as backticks in mysql, e.g. : "select \`table1\`.\`col1\` from \`table1\`";

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project