### PR TITLE
Don't use database as fallback when no schema parsed.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -301,6 +301,6 @@ class SqlExtractor(BaseExtractor):
             hierarchy.setdefault(
                 normalize_name(db) if db else db, {}
             ).setdefault(
-                normalize_name(table.schema) if table.schema else db, []
+                normalize_name(table.schema) if table.schema else None, []
             ).append(table.name)
         return hierarchy

--- a/integration/airflow/tests/extractors/test_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_sql_extractor.py
@@ -50,6 +50,14 @@ def test_get_tables_hierarchy():
         is_cross_db=True,
     ) == {"db": {"schema1": ["Table2"]}, "db2": {"schema1": ["Table1"]}}
 
+    # cross db, no db & schema parsed
+    assert SqlExtractor._get_tables_hierarchy(
+        [DbTableMeta("Table1"), DbTableMeta("Table2")],
+        normalize_name_lower,
+        database="Db",
+        is_cross_db=True,
+    ) == {"db": {None: ["Table1", "Table2"]}}
+
 
 def test_get_sql_iterator():
     assert SqlExtractor._normalize_sql("select * from asdf") == "select * from asdf"


### PR DESCRIPTION
### Problem

With cross-database queries to information schema there shouldn't be used database as fallback for no schema parsed.

### Solution

Set schema to None in TablesHierarchy. This will lead to no filter on schema level in information schema query.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project