### PR TITLE
ci: add always workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
                 for ln in $@; do
                   echo "$PWD/.circleci/workflows/$ln" >> workflow_files.txt
                 done
+                echo "$PWD/.circleci/workflows/openlineage-always.yml" >> workflow_files.txt
               fi
             fi
           }
@@ -113,7 +114,8 @@ jobs:
             # This configuration is piped into yq along with the continue_config.yml file and the
             # union of the two files is output to complete_config.yml
 
-            yq eval-all '.workflows | . as $wf ireduce({}; . * $wf) |
+            yq eval-all '.workflows[].jobs |= map(select(.[].requires == null) |= .[].requires = ["always_run"])
+                | .workflows | . as $wf ireduce({}; . * $wf) |
                 (map(.jobs[] | select(has("workflow_complete") | not)) | . as $item ireduce ([]; (. *+ $item) ))
                 + [(map(.jobs[] | select(has("workflow_complete"))) | .[] as $item ireduce ({}; . *+ $item))] | {"workflows": {"build": {"jobs": .}}}' $FILES | \
             yq eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -817,6 +817,12 @@ jobs:
             . venv/bin/activate
             pre-commit run --show-diff-on-failure --all-files
 
+  always_run:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - run: echo "This steps always run."
+
   workflow_complete:
     working_directory: ~/openlineage
     machine:

--- a/.circleci/workflows/openlineage-always.yml
+++ b/.circleci/workflows/openlineage-always.yml
@@ -1,0 +1,8 @@
+workflows:
+  openlineage-always:
+    jobs:
+      - run-pre-commit
+      - always_run:
+          requires:
+            - run-pre-commit
+

--- a/.circleci/workflows/openlineage-integration-python.yml
+++ b/.circleci/workflows/openlineage-integration-python.yml
@@ -1,37 +1,26 @@
 workflows:
   openlineage-integration-python:
     jobs:
-      - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.8"
           tox_env: py38
           py_env: "3.8"
-          requires:
-            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.9"
           tox_env: py39
           py_env: "3.9"
-          requires:
-            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.10"
           tox_env: py310
           py_env: "3.10"
-          requires:
-            - run-pre-commit
       - unit-test-client-python:
           name: "CPython 3.11"
           tox_env: py311
           py_env: "3.11"
-          requires:
-            - run-pre-commit
       - unit-test-client-python:
           name: "type checker"
           tox_env: type
           py_env: "3.11"
-          requires:
-            - run-pre-commit
       - unit-tests-client-python:
           requires:
             - "CPython 3.8"


### PR DESCRIPTION
### Problem

pre-commit should always run.

### Solution

This PR adds always workflow that contains steps executed before any other workflow derived from `determine_changed_modules`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project