### PR TITLE
ci: bump Go image version used in root CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
   # workflow
   determine_changed_modules:
     docker:
-      - image: cimg/go:1.17.8
+      - image: cimg/go:1.21.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`yq` now requires Go 1.20.0