### PR TITLE
sql: add quote information from sqlparser-rs

### DIFF
--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -355,7 +355,7 @@ def test_bigquery_escaping():
         dialect="bigquery",
         default_schema="public"
     )
-    assert sql_meta.in_tables == [DbTableMeta('random-project.dbt_test1.source_table')]
+    assert sql_meta.in_tables == [DbTableMeta('`random-project`.`dbt_test1`.`source_table`')]
 
 
 @pytest.mark.skipif(provider() == "python", reason="python does not understand DDL")

--- a/integration/sql/iface-java/src/lib.rs
+++ b/integration/sql/iface-java/src/lib.rs
@@ -82,13 +82,44 @@ impl AsJavaObject for rust_impl::SqlMeta {
     }
 }
 
+impl AsJavaObject for rust_impl::QuoteStyle {
+    fn java_class_name() -> &'static str {
+        "io/openlineage/sql/QuoteStyle"
+    }
+
+    fn ctor_signature() -> &'static str {
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"
+    }
+
+    fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
+        let arg1 = match &self.database {
+            Some(n) => env.new_string(n.to_string())?.into(),
+            None => JObject::null(),
+        };
+        let arg2 = match &self.schema {
+            Some(n) => env.new_string(n.to_string())?.into(),
+            None => JObject::null(),
+        };
+        let arg3 = match &self.name {
+            Some(n) => env.new_string(n.to_string())?.into(),
+            None => JObject::null(),
+        };
+
+        Ok(Box::new([
+            JValue::Object(arg1),
+            JValue::Object(arg2),
+            JValue::Object(arg3),
+        ]))
+    }
+}
+
 impl AsJavaObject for rust_impl::DbTableMeta {
     fn java_class_name() -> &'static str {
         "io/openlineage/sql/DbTableMeta"
     }
 
     fn ctor_signature() -> &'static str {
-        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/openlineage/sql/QuoteStyle;)V"
     }
 
     fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
@@ -102,10 +133,16 @@ impl AsJavaObject for rust_impl::DbTableMeta {
         };
         let arg3 = env.new_string(&self.name)?.into();
 
