### PR TITLE
Drop pkg_resource in favor of packaging

### DIFF
--- a/integration/airflow/openlineage/airflow/__init__.py
+++ b/integration/airflow/openlineage/airflow/__init__.py
@@ -5,7 +5,7 @@
 import logging
 
 from openlineage.airflow.version import __version__
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.version import version as AIRFLOW_VERSION
 

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -5,7 +5,7 @@ import os
 
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.version import version as AIRFLOW_VERSION

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from typing import Optional
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.lineage.backend import LineageBackend
 from airflow.version import version as AIRFLOW_VERSION

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -30,6 +30,7 @@ extras_require = {
         "Flask-SQLAlchemy",  # must be set to 2.4.* for airflow tests compatibility
         "pandas-gbq==0.14.1",       # must be set to 0.14.* for airflow tests compatibility
         "snowflake-connector-python",
+        "packaging",
     ],
     "airflow": [
         "apache-airflow-providers-postgres>=2.0.0",

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 from mock import patch
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.version import version as AIRFLOW_VERSION
 

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -19,7 +19,7 @@ from openlineage.common.provider.bigquery import (
     BigQueryStatisticsDatasetFacet,
 )
 from openlineage.common.utils import get_from_nullable_chain
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG, TaskInstance
 from airflow.utils import timezone

--- a/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
+++ b/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
@@ -11,7 +11,7 @@ import pytz
 from mock import MagicMock
 from openlineage.airflow.extractors.dbt_cloud_extractor import DbtCloudExtractor
 from openlineage.airflow.utils import try_import_from_string
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG, TaskInstance
 from airflow.utils import timezone

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -15,7 +15,7 @@ from openlineage.airflow.extractors.redshift_data_extractor import RedshiftDataE
 from openlineage.client.facet import ErrorMessageRunFacet, OutputStatisticsOutputDatasetFacet
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator

--- a/integration/airflow/tests/extractors/test_sagemaker_extractors.py
+++ b/integration/airflow/tests/extractors/test_sagemaker_extractors.py
@@ -13,7 +13,7 @@ from openlineage.airflow.extractors.sagemaker_extractors import (
     SageMakerTrainingExtractor,
     SageMakerTransformExtractor,
 )
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.operators.sagemaker import (

--- a/integration/airflow/tests/extractors/test_sftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_sftp_extractor.py
@@ -9,7 +9,7 @@ import pytest
 from openlineage.airflow.extractors.sftp_extractor import SFTPExtractor
 from openlineage.airflow.utils import try_import_from_string
 from openlineage.common.dataset import Dataset, Source
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG, Connection
 from airflow.providers.sftp.hooks.sftp import SFTPHook

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
@@ -5,7 +5,7 @@ import os
 from typing import Any
 
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow import DAG
 from airflow.models import BaseOperator

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -13,7 +13,7 @@ import psycopg2
 import pytest
 import requests
 from openlineage.common.test import match, setup_jinja
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from retrying import retry
 
 env = setup_jinja()

--- a/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -23,7 +23,7 @@ from openlineage.airflow.utils import (
     url_to_https,
 )
 from openlineage.client.utils import RedactMixin
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.models import DAG as AIRFLOW_DAG
 from airflow.models import DagModel

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -28,7 +28,8 @@ extras_require = {
         "pytest-cov",
         "ruff",
         "mypy>=0.9.6",
-        "sqlalchemy<2.0.0"
+        "sqlalchemy<2.0.0",
+        "packaging",
     ],
 }
 

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -6,7 +6,7 @@ import uuid
 from typing import Optional
 
 from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from dagster import DagsterEvent, DagsterEventType, EventLogEntry, EventLogRecord, PipelineRun
 from dagster.core.code_pointer import FileCodePointer


### PR DESCRIPTION
### Problem

The use of package `pkg_resources` is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html).

### Solution

This PR drops `pkg_resources` in favor of `packaging`. `packaging` is added to `setup.py` accordingly.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Drop `pkg_resource` in favor of packaging.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project