### PR TITLE
Change log level to DEBUG when extractor isn't found

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -62,7 +62,7 @@ class ExtractorManager:
                     f'Failed to extract metadata {e} {task_info}',
                 )
         else:
-            self.log.warning(
+            self.log.debug(
                 f'Unable to find an extractor. {task_info}')
 
             # Only include the unkonwnSourceAttribute facet if there is no extractor


### PR DESCRIPTION
There isn't much a user can do when an extractor is not even available for them to use. So changing this to DEBUG makes more sense IMO

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project