### PR TITLE
client/python: rename `config` to `config_class`.

### DIFF
--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -18,7 +18,7 @@ class ConsoleConfig(Config):
 
 class ConsoleTransport(Transport):
     kind = "console"
-    config = ConsoleConfig
+    config_class = ConsoleConfig
 
     def __init__(self, config: ConsoleConfig) -> None:  # noqa: ARG002
         self.log = logging.getLogger(__name__)

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -54,7 +54,7 @@ class DefaultTransportFactory(TransportFactory):
             msg = f"Transport {transport_class} has to be class, and subclass of Transport"
             raise TypeError(msg)
 
-        config_class = transport_class.config
+        config_class = transport_class.config_class
 
         if isinstance(config_class, str):
             config_class = try_import_from_string(config_class)

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -108,7 +108,7 @@ class HttpConfig(Config):
 
 class HttpTransport(Transport):
     kind = "http"
-    config = HttpConfig
+    config_class = HttpConfig
 
     def __init__(self, config: HttpConfig) -> None:
         url = config.url.strip()

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -54,7 +54,7 @@ def on_delivery(err: KafkaError, msg: Message) -> None:
 
 class KafkaTransport(Transport):
     kind = "kafka"
-    config = KafkaConfig
+    config_class = KafkaConfig
 
     def __init__(self, config: KafkaConfig) -> None:
         self.topic = config.topic

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -19,7 +19,7 @@ class NoopConfig(Config):
 
 class NoopTransport(Transport):
     kind = "noop"
-    config = NoopConfig
+    config_class = NoopConfig
 
     def __init__(self, config: NoopConfig) -> None:  # noqa: ARG002
         log.info("OpenLineage client is disabled. NoopTransport.")

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -35,7 +35,7 @@ class Config:
 
 class Transport:
     kind: str | None = None
-    config: type[Config] = Config
+    config_class: type[Config] = Config
 
     def emit(self, event: Union[RunEvent, DatasetEvent, JobEvent]) -> Any:  # noqa: ANN401, UP007
         raise NotImplementedError


### PR DESCRIPTION
### Problem

Currently class variable `config` may mislead to config instance instead of config class.

### Solution

This PR introduces small change from `config` to `config_class` class variable.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project