### PR TITLE
Remove `deref()` from openlineage-sql impl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [1.4.0](https://github.com/OpenLineage/OpenLineage/compare/1.3.1...1.4.0) - 2023-10-09
 ### Added
 * **Client: allow setting client's endpoint via environment variable** [`#2151`](https://github.com/OpenLineage/OpenLineage/pull/2151) [mars-lan](https://github.com/mars-lan)  
-    *Enalbes setting this endpoint via environment variable because creating the client manually in Airflow is not possible.*
+    *Enables setting this endpoint via environment variable because creating the client manually in Airflow is not possible.*
 * **Flink: expand Iceberg source types** [`#2149`](https://github.com/OpenLineage/OpenLineage/pull/2149) [HuangZhenQiu](https://github.com/HuangZhenQiu)  
     *Adds support for `FlinkIcebergSource` and `FlinkIcebergTableSource` for Flink Iceberg lineage.*
 * **Spark: add debug facet** [`#2147`](https://github.com/OpenLineage/OpenLineage/pull/2147) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -4,7 +4,6 @@
 mod alias_table;
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
 
 use crate::dialect::CanonicalDialect;
 use crate::lineage::*;
@@ -95,7 +94,7 @@ impl<'a> Context<'a> {
     // --- Table Lineage ---
 
     pub fn add_input(&mut self, table: String) {
-        let name = DbTableMeta::new(table, self.dialect.deref(), self.default_schema.clone());
+        let name = DbTableMeta::new(table, self.dialect, self.default_schema.clone());
         if !self.is_table_alias(&name) {
             self.inputs.insert(name);
         }
@@ -109,7 +108,7 @@ impl<'a> Context<'a> {
     ) {
         let name = DbTableMeta::new_with_namespace_and_schema(
             table,
-            self.dialect.deref(),
+            self.dialect,
             self.default_schema.clone(),
             provided_namespace,
             provided_field_schema,
@@ -121,7 +120,7 @@ impl<'a> Context<'a> {
     }
 
     pub fn add_output(&mut self, output: String) {
-        let name = DbTableMeta::new(output, self.dialect.deref(), self.default_schema.clone());
+        let name = DbTableMeta::new(output, self.dialect, self.default_schema.clone());
         if !self.is_table_alias(&name) {
             self.outputs.insert(name);
         }
@@ -135,7 +134,7 @@ impl<'a> Context<'a> {
     ) {
         let name = DbTableMeta::new_with_namespace_and_schema(
             output,
-            self.dialect.deref(),
+            self.dialect,
             self.default_schema.clone(),
             provided_namespace,
             provided_field_schema,
@@ -184,7 +183,7 @@ impl<'a> Context<'a> {
 
     pub fn add_table_alias(&mut self, table: DbTableMeta, alias: String) {
         if let Some(frame) = self.frames.last_mut() {
-            let alias = DbTableMeta::new(alias, self.dialect.deref(), self.default_schema.clone());
+            let alias = DbTableMeta::new(alias, self.dialect, self.default_schema.clone());
             frame.aliases.add_table_alias(table, alias);
         }
     }

--- a/integration/sql/impl/src/lineage.rs
+++ b/integration/sql/impl/src/lineage.rs
@@ -132,11 +132,11 @@ impl DbTableMeta {
             self.database
                 .as_ref()
                 .map(|x| format!("{}.", x))
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_default(),
             self.schema
                 .as_ref()
                 .map(|x| format!("{}.", x))
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_default(),
             self.name
         )
     }


### PR DESCRIPTION
### Problem

New release of rustc started to fail on unnecessary `defer`.

### Solution

Remove all `defer()` calls listed in failed build logs.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project