### PR TITLE
Add script to dev for generating release docs for the website

### DIFF
--- a/dev/create_release_doc.py
+++ b/dev/create_release_doc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from github import Github
+import rich_click as click
+
+class DocRelease:
+
+    def __init__(self, repo, tag: str):
+        self.repo = repo
+        self.tag: str = tag
+        self.release: str = ''
+        self.release_date: str = ''
+
+    def get_release(self):
+        self.release = self.repo.get_release(self.tag).body
+        self.release_date = self.repo.get_release(self.tag).created_at.strftime('%Y-%m-%d')
+
+    def create_doc(self):
+        doc = f'# {self.tag} - {self.release_date}' + '\n' * 2 + self.release
+        print(doc)
+
+@click.command()
+@click.option(
+    '--token', type=str, default=''
+)
+@click.option(
+    '--tag', type=str, default=''
+)
+
+def main(
+    token: str,
+    tag: str,
+):
+    
+    g = Github(token)
+    repo = g.get_repo('OpenLineage/openlineage')
+    c = DocRelease(repo, tag)
+    c.get_release()
+    c.create_doc()
+
+if __name__ == '__main__':
+    main()

--- a/dev/create_release_doc.py
+++ b/dev/create_release_doc.py
@@ -7,7 +7,7 @@ from github import Github
 import rich_click as click
 
 class DocRelease:
-
+    """A script for generating a release doc for the OpenLineage Docs site."""
     def __init__(self, repo, tag: str):
         self.repo = repo
         self.tag: str = tag


### PR DESCRIPTION
### Problem

We have a fairly complete solution for automating changelog updates, but we lack a solution for updating the release docs on the website.

### Solution

This is a first step in creating such a process. It adds a script to dev that uses the GitHub API to generate a doc that can then be used in opening a PR in the docs repo to update the release docs. To do: automate the process of creating the PR in OpenLineage/docs.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary: adds a script for generating release docs

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project