### PR TITLE
docs: Add openlineage-integration-common PyPI links

### DIFF
--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -12,6 +12,13 @@ with open("README.md") as readme_file:
 
 __version__ = "1.2.0"
 
+
+project_urls = {
+    "Homepage": "https://openlineage.io/",
+    "Source": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common",
+}
+
+
 requirements = [
     "attrs>=19.3.0",
     f"openlineage-python=={__version__}",


### PR DESCRIPTION
Add PyPi links to the **openlineage-integration-common** package so users can quickly check the project source code if they want to.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project