### PR TITLE
spark: publish ProcessingEngineRunFacet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.1.0...HEAD)
 ### Feature
 * **Spark: Publish the `ProcessingEngineRunFacet` as part of the normal operation of the `OpenLineageSparkEventListener`.** [`#2089`](https://github.com/OpenLineage/OpenLineage/pull/2089) [@d-m-h](https://github.com/d-m-h)
-  *Publishes the spec-defined `ProcessEngineRunFacet` alongside the custom `SparkVersionFacet`.* 
+  * **ADDITION:** Publishes the spec-defined `ProcessEngineRunFacet` alongside the custom `SparkVersionFacet` (for now).
+  * **DEPRECATES**: `SparkVersionFacet`. Will be removed in `1.4.0`.
 
 ### Fixed
 * **Spark: Improve RDDs on S3 integration. (TODO PR number)** [`#2039`](https://github.com/OpenLineage/OpenLineage/pull/2039) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.1.0...HEAD)
+### Feature
+* **Spark: Publish the `ProcessingEngineRunFacet` as part of the normal operation of the `OpenLineageSparkEventListener`.** [`#2089`](https://github.com/OpenLineage/OpenLineage/pull/2089) [@d-m-h](https://github.com/d-m-h)
+  *Publishes the spec-defined `ProcessEngineRunFacet` alongside the custom `SparkVersionFacet`.* 
+
 ### Fixed
 * **Spark: Improve RDDs on S3 integration. (TODO PR number)** [`#2039`](https://github.com/OpenLineage/OpenLineage/pull/2039) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Prepare integration test to access S3, fix input dataset duplicates and other minor fixes.*

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -19,6 +19,7 @@ import io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuild
 import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkVersionFacetBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
@@ -188,7 +189,8 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new ErrorFacetBuilder(),
                 new LogicalPlanRunFacetBuilder(context),
                 new SparkVersionFacetBuilder(context),
-                new SparkPropertyFacetBuilder(context));
+                new SparkPropertyFacetBuilder(context),
+                new SparkProcessingEngineRunFacetBuilder(context));
     if (DatabricksEnvironmentFacetBuilder.isDatabricksRuntime()) {
       listBuilder.add(new DatabricksEnvironmentFacetBuilder(context));
     } else if (context.getCustomEnvironmentVariables() != null) {

--- a/integration/spark/shared/facets/spark/v1/version-facet.json
+++ b/integration/spark/shared/facets/spark/v1/version-facet.json
@@ -7,6 +7,7 @@
           "type": "object",
           "properties": {
             "spark_version": {
+              "description": "This particular definition is deprecated, and will be removed in the future. Use the spec-defined ProcessingEngineRunFacet instead. Removal is ear marked in v1.4.0.",
               "type": "object",
               "required": [
                 "spark-version",

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
@@ -12,7 +12,17 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.apache.spark.SparkContext;
 
+/**
+ * Captures information pertinent to the running Apache Spark application and the OpenLineage Spark
+ * connector.
+ *
+ * @deprecated
+ *     <p>Since version 1.2.0.
+ *     <p>Will be removed in version 1.4.0.
+ *     <p>Please use {@link io.openlineage.client.OpenLineage.ProcessingEngineRunFacet} instead.
+ */
 @Getter
+@Deprecated
 public class SparkVersionFacet extends OpenLineage.DefaultRunFacet {
   @JsonProperty("spark-version")
   private String sparkVersion;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
@@ -1,0 +1,42 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.client.OpenLineage.ProcessingEngineRunFacet;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.function.BiConsumer;
+import org.apache.spark.scheduler.SparkListenerEvent;
+
+/**
+ * {@link CustomFacetBuilder} that adds the {@link ProcessingEngineRunFacet} to a run. This facet is
+ * generated for every {@link SparkListenerEvent}.
+ *
+ * <p>This class is a hacky way of solving this problem, because it wraps the creation of the {@link
+ * ProcessingEngineRunFacet} behind the {@link CustomFacetBuilder} interface. The actual creation is
+ * done by the delegate, namely: {@link SparkProcessingEngineRunFacetBuilderDelegate}. Why do we
+ * delegate to that? To prevent code duplication when code paths that do not use the {@link
+ * CustomFacetBuilder} functionality need to add the aforementioned facet to the {@link RunEvent},
+ * for example: {@code RddExecutionContext} located in the "app" subproject.
+ */
+public class SparkProcessingEngineRunFacetBuilder
+    extends CustomFacetBuilder<SparkListenerEvent, ProcessingEngineRunFacet> {
+
+  private final SparkProcessingEngineRunFacetBuilderDelegate delegate;
+
+  public SparkProcessingEngineRunFacetBuilder(OpenLineageContext openLineageContext) {
+    this.delegate =
+        new SparkProcessingEngineRunFacetBuilderDelegate(
+            openLineageContext.getOpenLineage(), openLineageContext.getSparkContext());
+  }
+
+  @Override
+  protected void build(
+      SparkListenerEvent event, BiConsumer<String, ? super ProcessingEngineRunFacet> consumer) {
+    consumer.accept("processing_engine", delegate.buildFacet());
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
@@ -1,0 +1,43 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.ProcessingEngineRunFacet;
+import org.apache.spark.SparkContext;
+
+/**
+ * This class is the one that actually does the work of building an instance of {@link
+ * ProcessingEngineRunFacet}. The reason for the name is to:
+ *
+ * <p>
+ *
+ * <ol>
+ *   <li>Alert the reader that it is related to {@link SparkProcessingEngineRunFacetBuilder}, and;
+ *   <li>Prevent inadvertent name collisions between it and the actual {@link
+ *       ProcessingEngineRunFacet} resulting in incredibly long lines.
+ * </ol>
+ */
+public final class SparkProcessingEngineRunFacetBuilderDelegate {
+  private final OpenLineage ol;
+  private final SparkContext sparkContext;
+
+  public SparkProcessingEngineRunFacetBuilderDelegate(OpenLineage ol, SparkContext sparkContext) {
+    this.ol = ol;
+    this.sparkContext = sparkContext;
+  }
+
+  public ProcessingEngineRunFacet buildFacet() {
+    // TODO: At some stage, we probably need to create a canonical dictionary for the names of the
+    //  processing engines, or define a convention - i.e., names of processing engines should be
+    //  snake_case
+    return ol.newProcessingEngineRunFacetBuilder()
+        .name("spark")
+        .version(sparkContext.version())
+        .openlineageAdapterVersion(this.getClass().getPackage().getImplementationVersion())
+        .build();
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
@@ -13,7 +13,6 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.JobSucceeded$;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
@@ -22,9 +21,9 @@ import org.apache.spark.scheduler.SparkListenerStageCompleted;
 import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import scala.collection.Seq$;
 
 class SparkProcessingEngineFacetBuilderTest {
@@ -32,14 +31,9 @@ class SparkProcessingEngineFacetBuilderTest {
 
   @BeforeAll
   public static void setupSparkContext() {
-    sparkContext =
-        SparkContext.getOrCreate(
-            new SparkConf().setAppName("SparkProcessingEngineFacetBuilderTest").setMaster("local"));
-  }
-
-  @AfterAll
-  public static void tearDownSparkContext() {
-    sparkContext.stop();
+    sparkContext = Mockito.mock(SparkContext.class);
+    Mockito.when(sparkContext.appName()).thenReturn("SparkProcessingEngineFacetBuilderTest");
+    Mockito.when(sparkContext.version()).thenReturn("3.3.0");
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.JobSucceeded$;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import scala.collection.Seq$;
+
+class SparkProcessingEngineFacetBuilderTest {
+  private static SparkContext sparkContext;
+
+  @BeforeAll
+  public static void setupSparkContext() {
+    sparkContext =
+        SparkContext.getOrCreate(
+            new SparkConf().setAppName("SparkProcessingEngineFacetBuilderTest").setMaster("local"));
+  }
+
+  @AfterAll
+  public static void tearDownSparkContext() {
+    sparkContext.stop();
+  }
+
+  @Test
+  void testIsDefinedForSparkListenerEvents() {
+    SparkProcessingEngineRunFacetBuilder builder =
+        new SparkProcessingEngineRunFacetBuilder(
+            OpenLineageContext.builder()
+                .sparkContext(sparkContext)
+                .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+                .build());
+    assertThat(builder.isDefinedAt(new SparkListenerSQLExecutionEnd(1, 1L))).isTrue();
+    assertThat(
+            builder.isDefinedAt(
+                new SparkListenerSQLExecutionStart(1L, "abc", "abc", "abc", null, 1L)))
+        .isTrue();
+    assertThat(
+            builder.isDefinedAt(
+                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+        .isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerJobEnd(1, 1L, JobSucceeded$.MODULE$))).isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerStageSubmitted(null, new Properties())))
+        .isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerStageCompleted(null))).isTrue();
+  }
+
+  @Test
+  void testBuild() {
+    SparkProcessingEngineRunFacetBuilder builder =
+        new SparkProcessingEngineRunFacetBuilder(
+            OpenLineageContext.builder()
+                .sparkContext(sparkContext)
+                .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+                .build());
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(new SparkListenerSQLExecutionEnd(1, 1L), runFacetMap::put);
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "processing_engine",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(OpenLineage.ProcessingEngineRunFacet.class)
+                    .hasFieldOrPropertyWithValue("name", "spark")
+                    .hasFieldOrPropertyWithValue("version", sparkContext.version()));
+  }
+}


### PR DESCRIPTION
### Problem

The Spark integration publishes a custom `SparkVersionFacet` that isn't defined in the spec, yet there is a facet that captures this information (and a bit more) called `ProcessingEngineRunFacet`.

Closes: [2086](https://github.com/OpenLineage/OpenLineage/issues/2086)

### Solution

Previously, the Spark integration published a custom facet named 'SparkVersion'. As it is custom, it isn't defined in the OpenLineage spec. However, the OpenLineage spec defines a ProcessingEngineRunFacet that is meant to capture details about the things that runs a job.

This change introduces this in the form of the
'SparkProcessingEngineRunFacetBuilder' and
'SparkProcessingEngineRunFacetBuilderDelegate'.

As the names suggest, these classes are meant to create and populate ProcessingEngineRunFacet.

The reason for the existence of the delegate is because there are two code paths that interact with the run facets, namely the code path within the RddExecutionContext and the other in the SparkSqlExecutionContext, albeit via a very roundabout way.

The delegate is the object that actually constructs the facet, whilst the builder provides an adapter that uses the CustomFacetBuilder interface.

Yes, its a hacky way of doing it and may need to be changed in the future. For now though, its good enough.

#### One-line summary: Publish ProcessingEngineRunFacet as part of the regular Spark Integration execution

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project