### PR TITLE
sql: add support for Apple Silicon to openlineage-sql-java

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -342,23 +342,27 @@ jobs:
             - target/debug/*.so
   
   compile-integration-sql-java-macos:
+    parameters:
+      resource_class:
+        type: string
+        default: "medium"
     working_directory: ~/openlineage/integration/sql/iface-java
     macos:
       xcode: 14.2.0
-    resource_class: medium
+    resource_class: << parameters.resource_class >>
     steps:
       - *checkout_project_root
       - run: bash script/compile.sh
       - persist_to_workspace:
           root: ../
           paths:
-            - target/debug/libopenlineage_sql_java.dylib
+            - target/debug/*.dylib
 
   build-integration-sql-java:
     working_directory: ~/openlineage/integration/sql/iface-java
     docker:
       - image: cimg/openjdk:8.0
-    resource_class: medium
+    resource_class: "medium"
     steps:
       - *checkout_project_root
       - attach_workspace:
@@ -788,6 +792,21 @@ workflows:
               ignore: /.*/
           context: release
       - compile-integration-sql-java-macos:
+          matrix:
+            alias: compile-integration-sql-java-macos-x86
+            parameters:
+              resource_class: [ "medium" ]
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+          context: release
+      - compile-integration-sql-java-macos:
+          matrix:
+            alias: compile-integration-sql-java-macos-arm
+            parameters:
+              resource_class: [ "macos.m1.medium.gen1" ]
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
@@ -821,7 +840,8 @@ workflows:
           requires:
             - compile-integration-sql-java-linux-x86
             - compile-integration-sql-java-linux-arm
-            - compile-integration-sql-java-macos
+            - compile-integration-sql-java-macos-x86
+            - compile-integration-sql-java-macos-arm
       - release-integration-flink:
           filters:
             tags:
@@ -888,7 +908,8 @@ workflows:
           requires:
             - compile-integration-sql-java-linux-x86
             - compile-integration-sql-java-linux-arm
-            - compile-integration-sql-java-macos
+            - compile-integration-sql-java-macos-x86
+            - compile-integration-sql-java-macos-arm
       - build-integration-sql:
           matrix:
             alias: build-integration-sql-x86

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *$py.class
 
 # C extensions
+*.dylib
 *.so
 
 # Distribution / packaging

--- a/integration/sql/iface-java/script/build.sh
+++ b/integration/sql/iface-java/script/build.sh
@@ -25,6 +25,9 @@ fi
 if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java.dylib" ]]; then
     cp $ROOT/../target/debug/libopenlineage_sql_java.dylib $RESOURCES
 fi
+if [[ -f "$ROOT/../target/debug/libopenlineage_sql_java_arm64.dylib" ]]; then
+    cp $ROOT/../target/debug/libopenlineage_sql_java_arm64.dylib $RESOURCES
+fi
 
 # Let's generate this header every run so that it is always
 # up to date.

--- a/integration/sql/iface-java/script/compile.sh
+++ b/integration/sql/iface-java/script/compile.sh
@@ -21,6 +21,8 @@ if [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "x86_64" ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java_x86_64.so
 elif [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "aarch64" ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java_aarch64.so
+elif [[ "$OSTYPE" == "darwin"* && "$(uname -m)" == "arm64" ]]; then
+    NATIVE_LIB_NAME=libopenlineage_sql_java_arm64.dylib
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java.dylib
 else

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
@@ -71,7 +71,9 @@ public final class OpenLineageSql {
 
   static {
     String libName = "libopenlineage_sql_java";
-    if (SystemUtils.IS_OS_MAC_OSX) {
+    if (SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64")) {
+      libName += "_arm64.dylib";
+    } else if (SystemUtils.IS_OS_MAC_OSX) {
       libName += ".dylib";
     } else if (SystemUtils.IS_OS_LINUX && SystemUtils.OS_ARCH.equals("aarch64")) {
       libName += "_aarch64.so";


### PR DESCRIPTION
### Problem

The [Java wrapper for the SQL integration](https://central.sonatype.com/artifact/io.openlineage/openlineage-sql-java) doesn't work on Macs with Apple Silicon, as a binary is only distributed for Intel Macs - currently running it will result in an `UnsatisfiedLink` error.

### Solution

- Expand the OS/architecture checks when compiling to produce a specific file for Apple Silicon
- Expand the corresponding OS/architecture checks when loading the binary at runtime from Java code
- Include a CircleCI job to compile on an M1 machine when releasing, also explicitly request an x86 machine for the existing build so it's unambiguous

I've tested this locally - not the CircleCI part, but in terms of compiling and building and then running against some Java code on an M1 Macbook.

~It's definitely incomplete - I haven't touched the Python side although I expect it'll need some changes too - I wanted to get some early feedback at this point.~

#### One-line summary:

Add support for Apple Silicon to `openlineage-sql-java`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project