### PR TITLE
Fix java class cast exception *1843

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -178,11 +178,14 @@ class OpenLineageRunEventBuilder {
   void registerJob(ActiveJob job) {
     jobMap.put(job.jobId(), job);
     stageMap.put(job.finalStage().id(), job.finalStage());
-    job.finalStage().parents().forall(toScalaFn(stage -> {
-        stageMap.put(stage.id(), stage);
-        return true;
-        }
-    ));
+    job.finalStage()
+        .parents()
+        .forall(
+            toScalaFn(
+                stage -> {
+                  stageMap.put(stage.id(), stage);
+                  return true;
+                }));
   }
 
   RunEvent buildRun(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -178,7 +178,11 @@ class OpenLineageRunEventBuilder {
   void registerJob(ActiveJob job) {
     jobMap.put(job.jobId(), job);
     stageMap.put(job.finalStage().id(), job.finalStage());
-    job.finalStage().parents().forall(toScalaFn(stage -> stageMap.put(stage.id(), stage)));
+    job.finalStage().parents().forall(toScalaFn(stage -> {
+        stageMap.put(stage.id(), stage);
+        return true;
+        }
+    ));
   }
 
   RunEvent buildRun(


### PR DESCRIPTION
### Problem

Main idea is to fix the error in the below issue. The error tries casting class org.apache.spark.scheduler.ShuffleMapStage to boolean, by calling the unboxToBoolean step.

Closes: #1843 

### Solution

The proposed solution is to return true after adding the stage to the stageMap.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project