### PR TITLE
airflow: add more graceful logging when no OL provider installed.

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -5,33 +5,36 @@ import logging
 from typing import List, Optional, Type
 
 from openlineage.airflow.extractors import BaseExtractor, Extractors, TaskMetadata
-from openlineage.airflow.facets import UnknownOperatorAttributeRunFacet, UnknownOperatorInstance
+from openlineage.airflow.facets import (
+    UnknownOperatorAttributeRunFacet,
+    UnknownOperatorInstance,
+)
 from openlineage.airflow.utils import get_job_name, get_operator_class
 
 
 class ExtractorManager:
     """Class abstracting management of custom extractors."""
+
     def __init__(self):
         self.extractors = {}
         self.task_to_extractor = Extractors()
-        self.log = logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
+        self.log = logging.getLogger(
+            f"{self.__class__.__module__}.{self.__class__.__name__}"
+        )
 
     def add_extractor(self, operator, extractor: Type[BaseExtractor]):
         self.task_to_extractor.add_extractor(operator, extractor)
 
     def extract_metadata(
-        self,
-        dagrun,
-        task,
-        complete: bool = False,
-        task_instance=None,
-        task_uuid = None
+        self, dagrun, task, complete: bool = False, task_instance=None, task_uuid=None
     ) -> TaskMetadata:
         extractor = self._get_extractor(task)
-        task_info = f'task_type={get_operator_class(task).__name__} ' \
-            f'airflow_dag_id={task.dag_id} ' \
-            f'task_id={task.task_id} ' \
-            f'airflow_run_id={dagrun.run_id} '
+        task_info = (
+            f"task_type={get_operator_class(task).__name__} "
+            f"airflow_dag_id={task.dag_id} "
+            f"task_id={task.task_id} "
+            f"airflow_run_id={dagrun.run_id} "
+        )
 
         if extractor:
             # Extracting advanced metadata is only possible when extractor for particular operator
@@ -40,7 +43,8 @@ class ExtractorManager:
                 extractor.set_context("task_uuid", task_uuid)
             try:
                 self.log.debug(
-                    f'Using extractor {extractor.__class__.__name__} {task_info}')
+                    f"Using extractor {extractor.__class__.__name__} {task_info}"
+                )
                 if complete:
                     task_metadata = extractor.extract_on_complete(task_instance)
                 else:
@@ -56,14 +60,23 @@ class ExtractorManager:
                         self.extract_inlets_and_outlets(task_metadata, inlets, outlets)
 
                     return task_metadata
-
+            except ImportError as e:
+                if e.name is not None and e.name.startswith("airflow.providers.openlineage"):
+                    self.log.warning(
+                        "Failed to import Airflow OpenLineage provider. "
+                        "If you're using Airflow 2.7+, please run "
+                        "`pip install apache-airflow-providers-openlineage`."
+                    )
+                else:
+                    self.log.exception(
+                        f"Failed to extract metadata {e} {task_info}",
+                    )
             except Exception as e:
                 self.log.exception(
-                    f'Failed to extract metadata {e} {task_info}',
+                    f"Failed to extract metadata {e} {task_info}",
                 )
         else:
-            self.log.debug(
-                f'Unable to find an extractor. {task_info}')
+            self.log.debug(f"Unable to find an extractor. {task_info}")
 
             # Only include the unkonwnSourceAttribute facet if there is no extractor
             task_metadata = TaskMetadata(
@@ -93,17 +106,17 @@ class ExtractorManager:
         if task.task_id in self.extractors:
             return self.extractors[task.task_id]
         extractor = self.task_to_extractor.get_extractor_class(get_operator_class(task))
-        self.log.debug(f'extractor for {task.__class__} is {extractor}')
+        self.log.debug(f"extractor for {task.__class__} is {extractor}")
         if extractor:
             self.extractors[task.task_id] = extractor(task)
             return self.extractors[task.task_id]
         return None
 
     def extract_inlets_and_outlets(
-            self,
-            task_metadata: TaskMetadata,
-            inlets: List,
-            outlets: List,
+        self,
+        task_metadata: TaskMetadata,
+        inlets: List,
+        outlets: List,
     ):
         from openlineage.airflow.extractors.converters import convert_to_dataset
 


### PR DESCRIPTION
### Problem

There's a corner case when `openlineage-airflow` is installed without `apache-airflow-providers-openlineage`. However, some other Airflow providers may use OL provider interface (which within `openlineage-airflow` package is basically `DefaultExtractor`). This results in unfriendly message.

### Solution

Recognize failed import of `airflow.providers.openlineage` and add more graceful logging.

#### One-line summary:

Add more graceful logging when no OL provider installed.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project