### PR TITLE
integration test on databricks platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
     type: enum
     default: "*"
     enum: ["*", "airflow", "dagster", "dbt", "publish", "python"]
+  databricks-test:
+    type: string
+    default: "disabled"
 
 jobs:
   # Determine the modules that have changed and trigger a series of workflow tasks as necessary.

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -34,6 +34,11 @@ commands:
             - run: pip install target/wheels/*manylinux_2_17_x86_64*.whl
       - run: (cd ~/openlineage/integration/common && pip install . --user)
 
+parameters:
+  databricks-test:
+    type: string
+    default: "disabled"
+
 jobs:
   unit-test-client-python:
     working_directory: ~/openlineage/client/python
@@ -451,20 +456,58 @@ jobs:
           sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
           sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
       - run: ./gradlew --no-daemon integrationTest -x test   -Pspark.version=<< parameters.spark-version >>
-      - run:
-          when: on_fail
-          command: cat build/test-results/integrationTest/TEST-*.xml
       - run: ./gradlew --no-daemon jacocoTestReport
       - store_test_results:
-          path: build/test-results/integrationTest
+          path: app/build/test-results/integrationTest
       - store_artifacts:
-          path: build/reports/tests/integrationTest
+          path: app/build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
           key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/.gradle
-  
+
+  integration-test-databricks-integration-spark:
+    parameters:
+      spark-version:
+        type: string
+    working_directory: ~/openlineage/integration/spark
+    machine:
+      image: ubuntu-2004:current
+    resource_class: large
+    environment:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    steps:
+      - *checkout_project_root
+      - when:
+          condition:
+            equal: [ enabled, << pipeline.parameters.databricks-test >> ]
+          steps:
+            - restore_cache:
+                keys:
+                  - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+                  - v1-integration-spark-{{ .Branch }}
+            - attach_workspace:
+                at: ~/.m2/repository/io/openlineage/
+            - run: |
+                sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+                sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+            - run: ./gradlew shadowJar -x test
+            - run: ./gradlew --no-daemon databricksIntegrationTest -x test   -Pspark.version=<< parameters.spark-version >> -PdatabricksHost=$DATABRICKS_HOST -PdatabricksToken=$DATABRICKS_TOKEN
+            - store_test_results:
+                path: app/build/test-results/databricksIntegrationTest
+            - store_artifacts:
+                path: app/build/reports/tests/databricksIntegrationTest
+                destination: test-report
+            - store_artifacts:
+                path: app/build/cluster-log4j.log
+                destination: cluster-log4j.log
+            - save_cache:
+                key: v1-databricks-integration-spark-{{ .Branch }}-{{ .Revision }}
+                paths:
+                  - ~/.gradle
+
   integration-test-integration-flink:
     parameters:
       flink-version:

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -8,6 +8,13 @@ workflows:
           requires:
            - build-integration-sql-java
            - build-client-java
+      - integration-test-databricks-integration-spark:
+          context: integration-tests
+          matrix:
+            parameters:
+              spark-version: [ '3.4.0' ]
+          requires:
+            - build-integration-spark
       - integration-test-integration-spark:
           context: integration-tests
           matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   *Extract dataset schema from `KafkaSource` when `GenericRecord` deserialized is used.*
 * **Flink: support Flink version 1.17.1** [`#1947`](https://github.com/OpenLineage/OpenLineage/pull/1947) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Support Flink versions: 1.15.4, 1.16.2 and 1.17.1.*
+* **Spark: Databricks platform integration test.** [`#1928`](https://github.com/OpenLineage/OpenLineage/pull/1928) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Spark integration test to verify behaviour on databricks platform to be run manually in CircleCI when needed.*
 
 ## [0.28.0](https://github.com/OpenLineage/OpenLineage/compare/0.27.2...0.28.0) - 2023-06-12
 ### Added

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.openlineage.client.OpenLineage.RunEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -85,6 +86,14 @@ public final class OpenLineageClientUtils {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  /**
+   * Converts the provided Json {@code string} to {@link RunEvent}. Useful as other `fromJson`
+   * method gets shaded.
+   */
+  public static RunEvent runEventFromJson(@NonNull final String json) {
+    return fromJson(json, new TypeReference<RunEvent>() {});
   }
 
   public static <T> T convertValue(Object fromValue, Class<T> toValueType) {

--- a/client/java/src/main/java/io/openlineage/client/transports/FileConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileConfig.java
@@ -1,0 +1,21 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.With;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@With
+public final class FileConfig implements TransportConfig {
+  @Getter @Setter private String location;
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
@@ -1,0 +1,50 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+/**
+ * Appends Openlineage events to a file specified. Events are separated by a newline character,
+ * while all the existing newline characters within event json are removed. FileTransport was
+ * introduced for the purpose of integration tests.
+ */
+@Slf4j
+public class FileTransport extends Transport {
+
+  File file;
+
+  public FileTransport(@NonNull final FileConfig fileConfig) {
+    super(Type.FILE);
+    file = new File(fileConfig.getLocation());
+  }
+
+  @Override
+  public void emit(OpenLineage.RunEvent runEvent) {
+    // if DEBUG loglevel is enabled, this will double-log even due to OpenLineageClient also logging
+    emit(OpenLineageClientUtils.toJson(runEvent));
+  }
+
+  public void emit(String eventAsJson) {
+    try {
+      FileUtils.writeStringToFile(
+          file,
+          eventAsJson.replace(System.lineSeparator(), "") + System.lineSeparator(),
+          StandardCharsets.UTF_8,
+          true);
+      log.info("emitted event: " + eventAsJson);
+    } catch (IOException | IllegalArgumentException e) {
+      log.error("Writing event to a file {} failed: {}", file.getPath(), e);
+    }
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransportBuilder.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+public class FileTransportBuilder implements TransportBuilder {
+
+  @Override
+  public TransportConfig getConfig() {
+    return new FileConfig();
+  }
+
+  @Override
+  public Transport build(TransportConfig config) {
+    return new FileTransport((FileConfig) config);
+  }
+
+  @Override
+  public String getType() {
+    return "file";
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 public abstract class Transport {
   enum Type {
     CONSOLE,
+    FILE,
     HTTP,
     KAFKA,
     KINESIS,

--- a/client/java/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
+++ b/client/java/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
@@ -1,4 +1,5 @@
 io.openlineage.client.transports.HttpTransportBuilder
 io.openlineage.client.transports.KafkaTransportBuilder
 io.openlineage.client.transports.ConsoleTransportBuilder
+io.openlineage.client.transports.FileTransportBuilder
 io.openlineage.client.transports.KinesisTransportBuilder

--- a/client/java/src/test/java/io/openlineage/client/transports/FileTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/FileTransportTest.java
@@ -1,0 +1,91 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FileTransportTest {
+
+  private static final String FILE_LOCATION_DIR = "/tmp/openlineage_transport_test";
+  private static final String FILE_LOCATION = FILE_LOCATION_DIR + "/events.log";
+
+  FileConfig fileConfig;
+  Transport transport;
+
+  @BeforeEach
+  @SneakyThrows
+  public void beforeEach() {
+    FileUtils.deleteDirectory(new File(FILE_LOCATION_DIR));
+
+    fileConfig = new FileConfig();
+    fileConfig.setLocation(FILE_LOCATION);
+    transport = new FileTransport(fileConfig);
+  }
+
+  @Test
+  @SneakyThrows
+  public void transportAppendsToFile() {
+    transport.emit(
+        new OpenLineage(URI.create("http://test.producer"))
+            .newRunEventBuilder()
+            .job(new OpenLineage.JobBuilder().name("test-job").namespace("test-ns").build())
+            .build());
+    List<String> lines = FileUtils.readLines(new File(FILE_LOCATION));
+
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).contains("test-job");
+  }
+
+  @Test
+  @SneakyThrows
+  public void transportCannotAppendToFileWhenFileNotWriteable() {
+    fileConfig = new FileConfig();
+    fileConfig.setLocation(FILE_LOCATION);
+    transport = new FileTransport(fileConfig);
+
+    transport.emit("{some-event}");
+
+    // make file unwritable
+    new File(FILE_LOCATION).setWritable(false);
+
+    // should not be written
+    transport.emit("{some-event}");
+
+    assertThat(FileUtils.readLines(new File(FILE_LOCATION)).size()).isEqualTo(1);
+  }
+
+  @Test
+  @SneakyThrows
+  public void multipleEventsAreSeparatedByNewline() {
+    transport.emit("{some-event-1}");
+    transport.emit("{some-event-2}");
+
+    List<String> lines = FileUtils.readLines(new File(FILE_LOCATION));
+
+    assertThat(lines.size()).isEqualTo(2);
+    assertThat(lines.get(0)).isEqualTo("{some-event-1}");
+    assertThat(lines.get(1)).isEqualTo("{some-event-2}");
+  }
+
+  @Test
+  @SneakyThrows
+  public void newlinesAreRemovedFromWrittenEvents() {
+    transport.emit("some-event-\n-same-event");
+    List<String> lines = FileUtils.readLines(new File(FILE_LOCATION));
+
+    assertThat(lines.size()).isEqualTo(1);
+    assertThat(lines.get(0)).isEqualTo("some-event--same-event");
+  }
+}

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -124,6 +124,10 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
     }
+    testFixturesApi("com.databricks:databricks-sdk-java:0.0.1") {
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.module'
+    }
 
     testFixturesApi("org.apache.hadoop:hadoop-client:${versions.hadoopclient}") { force=true }
     testFixturesApi("org.mock-server:mockserver-netty:5.14.0:shaded") {
@@ -213,12 +217,26 @@ task integrationTest(type: Test) {
     configure commonTestConfiguration
     useJUnitPlatform {
         includeTags "integration-test"
+        excludeTags "databricks"
         if(!sparkVersion.startsWith('3')) {excludeTags 'spark3'}
         if(versions.delta == "NA") {excludeTags 'delta'}
         if(versions.iceberg == "NA") {excludeTags 'iceberg'}
     }
+}
 
-
+task databricksIntegrationTest(type: Test) {
+    dependsOn shadowJar, copyDependencies
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
+    configure commonTestConfiguration
+    useJUnitPlatform {
+        includeTags "databricks"
+    }
 }
 
 spotless {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static io.openlineage.spark.agent.DatabricksUtils.DBFS_EVENTS_FILE;
+import static io.openlineage.spark.agent.DatabricksUtils.init;
+import static io.openlineage.spark.agent.DatabricksUtils.runScript;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.core.DatabricksConfig;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.OpenLineage.RunEvent;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests to check Openlineage Spark integration on a databricks platform. This test
+ * takes some time as it requires starting databricks cluster and this can take up to 10 minutes.
+ * Test suite is run in Circle CI when triggered manually with extra parameter `databricks-test` set
+ * to `enabled`.
+ */
+@Tag("integration-test")
+@Tag("databricks")
+@Slf4j
+public class DatabricksIntegrationTest {
+
+  private static WorkspaceClient workspace;
+  private static String clusterId;
+
+  @BeforeAll
+  @SneakyThrows
+  public static void setup() {
+    DatabricksConfig config =
+        new DatabricksConfig()
+            .setHost(System.getProperty("databricksHost"))
+            .setToken(System.getProperty("databricksToken"));
+
+    workspace = new WorkspaceClient(config);
+    clusterId = init(workspace);
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    workspace.dbfs().delete(DBFS_EVENTS_FILE);
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    DatabricksUtils.shutdown(workspace, clusterId);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testCreateTableAsSelect() {
+    List<RunEvent> runEvents = runScript(workspace, clusterId, "ctas.py");
+    RunEvent lastEvent = runEvents.get(runEvents.size() - 1);
+
+    OutputDataset outputDataset = lastEvent.getOutputs().get(0);
+    InputDataset inputDataset = lastEvent.getInputs().get(0);
+
+    assertThat(outputDataset.getNamespace()).isEqualTo("dbfs");
+    assertThat(outputDataset.getName()).isEqualTo("/user/hive/warehouse/ctas");
+
+    assertThat(inputDataset.getNamespace()).isEqualTo("dbfs");
+    assertThat(inputDataset.getName()).isEqualTo("/user/hive/warehouse/temp");
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -1,0 +1,253 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static java.nio.file.Files.readAllBytes;
+import static org.awaitility.Awaitility.await;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.service.compute.CreateClusterResponse;
+import com.databricks.sdk.service.compute.ListClustersRequest;
+import com.databricks.sdk.service.files.CreateResponse;
+import com.databricks.sdk.service.files.Delete;
+import com.databricks.sdk.service.jobs.RunSubmitTaskSettings;
+import com.databricks.sdk.service.jobs.SparkPythonTask;
+import com.databricks.sdk.service.jobs.SparkPythonTaskSource;
+import com.databricks.sdk.service.jobs.SubmitRun;
+import com.google.common.io.Resources;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.spark.agent.databricks.ClusterLogConf;
+import io.openlineage.spark.agent.databricks.CreateCluster;
+import io.openlineage.spark.agent.databricks.DbfsDestination;
+import io.openlineage.spark.agent.databricks.InitScript;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+public class DatabricksUtils {
+
+  public static final String CLUSTER_NAME = "openlineage-test-cluster";
+
+  public static final Map<String, String> PLATFORM_VERSIONS =
+      Stream.of(new AbstractMap.SimpleEntry<>("3.4.0", "13.0.x-scala2.12"))
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  public static final String NODE_TYPE = "m5d.large";
+  public static final String DBFS_EVENTS_FILE = "dbfs:/databricks/openlineage/events.log";
+  public static final String DBFS_INIT_SCRIPT_FILE =
+      "dbfs:/databricks/openlineage/open-lineage-init-script.sh";
+  public static final String DBFS_CLUSTER_LOGS = "dbfs:/databricks/openlineage/cluster-logs";
+  private static final String SPARK_VERSION = "spark.version";
+
+  @SneakyThrows
+  static String init(WorkspaceClient workspace) {
+    uploadOpenlineageJar(workspace);
+
+    // clear cluster logs
+    Delete deleteClusterLogs = new Delete();
+    deleteClusterLogs.setPath(DBFS_CLUSTER_LOGS);
+    deleteClusterLogs.setRecursive(true);
+    workspace.dbfs().delete(deleteClusterLogs);
+
+    // check if cluster is available
+    String clusterId =
+        StreamSupport.stream(
+                workspace.clusters().list(new ListClustersRequest()).spliterator(), false)
+            .filter(cl -> cl.getClusterName().equals(getClusterName()))
+            .map(cl -> cl.getClusterId())
+            .findAny()
+            .orElseGet(() -> createCluster(workspace));
+
+    log.info("Ensuring cluster is running");
+    workspace.clusters().ensureClusterIsRunning(clusterId);
+
+    return clusterId;
+  }
+
+  @SneakyThrows
+  static void shutdown(WorkspaceClient workspace, String clusterId) {
+    // remove events file
+    workspace.dbfs().delete(DBFS_EVENTS_FILE);
+
+    // need to terminate cluster to have access to cluster logs
+    workspace.clusters().delete(clusterId);
+    workspace.clusters().waitGetClusterTerminated(clusterId);
+
+    // wait for logs to be available
+    Path clusterLogs = Paths.get(DBFS_CLUSTER_LOGS + "/" + clusterId + "/driver/log4j-active.log");
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(3))
+        .until(
+            () -> {
+              try {
+                return workspace.dbfs().getStatus(clusterLogs.toString()) != null;
+              } catch (Exception e) {
+                return false;
+              }
+            });
+
+    // fetch logs and move to local file
+    FileWriter fileWriter = new FileWriter("./build/cluster-log4j.log");
+    workspace.dbfs().readAllLines(clusterLogs, StandardCharsets.UTF_8).stream()
+        .forEach(
+            line -> {
+              try {
+                fileWriter.write(line + System.lineSeparator());
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    workspace.dbfs().delete(clusterLogs.toAbsolutePath().toString());
+  }
+
+  @SneakyThrows
+  static List<RunEvent> runScript(WorkspaceClient workspace, String clusterId, String scriptName) {
+    // upload scripts upload init scripts
+    String dbfsScriptPath = "dbfs:/databricks/openlineage/scripts/" + scriptName;
+    String taskName = scriptName.replace(".py", "");
+
+    workspace
+        .dbfs()
+        .write(
+            Paths.get(dbfsScriptPath),
+            readAllBytes(
+                Paths.get(Resources.getResource("databricks_notebooks/" + scriptName).getPath())));
+
+    SparkPythonTask task = new SparkPythonTask();
+    task.setSource(SparkPythonTaskSource.WORKSPACE);
+    task.setPythonFile(dbfsScriptPath);
+
+    RunSubmitTaskSettings runSubmitTaskSettings = new RunSubmitTaskSettings();
+    runSubmitTaskSettings.setTaskKey(taskName);
+    runSubmitTaskSettings.setExistingClusterId(clusterId);
+    runSubmitTaskSettings.setSparkPythonTask(task);
+
+    SubmitRun submitRun = new SubmitRun();
+    submitRun.setRunName(taskName);
+    submitRun.setTasks(Collections.singletonList(runSubmitTaskSettings));
+
+    // trigger one time job
+    workspace.jobs().submit(submitRun).get();
+
+    return fetchEventsEmitted(workspace);
+  }
+
+  @SneakyThrows
+  private static String createCluster(WorkspaceClient workspace) {
+    // upload init scripts
+    workspace
+        .dbfs()
+        .write(
+            Paths.get(DBFS_INIT_SCRIPT_FILE),
+            readAllBytes(Paths.get("../databricks/open-lineage-init-script.sh")));
+
+    CreateCluster createCluster =
+        CreateCluster.builder()
+            .cluster_name(getClusterName())
+            .spark_version(getSparkPlatformVersion())
+            .node_type_id(NODE_TYPE)
+            .autotermination_minutes(10L)
+            .num_workers(1L)
+            .init_scripts(
+                new InitScript[] {new InitScript(new DbfsDestination(DBFS_INIT_SCRIPT_FILE))})
+            .spark_conf(
+                new HashMap<String, String>() {
+                  {
+                    put("spark.openlineage.transport.type", "file");
+                    put("spark.openlineage.transport.location", "/tmp/events.log");
+                    put(
+                        "spark.extraListeners",
+                        "io.openlineage.spark.agent.OpenLineageSparkListener");
+                    put("spark.openlineage.version", "v1");
+                  }
+                })
+            .cluster_log_conf(new ClusterLogConf(new DbfsDestination(DBFS_CLUSTER_LOGS)))
+            .build();
+
+    log.info("Creating cluster");
+    CreateClusterResponse response =
+        workspace
+            .apiClient()
+            .POST("/api/2.0/clusters/create", createCluster, CreateClusterResponse.class);
+
+    return response.getClusterId();
+  }
+
+  @NotNull
+  private static String getClusterName() {
+    return CLUSTER_NAME + "_" + getSparkPlatformVersion();
+  }
+
+  private static String getSparkPlatformVersion() {
+    if (!PLATFORM_VERSIONS.containsKey(System.getProperty(SPARK_VERSION))) {
+      log.error("Unsupported spark_version for databricks test");
+    }
+
+    return PLATFORM_VERSIONS.get(System.getProperty(SPARK_VERSION));
+  }
+
+  @SneakyThrows
+  private static void uploadOpenlineageJar(WorkspaceClient workspace) {
+    Path jarFile =
+        Files.list(Paths.get("../build/libs/"))
+            .filter(p -> p.getFileName().toString().startsWith("openlineage-spark-"))
+            .filter(p -> p.getFileName().toString().endsWith("jar"))
+            .findAny()
+            .orElseThrow(() -> new RuntimeException("openlineage-spark jar not found"));
+
+    // clear other jars in DBFS
+    StreamSupport.stream(
+            workspace.dbfs().list("dbfs:/databricks/openlineage/").spliterator(), false)
+        .filter(f -> f.getPath().contains("openlineage-spark"))
+        .filter(f -> f.getPath().endsWith(".jar"))
+        .forEach(f -> workspace.dbfs().delete(f.getPath()));
+
+    // upload to DBFS -> 12MB file upload need to go in chunks smaller than 1MB each
+    CreateResponse createResponse =
+        workspace.dbfs().create("dbfs:/databricks/openlineage/" + jarFile.getFileName());
+
+    FileInputStream fis = new FileInputStream(jarFile.toString());
+    OutputStream outputStream =
+        workspace.dbfs().getOutputStream("dbfs:/databricks/openlineage/" + jarFile.getFileName());
+
+    byte[] buf = new byte[500000]; // approx 0.5MB
+    int len = -1;
+    while ((len = fis.read(buf)) != -1) {
+      outputStream.write(buf, 0, len);
+      outputStream.flush();
+    }
+    outputStream.close();
+  }
+
+  @SneakyThrows
+  private static List<RunEvent> fetchEventsEmitted(WorkspaceClient workspace) {
+    return workspace.dbfs().readAllLines(Paths.get(DBFS_EVENTS_FILE), StandardCharsets.UTF_8)
+        .stream()
+        .map(event -> OpenLineageClientUtils.runEventFromJson(event))
+        .collect(Collectors.toList());
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/ClusterLogConf.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/ClusterLogConf.java
@@ -1,0 +1,15 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.databricks;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClusterLogConf {
+  DbfsDestination dbfs;
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/CreateCluster.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/CreateCluster.java
@@ -1,0 +1,25 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.databricks;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateCluster {
+  String cluster_name;
+  String spark_version;
+  String node_type_id;
+  Long autotermination_minutes;
+  Long num_workers;
+  InitScript[] init_scripts;
+  Map<String, String> spark_conf;
+  ClusterLogConf cluster_log_conf;
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/DbfsDestination.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/DbfsDestination.java
@@ -1,0 +1,15 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.databricks;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DbfsDestination {
+  String destination;
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/InitScript.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/InitScript.java
@@ -1,0 +1,15 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.databricks;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InitScript {
+  DbfsDestination dbfs;
+}

--- a/integration/spark/app/src/test/resources/databricks_notebooks/ctas.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/ctas.py
@@ -1,0 +1,24 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os, time;
+
+if os.path.exists("/tmp/events.log"):
+  os.remove("/tmp/events.log")
+
+spark.sql("DROP TABLE IF EXISTS default.temp")
+spark.sql("DROP TABLE IF EXISTS default.ctas")
+
+spark.createDataFrame([
+  {'a': 1, 'b': 2},
+  {'a': 3, 'b': 4}
+]).repartition(1).write.mode("overwrite").saveAsTable("default.temp")
+
+spark.sql("CREATE TABLE default.ctas AS SELECT a, b FROM default.temp")
+
+time.sleep(3)
+
+dbutils.fs.cp(
+  "file:/tmp/events.log",
+  "dbfs:/databricks/openlineage/events.log"
+)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -110,7 +110,14 @@ class OpenLineageRunEventTest {
                     .outputStatistics(ol.newOutputStatisticsOutputDatasetFacet(10L, 20L))
                     .build()));
     OpenLineage.RunEvent runStateUpdate =
-        ol.newRunEvent(dateTime, OpenLineage.RunEvent.EventType.START, run, job, inputs, outputs);
+        ol.newRunEventBuilder()
+            .eventTime(dateTime)
+            .eventType(OpenLineage.RunEvent.EventType.START)
+            .run(run)
+            .job(job)
+            .inputs(inputs)
+            .outputs(outputs)
+            .build();
 
     Map<String, Object> actualJson =
         mapper.readValue(mapper.writeValueAsString(runStateUpdate), mapTypeReference);


### PR DESCRIPTION
### Problem

Spark integration misses integration test on Databricks. This is important as many community users come with databricks scenarios and behaviour on databricks platform may differ from one on locally run vanilla-spark. 

Closes: #1882

### Solution

 * Prepare a test that spawns spark session on databricks cluster. 
 * Include it within CircleCI with the ability to being run manually.
 * Running databricks integration test requires extra parameters param: `databricks-test` set to `enabled`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project