### PR TITLE
req: bump minimum supported python version to 3.8

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -65,7 +65,7 @@ jobs:
   build-client-python:
     working_directory: ~/openlineage/client/python
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     parameters:
       build_tag:
         default: ""
@@ -267,7 +267,7 @@ jobs:
   unit-test-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - *checkout_project_root
       - attach_workspace:
@@ -281,7 +281,7 @@ jobs:
   build-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -417,7 +417,7 @@ jobs:
   build-integration-dbt:
     working_directory: ~/openlineage/integration/dbt
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -550,7 +550,7 @@ jobs:
         type: string
     working_directory: ~/openlineage/integration/airflow
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - *checkout_project_root
       - *install_python_client
@@ -566,7 +566,7 @@ jobs:
   build-integration-airflow:
     working_directory: ~/openlineage/integration/airflow
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -619,7 +619,7 @@ jobs:
       - run: cp -r ../client/python python
       - attach_workspace:
           at: .
-      - run: AIRFLOW_IMAGE=apache/airflow:2.3.4-python3.7 ./airflow/tests/integration/docker/up-failure.sh << parameters.failure-type >>
+      - run: AIRFLOW_IMAGE=apache/airflow:2.3.4-python3.8 ./airflow/tests/integration/docker/up-failure.sh << parameters.failure-type >>
       - store_artifacts:
           path: airflow/tests/integration/failures/airflow/logs
           destination: airflow-logs
@@ -627,7 +627,7 @@ jobs:
   unit-test-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - *checkout_project_root
       - *install_python_client
@@ -640,7 +640,7 @@ jobs:
   build-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     <<: *param_build_tag
     steps:
       - *checkout_project_root
@@ -655,7 +655,7 @@ jobs:
   release-python:
     working_directory: ~/openlineage
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
     steps:
       - *checkout_project_root
       - attach_workspace:

--- a/.circleci/workflows/openlineage-integration-airflow.yml
+++ b/.circleci/workflows/openlineage-integration-airflow.yml
@@ -38,11 +38,11 @@ workflows:
           matrix:
             parameters:
               airflow-image: [
-                'apache/airflow:2.1.4-python3.7',
-                'apache/airflow:2.2.4-python3.7',
-                'apache/airflow:2.3.4-python3.7',
-                'apache/airflow:2.4.3-python3.7',
-                'apache/airflow:2.5.0-python3.7'
+                'apache/airflow:2.1.4-python3.8',
+                'apache/airflow:2.2.4-python3.8',
+                'apache/airflow:2.3.4-python3.8',
+                'apache/airflow:2.4.3-python3.8',
+                'apache/airflow:2.5.0-python3.8'
               ]
           context: integration-tests
           requires:

--- a/.circleci/workflows/openlineage-integration-python.yml
+++ b/.circleci/workflows/openlineage-integration-python.yml
@@ -2,10 +2,6 @@ workflows:
   openlineage-integration-python:
     jobs:
       - unit-test-client-python:
-          name: "CPython 3.7"
-          tox_env: py37
-          py_env: "3.7"
-      - unit-test-client-python:
           name: "CPython 3.8"
           tox_env: py38
           py_env: "3.8"
@@ -31,7 +27,6 @@ workflows:
           py_env: "3.11"
       - unit-tests-client-python:
           requires:
-            - "CPython 3.7"
             - "CPython 3.8"
             - "CPython 3.9"
             - "CPython 3.10"

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -13,12 +13,11 @@ keywords = [
   "openlineage",
 ]
 authors = [{ name = "OpenLineage", email = "info@openlineage.io" }]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -105,7 +104,7 @@ select = [
     "RUF", # Ruff
 ]
 line-length = 100
-target-version = "py37"
+target-version = "py38"
 isort = { known-first-party = ["publication_set", "tests"] }
 namespace-packages = ["openlineage/client"]
 ignore = [

--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -3,7 +3,7 @@ current_version = 0.30.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<rc>.*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{rc}
 	{major}.{minor}.{patch}
 

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -7,7 +7,6 @@ env_list =
     py310
     py39
     py38
-    py37
     type
     fix
 skip_missing_interpreters = true

--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -32,7 +32,7 @@ usedevelop = True
 install_command = python -m pip install {opts} --find-links target/wheels/ \
 	--find-links ../sql/iface-py/target/wheels \
 	--use-deprecated=legacy-resolver \
-	--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-{env:AIRFLOW_VERSION}/constraints-3.7.txt \
+	--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-{env:AIRFLOW_VERSION}/constraints-3.8.txt \
 	{packages}
 deps = -r dev-requirements.txt
 	pytest

--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-ARG AIRFLOW_IMAGE=apache/airflow:2.4.0-python3.7
+ARG AIRFLOW_IMAGE=apache/airflow:2.4.3-python3.8
 FROM $AIRFLOW_IMAGE AS airflow
 COPY integration/dbt /app/openlineage/integration/dbt
 COPY integration/common /app/openlineage/integration/common
@@ -29,10 +29,10 @@ RUN python -m virtualenv dbt_venv && pwd && source dbt_venv/bin/activate && \
     python -m pip install -r tests/integration/tests/airflow/dbt-requirements.txt && deactivate  # We need separate env to run dbt due to dependency conflicts
 
 
-FROM python:3.7-slim as integration
+FROM python:3.8-slim as integration
 RUN mkdir -p /app/openlineage
 RUN apt-get update && \
-    apt-get install -y python3-dev default-libmysqlclient-dev build-essential
+    apt-get install -y python3-dev default-libmysqlclient-dev build-essential pkg-config
 COPY integration/common /app/openlineage/integration/common
 COPY integration/target /app/openlineage/integration/sql/target
 COPY integration/airflow /app/openlineage/integration/airflow

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -11,7 +11,7 @@ Wrapper script for automatic metadata collection from dbt
 
 ## Requirements
 
-- [Python >= 3.7](https://www.python.org/downloads)
+- [Python >= 3.8](https://www.python.org/downloads)
 - [dbt >= 0.20](https://www.getdbt.com/)
 
 Right now, `openlineage-dbt` only supports `bigquery`, `snowflake`, `spark` and `redshift` dbt adapters.

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
     keywords="openlineage",
 )

--- a/integration/sql/iface-py/pyproject.toml
+++ b/integration/sql/iface-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "openlineage_sql"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/integration/sql/iface-py/script/build.sh
+++ b/integration/sql/iface-py/script/build.sh
@@ -8,9 +8,9 @@
 set -e
 
 # Manylinux image has multiple "pythons" - in /opt/python directory.
-# We use Python 3.7, since it's the lowest we want to use
+# We use Python 3.8, since it's the lowest we want to use
 # and create local virtualenv - it's easier to proceed in venv than use python behind long absolute path
-/opt/python/cp37-cp37m/bin/python -m venv .env
+/opt/python/cp38-cp38/bin/python -m venv .env
 source .env/bin/activate
 
 # Maturin is build tool that we're using. It can build python wheels based on standard Rust Cargo.toml.


### PR DESCRIPTION
Python 3.7 is EOL and that already [causes problems.](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/7458/workflows/4d9071ba-fb19-4b2f-808a-8ec4b27c1379/jobs/121801) Let's bump this to 3.8 and keep aligned with Python EOL schedule.