### PR TITLE
[CI] fix circle CI caches

### DIFF
--- a/.circleci/checksum.sh
+++ b/.circleci/checksum.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+RESULT_FILE=$1
+
+if [ -f $RESULT_FILE ]; then
+  rm $RESULT_FILE
+fi
+touch $RESULT_FILE
+
+checksum_file() {
+  echo `openssl md5 $1 | awk '{print $2}'`
+}
+
+FILES=()
+while read -r -d ''; do
+	FILES+=("$REPLY")
+done < <(find . -name 'build.gradle' -type f -print0)
+
+# Loop through files and append MD5 to result file
+for FILE in ${FILES[@]}; do
+	echo `checksum_file $FILE` >> $RESULT_FILE
+done
+# Now sort the file so that it is
+sort $RESULT_FILE -o $RESULT_FILE

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -86,9 +86,12 @@ jobs:
       - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-client-java-{{ .Branch }}
       - run: ./gradlew --no-daemon --stacktrace build
       - run: ./gradlew --no-daemon jacocoTestReport
@@ -109,7 +112,7 @@ jobs:
           path: build/reports/tests/pmd
           destination: pmd-report
       - save_cache:
-          key: v1-client-java-{{ .Branch }}-{{ .Revision }}
+          key: v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
   
@@ -119,6 +122,9 @@ jobs:
       - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
@@ -134,7 +140,7 @@ jobs:
           path: ./build/libs
           destination: java-client-artifacts
       - save_cache:
-          key: v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+          key: v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.m2
   
@@ -144,9 +150,12 @@ jobs:
       - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-release-client-java-{{ .Branch }}
       - attach_workspace:
           at: ~/.m2/repository/io/openlineage/
@@ -178,9 +187,12 @@ jobs:
       JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-integration-spark-{{ .Branch }}
       - attach_workspace:
           at: ~/.m2/repository/io/openlineage/
@@ -203,7 +215,7 @@ jobs:
           path: build/reports/tests/pmd
           destination: pmd-report
       - save_cache:
-          key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+          key: v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
   
@@ -213,9 +225,12 @@ jobs:
       - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-release-client-java-{{ .Branch }}
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
@@ -241,9 +256,12 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-flink-{{ .Branch }}-{{ .Revision }}
+            - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-integration-flink-{{ .Branch }}
       - attach_workspace:
           at: .
@@ -260,7 +278,7 @@ jobs:
           path: build/reports/tests/test
           destination: test-report
       - save_cache:
-          key: v1-integration-flink-{{ .Branch }}-{{ .Revision }}
+          key: v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
   
@@ -382,9 +400,12 @@ jobs:
       - image: cimg/openjdk:8.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ .Revision }}
+            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-release-client-java-{{ .Branch }}
       - attach_workspace:
           at: ../
@@ -449,10 +470,13 @@ jobs:
       - *checkout_project_root
       - gcp-cli/install
       - gcp-cli/initialize
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - run: mkdir -p app/build/gcloud && echo $GCLOUD_SERVICE_KEY > app/build/gcloud/gcloud-service-key.json && chmod 644 app/build/gcloud/gcloud-service-key.json
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-integration-spark-{{ .Branch }}
       - attach_workspace:
           at: ~/.m2/repository/io/openlineage/
@@ -467,7 +491,7 @@ jobs:
           path: app/build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
-          key: v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+          key: v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -488,9 +512,12 @@ jobs:
           condition:
             equal: [ enabled, << pipeline.parameters.databricks-test >> ]
           steps:
+            - run:
+                name: Generate cache key
+                command: ./../../.circleci/checksum.sh /tmp/checksum.txt
             - restore_cache:
                 keys:
-                  - v1-integration-spark-{{ .Branch }}-{{ .Revision }}
+                  - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
                   - v1-integration-spark-{{ .Branch }}
             - attach_workspace:
                 at: ~/.m2/repository/io/openlineage/
@@ -508,7 +535,7 @@ jobs:
                 path: app/build/cluster-log4j.log
                 destination: cluster-log4j.log
             - save_cache:
-                key: v1-databricks-integration-spark-{{ .Branch }}-{{ .Revision }}
+                key: v1-databricks-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
                 paths:
                   - ~/.gradle
 
@@ -524,9 +551,12 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-flink-{{ .Branch }}-{{ .Revision }}
+            - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-integration-flink-{{ .Branch }}
       - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
       - run: chmod -R 777 data/iceberg/db
@@ -542,7 +572,7 @@ jobs:
           path: build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
-          key: v1-integration-flink-{{ .Branch }}-{{ .Revision }}
+          key: v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -697,9 +727,12 @@ jobs:
       - image: cimg/openjdk:11.0
     steps:
       - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-proxy-{{ .Branch }}-{{ .Revision }}
+            - v1-proxy-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-proxy-{{ .Branch }}
       - run: ./gradlew --no-daemon --stacktrace build
       - run: ./gradlew --no-daemon jacocoTestReport
@@ -710,7 +743,7 @@ jobs:
           path: build/reports/tests/test
           destination: test-report
       - save_cache:
-          key: v1-proxy-{{ .Branch }}-{{ .Revision }}
+          key: v1-proxy-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 


### PR DESCRIPTION
### Problem

Storing cache on Circle Ci takes a way too much of our credits. In August, we spent 195K credits on storage out of 535K used in general and over 90% of storage was spent on cache. This is because we store our cache based `{{ .Branch }}-{{ .Revision }}`
pattern. If a PR has 20 commits, we're going to store 20 caches. 

Instead, we want to evaluate checksum of all the `build.gradle` files within a project and store cache based on branch and checksum. 

### Solution

Cache key should be evaluated from branch name and hash of all build.gradle files within a project. As circle ci does not support checksum on multiple files, we need to run separate script to do this. 

More info: https://chrisbanes.medium.com/circleci-cache-key-over-many-files-c9e07f4d471a

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project