### PR TITLE
spark: get column-level lineage from JDBC dbtable option

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -358,6 +358,10 @@ jobs:
           root: ./
           paths:
             - target/debug/*.so
+      - store_artifacts:
+          path: ./target/debug/
+          destination: sql-linux-artifacts
+
   
   compile-integration-sql-java-macos:
     parameters:
@@ -375,6 +379,9 @@ jobs:
           root: ../
           paths:
             - target/debug/*.dylib
+      - store_artifacts:
+          path: ../target/debug/*.dylib
+          destination: sql-macos-artifacts
 
   build-integration-sql-java:
     working_directory: ~/openlineage/integration/sql/iface-java

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -68,8 +68,8 @@ ext {
     shortVersion = sparkVersion.substring(0,3)
 
     versionsMap = [
-            "3.5": ["module": "spark35", "scala": "2.12", "delta": "NA", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "NA", "hadoopclient": "3.3.4"],
-            "3.4": ["module": "spark34", "scala": "2.12", "delta": "2.4.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.4_2.12:1.3.0", "hadoopclient": "3.3.4"],
+            "3.5": ["module": "spark35", "scala": "2.12", "delta": "NA", "gcs": "hadoop3-2.2.9", "snowflake": "2.13.0-spark_3.4", "iceberg": "NA", "hadoopclient": "3.3.4"],
+            "3.4": ["module": "spark34", "scala": "2.12", "delta": "2.4.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.13.0-spark_3.4", "iceberg": "iceberg-spark-runtime-3.4_2.12:1.3.0", "hadoopclient": "3.3.4"],
             "3.3": ["module": "spark33", "scala": "2.12", "delta": "2.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.3_2.12:0.14.0", "hadoopclient": "3.3.4"],
             "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2", "iceberg": "iceberg-spark-runtime-3.2_2.12:0.14.0", "hadoopclient": "3.3.4"],
             "3.1": ["module": "spark3",  "scala": "2.12", "delta": "1.0.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.1", "iceberg": "iceberg-spark-runtime-3.1_2.12:0.13.0", "hadoopclient": "3.3.4"],
@@ -142,11 +142,13 @@ dependencies {
         }
     }
 
-    testFixturesApi ("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
-        exclude group: 'com.google.guava:guava'
-        exclude group: 'org.apache.spark:spark-core_2.11'
-        exclude group: 'org.apache.spark:spark-sql_2.11'
-        exclude group: 'org.apache.spark:spark-catalyst_2.11'
+    if(versions.snowflake != "NA") {
+        testFixturesApi ("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
+            exclude group: 'com.google.guava:guava'
+            exclude group: 'org.apache.spark:spark-core_2.11'
+            exclude group: 'org.apache.spark:spark-sql_2.11'
+            exclude group: 'org.apache.spark:spark-catalyst_2.11'
+        }
     }
 
     testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_${versions.scala}:${sparkVersion}"

--- a/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
@@ -71,11 +71,11 @@
                   "field": "v2"
                 },
                 {
-                  "name": "jdbc_source1",
+                  "name": "test.jdbc_source1",
                   "field": "j1"
                 },
                 {
-                  "name": "jdbc_source2",
+                  "name": "test.jdbc_source2",
                   "field": "j2"
                 },
                 {

--- a/integration/spark/app/integrations/container/columnLineageJDBCStart.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCStart.json
@@ -125,11 +125,11 @@
                   "field": "v2"
                 },
                 {
-                  "name": "jdbc_source1",
+                  "name": "test.jdbc_source1",
                   "field": "j1"
                 },
                 {
-                  "name": "jdbc_source2",
+                  "name": "test.jdbc_source2",
                   "field": "j2"
                 },
                 {

--- a/integration/spark/app/integrations/container/columnLineageSingleInputComplete.json
+++ b/integration/spark/app/integrations/container/columnLineageSingleInputComplete.json
@@ -1,0 +1,84 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "default",
+    "name": "iceberg_integration_test.execute_save_into_data_source_command.test_second_ol_clients"
+  },
+  "inputs": [
+    {
+      "name": "test.ol_clients",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "client_name",
+              "type": "string"
+            },
+            {
+              "name": "client_category",
+              "type": "string"
+            },
+            {
+              "name": "client_rating",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "name": "test.second_ol_clients",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "client_name",
+              "type": "string"
+            },
+            {
+              "name": "client_category",
+              "type": "string"
+            },
+            {
+              "name": "client_rating",
+              "type": "string"
+            }
+          ]
+        },
+        "columnLineage": {
+          "fields": {
+            "client_name": {
+              "inputFields": [
+                {
+                  "name": "test.ol_clients",
+                  "field": "client_name"
+                }
+              ]
+            },
+            "client_category": {
+              "inputFields": [
+                {
+                  "name": "test.ol_clients",
+                  "field": "client_category"
+                }
+              ]
+            },
+            "client_rating": {
+              "inputFields": [
+                {
+                  "name": "test.ol_clients",
+                  "field": "client_rating"
+                }
+              ]
+            }
+          }
+        },
+        "lifecycleStateChange": {
+          "lifecycleStateChange": "OVERWRITE"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -30,7 +30,8 @@ public class SparkContainerUtils {
   static MockServerContainer makeMockServerContainer(Network network) {
     return new MockServerContainer(MOCKSERVER_IMAGE)
         .withNetwork(network)
-        .withNetworkAliases("openlineageclient");
+        .withNetworkAliases("openlineageclient")
+        .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
   }
 
   static PostgreSQLContainer<?> makeMetastoreContainer(Network network) {

--- a/integration/spark/app/src/test/resources/column_lineage/init.sql
+++ b/integration/spark/app/src/test/resources/column_lineage/init.sql
@@ -9,3 +9,16 @@ insert into jdbc_source1 values (3 , 'je');
 insert into jdbc_source2 values (1 , 'jb');
 insert into jdbc_source2 values (2 , 'jd');
 insert into jdbc_source2 values (3 , 'jf');
+
+CREATE TABLE IF NOT EXISTS ol_clients (
+ client_name VARCHAR(255),
+ client_category VARCHAR(255),
+ client_rating VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS second_ol_clients (
+    client_name VARCHAR(255),
+    client_category VARCHAR(255),
+    client_rating VARCHAR(255)
+);
+

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
@@ -12,7 +12,10 @@ import io.openlineage.client.OpenLineage.Job;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.spark.agent.util.DatabricksUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class JobNameHook implements RunEventBuilderHook {
 
   public static final String SPARK_CONF_JOB_NAME_APPEND_DATASET_NAME =
@@ -72,10 +75,15 @@ public class JobNameHook implements RunEventBuilderHook {
     }
 
     if (runEvent.getOutputs() != null && runEvent.getOutputs().size() > 0) {
+      log.debug(
+          "Job name appends following output: {}",
+          Arrays.toString(runEvent.getOutputs().toArray()));
       // append output dataset name to job name
       jobNameBuilder
           .append(JOB_NAME_PARTS_SEPARATOR)
           .append(trimPath(runEvent.getOutputs().get(0).getName()).replace(".", INNER_SEPARATOR));
+    } else {
+      log.debug("No outputs - do not append anything to job name.");
     }
 
     String jobName = jobNameBuilder.toString();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -65,6 +65,7 @@ public class ColumnLevelLineageBuilder {
     inputs.computeIfAbsent(exprId, k -> new LinkedList<>());
 
     Pair<DatasetIdentifier, String> input = Pair.of(datasetIdentifier, attributeName);
+
     if (!inputs.get(exprId).contains(input)) {
       inputs.get(exprId).add(input);
     }
@@ -185,7 +186,6 @@ public class ColumnLevelLineageBuilder {
         schema.getFields().stream()
             .filter(field -> field.getName().equalsIgnoreCase(outputName))
             .findAny();
-
     if (!outputField.isPresent() || !outputs.containsKey(outputField.get())) {
       return Collections.emptyList();
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/JdbcRelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/JdbcRelationHandler.java
@@ -16,11 +16,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+@Slf4j
 public class JdbcRelationHandler<D extends OpenLineage.Dataset> {
 
   private final DatasetFactory<D> datasetFactory;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -7,6 +7,8 @@ package io.openlineage.spark.agent.util;
 
 import com.google.common.base.CharMatcher;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.sql.ColumnLineage;
+import io.openlineage.sql.ColumnMeta;
 import io.openlineage.sql.DbTableMeta;
 import io.openlineage.sql.ExtractionError;
 import io.openlineage.sql.OpenLineageSql;
@@ -21,6 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 
 @Slf4j
@@ -93,34 +96,44 @@ public class JdbcUtils {
   }
 
   public static Optional<SqlMeta> extractQueryFromSpark(JDBCRelation relation) {
-    String tableOrQuery = relation.jdbcOptions().tableOrQuery();
-    if (!tableOrQuery.trim().startsWith("(")) {
+    Optional<String> table =
+        ScalaConversionUtils.asJavaOptional(
+            relation.jdbcOptions().parameters().get(JDBCOptions$.MODULE$.JDBC_TABLE_NAME()));
+    if (table.isPresent()) {
+      DbTableMeta origin = new DbTableMeta(null, null, table.get());
       return Optional.of(
           new SqlMeta(
-              Collections.singletonList(new DbTableMeta(null, null, tableOrQuery)),
+              Collections.singletonList(origin),
               Collections.emptyList(),
-              Collections.emptyList(),
+              Arrays.stream(relation.schema().fields())
+                  .map(
+                      field ->
+                          new ColumnLineage(
+                              new ColumnMeta(null, field.name()),
+                              Collections.singletonList(new ColumnMeta(origin, field.name()))))
+                  .collect(Collectors.toList()),
               Collections.emptyList()));
     } else {
+      String tableOrQuery = relation.jdbcOptions().tableOrQuery();
       String query =
           tableOrQuery.substring(0, tableOrQuery.lastIndexOf(")")).replaceFirst("\\(", "");
 
       String dialect = extractDialectFromJdbcUrl(relation.jdbcOptions().url());
-      SqlMeta sqlMeta = OpenLineageSql.parse(Collections.singletonList(query), dialect).get();
+      Optional<SqlMeta> sqlMeta = OpenLineageSql.parse(Collections.singletonList(query), dialect);
 
-      if (!sqlMeta.errors().isEmpty()) { // error return nothing
+      if (!sqlMeta.get().errors().isEmpty()) { // error return nothing
         log.error(
             String.format(
                 "error while parsing query: %s",
-                sqlMeta.errors().stream()
+                sqlMeta.get().errors().stream()
                     .map(ExtractionError::toString)
                     .collect(Collectors.joining(","))));
         return Optional.empty();
-      } else if (sqlMeta.inTables().isEmpty()) {
+      } else if (sqlMeta.get().inTables().isEmpty()) {
         log.error("no tables defined in query, this should not happen");
         return Optional.empty();
       }
-      return Optional.of(sqlMeta);
+      return Optional.of(sqlMeta.get());
     }
   }
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -17,12 +17,17 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.api.DatasetFactory;
 import java.util.List;
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap;
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap$;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import scala.Tuple2;
+import scala.collection.immutable.Map$;
 
 public class JdbcRelationHandlerTest {
   JdbcRelationHandler jdbcRelationHandler;
@@ -45,6 +50,8 @@ public class JdbcRelationHandlerTest {
   @BeforeEach
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
+    when(jdbcOptions.parameters())
+        .thenReturn(CaseInsensitiveMap$.MODULE$.apply(Map$.MODULE$.empty()));
     when(jdbcOptions.url()).thenReturn("jdbc:" + url);
     when(relation.schema()).thenReturn(schema);
     jdbcRelationHandler = new JdbcRelationHandler(datasetFactory);
@@ -67,6 +74,13 @@ public class JdbcRelationHandlerTest {
 
   @Test
   void testHandlingJdbcTable() {
+    CaseInsensitiveMap params =
+        CaseInsensitiveMap$.MODULE$.apply(
+            Map$.MODULE$
+                .<String, String>newBuilder()
+                .$plus$eq(Tuple2.apply(JDBCOptions$.MODULE$.JDBC_TABLE_NAME(), jdbcTable))
+                .result());
+    when(jdbcOptions.parameters()).thenReturn(params);
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcTable);
     when(relation.schema()).thenReturn(schema);
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -70,7 +70,7 @@ public class InputFieldsCollector {
     if (isJDBCNode(node)) {
       JdbcColumnLineageCollector.extractExternalInputs(node, builder, datasetIdentifiers);
     } else {
-      extreactInternalInputs(node, builder, datasetIdentifiers);
+      extractInternalInputs(node, builder, datasetIdentifiers);
     }
   }
 
@@ -79,7 +79,7 @@ public class InputFieldsCollector {
         && ((LogicalRelation) node).relation() instanceof JDBCRelation;
   }
 
-  private static void extreactInternalInputs(
+  private static void extractInternalInputs(
       LogicalPlan node,
       ColumnLevelLineageBuilder builder,
       List<DatasetIdentifier> datasetIdentifiers) {
@@ -141,7 +141,10 @@ public class InputFieldsCollector {
         .map(
             meta ->
                 meta.inTables().stream()
-                    .map(e -> new DatasetIdentifier(e.name(), relation.jdbcOptions().url()))
+                    .map(
+                        e ->
+                            JdbcUtils.getDatasetIdentifierFromJdbcUrl(
+                                relation.jdbcOptions().url(), e.qualifiedName()))
                     .collect(Collectors.toList()))
         .orElse(Collections.emptyList());
   }


### PR DESCRIPTION
There were several problems with JDBC column level lineage.

First, it did not support dbtable option - which ment that one-to-one relationships weren't supported by column lineage collector.
Second, the `JdbcColumnLineageCollector` did not report the lineage when there was only one single input column.
Third, it used wrong, naive dataset name straight from the parser results, rather than fixed one from `JdbcUtils`. 

Those changes fix that.