### PR TITLE
python: skip redaction in column lineage facet

### DIFF
--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -345,10 +345,12 @@ class OwnershipDatasetFacet(BaseFacet):
 
 
 @attr.s
-class ColumnLineageDatasetFacetFieldsAdditionalInputFields:
+class ColumnLineageDatasetFacetFieldsAdditionalInputFields(RedactMixin):
     namespace: str = attr.ib()
     name: str = attr.ib()
     field: str = attr.ib()
+
+    _skip_redact: List[str] = ["namespace", "name", "field"]
 
 
 @attr.s


### PR DESCRIPTION
### Problem

Fields in `ColumnLineageDatasetFacetFieldsAdditionalInputFields` are redacted.

### Solution

Add  fields to be skipped.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project