### PR TITLE
ci: run always workflow really always.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,12 @@ jobs:
                 for ln in $@; do
                   echo "$PWD/.circleci/workflows/$ln" >> workflow_files.txt
                 done
-                echo "$PWD/.circleci/workflows/openlineage-always.yml" >> workflow_files.txt
               fi
             fi
           }
+
+          # Add always workflow
+          echo "$PWD/.circleci/workflows/openlineage-always.yml" >> workflow_files.txt
 
           # If we are on the main branch, run all of the workflows
           if [ "$CIRCLE_BRANCH" == "main" ]; then
@@ -98,29 +100,24 @@ jobs:
           fi
           touch workflow_files.txt
           FILES=$(sort workflow_files.txt | uniq | tr "\n" " ")
-            
-          # If no changes, generate a no-op build
-          if [ "$FILES" == "" ]; then
-            echo '{"workflows": {"no-op": {"jobs": ["workflow_complete"]}}}' | yq -P eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml
-          else
-            # yq eval-all the workflow files specified in the workflow_files.txt file.
-            # Collect all the jobs from each workflow except for the "workflow_complete" job and
-            # create a union of all jobs.
-            # Collect the "workflow_complete" job from each workflow and concatenate the "requires"
-            # section of each and create a single "workflow_complete" job that is the union of all.
-            # The output of this is a circleci configuration with a single workflow called "build"
-            # that contains the union of all jobs plus the "workflow_complete" job that depends on
-            # all required jobs.
-            #
-            # This configuration is piped into yq along with the continue_config.yml file and the
-            # union of the two files is output to complete_config.yml
+          
+          # yq eval-all the workflow files specified in the workflow_files.txt file.
+          # Collect all the jobs from each workflow except for the "workflow_complete" job and
+          # create a union of all jobs.
+          # Collect the "workflow_complete" job from each workflow and concatenate the "requires"
+          # section of each and create a single "workflow_complete" job that is the union of all.
+          # The output of this is a circleci configuration with a single workflow called "build"
+          # that contains the union of all jobs plus the "workflow_complete" job that depends on
+          # all required jobs.
+          #
+          # This configuration is piped into yq along with the continue_config.yml file and the
+          # union of the two files is output to complete_config.yml
 
-            yq eval-all '.workflows[].jobs |= map(select(.[].requires == null) |= .[].requires = ["always_run"])
-                | .workflows | . as $wf ireduce({}; . * $wf) |
-                (map(.jobs[] | select(has("workflow_complete") | not)) | . as $item ireduce ([]; (. *+ $item) ))
-                + [(map(.jobs[] | select(has("workflow_complete"))) | .[] as $item ireduce ({}; . *+ $item))] | {"workflows": {"build": {"jobs": .}}}' $FILES | \
-            yq eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml
-          fi
+          yq eval-all '.workflows[].jobs |= map(select(.[].requires == null) |= .[].requires = ["always_run"])
+              | .workflows | . as $wf ireduce({}; . * $wf) |
+              (map(.jobs[] | select(has("workflow_complete") | not)) | . as $item ireduce ([]; (. *+ $item) ))
+              + [(map(.jobs[] | select(has("workflow_complete"))) | .[] as $item ireduce ({}; . *+ $item))] | {"workflows": {"build": {"jobs": .}}}' $FILES | \
+          yq eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml
       - continuation/continue:
           configuration_path: complete_config.yml
 

--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -154,9 +154,15 @@ Identifier:
 - Name: {database}.{schema}.{table}
   - URI = snowflake://{organization name}-{account name}/{database}.{schema}.{table}
 
-Snowflake resolves and stores names for databases, schemas, tables and columns differently depending on how they are [expressed in statements](https://docs.snowflake.com/en/sql-reference/identifiers-syntax) (e.g. unquoted vs quoted). The representation of names in OpenLineage events should be based on the canonical name that Snowflake stores. Specifically:
+Snowflake resolves and stores names for databases, schemas, tables and columns differently depending on how they are
+[expressed in statements](https://docs.snowflake.com/en/sql-reference/identifiers-syntax) (e.g. unquoted vs quoted). The
+representation of names in OpenLineage events should be based on the canonical name that Snowflake stores. Specifically:
 
-- For dataset names, each period-delimited part (database/schema/table) should be in the simplest form it would take in a statement i.e. quoted only if necessary. For example, a table `My Table` in schema `MY_SCHEMA` and in database `MY_DATABASE` would be represented as `MY_DATABASE.MY_SCHEMA."My Table"`. If in doubt, check [Snowflake's `ACCESS_HISTORY` view](https://docs.snowflake.com/en/sql-reference/account-usage/access_history) to see how `objectName` is formed for a given table.
+- For dataset names, each period-delimited part (database/schema/table) should be in the simplest form it would take in
+  a statement i.e. quoted only if necessary. For example, a table `My Table` in schema `MY_SCHEMA` and in database
+  `MY_DATABASE` would be represented as `MY_DATABASE.MY_SCHEMA."My Table"`. If in doubt, check
+  [Snowflake's `ACCESS_HISTORY` view](https://docs.snowflake.com/en/sql-reference/account-usage/access_history) to see
+  how `objectName` is formed for a given table.
 - For column names, the canonical name should always be used verbatim.
 
 #### BigQuery


### PR DESCRIPTION
Fix spelling.

### Problem

There were cases (e.g. changes in markdown files) that didn't not trigger always workflow.

### Solution

Change logic. Remove `no-op` workflow.

This PR also fixes spelling in one of MD files.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project