### PR TITLE
revert bump: org.openapi.generator required JDK 11

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'signing'
     id "com.adarshr.test-logger" version "3.2.0"
     id 'com.diffplug.spotless' version '6.13.0'
-    id "org.openapi.generator" version "7.0.0"
+    id "org.openapi.generator" version "6.6.0"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
 }


### PR DESCRIPTION
We need to release with JDK 8. This solves the release issue https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/8049/workflows/203efbeb-ef4a-4ac9-a957-d9b894dd91ef/jobs/139099