### PR TITLE
dbt: render yaml configs lazily.

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/local.py
+++ b/integration/common/openlineage/common/provider/dbt/local.py
@@ -15,6 +15,51 @@ DBT_TARGET_PATH_ENVVAR = "DBT_TARGET_PATH"
 DEFAULT_TARGET_PATH = "target"
 
 
+T = TypeVar("T")
+
+
+class LazyJinjaLoadDict(dict):
+    """
+    A dictionary that lazily renders Jinja2 templates in its values.
+
+    This class is useful for passing data to templates without having to pre-render all of the data.
+    It works by traversing the dictionary and rendering any string value using Jinja2.
+    If the value is a dictionary, a new `LazyJinjaLoadDict` instance is created and returned.
+    """
+
+    def __init__(self, *args, jinja_env, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.jinja_env = jinja_env
+
+    def __getitem__(self, item):
+        arg = dict.__getitem__(self, item)
+        return LazyJinjaLoadDict.render_values_jinja(self.jinja_env, arg)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    @staticmethod
+    def render_values_jinja(jinja_env, value: T):
+        """
+        Traverses passed dictionary and render any string value using jinja.
+
+        Returns lazy load dictionary when value is dictionary instance.
+        """
+        if isinstance(value, list):
+            return [
+                LazyJinjaLoadDict.render_values_jinja(jinja_env, elem) for elem in value
+            ]
+        elif isinstance(value, str):
+            return jinja_env.from_string(value).render()
+        elif isinstance(value, dict):
+            return LazyJinjaLoadDict(value, jinja_env=jinja_env)
+        else:
+            return value
+
+
 class SkipUndefined(Undefined):
     def __getattr__(self, name):
         return SkipUndefined(name=f"{self._undefined_name}.{name}")
@@ -33,9 +78,6 @@ class SkipUndefined(Undefined):
             ]
         )
         return f"{{{{ {self._undefined_name}({arguments}) }}}}"
-
-
-T = TypeVar("T")
 
 
 class DbtLocalArtifactProcessor(DbtArtifactProcessor):
@@ -60,15 +102,11 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         self.target_path = target_path
         target_path = self.build_target_path(dbt_project)
 
-        self.manifest_path = os.path.join(
-            absolute_dir, target_path, "manifest.json"
-        )
+        self.manifest_path = os.path.join(absolute_dir, target_path, "manifest.json")
         self.run_result_path = os.path.join(
             absolute_dir, target_path, "run_results.json"
         )
-        self.catalog_path = os.path.join(
-            absolute_dir, target_path, "catalog.json"
-        )
+        self.catalog_path = os.path.join(absolute_dir, target_path, "catalog.json")
 
         self.target = target
         self.project_name = dbt_project["name"]
@@ -76,7 +114,9 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         if not self.profile_name:
             raise KeyError(f"profile not found in {dbt_project}")
 
-    def build_target_path(self, dbt_project: dict, target_path: Optional[str] = None) -> str:
+    def build_target_path(
+        self, dbt_project: dict, target_path: Optional[str] = None
+    ) -> str:
         """
         Build dbt target path. Uses the following:
         1. target_path (user-defined value, normally given in --target-path CLI flag)
@@ -89,11 +129,12 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         Reference:
         https://docs.getdbt.com/reference/project-configs/target-path
         """
