### PR TITLE
[FLINK] upgrade testcontainers

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -61,7 +61,7 @@ ext {
     junit5Version = '5.10.1'
     lombokVersion = '1.18.30'
     mockitoVersion = '5.2.0'
-    testcontainersVersion = '1.16.3'
+    testcontainersVersion = '1.19.2'
     isReleaseVersion = !version.endsWith('SNAPSHOT')
     icebergVersion = "1.3.0"
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 import lombok.SneakyThrows;
 import org.apache.avro.Schema;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.kafka.source.KafkaSource;
@@ -30,7 +31,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaPartitionDisco
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.testcontainers.shaded.org.apache.commons.lang.reflect.FieldUtils;
 
 class KafkaSourceWrapperTest {
 


### PR DESCRIPTION
### Problem

Dependabot fails on test containers upgrade: https://github.com/OpenLineage/OpenLineage/pull/2269

### Solution

Bump version and fix the failing tests.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project