### PR TITLE
Attempt to fix unquoted `[` and `]` in snowflake URIs.

### DIFF
--- a/integration/common/openlineage/common/provider/snowflake.py
+++ b/integration/common/openlineage/common/provider/snowflake.py
@@ -1,16 +1,16 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 
 def fix_account_name(name: str) -> str:
-    spl = name.split('.')
+    spl = name.split(".")
     if len(spl) == 1:
         account = spl[0]
-        region, cloud = 'us-west-1', 'aws'
+        region, cloud = "us-west-1", "aws"
     elif len(spl) == 2:
         account, region = spl
-        cloud = 'aws'
+        cloud = "aws"
     else:
         account, region, cloud = spl
     return f"{account}.{region}.{cloud}"
@@ -18,22 +18,28 @@ def fix_account_name(name: str) -> str:
 
 def fix_snowflake_sqlalchemy_uri(uri: str) -> str:
     """Snowflake sqlalchemy connection URI has following structure:
-        'snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>'
-        We want to canonicalize account identifier. It can have two forms:
-        - newer, in form of <organization>-<id>. In this case we want to do nothing.
-        - older, composed of <id>-<region>-<cloud> where region and cloud can be
-          optional in some cases.If <cloud> is omitted, it's AWS.
-          If region and cloud are omitted, it's AWS us-west-1
+    'snowflake://<user_login_name>:<password>@<account_identifier>/<database_name>/<schema_name>?warehouse=<warehouse_name>&role=<role_name>'
+    We want to canonicalize account identifier. It can have two forms:
+    - newer, in form of <organization>-<id>. In this case we want to do nothing.
+    - older, composed of <id>-<region>-<cloud> where region and cloud can be
+      optional in some cases.If <cloud> is omitted, it's AWS.
+      If region and cloud are omitted, it's AWS us-west-1
     """
 
-    parts = urlparse(uri)
+    try:
+        parts = urlparse(uri)
+    except ValueError:
+        # snowflake.sqlalchemy.URL does not quote `[` and `]`
+        # that's a rare case so we can run more debugging code here
+        # to make sure we replace only password
+        parts = urlparse(uri.replace("[", quote("[")).replace("]", quote("]")))
 
     hostname = parts.hostname
     if not hostname:
         return uri
 
     # old account identifier like xy123456
-    if '.' in hostname or not any(word in hostname for word in ['-', '_']):
+    if "." in hostname or not any(word in hostname for word in ["-", "_"]):
         hostname = fix_account_name(hostname)
     # else - its new hostname, just return it
     return urlunparse(

--- a/integration/common/tests/test_snowflake.py
+++ b/integration/common/tests/test_snowflake.py
@@ -15,7 +15,11 @@ from openlineage.common.provider.snowflake import fix_snowflake_sqlalchemy_uri
     ("snowflake://user:pass@xy12345.us-east4.gcp/database/schema",
         "snowflake://xy12345.us-east4.gcp/database/schema"),
     ("snowflake://user:pass@organization-account/database/schema",
-        "snowflake://organization-account/database/schema")
+        "snowflake://organization-account/database/schema"),
+    ("snowflake://user:p[ass@organization-account/database/schema",
+        "snowflake://organization-account/database/schema"),
+    ("snowflake://user:pass@organization]-account/database/schema",
+        "snowflake://organization%5D-account/database/schema")
 ])
 def test_snowflake_sqlite_account_urls(source, target):
     assert fix_snowflake_sqlalchemy_uri(source) == target


### PR DESCRIPTION
### Problem

Airflow Snowflake connection may contain one of `[` or `]` values that makes `urllib.parse.urlparse` fail.

### Solution

This PR introduces a workaround to replace `[` & `]` with quoted values.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project