### PR TITLE
Python: allow to modify `openlineage.*` logging levels via environment variables

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -70,3 +70,6 @@ This way of configuring the client supports only `http` transport, and only a su
 * `OPENLINEAGE_API_KEY` - set if the consumer of OpenLineage events requires a `Bearer` authentication key.
 
 `OPENLINEAGE_URL` and `OPENLINEAGE_API_KEY` can also be set up manually when creating a client instance.
+
+#### Logging level
+In addition to conventional logging approaches, the OpenLineage client library provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_CLIENT_LOGGING` environment variable, you can establish the logging level for the `openlineage.client` and its child modules.

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 import attr
@@ -41,6 +42,12 @@ class OpenLineageClient:
         transport: Transport | None = None,
         factory: TransportFactory | None = None,
     ) -> None:
+        # Set parent's logging level if environment variable is present
+        if "OPENLINEAGE_CLIENT_LOGGING" in os.environ:
+            logging.getLogger(__name__.rpartition(".")[0]).setLevel(
+                os.environ["OPENLINEAGE_CLIENT_LOGGING"],
+            )
+
         if factory is None:
             factory = get_default_factory()
 

--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -199,6 +199,9 @@ Setting it in `great_expectations.yml` files isn't enough - the operator overrid
 
 To see an example of a working configuration, see [DAG](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/tests/integration/airflow/dags/greatexpectations_dag.py) and [Great Expectations configuration](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow/tests/integration/data/great_expectations) in the integration tests.
 
+### Logging
+In addition to conventional logging approaches, the `openlineage-airflow` package provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_AIRFLOW_LOGGING` environment variable, you can establish the logging level for the `openlineage.airflow` and its child modules.
+
 ## Triggering Child Jobs
 Commonly, Airflow DAGs will trigger processes on remote systems, such as an Apache Spark or Apache
 Beam job. Those systems may have their own OpenLineage integrations and report their own

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -54,6 +54,10 @@ class OpenLineageAdapter:
 
     _client = None
 
+    def __init__(self):
+        if "OPENLINEAGE_AIRFLOW_LOGGING" in os.environ:
+            logging.getLogger(__name__.rpartition('.')[0]).setLevel(os.getenv("OPENLINEAGE_AIRFLOW_LOGGING"))
+
     @staticmethod
     def get_or_create_openlineage_client() -> OpenLineageClient:
         # Backcomp with Marquez integration

--- a/integration/airflow/openlineage/airflow/extractors/dbt_cloud_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbt_cloud_extractor.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import logging
 import re
 import traceback
 
@@ -20,8 +19,6 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudHook,
     fallback_to_default_account,
 )
-
-log = logging.getLogger(__name__)
 
 
 class DbtCloudExtractor(BaseExtractor):
@@ -47,7 +44,7 @@ class DbtCloudExtractor(BaseExtractor):
             job_facets: Dict = {}
 
         except Exception as e:
-            log.exception("Exception has occurred in extract()")
+            self.log.exception("Exception has occurred in extract()")
             error = ErrorMessageRunFacet(str(e), "python")
             error.stackTrace = traceback.format_exc()
             run_facets["errorMessage"] = error
@@ -173,7 +170,7 @@ class DbtCloudExtractor(BaseExtractor):
                 producer=_PRODUCER,
                 job_namespace=_DAG_NAMESPACE,
                 skip_errors=False,
-                logger=log,
+                logger=self.log,
                 manifest=manifest,
                 run_result=artifacts["run_results"],
                 profile=connection,

--- a/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
@@ -1,13 +1,10 @@
 # Copyright 2018-2022 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from typing import List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.run import Dataset
-
-log = logging.getLogger(__name__)
 
 
 class GCSToGCSExtractor(BaseExtractor):

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -1,14 +1,11 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from typing import List, Optional
 from urllib.parse import urlparse
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.client.run import Dataset
-
-log = logging.getLogger(__name__)
 
 
 class S3CopyObjectExtractor(BaseExtractor):

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -48,7 +48,7 @@ class TaskHolder:
         return ti.dag_id + ti.task_id + ti.run_id
 
 
-log = logging.getLogger("airflow")
+log = logging.getLogger(__name__)
 # TODO: move task instance runs to executor
 executor: Optional[Executor] = None
 

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -1,6 +1,7 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -28,3 +29,19 @@ def test_create_client_from_ol_env():
     assert client.transport.url == "http://ol-api:5000"
     assert "Authorization" in client.transport.session.headers
     assert client.transport.session.headers["Authorization"] == "Bearer api-key"
