### PR TITLE
python: loosen attrs and requests versions.

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -25,10 +25,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "attrs>=23.1",
+  "attrs>=20.0",
   "python-dateutil>=2.8.2",
   "pyyaml>=5.4",
-  "requests>=2.31",
+  "requests>=2.20.0",
 ]
 optional-dependencies.kafka = [
   "confluent-kafka>=2.1.1",

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -13,8 +13,7 @@ with open("README.md") as readme_file:
 __version__ = "1.5.0"
 
 requirements = [
-    "attrs>=20.3",
-    "requests>=2.20.0",
+    "attrs>=20.0",
     f"openlineage-integration-common[sql]=={__version__}",
     f"openlineage-python=={__version__}",
 ]


### PR DESCRIPTION
### Problem

Some Airflow instance providers, e.g. Google Cloud Composer have broader requirements for attrs and requests packages.

### Solution

Lower the requirements. Also remove dependency from `openlineage-airflow`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project