### PR TITLE
Add delta input and output builders only if the command is in the classpath

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -47,8 +47,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
             .add(new CommandPlanVisitor(context))
             .add(new DataSourceV2ScanRelationInputDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationInputDatasetBuilder(context, datasetFactory))
-            .add(new SubqueryAliasInputDatasetBuilder(context))
-            .add(new MergeIntoCommandInputDatasetBuilder(context));
+            .add(new SubqueryAliasInputDatasetBuilder(context));
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {
       builder.add(new MergeIntoCommandInputDatasetBuilder(context));
@@ -61,16 +60,20 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
       OpenLineageContext context) {
     DatasetFactory<OpenLineage.OutputDataset> datasetFactory = DatasetFactory.output(context);
-    return ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+    ImmutableList.Builder builder = ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
         .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
         .add(new SaveIntoDataSourceCommandVisitor(context))
         .add(new AppendDataDatasetBuilder(context, datasetFactory))
         .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
         .add(new TableContentChangeDatasetBuilder(context))
-        .add(new MergeIntoCommandOutputDatasetBuilder(context))
         .add(new CreateReplaceDatasetBuilder(context))
-        .add(new AlterTableDatasetBuilder(context))
-        .build();
+        .add(new AlterTableDatasetBuilder(context));
+
+    if (DeltaUtils.hasMergeIntoCommandClass()) {
+      builder.add(new MergeIntoCommandOutputDatasetBuilder(context));
+    }
+
+    return builder.build();
   }
 
   @Override

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -60,14 +60,15 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
       OpenLineageContext context) {
     DatasetFactory<OpenLineage.OutputDataset> datasetFactory = DatasetFactory.output(context);
-    ImmutableList.Builder builder = ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
-        .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
-        .add(new SaveIntoDataSourceCommandVisitor(context))
-        .add(new AppendDataDatasetBuilder(context, datasetFactory))
-        .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
-        .add(new TableContentChangeDatasetBuilder(context))
-        .add(new CreateReplaceDatasetBuilder(context))
-        .add(new AlterTableDatasetBuilder(context));
+    ImmutableList.Builder builder =
+        ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
+            .add(new SaveIntoDataSourceCommandVisitor(context))
+            .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
+            .add(new TableContentChangeDatasetBuilder(context))
+            .add(new CreateReplaceDatasetBuilder(context))
+            .add(new AlterTableDatasetBuilder(context));
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {
       builder.add(new MergeIntoCommandOutputDatasetBuilder(context));


### PR DESCRIPTION
This PR fixes a NoClassDefFoundError exception that occurs when delta command is not in the classpath.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project