### PR TITLE
Fix security vulnerabilities.

### DIFF
--- a/integration/airflow/tests/integration/test_failure.py
+++ b/integration/airflow/tests/integration/test_failure.py
@@ -82,7 +82,8 @@ def trigger_dag(dag_id):
     r = requests.post(
         f"http://airflow:8080/api/v1/dags/{dag_id}/dagRuns",
         auth=HTTPBasicAuth('airflow', 'airflow'),
-        json={}
+        json={},
+        timeout=5,
     )
     r.raise_for_status()
 

--- a/integration/common/openlineage/common/provider/dbt/local.py
+++ b/integration/common/openlineage/common/provider/dbt/local.py
@@ -113,7 +113,7 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
     @staticmethod
     def load_yaml(path: str) -> Dict:
         with open(path, "r") as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.safe_load(f)
 
     @staticmethod
     def setup_jinja() -> Environment:

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -523,7 +523,7 @@ def test_dataset_from_sql_custom_query_v3_api(test_db_file, tmpdir):
            include_schema_name: true
     """
 
-    ctx.add_datasource(**yaml.load(datasource_yaml))
+    ctx.add_datasource(**yaml.safe_load(datasource_yaml))
     checkpoint: Checkpoint = Checkpoint(
         "test_checkpoint",
         ctx,


### PR DESCRIPTION
### Problem

There are two security vulnerabilities.

### Solution

Replace `yaml.load` with `yaml.safe_load`. Add timeout to `requests.post`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project