### PR TITLE
dagster: support dagster 1.5.x

### DIFF
--- a/integration/dagster/README.md
+++ b/integration/dagster/README.md
@@ -17,7 +17,7 @@ and emits them to an OpenLineage backend.
 ## Requirements
 
 - [Python 3.8](https://www.python.org/downloads)
-- [Dagster 0.13.8+](https://dagster.io/)
+- [Dagster 0.15.0+](https://dagster.io/)
 
 ## Installation
 

--- a/integration/dagster/README.md
+++ b/integration/dagster/README.md
@@ -17,7 +17,7 @@ and emits them to an OpenLineage backend.
 ## Requirements
 
 - [Python 3.8](https://www.python.org/downloads)
-- [Dagster 0.15.0+](https://dagster.io/)
+- [Dagster 1.0.0+](https://dagster.io/)
 
 ## Installation
 

--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -28,7 +28,7 @@ def openlineage_sensor(
         description: Optional[str] = "OpenLineage sensor tails Dagster event logs, "
                                      "converts Dagster events into OpenLineage events, "
                                      "and emits them to an OpenLineage backend.",
-        concerned_event_types: Optional[Union[DagsterEventType, Set[DagsterEventType]]] = PIPELINE_EVENTS | STEP_EVENTS, # noqa: E501
+        concerned_event_types: Union[DagsterEventType, Set[DagsterEventType]] = PIPELINE_EVENTS | STEP_EVENTS, # noqa: E501
         minimum_interval_seconds: Optional[int] = DEFAULT_SENSOR_DAEMON_INTERVAL,
         record_filter_limit: Optional[int] = 30,
         after_storage_id: Optional[int] = 0

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -5,15 +5,12 @@ import uuid
 from datetime import datetime
 from typing import Iterable, Optional, Set, Union
 
-from pkg_resources import parse_version
-
 from dagster import (  # type: ignore
     DagsterEventType,
     DagsterInstance,
     EventLogRecord,
     EventRecordsFilter,
 )
-from dagster.version import __version__ as DAGSTER_VERSION
 
 NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -66,9 +63,11 @@ def get_repository_name(
     pipeline_run = instance.get_run_by_id(pipeline_run_id)
     repository_name = None
     if pipeline_run:
+        # DagsterRun changed attribute name from `external_pipeline_origin` to `external_job_origin`
+        # since 1.3.3
         ext_pipeline_origin = (
             pipeline_run.external_pipeline_origin
-            if parse_version(DAGSTER_VERSION) <= parse_version("1.3.2")
+            if hasattr(pipeline_run, "external_pipeline_origin")
             else pipeline_run.external_job_origin
         )
         if ext_pipeline_origin:

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -3,8 +3,9 @@
 
 import uuid
 from datetime import datetime
-from pkg_resources import parse_version
 from typing import Iterable, Optional, Set, Union
+
+from pkg_resources import parse_version
 
 from dagster import (  # type: ignore
     DagsterEventType,

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -5,15 +5,12 @@ import uuid
 from datetime import datetime
 from typing import Iterable, Optional, Set, Union
 
-from pkg_resources import parse_version
-
 from dagster import (  # type: ignore
     DagsterEventType,
     DagsterInstance,
     EventLogRecord,
     EventRecordsFilter,
 )
-from dagster.version import __version__ as DAGSTER_VERSION
 
 NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -3,6 +3,7 @@
 
 import uuid
 from datetime import datetime
+from pkg_resources import parse_version
 from typing import Iterable, Optional, Set, Union
 
 from dagster import (  # type: ignore
@@ -11,6 +12,7 @@ from dagster import (  # type: ignore
     EventLogRecord,
     EventRecordsFilter,
 )
+from dagster.version import __version__ as DAGSTER_VERSION
 
 NOMINAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -12,13 +12,13 @@ with open("README.md") as readme_file:
 
 __version__ = "1.6.0"
 
-DAGSTER_VERSION = "0.13.8"
+DAGSTER_VERSION = "1.0.0"
 
 requirements = [
     "attrs>=19.3",
     "cattrs",
     "protobuf<=3.20.0",
-    f"dagster>={DAGSTER_VERSION},<=0.14.5",
+    f"dagster>={DAGSTER_VERSION}",
     f"openlineage-python=={__version__}",
 ]
 
@@ -28,6 +28,9 @@ extras_require = {
         "pytest-cov",
         "ruff",
         "mypy>=0.9.6",
+        # The relevant compat layer of pydantic v2 is shipped with Dagster `1.5.5`.
+        # https://github.com/dagster-io/dagster/issues/15162
+        "pydantic<2.0.0",
         "sqlalchemy<2.0.0"
     ],
 }

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -132,15 +132,9 @@ def make_test_event_log_record(
         step_key: Optional[str] = None,
         storage_id: int = 1,
 ):
-    # handle removed message field from EventLogEntry since 0.14.3 by https://github.com/dagster-io/dagster/pull/6769 # noqa: E501
-    if parse_version(DAGSTER_VERSION) >= parse_version("0.15.0"):
-        event_log_entry = EventLogEntry(
-            None, "debug", "user_msg", pipeline_run_id, timestamp, step_key, pipeline_name,
-            _make_dagster_event(event_type, pipeline_name, step_key) if event_type else None)
-    else:
-        event_log_entry = EventLogEntry(
-            None, "msg", "debug", "user_msg", pipeline_run_id, timestamp, step_key, pipeline_name,
-            _make_dagster_event(event_type, pipeline_name, step_key) if event_type else None)
+    event_log_entry = EventLogEntry(
+        None, "debug", "user_msg", pipeline_run_id, timestamp, step_key, pipeline_name,
+        _make_dagster_event(event_type, pipeline_name, step_key) if event_type else None)
 
     return EventLogRecord(
         storage_id=storage_id,

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -13,8 +13,6 @@ from dagster import DagsterEvent, DagsterEventType, DagsterRun, EventLogEntry, E
 from dagster.core.execution.plan.objects import StepFailureData, StepSuccessData
 from dagster.core.host_representation import ExternalRepositoryOrigin
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
-
-
 from dagster.version import __version__ as DAGSTER_VERSION
 
 PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/" \

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -13,6 +13,8 @@ from dagster import DagsterEvent, DagsterEventType, DagsterRun, EventLogEntry, E
 from dagster.core.execution.plan.objects import StepFailureData, StepSuccessData
 from dagster.core.host_representation import ExternalRepositoryOrigin
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
+
+
 from dagster.version import __version__ as DAGSTER_VERSION
 
 PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/" \

--- a/integration/dagster/tests/test_sensor_evaluation.py
+++ b/integration/dagster/tests/test_sensor_evaluation.py
@@ -12,7 +12,7 @@ from openlineage.dagster.sensor import openlineage_sensor
 from dagster import (  # noqa: E501
     DagsterEventType,
     build_sensor_context,
-    execute_pipeline,
+    execute_job,
     job,
     op,
     reconstructable,
@@ -56,8 +56,8 @@ def test_sensor_with_complete_job_run_and_repository(mock_adapter, mock_step_run
             mock_step_run_id.return_value = step_run_id
             mock_get_repository_name.return_value = repository_name
 
-            result = execute_pipeline(
-                pipeline=reconstructable(a_job),
+            result = execute_job(
+                job=reconstructable(a_job),
                 instance=instance,
                 raise_on_error=False
             )

--- a/integration/dagster/tests/test_utils.py
+++ b/integration/dagster/tests/test_utils.py
@@ -13,6 +13,7 @@ from openlineage.dagster.utils import (
 )
 
 from dagster import EventRecordsFilter
+from dagster.core.events import PIPELINE_EVENTS, STEP_EVENTS
 
 from .conftest import make_pipeline_run_with_external_pipeline_origin
 
@@ -36,14 +37,16 @@ def test_make_step_job_name():
 def test_get_event_log_records(mock_instance):
     last_storage_id = 100
     record_filter_limit = 100
-    get_event_log_records(mock_instance, last_storage_id, record_filter_limit)
-    mock_instance.get_event_records.assert_called_once_with(
-        EventRecordsFilter(
-            after_cursor=last_storage_id
-        ),
-        limit=record_filter_limit,
-        ascending=True,
-    )
+    event_types = PIPELINE_EVENTS | STEP_EVENTS
+    get_event_log_records(mock_instance, event_types, last_storage_id, record_filter_limit)
+    for event_type in event_types:
+        mock_instance.get_event_records.assert_any_call(
+            EventRecordsFilter(
+                event_type=event_type,
+                after_cursor=last_storage_id
+            ),
+            limit=record_filter_limit,
+        )
 
 
 @patch("openlineage.dagster.utils.DagsterInstance")


### PR DESCRIPTION
### Problem

The dagster integration needs to get event records by calling `DagsterInstance.get_event_records()` method with a `EventRecordsFilter`. The current dagster integration has been broken since Dagster version [0.15.0](https://github.com/dagster-io/dagster/releases/tag/0.15.0) due to API change on `EventRecordsFilter` which requires a `DagsterEventType`.

Closes: #2043 

### Solution

In the factory method `openlineage_sensor`, an additional argument `concerned_event_types` is added with default value including events in `PIPELINE_EVENTS` and `STEP_EVENTS`. When getting event records, the dagster integration constructs `EventRecordsFilter` for each `DagsterEventType` embraced in the given `concerned_event_types` argument. The results will be consolidated and sorted against `timestamp` of event record. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary: get event records for each target Dagster event type to support Dagster version 0.15.0+

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project