### PR TITLE
fix ol proxy chart

### DIFF
--- a/proxy/backend/chart/templates/_helpers.tpl
+++ b/proxy/backend/chart/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the proxy image name
+*/}}
+{{- define "proxy.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.proxy.image "global" .Values.global) -}}
+{{- end -}}

--- a/proxy/backend/chart/templates/deployment.yaml
+++ b/proxy/backend/chart/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.proxy.image }}
+          image: {{ include "proxy.image" . }}
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           volumeMounts:
             - name: openlineage-proxy-volume


### PR DESCRIPTION
### Problem

The helm chart for the OL proxy was not working.

### Solution

This fix includes the proper image to deploy in the helm chart.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project