### PR TITLE
[SPARK] fix custom environment variables facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/0.29.2...HEAD)
+### Fixed
+* **Spark: fix custom environment variables facet** [`#1973`](https://github.com/OpenLineage/OpenLineage/pull/1973) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Spark environment variables facet sent in non-deterministic way.*
 
 ## [0.29.2](https://github.com/OpenLineage/OpenLineage/compare/0.28.0...0.29.2) - 2023-06-30
 ### Added


### PR DESCRIPTION
### Problem

Custom environment facet behaviour is non-deterministic: it's present in some case and it's not available when working on delta tables in Spark (https://openlineage.slack.com/archives/C01CK9T7HKR/p1689155719105569). This is weird as the facet and delta format have nothin in common.  However they do, as ` CustomEnvironmentFacetBuilder` has been implemented to be triggered `SparkListenerJobStart`. We do have two types of start events: `SparkListenerJobStart` and `SparkListenerSQLExecutionStart` and Openlineage event is only sent for one of them. It seems as other event type got triggered with delta tables.

### Solution

 * Prepare an integration test to verify facet is there. 
 * Fix `CustomEnvironmentFacetBuilder` class.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project