### PR TITLE
docs: add file transport documentation

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -31,7 +31,7 @@ transport:
 ```
 
 The `type` property is required. It can be one of the built-in transports or a custom one.
-There are three built-in transports, `http`, `kafka` and `console`.
+There are four built-in transports, `http`, `kafka`, `console` and `file`.
 Custom transports `type` is a fully qualified class name that can be imported.
 
 The rest of the properties are defined by the particular transport.
@@ -56,6 +56,10 @@ You can also install `pip install openlineage-python[kafka]`
 * `topic` - required string parameter. The topic on what events will be sent.
 * `flush` - optional boolean parameter. If set to True, Kafka will flush after each event. By default true.
 
+#### File
+
+* `log_file_path` - required string parameter specifying the path of the file (if `append` is true a file path is expected, otherwise a file prefix is expected).
+* `append` - optional boolean parameter. If set to True, each event will be appended to a single file (log_file_path), otherwise, all event would be written separatly in distinct files suffixed by a timestring. By default false.
 
 ### Custom transport
 


### PR DESCRIPTION
### Problem

Documentation was missing for File Transport option.

### Solution

Documentation added on README python client.

#### One-line summary:
Adding file transport documentation

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project