### PR TITLE
Adding a file transport

### DIFF
--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from openlineage.client.transport.console import ConsoleTransport
 from openlineage.client.transport.factory import DefaultTransportFactory
+from openlineage.client.transport.file import FileTransport
 from openlineage.client.transport.http import HttpConfig, HttpTransport
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 from openlineage.client.transport.noop import NoopTransport
@@ -14,6 +15,7 @@ _factory.register_transport(HttpTransport.kind, HttpTransport)
 _factory.register_transport(KafkaTransport.kind, KafkaTransport)
 _factory.register_transport(ConsoleTransport.kind, ConsoleTransport)
 _factory.register_transport(NoopTransport.kind, NoopTransport)
+_factory.register_transport(FileTransport.kind, FileTransport)
 
 
 def get_default_factory() -> DefaultTransportFactory:

--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -1,0 +1,52 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2018-2023 contributors to the Marquez project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+
+
+@dataclass
+class FileConfig:
+    log_file_path: str
+    append: bool = False
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> FileConfig:
+        if "log_file_path" not in params:
+            msg = "`log_file_path` key not passed to FileConfig"
+            raise RuntimeError(msg)
+
+        log_file_path = params["log_file_path"]
+
+        with open(log_file_path, "a" if cls.append else "w") as log_file_handle:
+            if not log_file_handle.writable():
+                msg = f"Log file {log_file_path} is not writeable"
+                raise RuntimeError(msg)
+
+        return cls(log_file_path)
+
+
+class FileTransport:
+    kind = "file"
+    config: FileConfig
+
+    def __init__(self, config: FileConfig) -> None:
+        self.config = config
+
+    def emit(self, event: RunEvent) -> None:
+        if self.config.append:
+            log_file_path = self.config.log_file_path
+        else:
+            timestr = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
+            log_file_path = f"{self.config.log_file_path}-{timestr}"
+
+        with open(log_file_path, "a" if self.config.append else "w") as log_file_handle:
+            log_file_handle.write(Serde.to_json(event) + "\n")

--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -8,13 +8,15 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from openlineage.client.transport.transport import Config, Transport
+
 if TYPE_CHECKING:
-    from openlineage.client.run import RunEvent
+    from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
 from openlineage.client.serde import Serde
 
 
 @dataclass
-class FileConfig:
+class FileConfig(Config):
     log_file_path: str
     append: bool = False
 
@@ -34,14 +36,14 @@ class FileConfig:
         return cls(log_file_path)
 
 
-class FileTransport:
+class FileTransport(Transport):
     kind = "file"
-    config: FileConfig
+    config_class = FileConfig
 
     def __init__(self, config: FileConfig) -> None:
         self.config = config
 
-    def emit(self, event: RunEvent) -> None:
+    def emit(self, event: RunEvent | DatasetEvent | JobEvent) -> None:
         if self.config.append:
             log_file_path = self.config.log_file_path
         else:

--- a/client/python/tests/test_file.py
+++ b/client/python/tests/test_file.py
@@ -1,0 +1,94 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+import json
+import tempfile
+import time
+import uuid
+from os import listdir
+from os.path import isfile, join
+from typing import Any, Dict
+
+from openlineage.client import OpenLineageClient
+from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.transport.file import FileConfig, FileTransport
+
+
+def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> list[Dict[str, Any]]:
+    test_event_set = [
+        {
+            "eventType": RunState.START,
+            "name": "test",
+            "namespace": "file",
+            "producer": "prod",
+        },
+        {
+            "eventType": RunState.COMPLETE,
+            "name": "test",
+            "namespace": "file",
+            "producer": "prod",
+        },
+    ]
+
+    for test_event in test_event_set:
+        event = RunEvent(
+            eventType=test_event["eventType"],
+            eventTime=datetime.datetime.now().isoformat(),
+            run=Run(runId=str(uuid.uuid4())),
+            job=Job(namespace=test_event["namespace"], name=test_event["name"]),
+            producer=test_event["producer"],
+        )
+
+        client.emit(event)
+        time.sleep(debuff_time)  # avoid writing on the same timestamp
+
+    return test_event_set
+
+
+def assert_test_events(log_line: list[Dict[str, Any]], test_event: list[Dict[str, Any]]) -> None:
+    assert log_line["eventType"] == test_event["eventType"].name
+    assert log_line["job"]["name"] == test_event["name"]
+    assert log_line["job"]["namespace"] == test_event["namespace"]
+    assert log_line["producer"] == test_event["producer"]
+
+
+def test_client_with_file_transport_append_emits() -> None:
+    log_file = tempfile.NamedTemporaryFile()
+    config = FileConfig(append=True, log_file_path=log_file.name)
+    transport = FileTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    test_event_set = emit_test_events(client)
+
+    with open(log_file.name) as log_file_handle:
+        log_file_handle.seek(0)
+        log_lines = log_file_handle.read().splitlines()
+
+        for i, raw_log_line in enumerate(log_lines):
+            log_line = json.loads(raw_log_line)
+            test_event = test_event_set[i]
+            assert_test_events(log_line, test_event)
+
+
+def test_client_with_file_transport_write_emits() -> None:
+    log_dir = tempfile.TemporaryDirectory()
+
+    config = FileConfig(log_file_path=join(log_dir.name, "logtest"))
+    transport = FileTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    test_event_set = emit_test_events(client, 0.01)
+
+    log_files = [
+        join(log_dir.name, f) for f in listdir(log_dir.name) if isfile(join(log_dir.name, f))
+    ]
+    log_files.sort()
+
+    for i, log_file in enumerate(log_files):
+        with open(log_file) as log_file_handle:
+            log_line = json.loads(log_file_handle.read())
+            test_event = test_event_set[i]
+
+            assert_test_events(log_line, test_event)

--- a/client/python/tests/test_file.py
+++ b/client/python/tests/test_file.py
@@ -7,14 +7,14 @@ import time
 import uuid
 from os import listdir
 from os.path import isfile, join
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.transport.file import FileConfig, FileTransport
 
 
-def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> list[Dict[str, Any]]:
+def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> List[Dict[str, Any]]:
     test_event_set = [
         {
             "eventType": RunState.START,
@@ -45,7 +45,7 @@ def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> list[Di
     return test_event_set
 
 
-def assert_test_events(log_line: list[Dict[str, Any]], test_event: list[Dict[str, Any]]) -> None:
+def assert_test_events(log_line: List[Dict[str, Any]], test_event: List[Dict[str, Any]]) -> None:
     assert log_line["eventType"] == test_event["eventType"].name
     assert log_line["job"]["name"] == test_event["name"]
     assert log_line["job"]["namespace"] == test_event["namespace"]


### PR DESCRIPTION
### Problem

We were missing a File transport for OpenLineage as we have a lot of log ingestion software depending on object storage/ (often fuse-mounted in our runtime environments). It was also asked on the Projects's Slack, so here's our take

### Solution

A FileTransport and its configuration classes were created. This transport supports append mode or write-new-file mode (especially useful on object storage not supporting append mode e.g: Databricks DBFS fuse)

Code written with  @TomRibuot (https://github.com/TomRibuot).

#### One-line summary:
Adding a file transport

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project