### PR TITLE
spec: remove facet ref from core

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -752,6 +752,38 @@ jobs:
       - run: ./docker/login.sh
       - run: ./docker/build-and-push-proxy.sh $CIRCLE_TAG
 
+  run-pre-commit:
+    # this job run pre-commit for Python client only
+    # add depedency to other files when pre-commit runs related checks
+    working_directory: ~/openlineage
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - *checkout_project_root
+      - restore_cache:
+          keys:
+          - v1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+
+      - run:
+          name: Install Dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install pre-commit
+            # Install the hooks now so that they'll be cached
+            pre-commit install-hooks
+      - save_cache:
+          paths:
+            - ~/.cache/pre-commit
+            - ./venv
+          key: v1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+
+      - run:
+          name: Run pre-commit
+          command: |
+            . venv/bin/activate
+            pre-commit run --show-diff-on-failure --all-files
+
   workflow_complete:
     working_directory: ~/openlineage
     machine:

--- a/.circleci/workflows/openlineage-integration-python.yml
+++ b/.circleci/workflows/openlineage-integration-python.yml
@@ -1,37 +1,43 @@
 workflows:
   openlineage-integration-python:
     jobs:
+      - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.8"
           tox_env: py38
           py_env: "3.8"
+          requires:
+            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.9"
           tox_env: py39
           py_env: "3.9"
+          requires:
+            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.10"
           tox_env: py310
           py_env: "3.10"
+          requires:
+            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.11"
           tox_env: py311
           py_env: "3.11"
-      - unit-test-client-python:
-          name: "pre-commit"
-          tox_env: fix
-          py_env: "3.11"
+          requires:
+            - run-pre-commit
       - unit-test-client-python:
           name: "type checker"
           tox_env: type
           py_env: "3.11"
+          requires:
+            - run-pre-commit
       - unit-tests-client-python:
           requires:
             - "CPython 3.8"
             - "CPython 3.9"
             - "CPython 3.10"
             - "CPython 3.11"
-            - "pre-commit"
             - "type checker"
       - build-client-python:
           filters:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,18 @@ repos:
       - id: prettier
         files: ^spec/
         args: ["--print-width=120", "--prose-wrap=always"]
+  - repo: local
+    hooks:
+      - id: check_schemas
+        name: Check JSON Schema spec files.
+        language: golang
+        additional_dependencies: ["github.com/santhosh-tekuri/jsonschema/cmd/jv@latest"]
+        entry: ./.pre_commit/json-schema/check-spec.sh
+        files: ^spec/.*\.json$
+        exclude: ^spec/tests/.*$
+      - id: test_events
+        name: Test events against JSON Schema spec files.
+        language: golang
+        additional_dependencies: ["github.com/santhosh-tekuri/jsonschema/cmd/jv@latest"]
+        entry: ./.pre_commit/json-schema/test-facets.sh
+        files: ^spec/facets/.*\.json$

--- a/.pre_commit/json-schema/check-spec.sh
+++ b/.pre_commit/json-schema/check-spec.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+# jv cli from: https://github.com/santhosh-tekuri/jsonschema
+
+set -e
+
+while [ "$1" ]; do
+  echo "Checking $1 schema"
+  jv $1
+  shift
+done

