### PR TITLE
sql: remove dependency to OpenLineage fork in ifaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
             # Changes to the spec require all workflows to run
             check_change spec "*"
             check_change .circleci "*"
+            check_change integration/sql/ "*"
 
             check_change client/java/ openlineage-java.yml openlineage-flink.yml openlineage-spark.yml
             check_change integration/spark/ openlineage-java.yml openlineage-spark.yml
@@ -91,7 +92,6 @@ jobs:
             check_change integration/airflow/ openlineage-integration-python.yml openlineage-integration-airflow.yml
             check_change integration/dagster/ openlineage-integration-python.yml openlineage-integration-dagster.yml
             check_change integration/dbt/ openlineage-integration-python.yml openlineage-integration-dbt.yml
-            check_change integration/sql/ openlineage-integration-python.yml openlineage-integration-airflow.yml
             check_change proxy/backend/ openlineage-proxy-backend.yml
           fi
           touch workflow_files.txt

--- a/integration/sql/iface-java/Cargo.toml
+++ b/integration/sql/iface-java/Cargo.toml
@@ -15,4 +15,3 @@ crate-type = ["cdylib"]
 openlineage_sql = {path = "../impl"}
 anyhow = {workspace = true}
 jni = "0.20.0"
-sqlparser = {git = "https://github.com/sqlparser-rs/sqlparser-rs", branch = "main"}

--- a/integration/sql/iface-py/Cargo.toml
+++ b/integration/sql/iface-py/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib"]
 openlineage_sql = {path = "../impl"}
 anyhow = {workspace = true}
 pyo3 = {version = "0.19.0", features = ["extension-module", "abi3", "abi3-py37", "anyhow"]}
-sqlparser = {git = "https://github.com/OpenLineage/sqlparser-rs", branch = "release"}
 
 [build-dependencies]
 pyo3-build-config = {version = "0.19.0"}


### PR DESCRIPTION
### Problem

Newest release of `sqlparser` breaks building java interface.

### Solution

Remove dependency to OpenLineage fork from ifaces

It also changes CI logic so it runs all workflows if sql integration is changed.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project