### PR TITLE
Updated the README.md of the sql parser

### DIFF
--- a/integration/sql/README.md
+++ b/integration/sql/README.md
@@ -9,6 +9,24 @@ If you're using OpenLineage integration, there's good chance that you're already
 This library is implemented in Rust and provides a Python and Java interface. The Rust implementation has not yet been published to Cargo.
 The interface is explained in INTERFACE.md.
 
+## Supported Dialects
+
+The parser supports several dialects. For an up-to-date list of supported dialects, please refer to [dialect.rs](impl/src/dialect.rs), specifically the function `get_dialect`.
+
+The supported dialects are:
+
+* `ansi`
+* `bigquery`
+* `hive`
+* `mysql`
+* `mssql`
+* `postgres`
+* `redshift`
+* `snowflake`
+* `sqlite`
+
+Support for a `generic` dialect is also provided.
+
 ## Installation
 
 ### Python


### PR DESCRIPTION
Why do this? To easily know what dialects are supported by the parser without having to dig into the code base.

#### One-line summary: Surface the supported dialects in the sql parser's README.md

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project