### PR TITLE
spec: add clarity to snowflake naming docs

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -131,11 +131,14 @@ Identifier:
 
 #### Snowflake
 
-See: [Object Identifiers — Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/identifiers.html)
+See:
+
+- [Account Identifiers | Snowflake Documentation](https://docs.snowflake.com/en/user-guide/admin-account-identifier)
+- [Object Identifiers | Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/identifiers.html)
 
 Datasource hierarchy:
 
-- account name
+- account identifier (composite of organization name and account name)
 
 Naming hierarchy:
 
@@ -143,16 +146,18 @@ Naming hierarchy:
 - Schema: {schema name} => unique within the database
 - Table: {table name} => unique within the schema
 
-Database, schema, table and column names are uppercase in Snowflake. Clients should make sure that they are sending them
-in uppercase.
-
 Identifier:
 
-- Namespace: snowflake://{account name}
+- Namespace: snowflake://{organization name}-{account name}
   - Scheme = snowflake
-  - Authority = {account name}
+  - Authority = {organization name}-{account name}
 - Name: {database}.{schema}.{table}
-  - URI = snowflake://{account name}/{database}.{schema}.{table}
+  - URI = snowflake://{organization name}-{account name}/{database}.{schema}.{table}
+
+Snowflake resolves and stores names for databases, schemas, tables and columns differently depending on how they are [expressed in statements](https://docs.snowflake.com/en/sql-reference/identifiers-syntax) (e.g. unquoted vs quoted). The representation of names in OpenLineage events should be based on the canonical name that Snowflake stores. Specifically:
+
+- For dataset names, each period-delimited part (database/schema/table) should be in the simplest form it would take in a statement i.e. quoted only if necessary. For example, a table `My Table` in schema `MY_SCHEMA` and in database `MY_DATABASE` would be represented as `MY_DATABASE.MY_SCHEMA."My Table"`. If in doubt, check [Snowflake's `ACCESS_HISTORY` view](https://docs.snowflake.com/en/sql-reference/account-usage/access_history) to see how `objectName` is formed for a given table.
+- For column names, the canonical name should always be used verbatim.
 
 #### BigQuery
 


### PR DESCRIPTION
### Problem

The spec was missing some clarity around Snowflake naming, particularly dataset names. The line...

> Database, schema, table and column names are uppercase in Snowflake. Clients should make sure that they are sending them in uppercase.

...didn't reflect the ability to specify richer names (mixed case, spaces, special characters) in quotes, and how these should be represented in a fully-qualified dataset name.

### Solution

The spec now acknowledges the naming resolution quirks and links to the relevant Snowflake doc.

Off the back of [a Marquez Slack discussion](https://marquezproject.slack.com/archives/C01E8MQGJP7/p1693500013385479), I used Snowflake's own https://github.com/Snowflake-Labs/OpenLineage-AccessHistory-Setup and the underlying `ACCESS_HISTORY` view as the reference implementation to outline the rules for representing names.

Also, that same Snowflake tool outputs the namespace authority as the account identifier composed of organization name and account name, so I've updated the spec to match that too. This is maybe more contentious because it's arguably harder to get a handle on that new-style identifier, especially for older accounts that use the legacy-style format as an endpoint - so I'm open to discussing that separately if it's preferred.

#### One-line summary:

Add clarity to snowflake naming docs

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project