### PR TITLE
Ci/fix pre commit step

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -767,7 +767,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            python3 -m venv venv
+            python3.8 -m venv venv
             . venv/bin/activate
             pip install pre-commit
             # Install the hooks now so that they'll be cached

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -762,21 +762,21 @@ jobs:
       - *checkout_project_root
       - restore_cache:
           keys:
-          - v1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+          - v1.1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Install Dependencies
           command: |
             python3.8 -m venv venv
             . venv/bin/activate
-            pip install pre-commit
+            pip3 install pre-commit
             # Install the hooks now so that they'll be cached
             pre-commit install-hooks
       - save_cache:
           paths:
             - ~/.cache/pre-commit
             - ./venv
-          key: v1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+          key: v1.1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Run pre-commit


### PR DESCRIPTION
### Problem

`cimg` python 3.8 image has changed so that `python3` command stopped working in venv properly.

### Solution

Fix to `python3.8`. Bump cache version to `v1.1`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project