+
+def test_setting_ol_adapter_log_level() -> None:
+    # DEBUG level set for `openlineage` logger in tests setup
+    default_log_level = logging.DEBUG
+    # without environment variable
+    OpenLineageAdapter()
+    parent_logger = logging.getLogger("openlineage.airflow")
+    logger = logging.getLogger("openlineage.airflow.adapter")
+    assert parent_logger.getEffectiveLevel() == default_log_level
+    assert logger.getEffectiveLevel() == default_log_level
+    with patch.dict(os.environ, {"OPENLINEAGE_AIRFLOW_LOGGING": "CRITICAL"}):
+        assert parent_logger.getEffectiveLevel() == default_log_level
+        assert logger.getEffectiveLevel() == default_log_level
+        OpenLineageAdapter()
+        assert parent_logger.getEffectiveLevel() == logging.CRITICAL
+        assert logger.getEffectiveLevel() == logging.CRITICAL

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -35,6 +35,7 @@ class Adapter(Enum):
     SPARK = "spark"
     POSTGRES = "postgres"
     DATABRICKS = "databricks"
+
     @staticmethod
     def adapters() -> str:
         # String representation of all supported adapter names
@@ -135,8 +136,6 @@ class DbtVersionRunFacet(BaseFacet):
         return GITHUB_LOCATION + "dbt-version-run-facet.json"
 
 
-logging.getLogger("null").addHandler(logging.NullHandler())
-
 
 class DbtArtifactProcessor:
     should_raise_on_unsupported_command = True
@@ -146,11 +145,13 @@ class DbtArtifactProcessor:
         producer: str,
         job_namespace: str,
         skip_errors: bool = False,
-        logger: logging.Logger = logging.getLogger("null"),
+        logger: Optional[logging.Logger] = None,
     ):
         self.producer = producer
         self._dbt_run_metadata: Optional[ParentRunMetadata] = None
-        self.logger = logger
+        self.logger = logger or logging.getLogger(
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
 
         self.job_namespace = job_namespace
         self.dataset_namespace = ""
@@ -540,7 +541,9 @@ class DbtArtifactProcessor:
             if "description" in field and field["description"] is not None:
                 description = field["description"]
             fields.append(
-                SchemaField(name=field["name"], type=of_type or "", description=description)
+                SchemaField(
+                    name=field["name"], type=of_type or "", description=description
+                )
             )
         return fields
 

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -42,6 +42,12 @@ The OpenLineage client depends on environment variables:
 * `OPENLINEAGE_NAMESPACE` - set if you are using something other than the `default` namespace for job namespace.
 
 
+### Logging
+
+In addition to conventional logging approaches, the OpenLineage dbt wrapper script provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_DBT_LOGGING` environment variable, you can establish the logging level for the `openlineage.dbt` and its child modules.
+
+You can also set log level of `dbtol` which is deprecated.
+
 ## Usage
 
 To begin collecting dbt metadata with OpenLineage, replace `dbt run` with `dbt-ol run`.

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -52,7 +52,9 @@ def dbt_run_event(
     )
 
 
-def dbt_run_event_start(job_name: str, job_namespace: str, parent_run_metadata: ParentRunMetadata) -> RunEvent:
+def dbt_run_event_start(
+    job_name: str, job_namespace: str, parent_run_metadata: ParentRunMetadata
+) -> RunEvent:
     return dbt_run_event(
         state=RunState.START,
         job_name=job_name,
@@ -89,12 +91,14 @@ def dbt_run_event_failed(
         parent=parent_run_metadata
     )
 
-
+openlineage_logger = logging.getLogger("openlineage.dbt")
+openlineage_logger.setLevel(os.getenv("OPENLINEAGE_DBT_LOGGING", "INFO"))
+openlineage_logger.addHandler(logging.StreamHandler(sys.stdout))
+# deprecated dbtol logger
 logger = logging.getLogger("dbtol")
-logger.setLevel("INFO")
-logger.addHandler(logging.StreamHandler(sys.stdout))
-logging.basicConfig(level=logging.INFO)
-
+for handler in openlineage_logger.handlers:
+    logger.addHandler(handler)
+    logger.setLevel(openlineage_logger.level)
 
 def main():
     logger.info(f"Running OpenLineage dbt wrapper version {__version__}")


### PR DESCRIPTION
### Problem

For some users it is impossible to programatically set Python logging levels.

### Solution

Add `OPENLINEAGE_{CLIENT/AIRFLOW/DBT}_LOGGING` environment variables that can set according module logging levels.

This PR also cleans up some logging calls in `openlineage-airflow`.

#### One-line summary:

Allow to modify `openlineage.*` logging levels via environment variables

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project