### PR TITLE
Run airflow CI jobs when dbt integration is changed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             check_change integration/common/ openlineage-integration-python.yml openlineage-integration-airflow.yml openlineage-integration-dbt.yml
             check_change integration/airflow/ openlineage-integration-python.yml openlineage-integration-airflow.yml
             check_change integration/dagster/ openlineage-integration-python.yml openlineage-integration-dagster.yml
-            check_change integration/dbt/ openlineage-integration-python.yml openlineage-integration-dbt.yml
+            check_change integration/dbt/ openlineage-integration-python.yml openlineage-integration-dbt.yml openlineage-integration-airflow.yml
             check_change proxy/backend/ openlineage-proxy-backend.yml
             check_change proxy/fluentd/ openlineage-proxy-fluentd.yml
           fi


### PR DESCRIPTION
### Problem

`dbt-ol` is tested in Airflow integration tests. However, CI might not be triggered.

### Solution

Add dependency in circleCI configuration.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project