### PR TITLE
Support more recent versions of GX

### DIFF
--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -26,7 +26,7 @@ ignore_missing_imports = True
 
 [tox:tox]
 envlist = 
-	py3-common-dbt-{1.0,1.3}
+	py3-common-dbt-{1.0,1.3}-ge-{0.15,0.16}
 skipsdist = True
 
 [testenv]
@@ -36,6 +36,8 @@ deps = ../../client/python
 	-e .[dev]
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
+	ge-0.15: great-expectations>=0.15.0,<0.16.0
+	ge-0.16: great-expectations>=0.16.0,<0.16.4
 commands = ruff .
 	python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
 	pytest --cov=openlineage --junitxml=test-results/junit.xml tests/

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -38,7 +38,7 @@ extras_require = {
         "pyyaml>=5.3.1"
     ],
     "great_expectations": [
-        "great_expectations>=0.13.26,<0.15.35",
+        "great_expectations>=0.15.0,<0.16.4",
         "sqlalchemy>=1.3.24,<2.0.0"
     ],
     "redshift": [

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -37,7 +37,15 @@ from great_expectations.data_context.types.resource_identifiers import (
     ExpectationSuiteIdentifier,
     ValidationResultIdentifier,
 )
-from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
+
+try:
+    from great_expectations.dataset import (
+        PandasDataset,
+        SqlAlchemyDataset,
+    )
+except ImportError:
+    from great_expectations.dataset.pandas_dataset import PandasDataset
+    from great_expectations.dataset.sqlalchemy_dataset import SqlAlchemyDataset
 
 current_env = os.environ
 


### PR DESCRIPTION
Limit upper GX version to <0.16.0.

Reopening #2024 accidentally closed by me.

Kudos to @ivanstillfront.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project