### PR TITLE
feat: added support for iceberg rest catalog

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -98,9 +98,9 @@ public class IcebergHandler implements CatalogHandler {
               di.getName(), File.separator), // parent location from a name becomes a namespace
           DatasetIdentifier.SymlinkType.TABLE);
     } else if (catalogConf.get(TYPE).equals("rest")) {
-      di.withSymlink(  
+      di.withSymlink(
           getRestIdentifier(
-            session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
+              session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
     }
 
     return di;
@@ -133,10 +133,7 @@ public class IcebergHandler implements CatalogHandler {
       SparkSession session, @Nullable String confUri, String table) {
 
     String uri = new URI(confUri).toString();
-    return new DatasetIdentifier.Symlink(
-        table,
-        uri,
-        DatasetIdentifier.SymlinkType.TABLE);
+    return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -97,6 +97,10 @@ public class IcebergHandler implements CatalogHandler {
           StringUtils.substringBeforeLast(
               di.getName(), File.separator), // parent location from a name becomes a namespace
           DatasetIdentifier.SymlinkType.TABLE);
+    } else if (catalogConf.get(TYPE).equals("rest")) {
+      di.withSymlink(  
+          getRestIdentifier(
+            session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
     }
 
     return di;
@@ -121,6 +125,17 @@ public class IcebergHandler implements CatalogHandler {
     return new DatasetIdentifier.Symlink(
         metastoreIdentifier.getName(),
         metastoreIdentifier.getNamespace(),
+        DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @SneakyThrows
+  private DatasetIdentifier.Symlink getRestIdentifier(
+      SparkSession session, @Nullable String confUri, String table) {
+
+    String uri = new URI(confUri).toString();
+    return new DatasetIdentifier.Symlink(
+        table,
+        uri,
         DatasetIdentifier.SymlinkType.TABLE);
   }
 


### PR DESCRIPTION
### Problem

Currently, Spark Iceberg integration for Openlineage only supports hive and hadoop catalogs. Iceberg also has RestCatalog. It would be good to have it supported for Openlineage also as it is gaining popularity.

Implements: #1940

### Solution
Add `rest` to the existing options of `hive` and `hadoop` in `IcebergHandler.getDatasetIdentifier()`
It's a _backwards-compatible_ change.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary: add support for iceberg rest catalog in `IcebergHandler`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project