### PR TITLE
[SPARK] support databricks 13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * **Spark: support `rdd` and `toDF` operations available in Spark Scala API.** [`#2188`](https://github.com/OpenLineage/OpenLineage/pull/2188) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
   *This PR includes the first Scala integration test, fixes `ExternalRddVisitor` and adds support for extracting inputs from `MapPartitionsRDD` and `ParallelCollectionRDD` plan nodes.*
 
+### Added
+* **Spark: support Databricks Runtime 13.3.** [`2185`](https://github.com/OpenLineage/OpenLineage/pull/2185) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Modify Spark integration to support latest Databricks Runtime version.*
+
 ### Fixed
 * **Spark: unify dataset naming for RDD jobs and Spark SQL.** [`2181`](https://github.com/OpenLineage/OpenLineage/pull/2181) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Use the same mechanism for RDD jobs to extract dataset identifier as used for Spark SQL.*

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -45,6 +45,7 @@ configurations {
     spark32.extendsFrom testImplementation
     spark33.extendsFrom testImplementation
     spark34.extendsFrom testImplementation
+    spark35.extendsFrom testImplementation
     pysparkContainerOnly
 }
 
@@ -60,7 +61,7 @@ ext {
     shortVersion = sparkVersion.substring(0,3)
 
     versionsMap = [
-            "3.5": ["module": "spark34", "scala": "2.12", "delta": "NA", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "NA", "hadoopclient": "3.3.4"],
+            "3.5": ["module": "spark35", "scala": "2.12", "delta": "NA", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "NA", "hadoopclient": "3.3.4"],
             "3.4": ["module": "spark34", "scala": "2.12", "delta": "2.4.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.4_2.12:1.3.0", "hadoopclient": "3.3.4"],
             "3.3": ["module": "spark33", "scala": "2.12", "delta": "2.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.3_2.12:0.14.0", "hadoopclient": "3.3.4"],
             "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2", "iceberg": "iceberg-spark-runtime-3.2_2.12:0.14.0", "hadoopclient": "3.3.4"],
@@ -89,6 +90,7 @@ dependencies {
     implementation(project(path: ":spark32"))
     implementation(project(path: ":spark33"))
     implementation(project(path: ":spark34"))
+    implementation(project(path: ":spark35"))
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 
 
@@ -286,6 +288,7 @@ shadowJar {
         exclude (project(":spark32"))
         exclude (project(":spark33"))
         exclude (project(":spark34"))
+        exclude (project(":spark35"))
     }
     classifier = ''
     // avoid conflict with any client version of that lib

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -6,28 +6,61 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
 import io.openlineage.spark.agent.util.DeltaUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
-import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import java.util.Collection;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import scala.PartialFunction;
 
 @Slf4j
 public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     implements DatasetBuilderFactory {
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+      OpenLineageContext context) {
+    DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
+    Builder builder =
+        ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
+            .add(new InMemoryRelationInputDatasetBuilder(context))
+            .add(new CommandPlanVisitor(context))
+            .add(new DataSourceV2ScanRelationInputDatasetBuilder(context, datasetFactory))
+            .add(new SubqueryAliasInputDatasetBuilder(context))
+            .add(new CreateReplaceInputDatasetBuilder(context))
+            .add(new DataSourceV2RelationInputDatasetBuilder(context, datasetFactory));
+
+    if (DeltaUtils.hasMergeIntoCommandClass()) {
+      builder.add(new MergeIntoCommandInputDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
 
   @Override
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
@@ -40,7 +73,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context))
-            .add(new CreateReplaceDatasetBuilder(context))
+            .add(getCreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new AlterTableCommandDatasetBuilder(context));
 
@@ -53,5 +86,28 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     }
 
     return builder.build();
+  }
+
+  private AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> getCreateReplaceDatasetBuilder(
+      OpenLineageContext context) {
+    // On Databricks platform Spark 3.4 needs to have the version of `CreateReplaceDatasetBuilder`
+    // from Spark 3.5. Distinction has to be done by sub object fields
+    String tableSpecClass = null;
+    try {
+      tableSpecClass =
+          MethodUtils.getAccessibleMethod(
+                  Class.forName("org.apache.spark.sql.catalyst.plans.logical.ReplaceTable"),
+                  "tableSpec")
+              .getReturnType()
+              .getCanonicalName();
+    } catch (ClassNotFoundException e) {
+      log.error("Could not find `ReplaceTable` class", e);
+    }
+
+    if (tableSpecClass.endsWith("TableSpecBase")) {
+      return new CreateReplaceOutputDatasetBuilder(context);
+    } else {
+      return new io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder(context);
+    }
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -6,20 +6,29 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
 import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
-import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import java.util.Collection;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +37,27 @@ import scala.PartialFunction;
 @Slf4j
 public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     implements DatasetBuilderFactory {
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.InputDataset>>> getInputBuilders(
+      OpenLineageContext context) {
+    DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
+    Builder builder =
+        ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
+            .add(new InMemoryRelationInputDatasetBuilder(context))
+            .add(new CommandPlanVisitor(context))
+            .add(new DataSourceV2ScanRelationInputDatasetBuilder(context, datasetFactory))
+            .add(new SubqueryAliasInputDatasetBuilder(context))
+            .add(new CreateReplaceInputDatasetBuilder(context))
+            .add(new DataSourceV2RelationInputDatasetBuilder(context, datasetFactory));
+
+    if (DeltaUtils.hasMergeIntoCommandClass()) {
+      builder.add(new MergeIntoCommandInputDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
 
   @Override
   public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
@@ -40,7 +70,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new AppendDataDatasetBuilder(context, datasetFactory))
             .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
             .add(new TableContentChangeDatasetBuilder(context))
-            .add(new CreateReplaceDatasetBuilder(context))
+            .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new AlterTableCommandDatasetBuilder(context));
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -51,7 +51,7 @@ public class DatabricksUtils {
 
   public static final String CLUSTER_NAME = "openlineage-test-cluster";
   public static final Map<String, String> PLATFORM_VERSIONS =
-      Stream.of(new AbstractMap.SimpleEntry<>("3.4.1", "13.0.x-scala2.12"))
+      Stream.of(new AbstractMap.SimpleEntry<>("3.4.1", "13.3.x-scala2.12"))
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   public static final String NODE_TYPE = "Standard_DS3_v2";
   public static final String DBFS_EVENTS_FILE = "dbfs:/databricks/openlineage/events.log";
@@ -174,6 +174,7 @@ public class DatabricksUtils {
             .spark_conf(
                 new HashMap<String, String>() {
                   {
+                    put("spark.openlineage.debugFacet", "enabled");
                     put("spark.openlineage.transport.type", "file");
                     put("spark.openlineage.transport.location", "/tmp/events.log");
                     put(

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation(project(path: ":spark32"))
     implementation(project(path: ":spark33"))
     implementation(project(path: ":spark34"))
+    implementation(project(path: ":spark35"))
 
     compileOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compileOnly "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
@@ -212,6 +213,8 @@ signing {
 }
 
 shadowJar {
+    dependsOn test
+
     minimize(){
         exclude (project(":shared"))
         exclude (project(":spark2"))
@@ -219,6 +222,7 @@ shadowJar {
         exclude (project(":spark32"))
         exclude (project(":spark33"))
         exclude (project(":spark34"))
+        exclude (project(":spark35"))
         exclude (project(":app"))
     }
     dependencies {

--- a/integration/spark/settings.gradle
+++ b/integration/spark/settings.gradle
@@ -3,6 +3,7 @@ include 'spark3'
 include 'spark32'
 include 'spark33'
 include 'spark34'
+include 'spark35'
 include 'shared'
 include 'app'
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -28,6 +28,7 @@ public class DatabricksEventFilter implements EventFilter {
           "collect_limit",
           "describe_table",
           "local_table_scan",
+          "append_data_exec_v1",
           "serialize_from_object",
           "execute_set_catalog_command");
 

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
@@ -1,0 +1,90 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan.column;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableAsSelect} and extracts the output
+ * {@link OpenLineage.Dataset} being written.
+ */
+@Slf4j
+public class CreateReplaceInputDatasetBuilder
+    extends AbstractQueryPlanInputDatasetBuilder<LogicalPlan> {
+
+  public CreateReplaceInputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    return true;
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    log.debug("Calling isDefinedAtLogicalPlan on {} with children {}", x.getClass(), x.children());
+    return ((x instanceof CreateTableAsSelect)
+            || (x instanceof ReplaceTable)
+            || (x instanceof ReplaceTableAsSelect)
+            || (x instanceof CreateTable))
+        && (x.children() == null || x.children().isEmpty());
+  }
+
+  @Override
+  public List<OpenLineage.InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
+    log.debug("Calling apply on {}", x.getClass());
+    return extractChildren(x).stream()
+        .flatMap(
+            plan ->
+                ScalaConversionUtils.fromSeq(
+                        plan.collect(
+                            delegate(
+                                context.getInputDatasetQueryPlanVisitors(),
+                                context.getInputDatasetBuilders(),
+                                event)))
+                    .stream()
+                    .flatMap(a -> a.stream()))
+        .collect(Collectors.toList());
+  }
+
+  protected List<LogicalPlan> extractChildren(LogicalPlan x) {
+    try {
+      Object query = MethodUtils.invokeMethod(x, "query");
+
+      // query can be a single query or a list
+      if (query instanceof List) {
+        log.debug("Query is a list of size {}", ((List) query).size());
+        // databricks addon to contain multiple plans as query
+        return ((List<?>) query)
+            .stream()
+                .filter(o -> o instanceof LogicalPlan)
+                .map(o -> (LogicalPlan) o)
+                .collect(Collectors.toList());
+      } else if (query instanceof LogicalPlan) {
+        return Collections.singletonList((LogicalPlan) query);
+      }
+    } catch (Exception e) {
+      // reflection didn't work
+      log.warn("Failed to extract child query from {}", x);
+    }
+    return Collections.emptyList();
+  }
+}

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark34.agent.lifecycle.plan.column;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.TableSpec;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+import scala.collection.JavaConversions;
+import scala.collection.Seq;
+import scala.collection.Seq$;
+
+public class CreateReplaceInputDatasetBuilderTest {
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+          .build();
+  CreateReplaceInputDatasetBuilder builder =
+      new CreateReplaceInputDatasetBuilder(openLineageContext);
+
+  TableCatalog catalog = mock(TableCatalog.class);
+
+  ResolvedTable namePlan =
+      new ResolvedTable(
+          catalog,
+          mock(Identifier.class),
+          mock(Table.class),
+          (Seq<Attribute>) Seq$.MODULE$.empty());
+
+  TableSpec tableSpec = mock(TableSpec.class);
+
+  @BeforeEach
+  public void setup() {}
+
+  @Test
+  void testIsDefined() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTable.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testIsDefinedWhenNodeHasChildren() {
+    CreateTableAsSelect node = mock(CreateTableAsSelect.class);
+    when(node.children())
+        .thenReturn(
+            JavaConversions.asScalaIterator(Arrays.asList(mock(LogicalPlan.class)).iterator())
+                .toSeq());
+
+    assertFalse(builder.isDefinedAtLogicalPlan(node));
+  }
+
+  @Test
+  void testApply() {
+    InputDataset inputDataset = mock(InputDataset.class);
+    LogicalPlan query = mock(LogicalPlan.class);
+    CreateTableAsSelect node =
+        new CreateTableAsSelect(
+            namePlan,
+            (Seq<Transform>) Seq$.MODULE$.empty(),
+            query,
+            tableSpec,
+            null,
+            false,
+            Option.empty());
+    when(query.collect(any()))
+        .thenReturn(
+            JavaConversions.asScalaIterator(
+                    Arrays.asList((Object) Collections.singletonList(inputDataset)).iterator())
+                .toSeq());
+
+    assertThat(builder.apply(mock(SparkListenerEvent.class), node)).containsExactly(inputDataset);
+  }
+}

--- a/integration/spark/spark34/src/test/resources/io/openlineage/spark/agent/version.properties
+++ b/integration/spark/spark34/src/test/resources/io/openlineage/spark/agent/version.properties
@@ -1,0 +1,1 @@
+version 1.3.0-SNAPSHOT

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -1,0 +1,153 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+import groovy.io.FileType
+
+import java.nio.file.Files
+
+
+plugins {
+    id 'java'
+    id 'java-library'
+    id 'java-test-fixtures'
+    id 'com.diffplug.spotless' version '6.12.0'
+    id "com.adarshr.test-logger" version "3.2.0"
+    id "org.gradle.test-retry" version "1.5.6"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "pmd"
+}
+
+pmd {
+    consoleOutput = true
+    toolVersion = "6.46.0"
+    rulesMinimumPriority = 5
+    ruleSetFiles = rootProject.files("pmd-openlineage.xml")
+    ruleSets = []
+    ignoreFailures = true
+}
+
+pmdMain {
+    reports {
+        html.required = true
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = 'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+    }
+}
+
+archivesBaseName='openlineage-spark-spark3'
+
+ext {
+    sparkVersion = '3.5.0'
+    jacksonVersion = '2.10.0'
+    lombokVersion = '1.18.30'
+    bigqueryVersion = '0.26.0'
+}
+
+dependencies {
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+
+    implementation(project(":shared"))
+    implementation(project(":spark3"))
+
+    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
+    compileOnly "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
+    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.module'
+        exclude group: 'com.sun.jmx'
+        exclude group: 'com.sun.jdmk'
+        exclude group: 'javax.jms'
+    }
+
+    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
+    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
+    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.3.1"
+    testFixturesApi "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
+    testImplementation(testFixtures(project(":shared")))
+    testImplementation(testFixtures(project(":spark3")))
+}
+
+def commonTestConfiguration = {
+    forkEvery 1
+    maxParallelForks 5
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+    }
+    systemProperties = [
+        'junit.platform.output.capture.stdout': 'true',
+        'junit.platform.output.capture.stderr': 'true',
+        'spark.version'                       : "${sparkVersion}",
+        'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
+        'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
+        'mockserver.logLevel'                 : 'ERROR'
+    ]
+
+    classpath = project.sourceSets.test.runtimeClasspath
+}
+
+
+test {
+    configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
+}
+
+task integrationTest(type: Test) {
+    retry {
+        boolean isCiServer = System.getenv().containsKey("CI")
+        if (isCiServer) {
+            maxRetries = 3
+            maxFailures = 3
+        }
+    }
+    configure commonTestConfiguration
+    useJUnitPlatform {
+        includeTags "integration-test"
+    }
+}
+
+assemble {
+    dependsOn shadowJar
+}
+
+
+shadowJar {
+    minimize()
+    classifier = ''
+    dependencies {
+        exclude(dependency('org.slf4j::'))
+    }
+    zip64 true
+}
+
+spotless {
+    def disallowWildcardImports = {
+        String text = it
+        def regex = ~/import .*\.\*;/
+        def m = regex.matcher(text)
+        if (m.find()) {
+            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
+        }
+    }
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+        custom 'disallowWildcardImports', disallowWildcardImports
+    }
+}

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -1,0 +1,170 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark35.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * {@link LogicalPlan} visitor that matches an {@link CreateTableAsSelect} and extracts the output
+ * {@link OpenLineage.Dataset} being written. Although the builder is within spark35 package, it's
+ * added as a dataset builder for Spark 3.4 on Databricks runtime.
+ */
+@Slf4j
+public class CreateReplaceOutputDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public CreateReplaceOutputDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof CreateTableAsSelect)
+        || (x instanceof ReplaceTable)
+        || (x instanceof ReplaceTableAsSelect)
+        || (x instanceof CreateTable);
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
+    if (plan instanceof CreateTableAsSelect) {
+      return apply(event, (CreateTableAsSelect) plan);
+    } else if (plan instanceof ReplaceTableAsSelect) {
+      return apply(event, (ReplaceTableAsSelect) plan);
+    } else if (plan instanceof CreateTable) {
+      return apply(event, (CreateTable) plan);
+    } else {
+      return apply(event, (ReplaceTable) plan);
+    }
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, CreateTable plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.CREATE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, CreateTableAsSelect plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.CREATE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, ReplaceTable plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.OVERWRITE))
+        .orElse(Collections.emptyList());
+  }
+
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, ReplaceTableAsSelect plan) {
+    return callCatalogMethod(plan.name())
+        .map(
+            catalogPlugin ->
+                apply(
+                    event,
+                    catalogPlugin,
+                    ScalaConversionUtils.<String, String>fromMap(plan.tableSpec().properties()),
+                    plan.tableName(),
+                    plan.tableSchema(),
+                    LifecycleStateChange.OVERWRITE))
+        .orElse(Collections.emptyList());
+  }
+
+  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
+    try {
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", null));
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+      log.error("Could not obtain catalog plugin", e);
+      return Optional.empty();
+    }
+  }
+
+  private List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event,
+      TableCatalog catalog,
+      Map<String, String> tableProperties,
+      Identifier identifier,
+      StructType schema,
+      LifecycleStateChange lifecycleStateChange) {
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(context, catalog, identifier, tableProperties);
+
+    if (!di.isPresent()) {
+      return Collections.emptyList();
+    }
+
+    OpenLineage openLineage = context.getOpenLineage();
+    OpenLineage.DatasetFacetsBuilder builder =
+        openLineage
+            .newDatasetFacetsBuilder()
+            .schema(PlanUtils.schemaFacet(openLineage, schema))
+            .lifecycleStateChange(
+                openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
+            .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+
+    if (includeDatasetVersion(event)) {
+      Optional<String> datasetVersion =
+          CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties);
+      datasetVersion.ifPresent(
+          version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
+    }
+
+    CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
+        .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
+    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+  }
+}

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -1,0 +1,255 @@
+/*
+/* Copyright 2018-2022 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark35.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.TableSpec;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+import scala.collection.Seq;
+import scala.collection.immutable.HashMap;
+import scala.collection.immutable.Map;
+import scala.collection.immutable.Seq$;
+
+public class CreateReplaceDatasetBuilderTest {
+
+  private static final String TABLE = "table";
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(Optional.of(mock(SparkSession.class)))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+          .build();
+
+  CreateReplaceOutputDatasetBuilder builder =
+      new CreateReplaceOutputDatasetBuilder(openLineageContext);
+
+  TableCatalog catalog = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Map<String, String> commandProperties = new HashMap<>();
+  Identifier tableName = Identifier.of(new String[] {"db"}, TABLE);
+
+  ResolvedTable namePlan =
+      new ResolvedTable(
+          catalog,
+          mock(Identifier.class),
+          mock(Table.class),
+          (Seq<Attribute>) Seq$.MODULE$.empty());
+
+  TableSpec tableSpec = mock(TableSpec.class);
+
+  @BeforeEach
+  public void setup() {
+    when(tableSpec.properties()).thenReturn(commandProperties);
+  }
+
+  @Test
+  void testIsDefined() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTableAsSelect.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceTable.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(CreateTable.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyForCreateTableAsSelect() {
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+  }
+
+  @Test
+  void testApplyForReplaceTable() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyForReplaceTableAsSelect() {
+    ReplaceTableAsSelect logicalPlan = mock(ReplaceTableAsSelect.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
+  }
+
+  @Test
+  void testApplyForCreateTable() {
+    CreateTable logicalPlan = mock(CreateTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+    verifyApply(
+        (LogicalPlan) logicalPlan,
+        commandProperties,
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
+  }
+
+  @Test
+  void testApplyDatasetVersionIncluded() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+        when(CatalogUtils3.getDatasetVersion(
+                openLineageContext,
+                catalog,
+                Identifier.of(new String[] {"db"}, TABLE),
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of("v2"));
+
+        when(PlanUtils3.getDatasetIdentifier(
+                openLineageContext,
+                catalog,
+                tableName,
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of(di));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());
+      }
+    }
+  }
+
+  @Test
+  void testApplyDatasetVersionMissing() {
+    ReplaceTable logicalPlan = mock(ReplaceTable.class);
+    when(logicalPlan.name()).thenReturn(namePlan);
+    when(logicalPlan.tableName()).thenReturn(tableName);
+    when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+    when(logicalPlan.tableSchema()).thenReturn(schema);
+
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+        when(CatalogUtils3.getDatasetVersion(
+                openLineageContext,
+                catalog,
+                Identifier.of(new String[] {"db"}, TABLE),
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.empty());
+
+        when(PlanUtils3.getDatasetIdentifier(
+                openLineageContext,
+                catalog,
+                tableName,
+                ScalaConversionUtils.<String, String>fromMap(commandProperties)))
+            .thenReturn(Optional.of(di));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals(null, outputDatasets.get(0).getFacets().getVersion());
+      }
+    }
+  }
+
+  private void verifyApply(
+      LogicalPlan logicalPlan,
+      Map<String, String> tableProperties,
+      OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange) {
+    DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalog,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals(
+          lifecycleStateChange,
+          outputDatasets.get(0).getFacets().getLifecycleStateChange().getLifecycleStateChange());
+      assertEquals(TABLE, outputDatasets.get(0).getName());
+      assertEquals("db", outputDatasets.get(0).getNamespace());
+    }
+  }
+
+  @Test
+  void testApplyWhenNoDatasetIdentifierReturned() {
+    CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(logicalPlan.name()).thenReturn(namePlan);
+      when(logicalPlan.tableName()).thenReturn(tableName);
+      when(logicalPlan.tableSpec()).thenReturn(tableSpec);
+      when(logicalPlan.tableSchema()).thenReturn(schema);
+
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext,
+              catalog,
+              tableName,
+              ScalaConversionUtils.<String, String>fromMap(tableSpec.properties())))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.empty()), logicalPlan);
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+}

--- a/integration/spark/spark35/src/test/resources/io/openlineage/spark/agent/version.properties
+++ b/integration/spark/spark35/src/test/resources/io/openlineage/spark/agent/version.properties
@@ -1,0 +1,1 @@
+version 1.3.0-SNAPSHOT


### PR DESCRIPTION
### Problem

The implementation of `CreateTableAsSelect` slightly differs for Spark 3.5 while databricks runtime, although running Spark 3.4, uses catalyst version that seems to have changes from Spark 3.5. This is something we also observed earlier

Closes: #2131

### Solution

 * Include Spark 3.5 submodule
 * Implement a copy of `CreateReplaceDatasetBuilder`, with a tiny difference `plan.tableSpec()` has different type. We need to compile this builder with Spark 3.5
 * include newly created builder for spark 3.4 if run on databricks. 
 * create input dataset builder `CreateReplaceInputDatasetBuilder` to extract inputs from query property of a LogicalPlan that is not registered as a child. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project