### PR TITLE
python: remove deprecated ruff option param

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - *checkout_project_root
       - run: pip install -e .[dev]
-      - run: ruff . --no-update-check
+      - run: ruff .
       - run: python -m mypy --install-types --non-interactive --ignore-missing-imports --no-namespace-packages openlineage
       - run: python -m pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)
@@ -494,7 +494,7 @@ jobs:
     steps:
       - *checkout_project_root
       - run: pip install ruff
-      - run: ruff . --no-update-check
+      - run: ruff .
       - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
       - persist_to_workspace:
           root: .
@@ -666,7 +666,7 @@ jobs:
       - *checkout_project_root
       - *install_python_client
       - run: pip install -e .[dev]
-      - run: ruff . --no-update-check
+      - run: ruff .
       - run: python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
       - run: pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -43,7 +43,7 @@ deps = -r dev-requirements.txt
 	airflow-2.4.3: apache-airflow==2.4.3
 	airflow-2.5.0: apache-airflow==2.5.0
 whitelist_externals = bash
-commands = ruff . --no-update-check
+commands = ruff .
 	bash -ec "if [[ ! -f $0/airflow.db ]]; then airflow db reset -y; fi" {envdir}
 	python -m pytest --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -36,7 +36,7 @@ deps = ../../client/python
 	-e .[dev]
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
-commands = ruff . --no-update-check
+commands = ruff .
 	python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
 	pytest --cov=openlineage --junitxml=test-results/junit.xml tests/
 	coverage xml


### PR DESCRIPTION
Ruff removed `--update-check` and `--no-update-check` options in https://github.com/charliermarsh/ruff/pull/4313/files