### PR TITLE
[DBT] Add send events command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   *Add option for flink job listener to read jobname and namespace from flink conf*
 * **Introduce `JobTypeJobFacet` to contain additional job related information**[`#2241`](https://github.com/OpenLineage/OpenLineage/pull/2241) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *`JobTypeJobFacet` contains processing type like `BATCH|STREAMING`, integration like `SPARK|FLINK|...` and job type `QUERY|COMMAND|DAG|...`.*
+* **Dbt: Add a new command `dbt-ol send-events` to send metadata of the last run without running the job** [`#2885`](https://github.com/OpenLineage/OpenLineage/pull/2285) [@sophiely](https://github.com/sophiely)
 
 ### Fixed
 * **Spark: update Jackson dependency to resolve `CVE-2022-1471`** [`#2185`](https://github.com/OpenLineage/OpenLineage/pull/2185) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -54,6 +54,8 @@ To begin collecting dbt metadata with OpenLineage, replace `dbt run` with `dbt-o
 
 Additional table and column level metadata will be available if `catalog.json`, a result of running `dbt docs generate`, will be found in the target directory.
 
+If you need to send events without running the job you can use the command `dbt-ol send-events`, it will send the metadata of your last run without running the job.
+
 ----
 SPDX-License-Identifier: Apache-2.0\
 Copyright 2018-2023 contributors to the OpenLineage project

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -153,7 +153,7 @@ def main():
     pre_run_time = time.time()
     # Execute dbt in external process
 
-    force_send_events = "send-events" in sys.argv[1:]
+    force_send_events = len(sys.argv) > 1 and sys.argv[1] == "send-events"
     if not force_send_events:
         process = subprocess.Popen(["dbt"] + sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr)
         return_code = process.wait()

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -152,13 +152,23 @@ def main():
 
     pre_run_time = time.time()
     # Execute dbt in external process
-    process = subprocess.Popen(["dbt"] + sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr)
-    return_code = process.wait()
+
+    force_send_events = "send-events" in sys.argv[1:]
+    if not force_send_events:
+        process = subprocess.Popen(
+            ["dbt"] + sys.argv[1:],
+            stdout=sys.stdout,
+            stderr=sys.stderr
+        )
+        return_code = process.wait()
+    else:
+        logger.warning(f"Sending events for the last run without running the job")
+        return_code = 0
 
     # If run_result has modification time before dbt command
     # or does not exist, do not emit dbt events.
     try:
-        if os.stat(processor.run_result_path).st_mtime < pre_run_time:
+        if os.stat(processor.run_result_path).st_mtime < pre_run_time and not force_send_events:
             logger.info(
                 f"OpenLineage events not emitted: run_result file "
                 f"({processor.run_result_path}) was not modified by dbt"

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -155,14 +155,10 @@ def main():
 
     force_send_events = "send-events" in sys.argv[1:]
     if not force_send_events:
-        process = subprocess.Popen(
-            ["dbt"] + sys.argv[1:],
-            stdout=sys.stdout,
-            stderr=sys.stderr
-        )
+        process = subprocess.Popen(["dbt"] + sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr)
         return_code = process.wait()
     else:
-        logger.warning(f"Sending events for the last run without running the job")
+        logger.warning("Sending events for the last run without running the job")
         return_code = 0
 
     # If run_result has modification time before dbt command


### PR DESCRIPTION
### Problem

Some of our users use dbt cloud to run their job but in dbt cloud you can't change the entrypoint from dbt to dbt-ol so we can't use the dbt integration.

That's why we need a command line to send OL events only (without running the job), with the latest generated metadata, in order to send metadata outside dbt cloud and without running the job again (I don't want to use dbt-ol run since the job has already run in dbt cloud and I don't want to trigger the job a second time just to send OL event).

It can also be usefull to generate static lineage or for testing purpose.

Closes: [2286](https://github.com/OpenLineage/OpenLineage/issues/2286)

### Solution

We can add another command line specific to dbt-ol like dbt-ol send-events to send events to Open-lineage acccording to the latest metadata generated without running any dbt command.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project