### PR TITLE
[SPARK] fix RDD & S3 findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.1.0...HEAD)
+### Fixed
+* **Spark: Improve RDDs on S3 integration. (TODO PR number)** [`#2039`](https://github.com/OpenLineage/OpenLineage/pull/2039) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Prepare integration test to access S3, fix input dataset duplicates and other minor fixes.*
 
 ## [1.1.0](https://github.com/OpenLineage/OpenLineage/compare/1.0.0...1.1.0) - 2023-08-23
 ### Added

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -112,7 +112,9 @@ dependencies {
     testFixturesApi "org.apache.spark:spark-sql_${versions.scala}:${sparkVersion}"
     testFixturesApi "org.apache.spark:spark-hive_${versions.scala}:${sparkVersion}"
     testFixturesApi 'commons-beanutils:commons-beanutils:1.9.4'
-
+    if(versions.module != "spark2") {
+        testFixturesApi "org.apache.spark:spark-hadoop-cloud_${versions.scala}:${sparkVersion}"
+    }
 
     testFixturesApi ("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
         exclude group: 'com.google.guava:guava'

--- a/integration/spark/app/integrations/container/pysparkRDDWithParquetComplete.json
+++ b/integration/spark/app/integrations/container/pysparkRDDWithParquetComplete.json
@@ -1,0 +1,36 @@
+{
+  "eventType" : "COMPLETE",
+  "job" : {
+    "namespace" : "testRddWithParquet",
+    "name" : "open_lineage_integration_rd_d_with_parquet.execute_insert_into_hadoop_fs_relation_command.tmp_rdd_c"
+  },
+  "inputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/rdd_a",
+    "facets" : {
+      "schema" : {
+        "fields" : [ ]
+      }
+    }
+  }, {
+    "namespace" : "file",
+    "name" : "/tmp/rdd_b",
+    "facets" : {
+      "schema" : {
+        "fields" : [ ]
+      }
+    }
+  } ],
+  "outputs" : [ {
+    "namespace" : "file",
+    "name" : "/tmp/rdd_c",
+    "facets" : {
+      "schema" : {
+        "fields" : [ {
+          "name" : "_1",
+          "type" : "string"
+        } ]
+      }
+    }
+  } ]
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -335,4 +335,13 @@ class SparkContainerIntegrationTest {
 
     mockServerClient.verify(request().withPath("/api/v1/lineage").withBody(new RegexBody(regex)));
   }
+
+  @Test
+  @SneakyThrows
+  void testRddWithParquet() {
+    SparkContainerUtils.runPysparkContainerWithDefaultConf(
+        network, openLineageClientMockContainer, "testRddWithParquet", "spark_rdd_with_parquet.py");
+
+    verifyEvents(mockServerClient, "pysparkRDDWithParquetComplete.json");
+  }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.Tabl
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Binder;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Module;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Provides;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.DatasetFacets;
@@ -72,6 +73,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
@@ -89,6 +91,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -110,6 +113,9 @@ class SparkReadWriteIntegTest {
   private static final String NAME = "name";
   private static final String AGE = "age";
   private static final String FILE_URI_PREFIX = "file://";
+  private static final String SPARK_3 = "(3.*)";
+  private static final String SPARK_VERSION = "spark.version";
+
   private final KafkaContainer kafkaContainer =
       new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.0"));
 
@@ -676,6 +682,70 @@ class SparkReadWriteIntegTest {
         .first()
         .hasFieldOrPropertyWithValue(NAMESPACE, FILE)
         .hasFieldOrPropertyWithValue(NAME, fileName);
+  }
+
+  @Test
+  @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3) // Spark version >= 3.*
+  void testExternalRDDWithS3Bucket(SparkSession spark)
+      throws InterruptedException, TimeoutException {
+
+    spark.conf().set("fs.s3a.secret.key", System.getenv("S3_SECRET_KEY"));
+    spark.conf().set("fs.s3a.access.key", System.getenv("S3_ACCESS_KEY"));
+
+    String bucketUrl = System.getenv("S3_BUCKET");
+
+    Dataset<Row> dataset =
+        spark.createDataFrame(
+            ImmutableList.of(RowFactory.create(1L, 2L), RowFactory.create(3L, 4L)),
+            new StructType(
+                new StructField[] {
+                  new StructField("a", LongType$.MODULE$, false, Metadata.empty()),
+                  new StructField("b", LongType$.MODULE$, false, Metadata.empty())
+                }));
+
+    dataset.write().mode("overwrite").parquet(bucketUrl + "/rdd_a");
+    dataset.write().mode("overwrite").parquet(bucketUrl + "/rdd_b");
+
+    JavaRDD<Row> rddA = spark.read().parquet(bucketUrl + "/rdd_a").toJavaRDD();
+    JavaRDD<Row> rddB = spark.read().parquet(bucketUrl + "/rdd_b").toJavaRDD();
+
+    JavaRDD<Row> javaRDD =
+        rddA.union(rddB).map(f -> f.getLong(0) + f.getLong(1)).map(l -> RowFactory.create(l));
+
+    spark
+        .createDataFrame(
+            javaRDD,
+            new StructType(
+                new StructField[] {
+                  new StructField("a", LongType$.MODULE$, false, Metadata.empty()),
+                }))
+        .toDF()
+        .write()
+        .mode("overwrite")
+        .parquet(bucketUrl + "/rdd_c");
+
+    // wait for event processing to complete
+    StaticExecutionContextFactory.waitForExecutionEnd();
+    ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
+        ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(1))
+        .emit(lineageEvent.capture());
+    List<OpenLineage.RunEvent> events = lineageEvent.getAllValues();
+    OpenLineage.RunEvent lastEvent = events.get(events.size() - 1);
+
+    assertThat(lastEvent.getOutputs())
+        .hasSize(1)
+        .first()
+        .hasFieldOrPropertyWithValue(NAMESPACE, bucketUrl)
+        .hasFieldOrPropertyWithValue(NAME, "rdd_c");
+
+    assertThat(lastEvent.getInputs())
+        .hasSize(2)
+        .first()
+        .hasFieldOrPropertyWithValue(NAMESPACE, bucketUrl)
+        .hasFieldOrPropertyWithValue(NAME, "rdd_b");
   }
 
   private CompletableFuture sendMessage(

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
@@ -1,0 +1,29 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder \
+    .master("local") \
+    .appName("Open Lineage Integration RDD with Parquet") \
+    .getOrCreate()
+
+# prepare some data and store in Parquet
+df = spark.createDataFrame([
+    {'a': 'x', 'b': 'z'},
+    {'a': 'y', 'b': 'z'}
+]);
+
+df.write.option("compression", "none").parquet("/tmp/rdd_a")
+df.write.option("compression", "none").parquet("/tmp/rdd_b")
+
+# read RDDs out of the parquet file
+rdd_a = spark.read.parquet("/tmp/rdd_a").rdd
+rdd_b = spark.read.parquet("/tmp/rdd_b").rdd
+
+# make a union, some map on RDDs, convert to dataframe and save as parquet
+rdd_a \
+  .union(rdd_b) \
+  .map(lambda x: (x['a'] + x['b'],)) \
+  .toDF() \
+  .write.parquet("/tmp/rdd_c")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
@@ -33,7 +33,9 @@ public class LogicalRDDVisitor<D extends OpenLineage.Dataset>
 
   @Override
   public boolean isDefinedAt(LogicalPlan x) {
-    return x instanceof LogicalRDD && !Rdds.findFileLikeRdds(((LogicalRDD) x).rdd()).isEmpty();
+    return x instanceof LogicalRDD
+        && !Rdds.findFileLikeRdds(((LogicalRDD) x).rdd()).isEmpty()
+        && !SqlExecutionRDDVisitor.containsSqlExecution((LogicalRDD) x);
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
@@ -9,7 +9,6 @@ import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.lifecycle.Rdds;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,15 +26,16 @@ public class SqlExecutionRDDVisitor extends AbstractRDDNodeVisitor<LogicalRDD, I
 
   @Override
   public boolean isDefinedAt(LogicalPlan x) {
-    return x instanceof LogicalRDD && !findSqlExecution((LogicalRDD) x).isEmpty();
+    return x instanceof LogicalRDD && containsSqlExecution((LogicalRDD) x);
   }
 
-  private Collection<SQLExecutionRDD> findSqlExecution(LogicalRDD logicalRDD) {
+  public static boolean containsSqlExecution(LogicalRDD logicalRDD) {
     Set<RDD<?>> rdds = Rdds.flattenRDDs(logicalRDD.rdd());
-    return rdds.stream()
+    return !rdds.stream()
         .filter(rdd -> rdd instanceof SQLExecutionRDD)
         .map(SQLExecutionRDD.class::cast)
-        .collect(Collectors.toList());
+        .collect(Collectors.toList())
+        .isEmpty();
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -52,6 +52,10 @@ public class PathUtils {
     return new DatasetIdentifier(name, namespace);
   }
 
+  public static DatasetIdentifier fromURI(URI location) {
+    return fromPath(new Path(location), DEFAULT_SCHEME);
+  }
+
   public static DatasetIdentifier fromURI(URI location, String defaultScheme) {
     return fromPath(new Path(location), defaultScheme);
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -10,6 +10,7 @@ import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.Lifecy
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import java.net.URI;
 import java.util.List;
@@ -123,9 +124,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    */
   public D getDataset(URI outputPath, StructType schema) {
     String namespace = PlanUtils.namespaceUri(outputPath);
-    return getDataset(
-        new DatasetIdentifier(outputPath.getPath(), namespace),
-        datasetFacetBuilder(schema, namespace));
+    return getDataset(PathUtils.fromURI(outputPath), datasetFacetBuilder(schema, namespace));
   }
 
   /**

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -11,6 +11,7 @@ import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilde
 import io.openlineage.spark.agent.util.BigQueryUtils;
 import io.openlineage.spark.agent.util.DatasetIdentifier;
 import io.openlineage.spark.agent.util.JdbcUtils;
+import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -145,9 +146,7 @@ public class InputFieldsCollector {
   private static List<DatasetIdentifier> extractDatasetIdentifier(LogicalRDD logicalRDD) {
     List<RDD<?>> fileLikeRdds = Rdds.findFileLikeRdds(logicalRDD.rdd());
     return PlanUtils.findRDDPaths(fileLikeRdds).stream()
-        .map(
-            path ->
-                new DatasetIdentifier(path.toUri().getPath(), PlanUtils.namespaceUri(path.toUri())))
+        .map(path -> PathUtils.fromURI(path.toUri()))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Problem

Integration test to read & write data into S3 has been written and revealed following issues: 
 * input datasets are duplicated
 * input dataset name starts with `/` although it shouldn't
 * it's not working in Spark 3.4.

Closes: #2037

### Solution

Fix the issues above. 

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modifcation(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project