### PR TITLE
airflow: fix find-links path in tox.

### DIFF
--- a/integration/airflow/setup.cfg
+++ b/integration/airflow/setup.cfg
@@ -30,7 +30,7 @@ skipsdist = True
 [testenv]
 usedevelop = True
 install_command = python -m pip install {opts} --find-links target/wheels/ \
-	--find-links ../sql/iface-py/target/wheels \
+	--find-links ../sql/target/wheels \
 	--use-deprecated=legacy-resolver \
 	--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-{env:AIRFLOW_VERSION}/constraints-3.8.txt \
 	{packages}


### PR DESCRIPTION
### Problem

The link should be changed. This bug breaks tutorial.

### Solution

Change path.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project