### PR TITLE
airflow: catch all exceptions in adapter's event emit.

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -6,7 +6,6 @@ import os
 import uuid
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-import requests.exceptions
 from openlineage.airflow.extractors import TaskMetadata
 from openlineage.airflow.utils import DagUtils, redact_with_exclusions
 from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
@@ -92,8 +91,9 @@ class OpenLineageAdapter:
         event = redact_with_exclusions(event)
         try:
             return self.client.emit(event)
-        except requests.exceptions.RequestException:
+        except Exception as e:
             log.exception(f"Failed to emit OpenLineage event of id {event.run.runId}")
+            log.debug(e)
 
     def start_task(
         self,


### PR DESCRIPTION
### Problem

Currently, `OpenLineageAdapter`'s `emit` method catches only `requests.exceptions.RequestException` which is rarely (or maybe even never) raised by currently implemented transports.

Closes: #ISSUE-NUMBER

### Solution

Catch all exceptions and log them.

#### One-line summary:

Airflow: catch all exceptions in adapter's event emit.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project