### PR TITLE
python, kafka: add workaround for airflow-sqlalchemy event mechanism bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         files: ^client/python/
       - id: trailing-whitespace
         files: ^client/python/
+        exclude: ^.*\.cfg$
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from typing import TYPE_CHECKING
+from unittest.mock import ANY, call
 
 import pytest
 
@@ -15,6 +16,18 @@ from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+@pytest.fixture()
+def event() -> RunEvent:
+    return RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(uuid.uuid4())),
+        job=Job(namespace="kafka", name="test"),
+        producer="prod",
+        schemaURL="schema",
+    )
 
 
 def test_kafka_loads_full_config() -> None:
@@ -56,7 +69,7 @@ def test_kafka_load_config_fails_on_no_config() -> None:
         )
 
 
-def test_client_with_kafka_transport_emits(mocker: MockerFixture) -> None:
+def test_client_with_kafka_transport_emits(event: RunEvent, mocker: MockerFixture) -> None:
     mocker.patch("confluent_kafka.Producer")
     config = KafkaConfig(
         config={"bootstrap.servers": "localhost:9092"},
@@ -79,5 +92,49 @@ def test_client_with_kafka_transport_emits(mocker: MockerFixture) -> None:
     transport.producer.produce.assert_called_once_with(
         topic="random-topic",
         value=Serde.to_json(event).encode("utf-8"),
+        on_delivery=ANY,
     )
     transport.producer.flush.assert_called_once()
+
+
+def test_airflow_sqlalchemy_constructs_producer_each_call(
+    event: RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "openlineage.client.transport.kafka._check_if_airflow_sqlalchemy_context",
+        return_value=True,
+    )
+    mock = mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(event)
+    client.emit(event)
+    mock.assert_has_calls([call(config.config), call(config.config)], any_order=True)
+
+
+def test_airflow_direct_onstructs_producer_once(event: RunEvent, mocker: MockerFixture) -> None:
+    mocker.patch(
+        "openlineage.client.transport.kafka._check_if_airflow_sqlalchemy_context",
+        return_value=False,
+    )
+    mock = mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(event)
+    client.emit(event)
+    mock.assert_called_once_with(config.config)

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -38,6 +38,7 @@ deps =
     types-PyYAML==6.0.12.10
     types-python-dateutil==2.8.19.13
     types-requests==2.31.0.1
+    types-setuptools==68.0.0.1
 set_env =
     {tty:MYPY_FORCE_COLOR = 1}
 commands =

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from airflow.models import BaseOperator, DagRun, TaskInstance
 
 
-
 class TaskHolder:
     """Class that stores run data - run_id and task in-memory. This is needed because Airflow
     does not always pass all runtime info to on_task_instance_success and


### PR DESCRIPTION
This PR adds workaround for another consequence of Airflow-sqlalchemy based event delivery mechanism. 

Due to known issues with fork and thread model there, Kafka producer left alone does not emit `COMPLETE` event.

Solution to that is to create a producer for each event when we detect that we're under Airflow 2.3 - 2.5. Unfortunately that means that Transport needs to be aware of Airflow, but that import is contained in a specific method.