### PR TITLE
spark: Enable nessie rest catalog

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -101,9 +101,21 @@ public class IcebergHandler implements CatalogHandler {
       di.withSymlink(
           getRestIdentifier(
               session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
+    } else if (catalogConf.get(TYPE).equals("nessie")) {
+      di.withSymlink(
+          getNessieIdentifier(
+              session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
     }
 
     return di;
+  }
+
+  @SneakyThrows
+  private DatasetIdentifier.Symlink getNessieIdentifier(
+      SparkSession session, @Nullable String confUri, String table) {
+
+    String uri = new URI(confUri).toString();
+    return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Problem

Nessie catalog is not supported when using spark.

Closes: #2084

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Add a new case to the if-else statement in the getDatasetIdentifier() method to handle Nessie catalogs.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project