--- a/.pre_commit/json-schema/test-facets.sh
+++ b/.pre_commit/json-schema/test-facets.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+# jv cli from: https://github.com/santhosh-tekuri/jsonschema
+
+
+set -e
+
+while [ "$1" ]; do
+  event_type=$(basename "$1" .json)
+  shopt -s nullglob
+  test_events=("spec/tests/$event_type"/*.json)
+  if [ ${#test_events[@]} -gt 0 ]; then
+    echo "Validating $test_events against $1"
+    jv $1 $test_events
+  fi
+  shift
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,17 @@ Look for tickets labeled ['good first issue'][goodfirstissues] and ['help wanted
 [goodfirstissues]: https://github.com/OpenLineage/OpenLineage/labels/good%20first%20issue
 [helpwantedissues]: https://github.com/OpenLineage/OpenLineage/labels/help%20wanted
 
+## Running pre-commit hooks
+
+Before submitting your pull request, make sure to set up and run pre-commit hooks to ensure code quality and consistency. [Pre-commit](pre-commit.com) hooks are automated checks that run before each commit is made. These checks include code formatting, linting and JSON Schema specification validations. To set up the pre-commit hooks for this project, follow these steps:
+
+* Install pre-commit: If you haven't already, install pre-commit on your local machine by running `pip install pre-commit` in your virtual environment.
+
+* Set up hooks: Once pre-commit is installed, navigate to the project's root directory and execute `pre-commit install`. This command will set up the necessary hooks in your local repository.
+
+* Run pre-commit: Now, every time you attempt to make a commit, the pre-commit hooks will automatically run on the staged files. If any issues are detected, the commit process will be halted, allowing you to address the problems before making the commit. You can also run `pre-commit run --all-files` to manually trigger the hooks for all files in the repository.
+
+
 ## Triggering CI runs from forks (committers)
 
 CI runs on forks are disabled due to the possibility of access by external services via CI run. 

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -75,6 +75,10 @@ public class Generator {
 
   private static void addURLs(Set<URL> urls, File dir)
       throws URISyntaxException, MalformedURLException {
+    if (dir.getName().equals("tests")) {
+      // Skip processing this directory if its name is "tests"
+      return;
+    }
     File[] jsonFiles = dir.listFiles((File f, String name) -> name.endsWith(JSON_EXT));
     for (File jsonFile : jsonFiles) {
       urls.add(jsonFile.toURI().toURL());

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -8,7 +8,6 @@ env_list =
     py39
     py38
     type
-    fix
 skip_missing_interpreters = true
 
 [testenv]
@@ -43,14 +42,6 @@ set_env =
     {tty:MYPY_FORCE_COLOR = 1}
 commands =
     mypy --namespace-packages --explicit-package-bases openlineage
-
-[testenv:fix]
-description = run static analysis and style check using flake8
-skip_install = true
-deps =
-    pre-commit>=3.3.2
-commands =
-    pre-commit run --all-files --show-diff-on-failure
 
 [testenv:dev]
 description = generate a DEV environment

--- a/spec/OpenLineage.json
+++ b/spec/OpenLineage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/2-0-1/OpenLineage.json",
+  "$id": "https://openlineage.io/spec/2-0-2/OpenLineage.json",
   "$defs": {
     "BaseEvent": {
       "type": "object",
@@ -72,7 +72,8 @@
               "$ref": "#/$defs/StaticDataset"
             }
           },
-          "required": ["dataset"]
+          "required": ["dataset"],
+          "not": { "required": ["job", "run"] }
         }
       ]
     },
@@ -100,7 +101,8 @@
               }
             }
           },
-          "required": ["job"]
+          "required": ["job"],
+          "not": { "required": ["run"] }
         }
       ]
     },
@@ -119,11 +121,7 @@
             {
               "type": "object",
               "additionalProperties": { "$ref": "#/$defs/RunFacet" }
-            },
-            { "$ref": "facets/ErrorMessageRunFacet.json" },
-            { "$ref": "facets/ExternalQueryRunFacet.json" },
-            { "$ref": "facets/NominalTimeRunFacet.json" },
-            { "$ref": "facets/ParentRunFacet.json" }
+            }
           ]
         }
       },
@@ -154,12 +152,7 @@
             {
               "type": "object",
               "additionalProperties": { "$ref": "#/$defs/JobFacet" }
-            },
-            { "$ref": "facets/DocumentationJobFacet.json" },
-            { "$ref": "facets/OwnershipJobFacet.json" },
-            { "$ref": "facets/SourceCodeJobFacet.json" },
-            { "$ref": "facets/SourceCodeLocationJobFacet.json" },
-            { "$ref": "facets/SQLJobFacet.json" }
+            }
           ]
         }
       },
@@ -198,8 +191,7 @@
                   "additionalProperties": {
                     "$ref": "#/$defs/InputDatasetFacet"
                   }
-                },
-                { "$ref": "facets/DataQualityMetricsInputDatasetFacet.json" }
+                }
               ]
             }
           }
@@ -228,8 +220,7 @@
                   "additionalProperties": {
                     "$ref": "#/$defs/OutputDatasetFacet"
                   }
-                },
-                { "$ref": "facets/OutputStatisticsOutputDatasetFacet.json" }
+                }
               ]
             }
           }
@@ -261,16 +252,7 @@
             {
               "type": "object",
               "additionalProperties": { "$ref": "#/$defs/DatasetFacet" }
-            },
-            { "$ref": "facets/ColumnLineageDatasetFacet.json" },
-            { "$ref": "facets/DatasourceDatasetFacet.json" },
-            { "$ref": "facets/DataQualityAssertionsDatasetFacet.json" },
-            { "$ref": "facets/LifecycleStateChangeDatasetFacet.json" },
-            { "$ref": "facets/OwnershipDatasetFacet.json" },
-            { "$ref": "facets/SchemaDatasetFacet.json" },
-            { "$ref": "facets/StorageDatasetFacet.json" },
-            { "$ref": "facets/SymlinksDatasetFacet.json" },
-            { "$ref": "facets/DatasetVersionDatasetFacet.json" }
+            }
           ]
         }
       },

--- a/spec/facets/ExtractionErrorRunFacet.json
+++ b/spec/facets/ExtractionErrorRunFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/ExtractionErrorRunFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-1-0/ExtractionErrorRunFacet.json",
   "$defs": {
     "ExtractionErrorRunFacet": {
       "allOf": [
@@ -44,7 +44,7 @@
               }
             }
           },
-          "required": ["totalElements", "failedElements", "errors"]
+          "required": ["totalTasks", "failedTasks", "errors"]
         }
       ]
     }

--- a/spec/facets/ProcessingEngineRunFacet.json
+++ b/spec/facets/ProcessingEngineRunFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/ProcessingEngineRunFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-1-0/ProcessingEngineRunFacet.json",
   "$defs": {
     "ProcessingEngineRunFacet": {
       "allOf": [
@@ -26,7 +26,7 @@
               "example": "0.19.0"
             }
           },
-          "required": ["engine_version"]
+          "required": ["version"]
         }
       ],
       "type": "object"

--- a/spec/tests/ColumnLineageDatasetFacet/1.json
+++ b/spec/tests/ColumnLineageDatasetFacet/1.json
@@ -1,0 +1,30 @@
+{
+  "columnLineage": {
+    "fields": {
+      "order_day_of_week": {
+        "inputFields": [
+          {
+            "field": "order_placed_on",
+            "name": "public.top_delivery_times",
+            "namespace": "postgres://postgres:5432"
+          }
+        ],
+        "transformationDescription": "",
+        "transformationType": ""
+      },
+      "order_placed_on": {
+        "inputFields": [
+          {
+            "field": "order_placed_on",
+            "name": "public.top_delivery_times",
+            "namespace": "postgres://postgres:5432"
+          }
+        ],
+        "transformationDescription": "",
+        "transformationType": ""
+      }
+    },
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ColumnLineageDatasetFacet.json"
+  }
+}

--- a/spec/tests/DataQualityAssertionsDatasetFacet/1.json
+++ b/spec/tests/DataQualityAssertionsDatasetFacet/1.json
@@ -1,0 +1,58 @@
+{
+  "dataQualityAssertions": {
+    "assertions": [
+      {
+        "assertion": "accepted_values",
+        "column": "status",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "amount",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "bank_transfer_amount",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "coupon_amount",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "credit_card_amount",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "customer_id",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "gift_card_amount",
+        "success": true
+      },
+      {
+        "assertion": "not_null",
+        "column": "order_id",
+        "success": true
+      },
+      {
+        "assertion": "relationships",
+        "column": "customer_id",
+        "success": true
+      },
+      {
+        "assertion": "unique",
+        "column": "order_id",
+        "success": true
+      }
+    ],
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DataQualityAssertionsDatasetFacet.json"
+  }
+}

--- a/spec/tests/DataQualityMetricsInputDatasetFacet/1.json
+++ b/spec/tests/DataQualityMetricsInputDatasetFacet/1.json
@@ -1,0 +1,23 @@
+{
+  "dataQualityMetrics": {
+    "columnMetrics": {
+      "amount": {
+        "count": 10,
+        "max": 1500,
+        "min": 100,
+        "sum": 6600
+      },
+      "counterparty_id": {
+        "nullCount": 0
+      },
+      "user_id": {
+        "distinctCount": 3,
+        "nullCount": 0
+      }
+    },
+    "rowCount": 10,
+
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DataQualityMetricsInputDatasetFacet.json"
+  }
+}

--- a/spec/tests/DatasetVersionDatasetFacet/1.json
+++ b/spec/tests/DatasetVersionDatasetFacet/1.json
@@ -1,0 +1,7 @@
+{
+  "version": {
+    "datasetVersion": "2",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json"
+  }
+}

--- a/spec/tests/DatasourceDatasetFacet/1.json
+++ b/spec/tests/DatasourceDatasetFacet/1.json
@@ -1,0 +1,7 @@
+{
+  "version": {
+    "datasetVersion": "2",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json"
+  }
+}

--- a/spec/tests/DocumentationDatasetFacet/1.json
+++ b/spec/tests/DocumentationDatasetFacet/1.json
@@ -1,0 +1,7 @@
+{
+  "documentation": {
+    "description": "Some dataset description",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DocumentationDatasetFacet.json"
+  }
+}

--- a/spec/tests/DocumentationJobFacet/1.json
+++ b/spec/tests/DocumentationJobFacet/1.json
@@ -1,0 +1,7 @@
+{
+  "documentation": {
+    "description": "Determines the popular day of week orders are placed.",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DocumentationDatasetFacet.json"
+  }
+}

--- a/spec/tests/ErrorMessageRunFacet/1.json
+++ b/spec/tests/ErrorMessageRunFacet/1.json
@@ -1,0 +1,9 @@
+{
+  "errorMessage": {
+    "message": "failed",
+    "programmingLanguage": "JAVA",
+    "stackTrace": "<stack_trace>",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ErrorMessageRunFacet.json"
+  }
+}

--- a/spec/tests/ExternalQueryRunFacet/1.json
+++ b/spec/tests/ExternalQueryRunFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "externalQuery": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/airflow",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ExternalQueryRunFacet.json",
+    "externalQueryId": "bigquery_1690280798993890_f4ade238a8121576708e1892f69e67fe",
+    "source": "bigquery"
+  }
+}

--- a/spec/tests/ExtractionErrorRunFacet/1.json
+++ b/spec/tests/ExtractionErrorRunFacet/1.json
@@ -1,0 +1,15 @@
+{
+  "extractionError": {
+    "totalTasks": 1,
+    "failedTasks": 1,
+    "errors": [
+      {
+        "errorMessage": "Expected an object type after CREATE, found: TYPE",
+        "task": "CREATE TYPE myrowtype AS (f1 int, f2 text, f3 numeric)",
+        "taskNumber": 0
+      }
+    ],
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ExtractionErrorRunFacet.json"
+  }
+}

--- a/spec/tests/LifecycleStateChangeDatasetFacet/1.json
+++ b/spec/tests/LifecycleStateChangeDatasetFacet/1.json
@@ -1,0 +1,11 @@
+{
+  "lifecycleStateChange": {
+    "lifecycleStateChange": "RENAME",
+    "previousIdentifier": {
+      "name": "/tmp/alter_test/alter_table_test",
+      "namespace": "file"
+    },
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json"
+  }
+}

--- a/spec/tests/NominalTimeRunFacet/1.json
+++ b/spec/tests/NominalTimeRunFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "nominalTime": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python",
+    "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/NominalTimeRunFacet",
+    "nominalEndTime": "2020-01-02",
+    "nominalStartTime": "2020-01-01"
+  }
+}

--- a/spec/tests/OutputStatisticsOutputDatasetFacet/1.json
+++ b/spec/tests/OutputStatisticsOutputDatasetFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "outputStatistics": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
+    "rowCount": 2000,
+    "size": 2097152
+  }
+}

--- a/spec/tests/OwnershipDatasetFacet/1.json
+++ b/spec/tests/OwnershipDatasetFacet/1.json
@@ -1,0 +1,11 @@
+{
+  "ownership": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/OwnershipDatasetFacet.json",
+    "owners": [
+      {
+        "name": "owner"
+      }
+    ]
+  }
+}

--- a/spec/tests/OwnershipJobFacet/1.json
+++ b/spec/tests/OwnershipJobFacet/1.json
@@ -1,0 +1,11 @@
+{
+  "ownership": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/OwnershipJobFacet.json",
+    "owners": [
+      {
+        "name": "owner"
+      }
+    ]
+  }
+}

--- a/spec/tests/ParentRunFacet/1.json
+++ b/spec/tests/ParentRunFacet/1.json
@@ -1,0 +1,13 @@
+{
+  "parent": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ParentRunFacet.json",
+    "run": {
+      "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+    },
+    "job": {
+      "namespace": "dbt",
+      "name": "dbt-job-name"
+    }
+  }
+}

--- a/spec/tests/ProcessingEngineRunFacet/1.json
+++ b/spec/tests/ProcessingEngineRunFacet/1.json
@@ -1,0 +1,9 @@
+{
+  "processing_engine": {
+    "version": "2.5.0",
+    "name": "Airflow",
+    "openlineageAdapterVersion": "0.29.2",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/ProcessingEngineRunFacet.json"
+  }
+}

--- a/spec/tests/SQLJobFacet/1.json
+++ b/spec/tests/SQLJobFacet/1.json
@@ -1,0 +1,7 @@
+{
+  "sql": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SQLJobFacet.json",
+    "query": "\n\nwith orders as (\n\n    select * from \"postgres\".\"public\".\"stg_orders\"\n\n),\n\npayments as (\n\n    select * from \"postgres\".\"public\".\"stg_payments\"\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final"
+  }
+}

--- a/spec/tests/SchemaDatasetFacet/1.json
+++ b/spec/tests/SchemaDatasetFacet/1.json
@@ -1,0 +1,24 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "user_id",
+        "type": "int64"
+      },
+      {
+        "name": "counterparty_id",
+        "type": "int64"
+      },
+      {
+        "name": "currency",
+        "type": "object"
+      },
+      {
+        "name": "amount",
+        "type": "int64"
+      }
+    ],
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json"
+  }
+}

--- a/spec/tests/SourceCodeJobFacet/1.json
+++ b/spec/tests/SourceCodeJobFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "sourceCode": {
+    "language": "bash",
+    "sourceCode": "ls -halt && exit 0",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SourceCodeJobFacet.json"
+  }
+}

--- a/spec/tests/SourceCodeLocationJobFacet/1.json
+++ b/spec/tests/SourceCodeLocationJobFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "sourceCodeLocation": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SourceCodeLocationJobFacet.json",
+    "type": "git",
+    "url": "http://example.com"
+  }
+}

--- a/spec/tests/StorageDatasetFacet/1.json
+++ b/spec/tests/StorageDatasetFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "storage": {
+    "storageLayer": "delta",
+    "fileFormat": "parquet",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/StorageDatasetFacet.json"
+  }
+}

--- a/spec/tests/SymlinksDatasetFacet/1.json
+++ b/spec/tests/SymlinksDatasetFacet/1.json
@@ -1,0 +1,13 @@
+{
+  "symlinks": {
+    "identifiers": [
+      {
+        "namespace": "/tmp/alter_test",
+        "name": "default.alter_table_test_new",
+        "type": "TABLE"
+      }
+    ],
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SymlinksDatasetFacet.json"
+  }
+}

--- a/spec/tests/example_full_event.json
+++ b/spec/tests/example_full_event.json
@@ -1,0 +1,24 @@
+{
+  "eventTime": "2023-07-17T10:54:22.355067Z",
+  "eventType": "COMPLETE",
+  "inputs": [],
+  "job": {
+    "facets": {
+      "sql": {
+        "query": "SELECT 1",
+        "_producer": "http://123",
+        "_schemaURL": "http://123"
+      }
+    },
+    "name": "dbt",
+    "namespace": "food_delivery"
+  },
+  "outputs": [],
+  "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.30.0/integration/airflow",
+  "run": {
+    "facets": {},
+    "runId": "f69a6e9b-9bac-3c9a-9cf6-eacb70ecc9a9"
+  },
+  "dataset": { "namespace": "123", "name": "1" },
+  "schemaURL": "https://openlineage.io/spec/1-0-5/OpenLineage.json#/definitions/RunEvent"
+}


### PR DESCRIPTION
### Problem

There are `$ref: facets/...` references in core `OpenLineage.json`. This breaks compatibility with JSON Schema specification.

### Solution

Remove references from core `OpenLineage.json`. Add spec tests.

#### One-line summary:

Remove references to facets in core spec.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project