### PR TITLE
airflow: convert lineage from legacy file definition

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/converters.py
+++ b/integration/airflow/openlineage/airflow/extractors/converters.py
@@ -22,7 +22,7 @@ def convert_from_object_storage_uri(uri: str) -> Optional[Dataset]:
             namespace=f"s3://{netloc}",
             name=path
         )
-    elif scheme.startswith("gcs") or scheme.startswith("gs"):
+    elif scheme.startswith(("gcs", "gs")):
         return Dataset(
             namespace=f"gs://{netloc}",
             name=path

--- a/integration/airflow/openlineage/airflow/extractors/converters.py
+++ b/integration/airflow/openlineage/airflow/extractors/converters.py
@@ -1,9 +1,38 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional, Tuple, cast
+from urllib.parse import urlparse
+
 from openlineage.client.run import Dataset
 
-from airflow.lineage.entities import Table
+from airflow.lineage.entities import File, Table
+
+
+def convert_from_object_storage_uri(uri: str) -> Optional[Dataset]:
+    try:
+        scheme, netloc, path, params, _, _ = cast(
+            Tuple[str, str, str, str, str, str],
+            urlparse(uri)
+        )
+    except Exception:
+        return None
+    if scheme.startswith("s3"):
+        return Dataset(
+            namespace=f"s3://{netloc}",
+            name=path
+        )
+    elif scheme.startswith("gcs") or scheme.startswith("gs"):
+        return Dataset(
+            namespace=f"gs://{netloc}",
+            name=path
+        )
+    elif "/" not in uri:
+        return None
+    return Dataset(
+        namespace=scheme,
+        name=f"/{netloc}{path}"
+    )
 
 
 def convert_to_dataset(obj):
@@ -11,9 +40,10 @@ def convert_to_dataset(obj):
         return obj
     elif isinstance(obj, Table):
         return Dataset(
-            namespace=f"{obj.cluster}",
+            namespace=obj.cluster,
             name=f"{obj.database}.{obj.name}",
-            facets={},
         )
+    elif isinstance(obj, File):
+        return convert_from_object_storage_uri(obj.url)
     else:
         return None

--- a/integration/airflow/tests/extractors/test_converters.py
+++ b/integration/airflow/tests/extractors/test_converters.py
@@ -1,9 +1,11 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
+import pytest
+from openlineage.airflow.extractors.converters import convert_to_dataset
+from openlineage.client.run import Dataset
+
 
 def test_table_to_dataset_conversion():
-    from openlineage.airflow.extractors.converters import convert_to_dataset
-
     from airflow.lineage.entities import Table
     t = Table(
         database="db",
@@ -18,8 +20,6 @@ def test_table_to_dataset_conversion():
 
 
 def test_dataset_to_dataset_conversion():
-    from openlineage.airflow.extractors.converters import convert_to_dataset
-    from openlineage.client.run import Dataset
     t = Dataset(
         namespace="c",
         name="db.table1",
@@ -30,3 +30,24 @@ def test_dataset_to_dataset_conversion():
 
     assert d.namespace == "c"
     assert d.name == "db.table1"
+
+
+@pytest.mark.parametrize("uri, dataset", [
+    ("s3://my-bucket/my-file", Dataset("s3://my-bucket", "/my-file")),
+    ("gcs://my-bucket/some/path/to/file", Dataset("gs://my-bucket", "/some/path/to/file")),
+    ("gs://my-bucket/some/path/to/file", Dataset("gs://my-bucket", "/some/path/to/file")),
+    ("something://asdf", Dataset("something", "/asdf")),
+    ("file://path/to/something", Dataset("file", "/path/to/something")),
+    ("not|a|uri", None)
+])
+def test_gcs_file_to_dataset_conversion(uri, dataset):
+    from airflow.lineage.entities import File
+
+    f = File(url=uri)
+    d = convert_to_dataset(f)
+
+    if dataset is None:
+        assert d is None
+    else:
+        assert d.namespace == dataset.namespace
+        assert d.name == dataset.name

--- a/integration/airflow/tests/extractors/test_extractor_manager.py
+++ b/integration/airflow/tests/extractors/test_extractor_manager.py
@@ -117,22 +117,30 @@ def test_extraction_from_inlets_and_outlets_without_extractor():
 def test_extraction_from_inlets_and_outlets_ignores_unhandled_types():
     from openlineage.client.run import Dataset
 
-    from airflow.lineage.entities import File, Table
+    from airflow.lineage.entities import File, Table, User
 
     dagrun = MagicMock()
 
     task = FakeOperator(
         task_id="task",
-        inlets=[Dataset(namespace="c1", name="d1.t0", facets={}),
-                File(url="http://test"), Table(database="d1", cluster="c1", name="t1")],
-        outlets=[Table(database="d1", cluster="c1", name="t2"), File(url="http://test")],
+        inlets=[
+            Dataset(namespace="c1", name="d1.t0", facets={}),
+            File(url="http://test"),
+            Table(database="d1", cluster="c1", name="t1"),
+            User(email="asdf@asdf.com")
+        ],
+        outlets=[
+            Table(database="d1", cluster="c1", name="t2"),
+            File(url="http://test"),
+            User(email="asdf@asdf.com")
+        ],
     )
 
     manager = ExtractorManager()
 
     metadata = manager.extract_metadata(dagrun, task)
-    # The File objects from inlets and outlets should not be converted
-    assert len(metadata.inputs) == 2 and len(metadata.outputs) == 1
+    # The User objects from inlets and outlets should not be converted
+    assert len(metadata.inputs) == 3 and len(metadata.outputs) == 2
 
 
 def test_fake_extractor_extracts_from_inlets_and_outlets():


### PR DESCRIPTION
To have more backwards compatibility with old Airflow legacy lineage description, coverage for File definition is added.