### PR TITLE
[SPARK] scala integration test with `rdd` and `toDf` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.4.1...HEAD)
 
+### Added
+* **Spark: support `rdd` and `toDF` operations available in Spark Scala API.** [`#2188`](https://github.com/OpenLineage/OpenLineage/pull/2188) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
+  *This PR includes the first Scala integration test, fixes `ExternalRddVisitor` and adds support for extracting inputs from `MapPartitionsRDD` and `ParallelCollectionRDD` plan nodes.*
+
 ### Fixed
 * **Spark: unify dataset naming for RDD jobs and Spark SQL.** [`2181`](https://github.com/OpenLineage/OpenLineage/pull/2181) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Use the same mechanism for RDD jobs to extract dataset identifier as used for Spark SQL.*

--- a/integration/spark/app/integrations/sparkrdd/1.json
+++ b/integration/spark/app/integrations/sparkrdd/1.json
@@ -17,11 +17,13 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "test_rdd.shuffled_map_partitions_hadoop"
+    "name" : "test_rdd.map_partitions_shuffled_map_partitions_hadoop"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",
     "name" : "gs://bucket/data.txt"
   } ],
-  "outputs" : [ ]
+  "outputs" : [ {
+    "namespace" : "file"
+  }]
 }

--- a/integration/spark/app/integrations/sparkrdd/2.json
+++ b/integration/spark/app/integrations/sparkrdd/2.json
@@ -18,11 +18,13 @@
   },
   "job" : {
     "namespace" : "ns_name",
-    "name" : "test_rdd.shuffled_map_partitions_hadoop"
+    "name" : "test_rdd.map_partitions_shuffled_map_partitions_hadoop"
   },
   "inputs" : [ {
     "namespace" : "gs.bucket",
     "name" : "gs://bucket/data.txt"
   } ],
-  "outputs" : [ ]
+  "outputs" : [ {
+    "namespace" : "file"
+  }]
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -164,7 +164,7 @@ public class SparkContainerUtils {
         network, waitMessage, mockServerContainer, sparkSubmit.toArray(new String[0]));
   }
 
