### PR TITLE
[FLINK] support iceberg sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.29.2...HEAD)
+### Added
+* **Flink: support Iceberg sinks** [`#1960`](https://github.com/OpenLineage/OpenLineage/pull/1960) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Detect output datasets when using Iceberg table as a sink.*
+
 ### Fixed
 * **Spark: fix custom environment variables facet** [`#1973`](https://github.com/OpenLineage/OpenLineage/pull/1973) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Spark environment variables facet sent in non-deterministic way.*

--- a/client/python/setup.cfg
+++ b/client/python/setup.cfg
@@ -3,7 +3,7 @@ current_version = 0.30.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<rc>.*)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{rc}
 	{major}.{minor}.{patch}
 

--- a/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 
@@ -38,6 +39,8 @@ public class TransformationUtils {
       sink = processSinkTransformation(transformation);
     } else if (transformation instanceof LegacySinkTransformation) {
       sink = processLegacySinkTransformation(transformation);
+    } else if (transformation instanceof OneInputTransformation) {
+      sink = transformation;
     } else {
       return Optional.empty();
     }

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.utils;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.flink.api.OpenLineageContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Table;
+
+public class IcebergUtils {
+
+  public static boolean hasClasses() {
+    try {
+      IcebergUtils.class
+          .getClassLoader()
+          .loadClass("org.apache.iceberg.flink.source.StreamingMonitorFunction");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  public static OpenLineage.SchemaDatasetFacet getSchema(OpenLineageContext context, Table table) {
+    List<SchemaDatasetFacetFields> fields =
+        table.schema().columns().stream()
+            .map(
+                field ->
+                    context
+                        .getOpenLineage()
+                        .newSchemaDatasetFacetFields(
+                            field.name(), field.type().typeId().name(), field.doc()))
+            .collect(Collectors.toList());
+    return context.getOpenLineage().newSchemaDatasetFacet(fields);
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSinkVisitor.java
@@ -1,0 +1,64 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.api.DatasetIdentifier;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.utils.IcebergUtils;
+import io.openlineage.flink.utils.PathUtils;
+import io.openlineage.flink.visitor.wrapper.IcebergSinkWrapper;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.iceberg.Table;
+
+@Slf4j
+public class IcebergSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
+
+  public IcebergSinkVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public boolean isDefinedAt(Object sink) {
+    return sink instanceof OneInputTransformation
+        && ((OneInputTransformation) sink)
+            .getOperatorFactory()
+            .getStreamOperatorClass(ClassLoader.getSystemClassLoader())
+            .getCanonicalName()
+            .equals("org.apache.iceberg.flink.sink.IcebergFilesCommitter");
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(Object icebergSink) {
+    IcebergSinkWrapper sinkWrapper =
+        IcebergSinkWrapper.of(((OneInputTransformation) icebergSink).getOperator());
+    return sinkWrapper
+        .getTable()
+        .map(table -> getDataset(context, table))
+        .map(dataset -> Collections.singletonList(dataset))
+        .orElse(Collections.emptyList());
+  }
+
+  private OpenLineage.OutputDataset getDataset(OpenLineageContext context, Table table) {
+    OpenLineage openLineage = context.getOpenLineage();
+    DatasetIdentifier datasetIdentifier = PathUtils.fromURI(URI.create(table.location()));
+    return openLineage
+        .newOutputDatasetBuilder()
+        .name(datasetIdentifier.getName())
+        .namespace(datasetIdentifier.getNamespace())
+        .facets(
+            openLineage
+                .newDatasetFacetsBuilder()
+                .schema(IcebergUtils.getSchema(context, table))
+                .build())
+        .build();
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
@@ -8,12 +8,12 @@ package io.openlineage.flink.visitor;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.flink.api.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.utils.IcebergUtils;
 import io.openlineage.flink.utils.PathUtils;
 import io.openlineage.flink.visitor.wrapper.IcebergSourceWrapper;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.Table;
@@ -25,18 +25,6 @@ public class IcebergSourceVisitor extends Visitor<OpenLineage.InputDataset> {
     super(context);
   }
 
-  public static boolean hasClasses() {
-    try {
-      IcebergSourceVisitor.class
-          .getClassLoader()
-          .loadClass("org.apache.iceberg.flink.source.StreamingMonitorFunction");
-      return true;
-    } catch (Exception e) {
-      // swallow- we don't care
-    }
-    return false;
-  }
-
   @Override
   public boolean isDefinedAt(Object source) {
     return source instanceof StreamingMonitorFunction;
@@ -45,30 +33,21 @@ public class IcebergSourceVisitor extends Visitor<OpenLineage.InputDataset> {
   @Override
   public List<OpenLineage.InputDataset> apply(Object source) {
     IcebergSourceWrapper sourceWrapper = IcebergSourceWrapper.of((StreamingMonitorFunction) source);
-    return Collections.singletonList(getDataset(sourceWrapper.getTable()));
+    return Collections.singletonList(getDataset(context, sourceWrapper.getTable()));
   }
 
-  private OpenLineage.SchemaDatasetFacet getSchema(Table table) {
-    List<OpenLineage.SchemaDatasetFacetFields> fields =
-        table.schema().columns().stream()
-            .map(
-                field ->
-                    context
-                        .getOpenLineage()
-                        .newSchemaDatasetFacetFields(
-                            field.name(), field.type().typeId().name(), field.doc()))
-            .collect(Collectors.toList());
-    return context.getOpenLineage().newSchemaDatasetFacet(fields);
-  }
-
-  private OpenLineage.InputDataset getDataset(Table table) {
+  private OpenLineage.InputDataset getDataset(OpenLineageContext context, Table table) {
     OpenLineage openLineage = context.getOpenLineage();
     DatasetIdentifier datasetIdentifier = PathUtils.fromURI(URI.create(table.location()));
     return openLineage
         .newInputDatasetBuilder()
         .name(datasetIdentifier.getName())
         .namespace(datasetIdentifier.getNamespace())
-        .facets(openLineage.newDatasetFacetsBuilder().schema(getSchema(table)).build())
+        .facets(
+            openLineage
+                .newDatasetFacetsBuilder()
+                .schema(IcebergUtils.getSchema(context, table))
+                .build())
         .build();
   }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -5,28 +5,47 @@
 
 package io.openlineage.flink.visitor;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.flink.api.DatasetFactory;
 import io.openlineage.flink.api.OpenLineageContext;
-import java.util.Arrays;
+import io.openlineage.flink.utils.IcebergUtils;
 import java.util.List;
 
 public class VisitorFactoryImpl implements VisitorFactory {
 
   @Override
   public List<Visitor<OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context) {
-    return Arrays.asList(
-        new KafkaSourceVisitor(context),
-        new FlinkKafkaConsumerVisitor(context),
-        new IcebergSourceVisitor(context),
+    Builder<Visitor<InputDataset>> builder = ImmutableList.<Visitor<InputDataset>>builder();
+
+    builder.add(new KafkaSourceVisitor(context));
+    builder.add(new FlinkKafkaConsumerVisitor(context));
+    builder.add(
         new LineageProviderVisitor<>(context, DatasetFactory.input(context.getOpenLineage())));
+
+    if (IcebergUtils.hasClasses()) {
+      builder.add(new IcebergSourceVisitor(context));
+    }
+
+    return builder.build();
   }
 
   @Override
   public List<Visitor<OpenLineage.OutputDataset>> getOutputVisitors(OpenLineageContext context) {
-    return Arrays.asList(
-        new KafkaSinkVisitor(context),
-        new FlinkKafkaProducerVisitor(context),
+    Builder<Visitor<OutputDataset>> builder = ImmutableList.<Visitor<OutputDataset>>builder();
+
+    builder.add(new KafkaSinkVisitor(context));
+    builder.add(new FlinkKafkaProducerVisitor(context));
+    builder.add(
         new LineageProviderVisitor<>(context, DatasetFactory.output(context.getOpenLineage())));
+
+    if (IcebergUtils.hasClasses()) {
+      builder.add(new IcebergSinkVisitor(context));
+    }
+
+    return builder.build();
   }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
@@ -19,7 +19,10 @@ import io.openlineage.flink.visitor.VisitorFactory;
 import io.openlineage.flink.visitor.VisitorFactoryImpl;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -71,16 +74,19 @@ public class FlinkExecutionContext implements ExecutionContext {
 
   public OpenLineage.RunEventBuilder buildEventForEventType(EventType eventType) {
     TransformationUtils converter = new TransformationUtils();
+
     List<SinkLineage> sinkLineages = converter.convertToVisitable(transformations);
 
     VisitorFactory visitorFactory = new VisitorFactoryImpl();
     List<OpenLineage.InputDataset> inputDatasets = new ArrayList<>();
     List<OpenLineage.OutputDataset> outputDatasets = new ArrayList<>();
 
+    Set<Object> sources = new HashSet<>();
     for (var lineage : sinkLineages) {
-      inputDatasets.addAll(getInputDatasets(visitorFactory, lineage.getSources()));
+      sources.addAll(lineage.getSources());
       outputDatasets.addAll(getOutputDatasets(visitorFactory, lineage.getSink()));
     }
+    inputDatasets.addAll(getInputDatasets(visitorFactory, Arrays.asList(sources.toArray())));
 
     return commonEventBuilder().inputs(inputDatasets).outputs(outputDatasets).eventType(eventType);
   }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSinkWrapper.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.wrapper;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+
+@Slf4j
+public class IcebergSinkWrapper {
+
+  /** IcebergFilesCommitter */
+  private final Object icebergFilesCommitter;
+
+  private IcebergSinkWrapper(Object icebergFilesCommitter) {
+    this.icebergFilesCommitter = icebergFilesCommitter;
+  }
+
+  public static IcebergSinkWrapper of(Object icebergFilesCommitter) {
+    return new IcebergSinkWrapper(icebergFilesCommitter);
+  }
+
+  public Optional<Table> getTable() {
+    Class icebergFilesCommiterClass = null;
+    try {
+      icebergFilesCommiterClass =
+          Class.forName("org.apache.iceberg.flink.sink.IcebergFilesCommitter");
+      return WrapperUtils.<TableLoader>getFieldValue(
+              icebergFilesCommiterClass, icebergFilesCommitter, "tableLoader")
+          .map(TableLoader::loadTable);
+    } catch (ClassNotFoundException e) {
+      log.warn("Failed extracting table from IcebergFilesCommitter", e);
+    }
+
+    return Optional.empty();
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
@@ -32,7 +32,10 @@ public class WrapperUtils {
   public static <T> Optional<T> getFieldValue(Class aClass, Object object, String field) {
     try {
       return Optional.ofNullable((T) FieldUtils.getField(aClass, field, true).get(object));
-    } catch (IllegalAccessException | ClassCastException | NullPointerException e) {
+    } catch (IllegalAccessException
+        | ClassCastException
+        | NullPointerException
+        | IllegalArgumentException e) {
       log.debug("cannot extract field {} from {}", field, aClass.getName(), e);
       return Optional.empty();
     }

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSinkVisitorTest.java
@@ -1,0 +1,78 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.client.EventEmitter;
+import io.openlineage.flink.visitor.wrapper.IcebergSinkWrapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class IcebergSinkVisitorTest {
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  IcebergSinkWrapper wrapper = mock(IcebergSinkWrapper.class);
+  OneInputTransformation sink = mock(OneInputTransformation.class);
+  OneInputStreamOperator icebergFilesCommitter = mock(OneInputStreamOperator.class);
+  IcebergSinkVisitor sinkVisitor = new IcebergSinkVisitor(context);
+  OpenLineage openLineage = new OpenLineage(EventEmitter.OPEN_LINEAGE_CLIENT_URI);
+
+  @BeforeEach
+  @SneakyThrows
+  public void setup() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+    when(sink.getOperator()).thenReturn(icebergFilesCommitter);
+  }
+
+  @Test
+  void testIsDefinedOnNonIcebergSink() {
+    assertFalse(sinkVisitor.isDefinedAt(mock(Object.class)));
+  }
+
+  @Test
+  @SneakyThrows
+  void testApply() {
+    Table table = mock(Table.class, RETURNS_DEEP_STUBS);
+
+    try (MockedStatic<IcebergSinkWrapper> mockedStatic = mockStatic(IcebergSinkWrapper.class)) {
+      when(IcebergSinkWrapper.of(icebergFilesCommitter)).thenReturn(wrapper);
+      when(table.location()).thenReturn("s3://bucket/table/");
+      when(table.schema().columns())
+          .thenReturn(
+              Collections.singletonList(Types.NestedField.of(1, false, "a", Types.LongType.get())));
+      when(wrapper.getTable()).thenReturn(Optional.of(table));
+
+      List<OutputDataset> outputDatasets = sinkVisitor.apply(sink);
+      List<OpenLineage.SchemaDatasetFacetFields> fields =
+          outputDatasets.get(0).getFacets().getSchema().getFields();
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals("table", outputDatasets.get(0).getName());
+      assertEquals("s3://bucket", outputDatasets.get(0).getNamespace());
+
+      assertEquals(1, fields.size());
+      assertEquals("a", fields.get(0).getName());
+      assertEquals("LONG", fields.get(0).getType());
+    }
+  }
+}

--- a/integration/flink/src/test/resources/events/expected_iceberg.json
+++ b/integration/flink/src/test/resources/events/expected_iceberg.json
@@ -15,5 +15,19 @@
       }
     }
   }],
-  "outputs": []
+  "outputs" : [{
+  "namespace" : "file",
+  "name" : "tmp/warehouse/db/sink",
+  "facets" : {
+    "schema" : {
+      "fields" : [ {
+        "name" : "x",
+        "type" : "INTEGER"
+      }, {
+        "name" : "y",
+        "type" : "INTEGER"
+      } ]
+    }
+  }
+  }]
 }


### PR DESCRIPTION
### Problem

Flink integration does not capture output dataset when writing to an iceberg table. 

Closes: #782

### Solution

* Support iceberg sinks. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project