### PR TITLE
fix: Support parsing dbt_project.yml without target-path

### DIFF
--- a/integration/common/tests/dbt/small/dbt_project.yml
+++ b/integration/common/tests/dbt/small/dbt_project.yml
@@ -19,7 +19,6 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
-target-path: "target"  # directory which will store compiled SQL files
 clean-targets:         # directories to be removed by `dbt clean`
     - "target"
     - "dbt_modules"

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -238,3 +238,41 @@ def test_logging_handler_does_not_warn():
     DbtLocalArtifactProcessor.load_metadata(path, [2], logger)
 
     logger.warning.assert_not_called()
+
+
+@mock.patch.dict(os.environ, {"DBT_TARGET_PATH": "target-from-envvar"}, clear=True)
+def test_build_target_path_with_user_defined():
+    processor = DbtLocalArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/env_vars',
+        target='prod',
+        target_path="arg-target-name",
+        job_namespace="ol-namespace"
+    )
+    assert processor.build_target_path({}) == "arg-target-name"
+
+@mock.patch.dict(os.environ, {"DBT_TARGET_PATH": "target-from-envvar"}, clear=True)
+def test_build_target_path_with_envvar():
+    processor = DbtLocalArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/env_vars',
+        target='prod',
+        job_namespace="ol-namespace"
+    )
+    assert processor.build_target_path({}) == "target-from-envvar"
+
+@pytest.mark.parametrize(
+    "test_name,dbt_project,expected",
+    [
+        ("with_dbt_project", {"target-path": "from-dbt-project"}, "from-dbt-project"),
+        ("with_default", {}, "target")
+    ]
+)
+def test_build_target_path(test_name, dbt_project, expected):
+    processor = DbtLocalArtifactProcessor(
+        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
+        project_dir='tests/dbt/env_vars',
+        target='prod',
+        job_namespace="ol-namespace"
+    )
+    assert processor.build_target_path(dbt_project) == expected


### PR DESCRIPTION
As of dbt v1.5, usage of target-path in the dbt_project.yml file has been deprecated, now preferring a CLI flag or env var. It will be removed in a future version. See dbt-labs/dbt-core#6882

Docs: https://docs.getdbt.com/reference/project-configs/target-path

This change allows users to run `DbtLocalArtifactProcessor` in dbt projects that don't declare target-path

Closes: #2093

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project