### PR TITLE
JobTypeJobFacet added and used in Flink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 * **Flink: add option for flink job listener to read from flink conf** [`#2229`](https://github.com/OpenLineage/OpenLineage/pull/2229) [@ensctom](https://github.com/ensctom)  
   *Add option for flink job listener to read jobname and namespace from flink conf*
+* **Introduce `JobTypeJobFacet` to contain additional job related information**[`#2241`](https://github.com/OpenLineage/OpenLineage/pull/2241) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *`JobTypeJobFacet` contains processing type like `BATCH|STREAMING`, integration like `SPARK|FLINK|...` and job type `QUERY|COMMAND|DAG|...`.*
 
 ### Fixed
 * **Spark: update Jackson dependency to resolve `CVE-2022-1471`** [`#2185`](https://github.com/OpenLineage/OpenLineage/pull/2185) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -286,6 +286,20 @@ class OwnershipJobFacet(BaseFacet):
 
 
 @attr.s
+class JobTypeJobFacet(BaseFacet):
+
+    """This facet represents job type properties."""
+
+    processingType: str = attr.ib()  # noqa: N815
+    integration: str = attr.ib()
+    jobType: str = attr.ib()  # noqa: N815
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/JobTypeJobFacet"
+
+
+@attr.s
 class DatasetVersionDatasetFacet(BaseFacet):
 
     """This facet represents version of a dataset."""

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -14,6 +14,7 @@ from openlineage.client.facet import (
     ColumnLineageDatasetFacetFieldsAdditional,
     ColumnLineageDatasetFacetFieldsAdditionalInputFields,
     DatasetVersionDatasetFacet,
+    JobTypeJobFacet,
     LifecycleStateChange,
     LifecycleStateChangeDatasetFacet,
     LifecycleStateChangeDatasetFacetPreviousIdentifier,
@@ -424,5 +425,43 @@ def test_column_lineage_dataset_facet(event: dict[str, Any]) -> None:
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
     expected_event["outputs"][0]["facets"]["columnLineage"] = column_lineage_dataset_facet
+
+    assert expected_event == event_sent
+
+
+def test_job_type_job_facet(event: dict[str, Any]) -> None:
+    session = MagicMock()
+    client = OpenLineageClient(url="http://example.com", session=session)
+
+    job_type_facet = {
+        "processingType": "BATCH",
+        "integration": "SPARK",
+        "jobType": "QUERY",
+        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/client/python",
+        "_schemaURL": "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json#/definitions/JobTypeJobFacet",
+    }
+
+    client.emit(
+        RunEvent(
+            RunState.START,
+            "2021-11-03T10:53:52.427343",
+            Run("69f4acab-b87d-4fc0-b27b-8ea950370ff3"),
+            Job(
+                namespace="openlineage",
+                name="job",
+                facets={"jobType": JobTypeJobFacet("BATCH", "SPARK", "QUERY")},
+            ),
+            "some-producer",
+            [],
+            [],
+        ),
+    )
+
+    event_sent = json.loads(session.post.call_args[0][1])
+
+    expected_event = copy.deepcopy(event)
+    expected_event["outputs"] = []
+    expected_event["job"]["facets"] = {}
+    expected_event["job"]["facets"]["jobType"] = job_type_facet
 
     assert expected_event == event_sent

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/JobTypeUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/JobTypeUtils.java
@@ -1,0 +1,62 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.utils;
+
+import java.util.List;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.WithBoundedness;
+
+/**
+ * Class to extract if a job is of streaming or batch type. It contains copy of code snippets from
+ * Flink internals to determine a job type.
+ */
+public class JobTypeUtils {
+
+  public static final String BATCH = "BATCH";
+  public static final String STREAMING = "STREAMING";
+
+  /**
+   * Modified version of
+   * https://github.com/apache/flink/blob/50ca1de29df7ca36c57e8524b5444a4d7529a5e1/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java#L494
+   *
+   * @param executionMode
+   * @param transformations
+   * @return
+   */
+  public static String extract(
+      RuntimeExecutionMode executionMode, List<Transformation<?>> transformations) {
+    if (executionMode != RuntimeExecutionMode.AUTOMATIC) {
+      return (executionMode == RuntimeExecutionMode.BATCH) ? BATCH : STREAMING;
+    }
+
+    return existsUnboundedSource(transformations) ? STREAMING : BATCH;
+  }
+
+  private static boolean existsUnboundedSource(List<Transformation<?>> transformations) {
+    return transformations.stream()
+        .anyMatch(
+            transformation ->
+                isUnboundedSource(transformation)
+                    || transformation.getTransitivePredecessors().stream()
+                        .anyMatch(t -> isUnboundedSource(t)));
+  }
+
+  /**
+   * https://github.com/apache/flink/blob/50ca1de29df7ca36c57e8524b5444a4d7529a5e1/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java#L524
+   *
+   * <p>Verifies if a transformation contains streaming source. Method copied from Flink internals,
+   * as there is no way access it through reflection.
+   *
+   * @param transformation
+   * @return
+   */
+  private static boolean isUnboundedSource(final Transformation<?> transformation) {
+    return transformation instanceof WithBoundedness
+        && ((WithBoundedness) transformation).getBoundedness() != Boundedness.BOUNDED;
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
@@ -21,9 +21,11 @@ public class FlinkExecutionContextFactory {
       String jobNamespace,
       String jobName,
       JobID jobId,
+      String jobType,
       List<Transformation<?>> transformations) {
     return new FlinkExecutionContext.FlinkExecutionContextBuilder()
         .jobId(jobId)
+        .jobType(jobType)
         .jobName(jobName)
         .jobNamespace(jobNamespace)
         .transformations(transformations)

--- a/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.flink.tracker.OpenLineageContinousJobTracker;
 import io.openlineage.flink.tracker.OpenLineageContinousJobTrackerFactory;
+import io.openlineage.flink.utils.JobTypeUtils;
 import io.openlineage.flink.visitor.lifecycle.FlinkExecutionContext;
 import io.openlineage.flink.visitor.lifecycle.FlinkExecutionContextFactory;
 import java.util.ArrayList;
@@ -79,7 +80,12 @@ class JobListenerTest {
     try (MockedStatic<FlinkExecutionContextFactory> contextFactory =
         mockStatic(FlinkExecutionContextFactory.class)) {
       when(FlinkExecutionContextFactory.getContext(
-              eq(readableConfig), eq(jobNamespace), eq(jobName), eq(jobId), eq(transformations)))
+              eq(readableConfig),
+              eq(jobNamespace),
+              eq(jobName),
+              eq(jobId),
+              eq(JobTypeUtils.STREAMING),
+              eq(transformations)))
           .thenReturn(context);
       doNothing().when(context).onJobSubmitted();
 
@@ -120,6 +126,7 @@ class JobListenerTest {
               eq(customNamespace),
               eq(customJobName),
               eq(jobId),
+              eq(JobTypeUtils.STREAMING),
               eq(transformations)))
           .thenReturn(context);
       when(OpenLineageContinousJobTrackerFactory.getTracker(
@@ -158,7 +165,12 @@ class JobListenerTest {
     try (MockedStatic<FlinkExecutionContextFactory> contextFactory =
         mockStatic(FlinkExecutionContextFactory.class)) {
       when(FlinkExecutionContextFactory.getContext(
-              eq(readableConfig), eq(jobNamespace), eq(jobName), eq(jobId), eq(transformations)))
+              eq(readableConfig),
+              eq(jobNamespace),
+              eq(jobName),
+              eq(jobId),
+              eq(JobTypeUtils.STREAMING),
+              eq(transformations)))
           .thenReturn(context);
       doNothing().when(context).onJobSubmitted();
 
@@ -197,6 +209,7 @@ class JobListenerTest {
               eq(DEFAULT_JOB_NAMESPACE),
               eq(StreamGraphGenerator.DEFAULT_STREAMING_JOB_NAME),
               eq(jobId),
+              eq(JobTypeUtils.STREAMING),
               eq(transformations)))
           .thenReturn(context);
       doNothing().when(context).onJobSubmitted();

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.WithBoundedness;
+import org.junit.jupiter.api.Test;
+
+public class JobTypeUtilsTest {
+
+  @Test
+  void testExtractWhenExecutionModeIsBatch() {
+    assertThat(JobTypeUtils.extract(RuntimeExecutionMode.BATCH, Collections.emptyList()))
+        .isEqualTo(JobTypeUtils.BATCH);
+  }
+
+  @Test
+  void testExtractWhenExecutionModeIsStreaming() {
+    assertThat(JobTypeUtils.extract(RuntimeExecutionMode.STREAMING, Collections.emptyList()))
+        .isEqualTo(JobTypeUtils.STREAMING);
+  }
+
+  @Test
+  void testExtractWhenExecutionModeIsAutomaticAndNoUnboundedDatasets() {
+    Transformation dataset =
+        mock(Transformation.class, withSettings().extraInterfaces(WithBoundedness.class));
+    when(((WithBoundedness) dataset).getBoundedness()).thenReturn(Boundedness.CONTINUOUS_UNBOUNDED);
+    List<Transformation<?>> transformations = Collections.singletonList(dataset);
+
+    assertThat(JobTypeUtils.extract(RuntimeExecutionMode.AUTOMATIC, transformations))
+        .isEqualTo(JobTypeUtils.STREAMING);
+  }
+
+  @Test
+  void testExtractWhenExecutionModeIsAutomaticWithUnboundedDatasets() {
+    Transformation dataset =
+        mock(Transformation.class, withSettings().extraInterfaces(WithBoundedness.class));
+    when(((WithBoundedness) dataset).getBoundedness()).thenReturn(Boundedness.BOUNDED);
+    List<Transformation<?>> transformations = Collections.singletonList(dataset);
+
+    assertThat(JobTypeUtils.extract(RuntimeExecutionMode.AUTOMATIC, transformations))
+        .isEqualTo(JobTypeUtils.BATCH);
+  }
+}

--- a/integration/flink/src/test/resources/events/expected_kafka.json
+++ b/integration/flink/src/test/resources/events/expected_kafka.json
@@ -3,7 +3,13 @@
   "eventTime": "${json-unit.any-string}",
   "job" : {
     "namespace" : "flink_job_namespace",
-    "name": "flink_examples_stateful"
+    "name": "flink_examples_stateful",
+    "facets": {
+      "jobType": {
+        "processingType" : "FLINK",
+        "jobType" : "STREAMING"
+      }
+    }
   },
   "run": {
     "runId": "${json-unit.any-string}"

--- a/spec/facets/JobTypeJobFacet.json
+++ b/spec/facets/JobTypeJobFacet.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json",
+  "$defs": {
+    "JobTypeJobFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "processingType": {
+              "description": "Job processing type like: BATCH or STREAMING",
+              "type": "string",
+              "example": "BATCH"
+            },
+            "integration": {
+              "description": "OpenLineage integration type of this job: SPARK|DBT|AIRFLOW|FLINK",
+              "type": "string",
+              "example": "SPARK"
+            },
+            "jobType": {
+              "description": "Run type like: QUERY|COMMAND|DAG|TASK|JOB|MODEL",
+              "type": "string",
+              "example": "QUERY"
+            }
+          },
+          "required": ["processingType", "integration"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "jobType": {
+      "$ref": "#/$defs/JobTypeJobFacet"
+    }
+  }
+}

--- a/spec/tests/JobTypeJobFacet/1.json
+++ b/spec/tests/JobTypeJobFacet/1.json
@@ -1,0 +1,9 @@
+{
+  "jobType": {
+    "processingType": "BATCH",
+    "integration": "SPARK",
+    "jobType": "QUERY",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json"
+  }
+}


### PR DESCRIPTION
### Problem

Currently, a lineage backend has no way to distinguish if a `RunEvent` corresponds to `BATCH` or `STREAMING` job. We need to have the extra `jobType` property attached to have clear distinction about this. `BATCH` is assumed to be a default behaviour. 

Within Flink integration library, we need to distinguish which jobType a Flink job is, as Flink jobs can be both: batch and streaming. 

### Solution

 * Introduce new facet,
 * Include new facet within Flink integration. 
 
> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project