### PR TITLE
python: deprecate client.from_environment, do not skip loading config on it

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -101,7 +101,8 @@ class OpenLineageClient:
 
     @classmethod
     def from_environment(cls: type[_T]) -> _T:
-        return cls(transport=get_default_factory().create())
+        # Deprecated way of creating client, use constructor or from_dict
+        return cls()
 
     @classmethod
     def from_dict(cls: type[_T], config: dict[str, str]) -> _T:


### PR DESCRIPTION
In 0.27.1, we added filters to Python OL client. This required us to move place where OL config is read - which now is on client construction, not transport.

However, OpenLineageClient.from_environment() method wasn't changed to accomodate that - and using it skipped config loading.

This change deprecates that method and recommends using constructor instead - after the fix, using it shouldn't differ now from using constructor.
