### PR TITLE
[SPARK] fix single-file datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * **Spark: add Spark/Delta `merge into` support** [`#1823`](https://github.com/OpenLineage/OpenLineage/pull/1823) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Adds support for `merge into` queries.*
 
+* **Spark: support single file datasets.** [`#1855`](https://github.com/OpenLineage/OpenLineage/pull/1855) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Properly name datasets created on the top of single file, like `spark.read.csv('file.csv')`.*
+
 ### Fixed
 * **Spark: fix JDBC query handling** [`#1808`](https://github.com/OpenLineage/OpenLineage/pull/1808) [@nataliezeller1](https://github.com/nataliezeller1)  
     *Makes query handling more tolerant of variations in syntax and formatting.*

--- a/integration/spark/app/integrations/container/pysparkWordCountWithCliArgsCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkWordCountWithCliArgsCompleteEvent.json
@@ -11,7 +11,7 @@
   "inputs": [
     {
       "namespace": "file",
-      "name": "/test_data",
+      "name": "/test_data/data.txt",
       "facets": {
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/pysparkWordCountWithCliArgsStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkWordCountWithCliArgsStartEvent.json
@@ -11,7 +11,7 @@
   "inputs": [
     {
       "namespace": "file",
-      "name": "/test_data",
+      "name": "/test_data/data.txt",
       "facets": {
         "schema": {
           "fields": [

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -77,7 +77,8 @@ class LogicalRelationDatasetBuilderTest {
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
     when(fileIndex.rootPaths())
         .thenReturn(
-            scala.collection.JavaConverters.collectionAsScalaIterableConverter(Arrays.asList(path))
+            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+                    Arrays.asList(path, path))
                 .asScala()
                 .toSeq());
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(new OpenLineage.DatasetFacetsBuilder());


### PR DESCRIPTION
### Problem

If a spark dataset is a single file, it's wrongly represented as its parent directory. 

Closes: #1841

### Solution

In case of single file datasets, a file path should be a dataset name (currently parent dir path is set to it)/

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project