-        return self.target_path or \
-            os.getenv(DBT_TARGET_PATH_ENVVAR) or \
-            dbt_project.get("target-path") or \
-            DEFAULT_TARGET_PATH
-
+        return (
+            self.target_path
+            or os.getenv(DBT_TARGET_PATH_ENVVAR)
+            or dbt_project.get("target-path")
+            or DEFAULT_TARGET_PATH
+        )
 
     @classmethod
     def load_metadata(
@@ -148,50 +189,15 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         env.globals["env_var"] = DbtLocalArtifactProcessor.env_var
         return env
 
-    def load_yaml_with_jinja(
-        self, path: str, include_section: Optional[List[Optional[str]]] = None
-    ) -> Dict:
+    def load_yaml_with_jinja(self, path: str) -> Dict:
         loaded = self.load_yaml(path)
         if not self.jinja_environment:
             self.jinja_environment = self.setup_jinja()
-        return self.render_values_jinja(
-            environment=self.jinja_environment,
-            value=loaded,
-            include_section=include_section,
-        )
+        return LazyJinjaLoadDict(loaded, jinja_env=self.jinja_environment)
 
-    @classmethod
-    def render_values_jinja(
-        cls,
-        environment: Environment,
-        value: T,
-        include_section: Optional[List[Optional[str]]] = None,
-    ) -> T:
-        """
-        Traverses passed dictionary and render any string value using jinja.
-        Returns copy of the dict with parsed values.
-        """
-        include_section = include_section or []
-        if isinstance(value, dict):
-            parsed_dict = {}
-            for key, val in value.items():
-                if include_section and key != include_section[0]:
-                    continue
-                parsed_dict[key] = cls.render_values_jinja(
-                    environment, val, include_section=include_section[1:]
-                )
-            return parsed_dict  # type: ignore
-        elif isinstance(value, list):
-            parsed_list = []
-            for elem in value:
-                parsed_list.append(cls.render_values_jinja(environment, elem))
-            return parsed_list  # type: ignore
-        elif isinstance(value, str):
-            return environment.from_string(value).render()  # type: ignore
-        else:
-            return value
-
-    def get_dbt_metadata(self) -> Tuple[
+    def get_dbt_metadata(
+        self,
+    ) -> Tuple[
         Dict[Any, Any], Dict[Any, Any], Dict[Any, Any], Optional[Dict[Any, Any]]
     ]:
         manifest = self.load_metadata(
@@ -209,10 +215,9 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
 
         profile_dir = run_result["args"]["profiles_dir"]
 
-        profile = self.load_yaml_with_jinja(
-            os.path.join(profile_dir, "profiles.yml"),
-            include_section=[self.profile_name],
-        )[self.profile_name]
+        profile = self.load_yaml_with_jinja(os.path.join(profile_dir, "profiles.yml"))[
+            self.profile_name
+        ]
 
         if not self.target:
             self.target = profile["target"]

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -10,22 +10,29 @@ from unittest import mock
 import attr
 import pytest
 from openlineage.client import set_producer
-from openlineage.common.provider.dbt.local import DbtLocalArtifactProcessor
+from openlineage.common.provider.dbt.local import (
+    DbtLocalArtifactProcessor,
+    LazyJinjaLoadDict,
+)
 from openlineage.common.provider.dbt.processor import ParentRunMetadata
 from openlineage.common.test import match
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def setup_producer():
-    set_producer('https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt')
+    set_producer(
+        "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt"
+    )
+
 
 @pytest.fixture
 def parent_run_metadata():
     return ParentRunMetadata(
         run_id="f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11",
         job_name="dbt-job-name",
-        job_namespace="dbt"
+        job_namespace="dbt",
     )
+
 
 def serialize(inst, field, value):
     if isinstance(value, Enum):
@@ -47,54 +54,54 @@ def serialize(inst, field, value):
         "tests/dbt/spark/odbc",
         "tests/dbt/postgres",
         "tests/dbt/snapshot",
-    ]
+    ],
 )
 def test_dbt_parse_and_compare_event(path, parent_run_metadata):
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        job_namespace='job-namespace',
-        project_dir=path
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="job-namespace",
+        project_dir=path,
     )
     processor.dbt_run_metadata = parent_run_metadata
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+        for event in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
-    with open(f'{path}/result.json', 'r') as f:
+    with open(f"{path}/result.json", "r") as f:
         assert match(json.load(f), events)
 
 
-@mock.patch('uuid.uuid4')
-@mock.patch('datetime.datetime')
+@mock.patch("uuid.uuid4")
+@mock.patch("datetime.datetime")
 def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata):
-    mock_datetime.now.return_value.isoformat.return_value = '2021-08-25T11:00:25.277467+00:00'
+    mock_datetime.now.return_value.isoformat.return_value = (
+        "2021-08-25T11:00:25.277467+00:00"
+    )
     mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
