### PR TITLE
spark: fix wrong naming of JDBC datasets

### DIFF
--- a/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "name": "jdbc_source1",
+      "name": "test.jdbc_source1",
       "facets": {
         "schema": {
           "fields": [
@@ -23,7 +23,7 @@
       }
     },
     {
-      "name": "jdbc_source2",
+      "name": "test.jdbc_source2",
       "facets": {
         "schema": {
           "fields": [
@@ -38,7 +38,7 @@
   ],
   "outputs": [
     {
-      "name": "test",
+      "name": "test.test",
       "facets": {
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/columnLineageJDBCStart.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCStart.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "name": "jdbc_source1",
+      "name": "test.jdbc_source1",
       "facets": {
         "schema": {
           "fields": [
@@ -23,7 +23,7 @@
       }
     },
     {
-      "name": "jdbc_source2",
+      "name": "test.jdbc_source2",
       "facets": {
         "schema": {
           "fields": [
@@ -92,7 +92,7 @@
   ],
   "outputs": [
     {
-      "name": "test",
+      "name": "test.test",
       "facets": {
         "schema": {
           "fields": [

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.mockserver.model.HttpRequest.request;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -71,6 +72,7 @@ public class ColumnLineageIntegrationTest {
                 "/docker-entrypoint-initdb.d/init.sql");
   }
 
+  @SneakyThrows
   @BeforeAll
   public static void setup() {
     metastoreContainer.start();
@@ -161,7 +163,8 @@ public class ColumnLineageIntegrationTest {
     dataFrame.registerTempTable("temp" + type);
     spark.sql(
         String.format(
-            "create table v2_source_%s USING ICEBERG as select * from temp%s", type, type));
+            "create table if not exists v2_source_%s USING ICEBERG as select * from temp%s",
+            type, type));
     return dataFrame;
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -5,11 +5,16 @@
 
 package io.openlineage.spark.agent.util;
 
+import com.google.common.base.CharMatcher;
 import io.openlineage.sql.DbTableMeta;
 import io.openlineage.sql.ExtractionError;
 import io.openlineage.sql.OpenLineageSql;
 import io.openlineage.sql.SqlMeta;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,14 +29,51 @@ public class JdbcUtils {
    * strip the jdbc prefix from the url
    */
   public static String sanitizeJdbcUrl(String jdbcUrl) {
-    String jdbcUrlCroppedPrefix = jdbcUrl.substring(5);
-    return jdbcUrlCroppedPrefix
+    return jdbcUrl
         .replaceFirst("^jdbc:", "")
         .replaceFirst("^postgresql:", "postgres:")
         .replaceAll(PlanUtils.SLASH_DELIMITER_USER_PASSWORD_REGEX, "@")
         .replaceAll(PlanUtils.COLON_DELIMITER_USER_PASSWORD_REGEX, "$1")
         .replaceAll("(?<=[?,;&:)=])\\(?(?i)(?:user|username|password)=[^;&,)]+(?:[;&;)]|$)", "")
         .replaceAll("\\?.+$", "");
+  }
+
+  public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(String jdbcUrl, String name) {
+    List<String> parts = Arrays.stream(name.split("\\.")).collect(Collectors.toList());
+    return getDatasetIdentifierFromJdbcUrl(jdbcUrl, parts);
+  }
+
+  public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(
+      String jdbcUrl, List<String> parts) {
+    jdbcUrl = sanitizeJdbcUrl(jdbcUrl);
+    String namespace = jdbcUrl;
+    String urlDatabase = null;
+
+    try {
+      URI uri = new URI(jdbcUrl);
+      String path = uri.getPath();
+      if (path != null) {
+        namespace = String.format("%s://%s", uri.getScheme(), uri.getAuthority());
+
+        if (path.startsWith("/")) {
+          path = path.substring(1);
+        }
+
+        if (path.length() > 1
+            && CharMatcher.forPredicate(Character::isAlphabetic).matchesAllOf(path)) {
+          urlDatabase = path;
+        }
+      }
+    } catch (URISyntaxException ignored) {
+    }
+
+    if (urlDatabase != null && parts.size() <= 3) {
+      parts.add(0, urlDatabase);
+    }
+
+    String name = String.join(".", parts);
+
+    return new DatasetIdentifier(name, namespace);
   }
 
   public static Optional<SqlMeta> extractQueryFromSpark(JDBCRelation relation) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -43,6 +43,19 @@ public class JdbcUtils {
     return getDatasetIdentifierFromJdbcUrl(jdbcUrl, parts);
   }
 
+  /**
+   * The algorithm for this method is as follows. First we parse URI and check if it includes path
+   * part of URI. If yes, then we check if it contains database. Database is the first part after
+   * slash in URI - the "db" in something like postgres://host:5432/db. If it does contain it, and
+   * provided parts list has less than three elements, then we use it as database part of name -
+   * this indicates that database is the default one in this context. Otherwise, we take database
+   * from parts list.
+   *
+   * @param jdbcUrl String URI we want to take dataset identifier from
+   * @param parts Provided list of delimited parts of table qualified name parts. Can include
+   *     database name.
+   * @return DatasetIdentifier
+   */
   public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(
       String jdbcUrl, List<String> parts) {
     jdbcUrl = sanitizeJdbcUrl(jdbcUrl);
@@ -65,6 +78,8 @@ public class JdbcUtils {
         }
       }
     } catch (URISyntaxException ignored) {
+      // If URI parsing fails, we can't do anything smart - let's return provided URI
+      // as a dataset namespace
     }
 
     if (urlDatabase != null && parts.size() <= 3) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -71,10 +71,12 @@ public class PathUtils {
 
     DatasetIdentifier di;
     if (catalogTable.storage() != null && catalogTable.storage().locationUri().isDefined()) {
+      log.error("From Storage");
       di = PathUtils.fromURI(catalogTable.storage().locationUri().get(), DEFAULT_SCHEME);
     } else {
       // try to obtain location
       try {
+        log.error("From Default Table Path");
         di = prepareDatasetIdentifierFromDefaultTablePath(catalogTable);
       } catch (IllegalStateException e) {
         // session inactive - no way to find DatasetProvider
@@ -84,11 +86,13 @@ public class PathUtils {
     }
 
     if (metastoreUri.isPresent() && metastoreUri.get() != null) {
+      log.error("From Metastore");
       // dealing with Hive tables
       DatasetIdentifier symlink = prepareHiveDatasetIdentifier(catalogTable, metastoreUri.get());
       return di.withSymlink(
           symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.TABLE);
     } else {
+      log.error("From Table Identifier");
       return di.withSymlink(
           nameFromTableIdentifier(catalogTable.identifier()),
           StringUtils.substringBeforeLast(di.getName(), File.separator),

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.api.DatasetFactory;
 import java.util.List;
@@ -58,8 +59,10 @@ public class JdbcRelationHandlerTest {
 
     jdbcRelationHandler.getDatasets(relation, url);
 
-    verify(datasetFactory, times(1)).getDataset("jdbc_source1", url, schema1);
-    verify(datasetFactory, times(1)).getDataset("jdbc_source2", url, schema2);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source1", "postgres://localhost:5432", schema1);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source2", "postgres://localhost:5432", schema2);
   }
 
   @Test
@@ -67,9 +70,10 @@ public class JdbcRelationHandlerTest {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcTable);
     when(relation.schema()).thenReturn(schema);
 
-    jdbcRelationHandler.getDatasets(relation, url);
+    List<OpenLineage.Dataset> datasets = jdbcRelationHandler.getDatasets(relation, url);
 
-    verify(datasetFactory, times(1)).getDataset("tablename", url, schema);
+    verify(datasetFactory, times(1))
+        .getDataset("test.tablename", "postgres://localhost:5432", schema);
   }
 
   @Test
@@ -81,8 +85,10 @@ public class JdbcRelationHandlerTest {
 
     jdbcRelationHandler.getDatasets(relation, url);
 
-    verify(datasetFactory, times(1)).getDataset("jdbc_source1", url, schema1);
-    verify(datasetFactory, times(1)).getDataset("jdbc_source2", url, schema2);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source1", "postgres://localhost:5432", schema1);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source2", "postgres://localhost:5432", schema2);
   }
 
   @Test
@@ -95,8 +101,10 @@ public class JdbcRelationHandlerTest {
 
     jdbcRelationHandler.getDatasets(relation, mysqlUrl);
 
-    verify(datasetFactory, times(1)).getDataset("jdbc_source1", mysqlUrl, schema1);
-    verify(datasetFactory, times(1)).getDataset("jdbc_source2", mysqlUrl, schema2);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source1", "mysql://localhost:3306", schema1);
+    verify(datasetFactory, times(1))
+        .getDataset("test.jdbc_source2", "mysql://localhost:3306", schema2);
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -71,12 +71,12 @@ class LogicalRelationDatasetBuilderTest {
 
   @ParameterizedTest
   @CsvSource({
-    "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432/sparkdata",
-    "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata",
-    "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl",
-    "jdbc:mysql://localhost/sparkdata,mysql://localhost/sparkdata"
+    "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432,sparkdata.my_spark_table",
+    "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata,my_spark_table",
+    "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl,my_spark_table",
+    "jdbc:mysql://localhost/sparkdata,mysql://localhost,sparkdata.my_spark_table"
   })
-  void testApply(String connectionUri, String targetUri) {
+  void testApply(String connectionUri, String targetUri, String targetTableName) {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
     String sparkTableName = "my_spark_table";
     JDBCRelation relation =
@@ -126,7 +126,7 @@ class LogicalRelationDatasetBuilderTest {
     assertEquals(1, datasets.size());
     OutputDataset ds = datasets.get(0);
     assertEquals(targetUri, ds.getNamespace());
-    assertEquals(sparkTableName, ds.getName());
+    assertEquals(targetTableName, ds.getName());
     assertEquals(URI.create(targetUri), ds.getFacets().getDataSource().getUri());
     assertEquals(targetUri, ds.getFacets().getDataSource().getName());
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -23,14 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class PlanUtilsTest {
 
   @ParameterizedTest
-  @MethodSource("provideJdbcUrls")
-  void testJdbcUrlSanitizer(String jdbcUrl, String expectedResult) {
-
-    String actualResult = JdbcUtils.sanitizeJdbcUrl(jdbcUrl);
-
-    assertEquals(expectedResult, actualResult);
-  }
-
+  @MethodSource()
   private static Stream<Arguments> provideJdbcUrls() {
     return Stream.of(
         Arguments.of(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -8,6 +8,7 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.JdbcUtils;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,11 +41,11 @@ public class JdbcHandler implements CatalogHandler {
     JDBCTableCatalog catalog = (JDBCTableCatalog) tableCatalog;
     JDBCOptions options = (JDBCOptions) FieldUtils.readField(catalog, "options", true);
 
-    String name =
+    List<String> parts =
         Stream.concat(Arrays.stream(identifier.namespace()), Stream.of(identifier.name()))
-            .collect(Collectors.joining("."));
+            .collect(Collectors.toList());
 
-    return new DatasetIdentifier(name, JdbcUtils.sanitizeJdbcUrl(options.url()));
+    return JdbcUtils.getDatasetIdentifierFromJdbcUrl(options.url(), parts);
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -41,4 +41,25 @@ class JdbcHandlerTest {
     assertEquals("database.schema.table", datasetIdentifier.getName());
     assertEquals("postgres://postgreshost:5432", datasetIdentifier.getNamespace());
   }
+
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierWithDatabase() {
+    JdbcHandler handler = new JdbcHandler();
+
+    JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
+    JDBCOptions options = mock(JDBCOptions.class);
+    when(options.url()).thenReturn("jdbc:postgresql://postgreshost:5432/database");
+    FieldUtils.writeField(tableCatalog, "options", options, true);
+
+    DatasetIdentifier datasetIdentifier =
+        handler.getDatasetIdentifier(
+            mock(SparkSession.class),
+            tableCatalog,
+            Identifier.of(new String[] {"schema"}, "table"),
+            new HashMap<>());
+
+    assertEquals("database.schema.table", datasetIdentifier.getName());
+    assertEquals("postgres://postgreshost:5432", datasetIdentifier.getNamespace());
+  }
 }

--- a/integration/sql/iface-java/script/compile.sh
+++ b/integration/sql/iface-java/script/compile.sh
@@ -6,9 +6,11 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-# Install Rust
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source $HOME/.cargo/env
+if ! [ -x "$(command -v cargo)" ]; then
+  # Install Rust
+  curl https://sh.rustup.rs -sSf | sh -s -- -y
+  source $HOME/.cargo/env
+fi
 
 BASEDIR=$(dirname $BASH_SOURCE)
 ROOT=$BASEDIR/..
@@ -35,4 +37,5 @@ cd $ROOT/..
 cargo build -p openlineage_sql_java
 
 shopt -s extglob
+pwd
 mv target/debug/libopenlineage_sql_java*(*.so|*.dylib) target/debug/$NATIVE_LIB_NAME

--- a/integration/sql/iface-java/script/compile.sh
+++ b/integration/sql/iface-java/script/compile.sh
@@ -37,5 +37,4 @@ cd $ROOT/..
 cargo build -p openlineage_sql_java
 
 shopt -s extglob
-pwd
 mv target/debug/libopenlineage_sql_java*(*.so|*.dylib) target/debug/$NATIVE_LIB_NAME


### PR DESCRIPTION
According to OpenLineage naming schema, in SQL databases the general schema is that it has a format
```
namespace: scheme://authority
name: database.schema.table
```
with specific changes according to particular database.

JDBC/Spark connector added database to the namespace - this fixes it.