### PR TITLE
Upgrade iceberg-spark-runtime version in support of time-travel usage

### DIFF
--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark3-runtime:0.12.1"
+    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.3.0"
     compileOnly "io.delta:delta-core_2.12:1.0.0"
     compileOnly "com.databricks:dbutils-api_2.12:0.0.6"
 
@@ -74,7 +74,7 @@ dependencies {
     testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark3-runtime:0.12.1"
+    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.3.0"
     testFixturesApi "io.delta:delta-core_2.12:1.0.0"
     testFixturesApi "com.databricks:dbutils-api_2.12:0.0.6"
     testImplementation(testFixtures(project(":shared")))

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark3-runtime:0.13.0"
+    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:1.3.0"
     compileOnly "io.delta:delta-core_2.12:1.1.0"
     compileOnly "com.databricks:dbutils-api_2.12:0.0.6"
 
@@ -69,7 +69,7 @@ dependencies {
     testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.13.0"
+    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:1.3.0"
     testFixturesApi "io.delta:delta-core_2.12:1.1.0"
     testFixturesApi "com.databricks:dbutils-api_2.12:0.0.6"
     testImplementation(testFixtures(project(":shared")))

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
+    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.3.0"
     compileOnly "io.delta:delta-core_2.12:2.1.0"
 
     testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
@@ -75,7 +75,7 @@ dependencies {
     testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
+    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.3.0"
     testFixturesApi "io.delta:delta-core_2.12:2.1.0"
     testImplementation(testFixtures(project(":shared")))
     testImplementation(testFixtures(project(":spark3")))


### PR DESCRIPTION
### Problem
The current version specified for spark integration in spark3 project `0.12.1`, is quite old and missing SQL support for time travel (supported from iceberg 0.14.0 / Spark 3.3 onward). This alone is not enough, but since the change seems not impacting anything, it may be worth doing until the spark projects get fully merged and upgraded. 

Closes: #1969

### Solution
Simply upgrade the spark-iceberg runtime version. Does not have any impact on existing tests and does have the immediate benefit of capturing the `snapshotid` within `SparkTable`

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary: 

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project