-        '1a69c0a7-04bb-408b-980e-cbbfb1831ef7',
-        'f99310b4-339a-4381-ad3e-c1b95c24ff11',
-        'c11f2efd-4415-45fc-8081-10d2aaa594d2',
+        "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+        "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+        "f99310b4-339a-4381-ad3e-c1b95c24ff11",
+        "c11f2efd-4415-45fc-8081-10d2aaa594d2",
     ]
 
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        job_namespace='dbt-test-namespace',
-        project_dir='tests/dbt/test',
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="dbt-test-namespace",
+        project_dir="tests/dbt/test",
     )
     processor.dbt_run_metadata = parent_run_metadata
 
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+        for event in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
-    with open('tests/dbt/test/result.json', 'r') as f:
+    with open("tests/dbt/test/result.json", "r") as f:
         assert match(json.load(f), events)
 
 
-@mock.patch('uuid.uuid4')
+@mock.patch("uuid.uuid4")
 @mock.patch.dict(
     os.environ,
     {
@@ -104,125 +111,111 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         "USER_NAME": "foo_user",
         "PASSWORD": "foo_password",
         "SCHEMA": "foo_schema",
-    }
+    },
 )
 def test_dbt_parse_profile_with_env_vars(mock_uuid, parent_run_metadata):
     mock_uuid.side_effect = [
-        '6edf42ed-d8d0-454a-b819-d09b9067ff99',
+        "6edf42ed-d8d0-454a-b819-d09b9067ff99",
     ]
 
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/env_vars',
-        target='prod',
-        job_namespace="ol-namespace"
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        project_dir="tests/dbt/env_vars",
+        target="prod",
+        job_namespace="ol-namespace",
     )
     processor.dbt_run_metadata = parent_run_metadata
 
     dbt_events = processor.parse()
     events = [
         attr.asdict(event, value_serializer=serialize)
-        for event
-        in dbt_events.starts + dbt_events.completes + dbt_events.fails
+        for event in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
-    with open('tests/dbt/env_vars/result.json', 'r') as f:
+    with open("tests/dbt/env_vars/result.json", "r") as f:
         assert match(json.load(f), events)
 
 
 @pytest.fixture()
 def jinja_env():
     env = DbtLocalArtifactProcessor.setup_jinja()
-    env.globals.update({
-        "test": "test_variable",
-        "method": lambda: "test_method"
-    })
+    env.globals.update({"test": "test_variable", "method": lambda: "test_method"})
     return env
 
 
 def test_jinja_undefined_variable(jinja_env):
     text = "{{ variable }}"
-    assert text == DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
+    assert text == LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
 
 
 def test_jinja_undefined_method(jinja_env):
     text = "{{ undefined_method() }}"
-    assert text == DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
+    assert text == LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
 
 
 def test_jinja_defined_method(jinja_env):
-    os.environ['PORT_REDSHIFT'] = "13"
+    os.environ["PORT_REDSHIFT"] = "13"
     text = "{{ env_var('PORT_REDSHIFT') | as_number }}"
-    assert '13' == DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
-    del os.environ['PORT_REDSHIFT']
+    assert "13" == LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
+    del os.environ["PORT_REDSHIFT"]
 
 
 def test_jinja_defined_variable(jinja_env):
     text = "{{ test }}"
-    assert 'test_variable' == DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
+    assert "test_variable" == LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
 
 
 def test_jinja_undefined_method_with_args(jinja_env):
     text = "# {{ does_not_exist(some_arg.subarg.subarg2) }}"
-    assert text == DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
-
-@mock.patch.dict(os.environ, {"PORT": "1111"})
-def test_jinja_include_section(jinja_env):
-    object = {
-        "proper_one": "{{ env_var('PORT') }}",
-        "to_ignore": "{{ env_var('FAKE_VAR') }}",
-    }
-
-    parsed = DbtLocalArtifactProcessor.render_values_jinja(
-        jinja_env, object, include_section=["proper_one"]
-    )
-
-    assert parsed == {"proper_one": "1111"}
-
-    with pytest.raises(Exception):
-        DbtLocalArtifactProcessor.render_values_jinja(
-            jinja_env, object, include_section=[]
-        )
-
+    assert text == LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
 
 
 def test_jinja_multiline(jinja_env):
-    os.environ['PORT_REDSHIFT'] = "13"
+    os.environ["PORT_REDSHIFT"] = "13"
 
-    text = textwrap.dedent("""
+    text = textwrap.dedent(
+        """
     # {{ does_not_exist(some_arg.subarg.subarg2) }}
     {{ env_var('PORT_REDSHIFT') | as_number }}
     {{ undefined }}
     more_text
-    even_more_text""")
+    even_more_text"""
+    )
 
-    parsed = DbtLocalArtifactProcessor.render_values_jinja(jinja_env, text)
+    parsed = LazyJinjaLoadDict.render_values_jinja(jinja_env, text)
 
-    assert parsed == textwrap.dedent("""
+    assert parsed == textwrap.dedent(
+        """
     # {{ does_not_exist(some_arg.subarg.subarg2) }}
     13
     {{ undefined }}
     more_text
-    even_more_text""")
+    even_more_text"""
+    )
 
-    del os.environ['PORT_REDSHIFT']
+    del os.environ["PORT_REDSHIFT"]
 
 
-def test_jinja_dict(jinja_env):
+def test_lazy_load_jinja_dict(jinja_env):
     dictionary = {"key": "{{ test }}"}
-    assert {"key": "test_variable"} == DbtLocalArtifactProcessor.render_values_jinja(
+    assert {"key": "{{ test }}"} == LazyJinjaLoadDict.render_values_jinja(
         jinja_env, dictionary
+    )
+
+    assert (
+        "test_variable"
+        == LazyJinjaLoadDict.render_values_jinja(jinja_env, dictionary)["key"]
     )
 
 
 def test_jinja_list(jinja_env):
     test_list = ["key", "{{ test }}"]
-    assert ["key", "test_variable"] == DbtLocalArtifactProcessor.render_values_jinja(
+    assert ["key", "test_variable"] == LazyJinjaLoadDict.render_values_jinja(
         jinja_env, test_list
     )
 
 
 def test_logging_handler_warns():
-    path = 'tests/dbt/test/target/manifest.json'
+    path = "tests/dbt/test/target/manifest.json"
     logger = mock.Mock()
     DbtLocalArtifactProcessor.load_metadata(path, [1], logger)
 
@@ -233,7 +226,7 @@ def test_logging_handler_warns():
 
 
 def test_logging_handler_does_not_warn():
-    path = 'tests/dbt/test/target/manifest.json'
+    path = "tests/dbt/test/target/manifest.json"
     logger = mock.Mock()
     DbtLocalArtifactProcessor.load_metadata(path, [2], logger)
 
@@ -243,36 +236,38 @@ def test_logging_handler_does_not_warn():
 @mock.patch.dict(os.environ, {"DBT_TARGET_PATH": "target-from-envvar"}, clear=True)
 def test_build_target_path_with_user_defined():
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/env_vars',
-        target='prod',
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        project_dir="tests/dbt/env_vars",
+        target="prod",
         target_path="arg-target-name",
-        job_namespace="ol-namespace"
+        job_namespace="ol-namespace",
     )
     assert processor.build_target_path({}) == "arg-target-name"
+
 
 @mock.patch.dict(os.environ, {"DBT_TARGET_PATH": "target-from-envvar"}, clear=True)
 def test_build_target_path_with_envvar():
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/env_vars',
-        target='prod',
-        job_namespace="ol-namespace"
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        project_dir="tests/dbt/env_vars",
+        target="prod",
+        job_namespace="ol-namespace",
     )
     assert processor.build_target_path({}) == "target-from-envvar"
+
 
 @pytest.mark.parametrize(
     "test_name,dbt_project,expected",
     [
         ("with_dbt_project", {"target-path": "from-dbt-project"}, "from-dbt-project"),
-        ("with_default", {}, "target")
-    ]
+        ("with_default", {}, "target"),
+    ],
 )
 def test_build_target_path(test_name, dbt_project, expected):
     processor = DbtLocalArtifactProcessor(
-        producer='https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt',
-        project_dir='tests/dbt/env_vars',
-        target='prod',
-        job_namespace="ol-namespace"
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        project_dir="tests/dbt/env_vars",
+        target="prod",
+        job_namespace="ol-namespace",
     )
     assert processor.build_target_path(dbt_project) == expected


### PR DESCRIPTION
### Problem

Sometimes rendering yamls in dbt integration fails when it doesn't need to, e.g. it tries to load key file that would be never used in the integration.

Related to: #2215 

### Solution

Introduce lazily rendered dictionary.

#### One-line summary:

Don't render each entry in yaml files at start.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project