### PR TITLE
ci: replace removed --universal2 option

### DIFF
--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -3,7 +3,7 @@ current_version = 0.28.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<rc>.*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{rc}
 	{major}.{minor}.{patch}
 

--- a/integration/sql/iface-py/script/build-macos.sh
+++ b/integration/sql/iface-py/script/build-macos.sh
@@ -35,7 +35,7 @@ if [[ -d "./iface-py" ]]
 then
   cd iface-py
 fi
-maturin build --universal2 --out target/wheels
+maturin build --target universal2-apple-darwin --out target/wheels
 
 echo "Package build, trying to import"
 echo "Platform:"


### PR DESCRIPTION
Maturin release removed `--universal2` option: https://github.com/PyO3/maturin/pull/1620