+        let arg4 = match &self.quote_style {
+            Some(q) => q.as_java_object(env).unwrap(),
+            None => JObject::null(),
+        };
+
         Ok(Box::new([
             JValue::Object(arg1),
             JValue::Object(arg2),
             JValue::Object(arg3),
+            JValue::Object(arg4),
         ]))
     }
 }

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
@@ -11,11 +11,20 @@ public class DbTableMeta {
   private final String database;
   private final String schema;
   private final String name;
+  private final QuoteStyle quoteStyle;
+
+  public DbTableMeta(String database, String schema, String name, QuoteStyle quoteStyle) {
+    this.database = database;
+    this.schema = schema;
+    this.name = name;
+    this.quoteStyle = quoteStyle;
+  }
 
   public DbTableMeta(String database, String schema, String name) {
     this.database = database;
     this.schema = schema;
     this.name = name;
+    this.quoteStyle = new QuoteStyle(null, null, null);
   }
 
   public String database() {
@@ -28,6 +37,10 @@ public class DbTableMeta {
 
   public String name() {
     return name;
+  }
+
+  public QuoteStyle quote_style() {
+    return quoteStyle;
   }
 
   public String qualifiedName() {

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/QuoteStyle.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/QuoteStyle.java
@@ -1,0 +1,43 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.sql;
+
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class QuoteStyle {
+  private final String database;
+  private final String schema;
+  private final String name;
+
+  public QuoteStyle(String database, String schema, String name) {
+    this.database = database;
+    this.schema = schema;
+    this.name = name;
+  }
+
+  public String database() {
+    return database;
+  }
+
+  public String schema() {
+    return schema;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "{\"database\": %s, \"schema\": %s, \"name\": %s}", database, schema, name);
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(database).append(schema).append(name).toHashCode();
+  }
+}

--- a/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
+++ b/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
@@ -39,7 +39,9 @@ class OpenLineageSqlTest {
     assertEquals(
         output,
         new SqlMeta(
-            Arrays.asList(new DbTableMeta("random-project", "dbt_test1", "source_table")),
+            Arrays.asList(
+                new DbTableMeta(
+                    "random-project", "dbt_test1", "source_table", new QuoteStyle("`", "`", "`"))),
             new ArrayList<DbTableMeta>(),
             Collections.emptyList(),
             Collections.emptyList()));

--- a/integration/sql/iface-py/openlineage_sql.pyi
+++ b/integration/sql/iface-py/openlineage_sql.pyi
@@ -1,11 +1,15 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
-
 """
 Definition of the public interface for openlineage_sql
 """
+
+class QuoteStyle:
+    database: str | None
+    schema: str | None
+    name: str | None
+    def __init__(self, database, schema, name) -> None: ...
 
 class DbTableMeta:
     """
@@ -21,6 +25,8 @@ class DbTableMeta:
     provided_namespace: bool
     # determines if fields schema is provided by parser
     provided_field_schema: bool
+    # quotes information
+    quote_style: QuoteStyle | None
     def __init__(self, name: str) -> None: ...
 
 class ColumnMeta:

--- a/integration/sql/impl/src/context/alias_table.rs
+++ b/integration/sql/impl/src/context/alias_table.rs
@@ -21,9 +21,19 @@ impl AliasTable {
         self.table_aliases.insert(alias, table);
     }
 
+    pub fn get_table_from_alias(&self, alias: String) -> Option<&DbTableMeta> {
+        self.table_aliases.iter().find_map(|entry| {
+            if entry.0.qualified_name() == alias {
+                Some(entry.1)
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn resolve_table<'a>(&'a self, name: &'a DbTableMeta) -> &'a DbTableMeta {
         let mut current = name;
-        while let Some(next) = self.table_aliases.get(current) {
+        while let Some(next) = self.get_table_from_alias(current.qualified_name()) {
             current = next;
         }
         current

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use crate::dialect::CanonicalDialect;
 use crate::lineage::*;
 use alias_table::AliasTable;
+use sqlparser::ast::Ident;
 use sqlparser::dialect::SnowflakeDialect;
 
 type ColumnAncestors = HashSet<ColumnMeta>;
@@ -93,7 +94,7 @@ impl<'a> Context<'a> {
 
     // --- Table Lineage ---
 
-    pub fn add_input(&mut self, table: String) {
+    pub fn add_input(&mut self, table: Vec<Ident>) {
         let name = DbTableMeta::new(table, self.dialect, self.default_schema.clone());
         if !self.is_table_alias(&name) {
             self.inputs.insert(name);
@@ -102,7 +103,7 @@ impl<'a> Context<'a> {
 
     pub fn add_non_table_input(
         &mut self,
-        table: String,
+        table: Vec<Ident>,
         provided_namespace: bool,
         provided_field_schema: bool,
     ) {
@@ -119,7 +120,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn add_output(&mut self, output: String) {
+    pub fn add_output(&mut self, output: Vec<Ident>) {
         let name = DbTableMeta::new(output, self.dialect, self.default_schema.clone());
         if !self.is_table_alias(&name) {
             self.outputs.insert(name);
@@ -128,7 +129,7 @@ impl<'a> Context<'a> {
 
     pub fn add_non_table_output(
         &mut self,
-        output: String,
+        output: Vec<Ident>,
         provided_namespace: bool,
         provided_field_schema: bool,
     ) {
@@ -181,7 +182,7 @@ impl<'a> Context<'a> {
         self.frames.pop()
     }
 
-    pub fn add_table_alias(&mut self, table: DbTableMeta, alias: String) {
+    pub fn add_table_alias(&mut self, table: DbTableMeta, alias: Vec<Ident>) {
         if let Some(frame) = self.frames.last_mut() {
             let alias = DbTableMeta::new(alias, self.dialect, self.default_schema.clone());
             frame.aliases.add_table_alias(table, alias);

--- a/integration/sql/impl/src/lib.rs
+++ b/integration/sql/impl/src/lib.rs
@@ -77,7 +77,7 @@ pub fn parse_sql(
 
 #[cfg(test)]
 mod tests {
-    use crate::DbTableMeta;
+    use crate::{DbTableMeta, QuoteStyle};
 
     #[test]
     fn compare_db_meta() {
@@ -88,6 +88,11 @@ mod tests {
                 name: "discount".to_string(),
                 provided_namespace: false,
                 provided_field_schema: false,
+                quote_style: Some(QuoteStyle {
+                    database: None,
+                    schema: None,
+                    name: Some('"')
+                })
             },
             DbTableMeta {
                 database: None,
@@ -95,6 +100,11 @@ mod tests {
                 name: "discount".to_string(),
                 provided_namespace: false,
                 provided_field_schema: false,
+                quote_style: Some(QuoteStyle {
+                    database: None,
+                    schema: None,
+                    name: Some('"')
+                })
             }
         );
     }

--- a/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
@@ -1,7 +1,5 @@
 use crate::test_utils::*;
-use openlineage_sql::{
-    ColumnLineage, ColumnMeta, DbTableMeta, ExtractionError, SqlMeta, TableLineage,
-};
+use openlineage_sql::{ColumnLineage, ColumnMeta, ExtractionError, SqlMeta, TableLineage};
 
 #[test]
 fn test_failing_statement_with_insert() {
@@ -23,7 +21,7 @@ fn test_failing_statement_with_insert() {
                     name: "key".to_string()
                 },
                 lineage: vec![ColumnMeta {
-                    origin: Some(DbTableMeta::new_default_dialect("temp.table".to_string())),
+                    origin: Some(table("temp.table")),
                     name: "key".to_string(),
                 }],
             }],

--- a/integration/sql/impl/tests/table_lineage/tests_insert.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_insert.rs
@@ -62,8 +62,8 @@ fn insert_select_table_2() {
         .unwrap()
         .table_lineage,
         TableLineage {
-            in_tables: tables(vec!["b1.b2", "m.dim"]),
-            out_tables: tables(vec!["a1.a2"])
+            in_tables: tables(vec!["\"b1\".\"b2\"", "\"m\".\"dim\""]),
+            out_tables: tables(vec!["\"a1\".\"a2\""])
         }
     )
 }
@@ -291,8 +291,8 @@ fn insert_group_by() {
         .unwrap()
         .table_lineage,
         TableLineage {
-            in_tables: tables(vec!["b1.b2"]),
-            out_tables: tables(vec!["a1.a2"])
+            in_tables: tables(vec!["\"b1\".\"b2\""]),
+            out_tables: tables(vec!["\"a1\".\"a2\""])
         }
     )
 }
@@ -407,8 +407,14 @@ fn insert_nested_with_select() {
         .unwrap()
         .table_lineage,
         TableLineage {
-            in_tables: tables(vec!["b1.b2", "c1.c2", "d1.d2", "e1.e2", "f1.f2"]),
-            out_tables: tables(vec!["a1.a2"])
+            in_tables: tables(vec![
+                "\"b1\".\"b2\"",
+                "\"c1\".\"c2\"",
+                "\"d1\".\"d2\"",
+                "\"e1\".\"e2\"",
+                "\"f1\".\"f2\""
+            ]),
+            out_tables: tables(vec!["\"a1\".\"a2\""])
         }
     )
 }

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -98,7 +98,7 @@ fn select_bigquery_excaping() {
         .unwrap()
         .table_lineage,
         TableLineage {
-            in_tables: tables(vec!["random-project.dbt_test1.source_table"]),
+            in_tables: tables(vec!["`random-project`.`dbt_test1`.`source_table`"]),
             out_tables: vec![]
         }
     )
@@ -124,7 +124,7 @@ fn select_redshift() {
             .unwrap()
             .table_lineage,
         TableLineage {
-            in_tables: tables(vec!["test_schema.test_table"]),
+            in_tables: tables(vec!["[test_schema].[test_table]"]),
             out_tables: vec![]
         }
     )

--- a/integration/sql/impl/tests/test_utils/mod.rs
+++ b/integration/sql/impl/tests/test_utils/mod.rs
@@ -23,12 +23,9 @@ pub fn test_sql_dialect(sql: &str, dialect: &str) -> Result<SqlMeta> {
 }
 
 pub fn table(name: &str) -> DbTableMeta {
-    DbTableMeta::new_default_dialect(String::from(name))
+    DbTableMeta::new_default_dialect(name.to_string())
 }
 
 pub fn tables(names: Vec<&str>) -> Vec<DbTableMeta> {
-    names
-        .into_iter()
-        .map(|name| DbTableMeta::new_default_dialect(String::from(name)))
-        .collect()
+    names.into_iter().map(table).collect()
 }


### PR DESCRIPTION
### Problem

Information if identifier was quoted in the SQL statement might be precious in some cases, e.g. when dealing with Snowflake.

### Solution

Add additional field `quotes` with optional values each corresponding for `database`, `schema` and `name`.
This change is backwards compatible. It was also tested with latest Airflow OpenLineage provider.

#### One-line summary:

Add quote information from sqlparser-rs

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project