-  static void addSparkConfig(List command, String value) {
+  public static void addSparkConfig(List command, String value) {
     command.add("--conf");
     command.add(value);
   }
@@ -201,7 +201,7 @@ public class SparkContainerUtils {
   }
 
   @SuppressWarnings("PMD")
-  private static void consumeOutput(org.testcontainers.containers.output.OutputFrame of) {
+  static void consumeOutput(org.testcontainers.containers.output.OutputFrame of) {
     try {
       switch (of.getType()) {
         case STDOUT:

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -1,0 +1,171 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockserver.model.HttpRequest.request;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockserver.client.MockServerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * This class runs integration test for a Spark job written in scala. All the other tests run python
+ * spark scripts instead. Having a Scala job allows us to test `toDF`/`rdd` methods which are
+ * slightly different for Spark jobs written in Scala.
+ *
+ * <p>The integration test relies on bitnami/spark docker image. It requires `spark.version` to
+ * specify which Spark version should be tested. It also requires `openlineage.spark.jar` system
+ * property which is set in `build.gradle`. @See https://hub.docker.com/r/bitnami/spark/
+ */
+@Tag("integration-test")
+@Testcontainers
+@Slf4j
+public class SparkScalaContainerTest {
+
+  private static final Network network = Network.newNetwork();
+
+  @Container
+  private static final MockServerContainer openLineageClientMockContainer =
+      SparkContainerUtils.makeMockServerContainer(network);
+
+  private static GenericContainer<?> spark;
+  private static MockServerClient mockServerClient;
+  private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
+
+  @BeforeAll
+  public static void setup() {
+    mockServerClient =
+        new MockServerClient(
+            openLineageClientMockContainer.getHost(),
+            openLineageClientMockContainer.getServerPort());
+    mockServerClient
+        .when(request("/api/v1/lineage"))
+        .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
+
+    Awaitility.await().until(openLineageClientMockContainer::isRunning);
+  }
+
+  @AfterEach
+  public void cleanupSpark() {
+    mockServerClient.reset();
+    try {
+      if (spark != null) spark.stop();
+    } catch (Exception e) {
+      logger.error("Unable to shut down pyspark container", e);
+    }
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    try {
+      openLineageClientMockContainer.stop();
+    } catch (Exception e) {
+      logger.error("Unable to shut down openlineage client container", e);
+    }
+    network.close();
+  }
+
+  private GenericContainer createSparkContainer(String script) {
+    return new GenericContainer<>(
+            DockerImageName.parse("bitnami/spark:" + System.getProperty("spark.version")))
+        .withNetwork(network)
+        .withNetworkAliases("spark")
+        .withFileSystemBind("src/test/resources/spark_scala_scripts", "/opt/spark_scala_scripts")
+        .withFileSystemBind("src/test/resources/log4j.properties", "/opt/log4j.properties")
+        .withFileSystemBind("build/libs", "/opt/libs")
+        .withLogConsumer(SparkContainerUtils::consumeOutput)
+        .waitingFor(Wait.forLogMessage(".*scala> :quit.*", 1))
+        .withStartupTimeout(Duration.of(10, ChronoUnit.MINUTES))
+        .dependsOn(openLineageClientMockContainer)
+        .withReuse(true)
+        .withCommand(
+            sparkShellCommandForScript("/opt/spark_scala_scripts/" + script)
+                .toArray(new String[] {}));
+  }
+
+  private List<String> sparkShellCommandForScript(String script) {
+    List<String> command = new ArrayList<>();
+    addSparkConfig(command, "spark.openlineage.transport.type=http");
+    addSparkConfig(
+        command,
+        "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
+    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+    addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(command, "spark.openlineage.facets.disabled=");
+    addSparkConfig(
+        command, "spark.driver.extraJavaOptions=-Dlog4j.configuration=/opt/log4j.properties");
+
+    List<String> sparkShell =
+        new ArrayList(Arrays.asList("./bin/spark-shell", "--master", "local", "-i", script));
+    sparkShell.addAll(command);
+    sparkShell.addAll(
+        Arrays.asList("--jars", "/opt/libs/" + System.getProperty("openlineage.spark.jar")));
+
+    log.info("Running spark-shell command: ", String.join(" ", sparkShell));
+
+    return sparkShell;
+  }
+
+  @Test
+  void testScalaUnionRddToParquet() {
+    spark = createSparkContainer("rdd_union.scala");
+    spark.start();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              List<OpenLineage.RunEvent> events =
+                  Arrays.stream(
+                          mockServerClient.retrieveRecordedRequests(
+                              request().withPath("/api/v1/lineage")))
+                      .map(r -> r.getBodyAsString())
+                      .map(event -> OpenLineageClientUtils.runEventFromJson(event))
+                      .collect(Collectors.toList());
+              RunEvent lastEvent = events.get(events.size() - 1);
+
+              assertThat(events).isNotEmpty();
+              assertThat(lastEvent.getOutputs().get(0))
+                  .hasFieldOrPropertyWithValue("namespace", "file")
+                  .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");
+
+              assertThat(lastEvent.getInputs().stream().map(d -> d.getName()))
+                  .contains("/tmp/scala-test/rdd_input1", "/tmp/scala-test/rdd_input2");
+            });
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -20,6 +20,7 @@ import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +37,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import scala.Tuple2;
@@ -95,7 +97,7 @@ class LibraryTest {
   //  }
 
   @Test
-  void testRdd(SparkSession spark) throws IOException {
+  void testRdd(@TempDir Path tmpDir, SparkSession spark) throws IOException {
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getJobNamespace())
         .thenReturn("ns_name");
     when(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT.getParentJobName())
@@ -111,7 +113,7 @@ class LibraryTest {
         .flatMap(s -> Arrays.asList(s.split(" ")).iterator())
         .mapToPair(word -> new Tuple2<>(word, 1))
         .reduceByKey(Integer::sum)
-        .count();
+        .saveAsTextFile(tmpDir.toString() + "/output");
 
     sc.stop();
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -364,7 +364,7 @@ class SparkReadWriteIntegTest {
     List<InputDataset> inputs = event.getInputs();
     assertEquals(1, inputs.size());
     assertEquals(FILE, inputs.get(0).getNamespace());
-    assertEquals(testFile.toAbsolutePath().getParent().toString(), inputs.get(0).getName());
+    assertEquals(testFile.toAbsolutePath().toString(), inputs.get(0).getName());
   }
 
   @Test
@@ -383,9 +383,9 @@ class SparkReadWriteIntegTest {
 
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(6))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, times(4))
         .emit(lineageEvent.capture());
-    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(5);
+    OpenLineage.RunEvent completeEvent = lineageEvent.getAllValues().get(3);
     assertThat(completeEvent).hasFieldOrPropertyWithValue(EVENT_TYPE, RunEvent.EventType.COMPLETE);
     assertThat(completeEvent.getInputs())
         .first()
@@ -481,9 +481,13 @@ class SparkReadWriteIntegTest {
 
     ArgumentCaptor<OpenLineage.RunEvent> lineageEvent =
         ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
-    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(6))
+    Mockito.verify(SparkAgentTestExtension.OPEN_LINEAGE_SPARK_CONTEXT, atLeast(4))
         .emit(lineageEvent.capture());
-    OpenLineage.RunEvent event = lineageEvent.getAllValues().get(5);
+    OpenLineage.RunEvent event =
+        lineageEvent.getAllValues().stream()
+            .filter(ev -> ev.getInputs() != null && !ev.getInputs().isEmpty())
+            .findFirst()
+            .get();
 
     assertThat(lineageEvent.getAllValues().get(lineageEvent.getAllValues().size() - 1))
         .hasFieldOrPropertyWithValue(EVENT_TYPE, RunEvent.EventType.COMPLETE);

--- a/integration/spark/app/src/test/resources/log4j.properties
+++ b/integration/spark/app/src/test/resources/log4j.properties
@@ -10,3 +10,4 @@ log4j.logger.io.openlineage=DEBUG
 log4j.logger.io.openlineage.spark.shaded=WARN
 log4j.logger.org.apache.spark.storage=WARN
 log4j.logger.org.apache.spark.scheduler=WARN
+

--- a/integration/spark/app/src/test/resources/spark_scala_scripts/rdd_union.scala
+++ b/integration/spark/app/src/test/resources/spark_scala_scripts/rdd_union.scala
@@ -1,0 +1,33 @@
+{
+  import spark.implicits._
+  import org.apache.spark.sql.SaveMode
+
+  sc
+    .parallelize(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    .map(a => a.toString())
+    .toDF()
+    .write
+    .mode(SaveMode.Overwrite)
+    .parquet("/tmp/scala-test/rdd_input1")
+
+  sc
+    .parallelize(Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    .map(a => a.toString())
+    .toDF()
+    .write
+    .mode(SaveMode.Overwrite)
+    .parquet("/tmp/scala-test/rdd_input2")
+
+  val rdd1 = spark.read.parquet("/tmp/scala-test/rdd_input1").rdd
+  val rdd2 = spark.read.parquet("/tmp/scala-test/rdd_input2").rdd
+
+  rdd1
+    .union(rdd2)
+    .map(i => OLC(i.toString))
+    .toDF()
+    .write
+    .mode(SaveMode.Overwrite)
+    .parquet("/tmp/scala-test/rdd_output")
+}
+
+case class OLC(payload: String)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
@@ -22,6 +22,11 @@ public class ExternalRDDVisitor extends AbstractRDDNodeVisitor<ExternalRDD<?>, I
   }
 
   @Override
+  public boolean isDefinedAt(LogicalPlan x) {
+    return x instanceof ExternalRDD;
+  }
+
+  @Override
   public List<InputDataset> apply(LogicalPlan x) {
     ExternalRDD externalRDD = (ExternalRDD) x;
     List<RDD<?>> fileRdds = Rdds.findFileLikeRdds(externalRDD.rdd());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -10,7 +10,6 @@ import io.openlineage.spark.agent.Versions;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -18,16 +17,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.spark.package$;
-import org.apache.spark.rdd.HadoopRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
-import org.apache.spark.sql.execution.datasources.FileScanRDD;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import scala.PartialFunction;
@@ -227,36 +221,7 @@ public class PlanUtils {
    */
   public static List<Path> findRDDPaths(List<RDD<?>> fileRdds) {
     return fileRdds.stream()
-        .flatMap(
-            rdd -> {
-              if (rdd instanceof HadoopRDD) {
-                HadoopRDD hadoopRDD = (HadoopRDD) rdd;
-                Path[] inputPaths = FileInputFormat.getInputPaths(hadoopRDD.getJobConf());
-                Configuration hadoopConf = hadoopRDD.getConf();
-                return Arrays.stream(inputPaths)
-                    .map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
-              } else if (rdd instanceof FileScanRDD) {
-                FileScanRDD fileScanRDD = (FileScanRDD) rdd;
-                return ScalaConversionUtils.fromSeq(fileScanRDD.filePartitions()).stream()
-                    .flatMap(fp -> Arrays.stream(fp.files()))
-                    .map(
-                        f -> {
-                          if (package$.MODULE$.SPARK_VERSION().compareTo("3.4") > 0) {
-                            // filePath returns SparkPath for Spark 3.4
-                            return ReflectionUtils.tryExecuteMethod(f, "filePath")
-                                .map(o -> ReflectionUtils.tryExecuteMethod(o, "toPath"))
-                                .map(o -> (Path) o.get())
-                                .get()
-                                .getParent();
-                          } else {
-                            return new Path(f.filePath()).getParent();
-                          }
-                        });
-              } else {
-                log.warn("Unknown RDD class {}", rdd.getClass().getCanonicalName());
-                return Stream.empty();
-              }
-            })
+        .flatMap(RddPathUtils::findRDDPaths)
         .distinct()
         .collect(Collectors.toList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -1,0 +1,157 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.spark.package$;
+import org.apache.spark.rdd.HadoopRDD;
+import org.apache.spark.rdd.MapPartitionsRDD;
+import org.apache.spark.rdd.ParallelCollectionRDD;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.execution.datasources.FileScanRDD;
+import scala.Tuple2;
+import scala.collection.immutable.Seq;
+
+/** Utility class to extract paths from RDD nodes. */
+@Slf4j
+public class RddPathUtils {
+
+  public static Stream<Path> findRDDPaths(RDD rdd) {
+    return Stream.<RddPathExtractor>of(
+            new HadoopRDDExtractor(),
+            new FileScanRDDExtractor(),
+            new MapPartitionsRDDExtractor(),
+            new ParallelCollectionRDDExtractor())
+        .filter(e -> e.isDefinedAt(rdd))
+        .findFirst()
+        .orElse(new UnknownRDDExtractor())
+        .extract(rdd)
+        .filter(p -> p != null);
+  }
+
+  static class UnknownRDDExtractor implements RddPathExtractor<RDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return true;
+    }
+
+    @Override
+    public Stream<Path> extract(RDD rdd) {
+      log.warn("Unknown RDD class {}", rdd);
+      return Stream.empty();
+    }
+  }
+
+  static class HadoopRDDExtractor implements RddPathExtractor<HadoopRDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof HadoopRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(HadoopRDD rdd) {
+      org.apache.hadoop.fs.Path[] inputPaths = FileInputFormat.getInputPaths(rdd.getJobConf());
+      Configuration hadoopConf = rdd.getConf();
+      return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
+    }
+  }
+
+  static class MapPartitionsRDDExtractor implements RddPathExtractor<MapPartitionsRDD> {
+
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof MapPartitionsRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(MapPartitionsRDD rdd) {
+      return findRDDPaths(rdd.prev());
+    }
+  }
+
+  static class FileScanRDDExtractor implements RddPathExtractor<FileScanRDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof FileScanRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(FileScanRDD rdd) {
+      return ScalaConversionUtils.fromSeq(rdd.filePartitions()).stream()
+          .flatMap(fp -> Arrays.stream(fp.files()))
+          .map(
+              f -> {
+                if (package$.MODULE$.SPARK_VERSION().compareTo("3.4") > 0) {
+                  // filePath returns SparkPath for Spark 3.4
+                  return ReflectionUtils.tryExecuteMethod(f, "filePath")
+                      .map(o -> ReflectionUtils.tryExecuteMethod(o, "toPath"))
+                      .map(o -> (Path) o.get())
+                      .get()
+                      .getParent();
+                } else {
+                  return parentOf(f.filePath());
+                }
+              });
+    }
+  }
+
+  static class ParallelCollectionRDDExtractor implements RddPathExtractor<ParallelCollectionRDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof ParallelCollectionRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(ParallelCollectionRDD rdd) {
+      try {
+        Object data = FieldUtils.readField(rdd, "data", true);
+        log.debug("ParallelCollectionRDD data: {} {}", data);
+        if (data instanceof Seq) {
+          return ScalaConversionUtils.fromSeq((Seq) data).stream()
+              .map(
+                  el -> {
+                    Path path = null;
+                    if (el instanceof Tuple2) {
+                      // we're able to extract path
+                      path = parentOf(((Tuple2) el)._1.toString());
+                      log.debug("Found input {}", path);
+                    } else {
+                      log.warn("unable to extract Path from {}", el.getClass().getCanonicalName());
+                    }
+                    return path;
+                  })
+              .filter(Objects::nonNull);
+        } else {
+          log.warn("Cannot extract path from ParallelCollectionRDD {}", data);
+        }
+      } catch (IllegalAccessException | IllegalArgumentException e) {
+        log.warn("Cannot read data field from ParallelCollectionRDD {}", rdd);
+      }
+      return Stream.empty();
+    }
+  }
+
+  private static Path parentOf(String path) {
+    try {
+      return new Path(path).getParent();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  interface RddPathExtractor<T extends RDD> {
+    boolean isDefinedAt(Object rdd);
+
+    Stream<Path> extract(T rdd);
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.spark.rdd.MapPartitionsRDD;
+import org.apache.spark.rdd.ParallelCollectionRDD;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.execution.datasources.FilePartition;
+import org.apache.spark.sql.execution.datasources.FileScanRDD;
+import org.apache.spark.sql.execution.datasources.PartitionedFile;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.reflect.FieldUtils;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+public class RddPathUtilsTest {
+
+  @Test
+  void testFindRDDPathsForMapPartitionsRDD() {
+    FilePartition filePartition = mock(FilePartition.class);
+    PartitionedFile partitionedFile = mock(PartitionedFile.class);
+    FileScanRDD fileScanRDD = mock(FileScanRDD.class);
+    MapPartitionsRDD mapPartitions = mock(MapPartitionsRDD.class);
+
+    when(mapPartitions.prev()).thenReturn(fileScanRDD);
+    when(fileScanRDD.filePartitions())
+        .thenReturn(JavaConversions.asScalaBuffer(Collections.singletonList(filePartition)));
+    when(filePartition.files()).thenReturn(new PartitionedFile[] {partitionedFile});
+    when(partitionedFile.filePath()).thenReturn("/some-path/sub-path");
+
+    List rddPaths = PlanUtils.findRDDPaths(Collections.singletonList(mapPartitions));
+
+    assertThat(rddPaths).hasSize(1);
+    assertThat(rddPaths.get(0).toString()).isEqualTo("/some-path");
+  }
+
+  @Test
+  void testFindRDDPathsForParallelCollectionRDD() throws IllegalAccessException {
+    ParallelCollectionRDD parallelCollectionRDD = mock(ParallelCollectionRDD.class);
+    Seq<Tuple2<String, Integer>> data =
+        JavaConverters.asScalaIteratorConverter(
+                Arrays.asList(
+                        new Tuple2<>("/some-path1/data-file-325342.snappy.parquet", 345),
+                        new Tuple2<>("/some-path2/data-file-654342.snappy.parquet", 345))
+                    .iterator())
+            .asScala()
+            .toSeq();
+
+    FieldUtils.writeDeclaredField(parallelCollectionRDD, "data", data, true);
+
+    List rddPaths = PlanUtils.findRDDPaths(Collections.singletonList(parallelCollectionRDD));
+
+    assertThat(rddPaths).hasSize(2);
+    assertThat(rddPaths.get(0).toString()).isEqualTo("/some-path1");
+    assertThat(rddPaths.get(1).toString()).isEqualTo("/some-path2");
+  }
+
+  @Test
+  void testFindRDDPathsForParallelCollectionRDDWhenNoDataField() throws IllegalAccessException {
+    ParallelCollectionRDD parallelCollectionRDD = mock(ParallelCollectionRDD.class);
+
+    FieldUtils.writeDeclaredField(parallelCollectionRDD, "data", null, true);
+    assertThat(PlanUtils.findRDDPaths(Collections.singletonList(parallelCollectionRDD))).hasSize(0);
+  }
+
+  @Test
+  void testFindRDDPathsForParallelCollectionRDDWhenDataFieldNotSeqOfTuples()
+      throws IllegalAccessException {
+    ParallelCollectionRDD parallelCollectionRDD = mock(ParallelCollectionRDD.class);
+    Seq<Integer> data =
+        JavaConverters.asScalaIteratorConverter(Arrays.asList(333).iterator()).asScala().toSeq();
+
+    FieldUtils.writeDeclaredField(parallelCollectionRDD, "data", data, true);
+    assertThat(PlanUtils.findRDDPaths(Collections.singletonList(parallelCollectionRDD))).hasSize(0);
+  }
+
+  @Test
+  void testFindRDDPathsEmptyStringPath() {
+    FilePartition filePartition = mock(FilePartition.class);
+    FileScanRDD fileScanRDD = mock(FileScanRDD.class);
+    PartitionedFile partitionedFile = mock(PartitionedFile.class);
+
+    when(filePartition.files()).thenReturn(new PartitionedFile[] {partitionedFile});
+    when(partitionedFile.filePath()).thenReturn("");
+    when(fileScanRDD.filePartitions())
+        .thenReturn(JavaConversions.asScalaBuffer(Collections.singletonList(filePartition)));
+
+    List rddPaths = PlanUtils.findRDDPaths(Collections.singletonList(fileScanRDD));
+
+    assertThat(rddPaths).hasSize(0);
+  }
+
+  @Test
+  void testFindRDDPathsUnknownRdd() {
+    assertThat(PlanUtils.findRDDPaths(Collections.singletonList(mock(RDD.class)))).isEmpty();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
 import org.apache.spark.sql.catalyst.plans.logical.UnaryNode;
+import org.apache.spark.sql.execution.ExternalRDD;
 import org.apache.spark.sql.execution.LogicalRDD;
 import org.apache.spark.sql.execution.columnar.InMemoryRelation;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
@@ -124,7 +125,9 @@ public class InputFieldsCollector {
       // implemented in
       // io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageUtils.collectInputsAndExpressionDependencies
       // requires merging multiple LogicalPlans
-    } else if (node instanceof OneRowRelation || node instanceof LocalRelation) {
+    } else if (node instanceof OneRowRelation
+        || node instanceof LocalRelation
+        || node instanceof ExternalRDD) {
       // skip without warning
     } else if (node instanceof LeafNode) {
       log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());


### PR DESCRIPTION
### Problem

We don't have any test that covers Spark job written in Scala. Scala API provides smooth way to switch beetween RDD api and Dataset/dataframe api with `rdd` and `toDf` methods. Lineage is not tracked correctly in case of such operations. 

### Solution

* Write integration test for Scala job.
* Extract paths from `ParallelCollectionRDD` and `MapPartitionsRDD`.
* Refactor code to avoid extending if-else-if chain.
* Fix `ExternalRddVisitor` which is not turned on now and it's not present in any of the integration tests. 
* Avoid sending OL events for RDD operations when no outputs are detected. Events for RDD jobs, which have input only (like RDD creation without storing it), will not be emitted.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project