### PR TITLE
Allow setting client's endpoint via environment variable

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -71,9 +71,10 @@ If there is no config file found, the OpenLineage client looks at environment va
 This way of configuring the client supports only `http` transport, and only a subset of its config.
 
 * `OPENLINEAGE_URL` - point to the service that will consume OpenLineage events.
+* `OPENLINEAGE_ENDPOINT` - specify the endpoint to send the OpenLineage events.
 * `OPENLINEAGE_API_KEY` - set if the consumer of OpenLineage events requires a `Bearer` authentication key.
 
-`OPENLINEAGE_URL` and `OPENLINEAGE_API_KEY` can also be set up manually when creating a client instance.
+`OPENLINEAGE_URL`, `OPENLINEAGE_ENDPOINT`, and `OPENLINEAGE_API_KEY` can also be set up manually when creating a client instance.
 
 #### Logging level
 In addition to conventional logging approaches, the OpenLineage client library provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_CLIENT_LOGGING` environment variable, you can establish the logging level for the `openlineage.client` and its child modules.

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -79,7 +79,6 @@ class DefaultTransportFactory(TransportFactory):
             return None
         config = HttpConfig(
             url=os.environ["OPENLINEAGE_URL"],
-            endpoint=os.environ.get("OPENLINEAGE_ENDPOINT"),
             auth=create_token_provider(
                 {
                     "type": "api_key",
@@ -87,4 +86,8 @@ class DefaultTransportFactory(TransportFactory):
                 },
             ),
         )
+        endpoint = os.environ.get("OPENLINEAGE_ENDPOINT", None)
+        if endpoint is not None:
+            config.endpoint = endpoint
+
         return HttpTransport(config)

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -73,12 +73,13 @@ class DefaultTransportFactory(TransportFactory):
         )
 
         # backwards compatibility: create Transport from
-        # OPENLINEAGE_URL and OPENLINEAGE_API_KEY
+        # OPENLINEAGE_URL, OPENLINEAGE_ENDPOINT, and OPENLINEAGE_API_KEY
         if "OPENLINEAGE_URL" not in os.environ:
             log.error("Did not find openlineage.yml and OPENLINEAGE_URL is not set")
             return None
         config = HttpConfig(
             url=os.environ["OPENLINEAGE_URL"],
+            endpoint=os.environ.get("OPENLINEAGE_ENDPOINT"),
             auth=create_token_provider(
                 {
                     "type": "api_key",

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -23,11 +23,14 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@patch.dict(os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000"})
+@patch.dict(
+    os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000", "OPENLINEAGE_ENDPOINT": "endpoint"}
+)
 def test_client_uses_default_http_factory() -> None:
     client = OpenLineageClient()
     assert isinstance(client.transport, HttpTransport)
     assert client.transport.url == "http://mock-url:5000"
+    assert client.transport.endpoint == "endpoint"
 
 
 def test_factory_registers_new_transports(mocker: MockerFixture) -> None:

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 
 
 @patch.dict(
-    os.environ, {"OPENLINEAGE_URL": "http://mock-url:5000", "OPENLINEAGE_ENDPOINT": "endpoint"}
+    os.environ,
+    {"OPENLINEAGE_URL": "http://mock-url:5000", "OPENLINEAGE_ENDPOINT": "endpoint"},
 )
 def test_client_uses_default_http_factory() -> None:
     client = OpenLineageClient()


### PR DESCRIPTION
### Problem

Currently, it's not possible to set the OpenLineage endpoint (hard-coded to `/api/v1/lineage`) using an environment variable when running the Airflow integration.

### Solution

Given that it's not possible to create the client manually in Airflow, especially now that OpenLineage has become an official Airflow provider, this change seems like the only feasible solution.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Allow setting client's endpoint via environment variable.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project