### PR TITLE
python: fix custom http transport TokenProvider

### DIFF
--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -55,7 +55,7 @@ def create_token_provider(auth: dict[str, str]) -> TokenProvider:
         of_type: str = auth["type"]
         subclass = try_import_from_string(of_type)
         if inspect.isclass(subclass) and issubclass(subclass, TokenProvider):
-            return TokenProvider(auth)
+            return subclass(auth)
 
     return TokenProvider({})
 
@@ -115,7 +115,11 @@ class HttpTransport(Transport):
         url = config.url.strip()
         self.config = config
 
-        log.debug("Constructing openlineage client to send events to %s - config %s", url, config)
+        log.debug(
+            "Constructing openlineage client to send events to %s - config %s",
+            url,
+            config,
+        )
         try:
             from urllib3.util import parse_url
 
@@ -145,7 +149,9 @@ class HttpTransport(Transport):
         if self.session:
             self.session.mount(self.url, adapter)
 
-    def emit(self, event: Union[RunEvent, DatasetEvent, JobEvent]) -> Response:  # noqa: UP007
+    def emit(
+        self, event: Union[RunEvent, DatasetEvent, JobEvent]
+    ) -> Response:  # noqa: UP007
         event_str = Serde.to_json(event)
         if self.session:
             resp = self.session.post(

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -115,11 +115,7 @@ class HttpTransport(Transport):
         url = config.url.strip()
         self.config = config
 
-        log.debug(
-            "Constructing openlineage client to send events to %s - config %s",
-            url,
-            config,
-        )
+        log.debug("Constructing openlineage client to send events to %s - config %s", url, config)
         try:
             from urllib3.util import parse_url
 
@@ -149,9 +145,7 @@ class HttpTransport(Transport):
         if self.session:
             self.session.mount(self.url, adapter)
 
-    def emit(
-        self, event: Union[RunEvent, DatasetEvent, JobEvent]
-    ) -> Response:  # noqa: UP007
+    def emit(self, event: Union[RunEvent, DatasetEvent, JobEvent]) -> Response:  # noqa: UP007
         event_str = Serde.to_json(event)
         if self.session:
             resp = self.session.post(


### PR DESCRIPTION
### Problem

Looks like in #1869 we introduced a bug where we would always use the base `TokenProvider` class instead of a given custom token provider, even if the validation conditions passed. 

### Solution

Revert this to instantiate the subclass

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project