### PR TITLE
revert #2216 as is no longer required

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -219,11 +219,7 @@ def commonTestConfiguration = {
             'spark.version'                       :  sparkVersion,
             'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
             'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_${versions.scala}:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR',
-            'bitnami.image.3.2.4.arm.hash'        : 'f17e504c82fd19a4fc7dca8a573a83f8f58d31976dc87cc71a09ae86dc6e58cf',
-            'bitnami.image.3.2.4.amd.hash'        : '2d1fcfdf3da3e3888c09c4944874b95822b1b913aa27fbadebb94e2b084f5939',
-            'bitnami.image.3.3.3.arm.hash'        : 'a88399d0628a03a83ddada04e92742b3064d5726da23719c31c36baf4658211a',
-            'bitnami.image.3.3.3.amd.hash'        : '2aaa84e050463512b6829145ef7928518394332f55e9a48dbda65a3dda5159b9'
+            'mockserver.logLevel'                 : 'ERROR'
     ]
 
     classpath = project.sourceSets.test.runtimeClasspath

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.mockserver.client.MockServerClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
@@ -54,24 +53,8 @@ public class SparkContainerUtils {
       String waitMessage,
       MockServerContainer mockServerContainer,
       String... command) {
-    // https://github.com/bitnami/containers/issues/52170 -> bitnami/spark issue
-    // property can be removed when image is fixed
-    String osArch =
-        Optional.of(System.getProperty("os.arch"))
-            .filter(e -> e.contains("arm") || e.contains("aarch"))
-            .map(e -> "arm")
-            .orElse("amd");
-
-    String bitnamiHash = "";
-    String property =
-        String.format("bitnami.image.%s.%s.hash", System.getProperty("spark.version"), osArch);
-    if (System.getProperty(property) != null) {
-      bitnamiHash = "@sha256:" + System.getProperty(property);
-    }
-
     return new GenericContainer<>(
-            DockerImageName.parse(
-                "bitnami/spark:" + System.getProperty("spark.version") + bitnamiHash))
+            DockerImageName.parse("bitnami/spark:" + System.getProperty("spark.version")))
         .withNetwork(network)
         .withNetworkAliases("spark")
         .withFileSystemBind("build/gcloud", "/opt/gcloud")


### PR DESCRIPTION
### Problem

Spark bitnami docker images got fixed. We can revert: https://github.com/OpenLineage/OpenLineage/pull/2216/files

Issue: #2232

### Solution

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project