### PR TITLE
ci: remove releasing snapshots to Artifactory

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -122,24 +122,6 @@ jobs:
           paths:
             - ~/.m2
   
-  publish-snapshot-client-java:
-    working_directory: ~/openlineage/client/java
-    docker:
-      - image: cimg/openjdk:8.0
-    steps:
-      - *checkout_project_root
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
-          # Publish *.jar
-          ./gradlew --no-daemon publish
-      - save_cache:
-          key: v1-release-client-java-snapshot-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - ~/.m2
-  
   release-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
@@ -167,29 +149,6 @@ jobs:
           path: ./build/libs
           destination: spark-client-artifacts
   
-  publish-snapshot-integration-spark:
-    working_directory: ~/openlineage/integration/spark
-    docker:
-      - image: cimg/openjdk:8.0
-    steps:
-      - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-release-client-java-snapshot-{{ .Branch }}-{{ .Revision }}
-            - v1-release-client-java-snapshot-{{ .Branch }}
-      - attach_workspace:
-          at: ~/.m2/repository/io/openlineage/
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
-          cd ../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
-          cd -
-          # Publish *.jar
-          ./gradlew --no-daemon publish
-
   build-integration-spark:
     parameters:
       spark-version:
@@ -248,27 +207,6 @@ jobs:
           export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
-          cd ../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
-          cd -
-          # Publish *.jar
-          ./gradlew --no-daemon publish
-
-  publish-snapshot-integration-flink:
-    working_directory: ~/openlineage/integration/flink
-    docker:
-      - image: cimg/openjdk:11.0
-    steps:
-      - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-release-client-java-snapshot-{{ .Branch }}-{{ .Revision }}
-            - v1-release-client-java-snapshot-{{ .Branch }}
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
           cd ../../client/java
           ./gradlew --no-daemon publishToMavenLocal
           cd -
@@ -417,32 +355,6 @@ jobs:
       - store_artifacts:
           path: ./build/libs
           destination: sql-java-artifacts
-
-  publish-snapshot-sql-java:
-    working_directory: ~/openlineage/integration/sql/iface-java
-    docker:
-      - image: cimg/openjdk:8.0
-    resource_class: medium
-    steps:
-      - *checkout_project_root
-      - restore_cache:
-          keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
-            - v1-release-client-java-{{ .Branch }}
-      - attach_workspace:
-          at: ../
-      - run: bash script/build.sh
-      - run: |
-          # Get, then decode the GPG private key used to sign *.jar
-          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
-          export RELEASE_PASSWORD=$(echo $ARTIFACTORY_PASSWORD)
-          export RELEASE_USERNAME=$(echo $ARTIFACTORY_USERNAME)
-
-          cd ../../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
-          cd -
-          # Publish *.jar
-          ./gradlew --no-daemon publish
 
   release-integration-sql-java:
     working_directory: ~/openlineage/integration/sql/iface-java
@@ -686,18 +598,6 @@ jobs:
             - ./dist/*.whl
             - ./dist/*.tar.gz
 
-  publish-snapshot-python:
-    working_directory: ~/openlineage
-    docker:
-      - image: cimg/python:3.7
-    steps:
-      - *checkout_project_root
-      - attach_workspace:
-          at: .
-      - run: pip install wheel twine
-      - run: mkdir -p target/wheels && cp target/wheels/* dist/
-      - run: python -m twine upload --non-interactive --verbose -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD --repository-url https://astronomer.jfrog.io/artifactory/api/pypi/pypi-public-libs-release dist/*
-  
   release-python:
     working_directory: ~/openlineage
     docker:

--- a/.circleci/workflows/openlineage-integration-publish.yml
+++ b/.circleci/workflows/openlineage-integration-publish.yml
@@ -1,19 +1,6 @@
 workflows:
   openlineage-integration-publish:
     jobs:
-      - publish-snapshot-python:
-          filters:
-            branches:
-              only: main
-          context: release
-          requires:
-            - build-client-python
-            - build-integration-common
-            - build-integration-airflow
-            - build-integration-dbt
-            - build-integration-dagster
-            - build-integration-sql-x86
-            - build-integration-sql-arm
       - publish-spec:
           filters:
             branches:
@@ -21,5 +8,4 @@ workflows:
           context: release
       - workflow_complete:
           requires:
-            - publish-snapshot-python
             - publish-spec

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -24,20 +24,6 @@ workflows:
             - compile-integration-sql-java-linux-arm
             - compile-integration-sql-java-linux-x86
             - compile-integration-sql-java-macos
-      - publish-snapshot-sql-java:
-          filters:
-            branches:
-              only: main
-          context: release
-          requires:
-            - build-integration-sql-java
-      - publish-snapshot-client-java:
-          filters:
-            branches:
-              only: main
-          context: release
-          requires:
-            - build-client-java
       - publish-javadoc:
           filters:
             branches:
@@ -45,5 +31,4 @@ workflows:
           context: release
       - workflow_complete:
           requires:
-            - publish-snapshot-client-java
             - publish-javadoc

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -15,14 +15,6 @@ workflows:
               spark-version: [ '2.4.6', '3.2.2', '3.3.1' ]
           requires:
             - build-integration-spark
-      - publish-snapshot-integration-spark:
-          filters:
-            branches:
-              only: main
-          context: release
-          requires:
-            - integration-test-integration-spark
       - workflow_complete:
           requires:
-            - publish-snapshot-integration-spark
             - integration-test-integration-spark

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -37,9 +37,6 @@ pmdMain {
 repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
-    }
 }
 
 ext {
@@ -180,8 +177,7 @@ publishing {
 
     repositories {
         maven {
-            url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -40,9 +40,6 @@ repositories {
     maven {
         url = "https://packages.confluent.io/maven/"
     }
-    maven {
-        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
-    }
 }
 
 configurations {
@@ -271,8 +268,7 @@ publishing {
 
     repositories {
         maven {
-            url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')

--- a/integration/sql/iface-java/build.gradle
+++ b/integration/sql/iface-java/build.gradle
@@ -103,8 +103,7 @@ publishing {
 
     repositories {
         maven {
-            url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')

--- a/proxy/backend/build.gradle
+++ b/proxy/backend/build.gradle
@@ -131,8 +131,7 @@ publishing {
 
     repositories {
         maven {
-            url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             credentials {
                 username = System.getenv('RELEASE_USERNAME')
                 password = System.getenv('RELEASE_PASSWORD')


### PR DESCRIPTION
Artifactory snapshots upload often break and usage does not justify continuously keeping up with it. This PR removes that uploads.