### PR TITLE
fix: serde filtering

### DIFF
--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -33,7 +33,7 @@ class Serde:
         if isinstance(obj, List):
             return list(
                 filter(
-                    lambda x: False if x is None else not (isinstance(x, dict) and x == {}),
+                    lambda x: x is not None and (not isinstance(x, dict) or x != {}),
                     [cls.remove_nulls_and_enums(v) for v in obj if v is not None],
                 ),
             )

--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -33,7 +33,7 @@ class Serde:
         if isinstance(obj, List):
             return list(
                 filter(
-                    lambda x: x is not None and (isinstance(x, dict) and x != {}),
+                    lambda x: False if x is None else not (isinstance(x, dict) and x == {}),
                     [cls.remove_nulls_and_enums(v) for v in obj if v is not None],
                 ),
             )

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -118,6 +118,64 @@ class NestingObject:
     optional: int | None = attr.ib(default=None)
 
 
+@attr.s
+class ListOfStrings:
+    values: list[str] = attr.ib()
+
+
+@attr.s
+class NestedListOfStrings:
+    nested: list[ListOfStrings] = attr.ib()
+
+
+def test_serde_list_of_strings() -> None:
+    assert (
+        Serde.to_json(
+            ListOfStrings(
+                values=["str_1", "str_2", "str_3"],
+            ),
+        )
+        == '{"values": ["str_1", "str_2", "str_3"]}'
+    )
+
+    assert (
+        Serde.to_json(
+            NestingObject(
+                nested=[
+                    NestedObject(),
+                ],
+            ),
+        )
+        == '{"nested": []}'
+    )
+
+
+def test_serde_nested_list_of_strings() -> None:
+    assert (
+        Serde.to_json(
+            NestedListOfStrings(
+                nested=[
+                    ListOfStrings(values=["str_1", "str_2", "str_3"]),
+                    ListOfStrings(values=["str_a", "str_b", "str_c"]),
+                ],
+            ),
+        )
+        == '{"nested": [{"values": ["str_1", "str_2", "str_3"]}, '
+        '{"values": ["str_a", "str_b", "str_c"]}]}'
+    )
+
+    assert (
+        Serde.to_json(
+            NestingObject(
+                nested=[
+                    NestedObject(),
+                ],
+            ),
+        )
+        == '{"nested": []}'
+    )
+
+
 def test_serde_nested_nulls() -> None:
     assert (
         Serde.to_json(


### PR DESCRIPTION
### Problem
Values in list objects will be accidently filtered out so that they will not be included in the output.

### Solution
Remove unnecessary instance type check (which filters out single value by mistake) in Serde.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:
Fix the bug that causes values in list objects being accidently filtered.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project