### PR TITLE
airflow: Repair run_id for FAIL event in Airflow 2.6+

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -76,7 +76,8 @@ class OpenLineageAdapter:
             self._client = OpenLineageAdapter.get_or_create_openlineage_client()
         return self._client
 
-    def build_dag_run_id(self, dag_id, dag_run_id):
+    @staticmethod
+    def build_dag_run_id(dag_id, dag_run_id):
         return str(uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}"))
 
     @staticmethod

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -122,7 +122,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
         parent_run_id = adapter.build_dag_run_id(task.dag.dag_id, dagrun.run_id)
 
         task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            task.task_id, ti.execution_date, ti.try_number
+            task.task_id, ti.execution_date, ti._try_number
         )
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task, task_uuid=task_uuid)
@@ -160,7 +160,7 @@ def on_task_instance_success(previous_state, task_instance: "TaskInstance", sess
     dagrun = task_instance.dag_run
 
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance.try_number - 1
+        task.task_id, task_instance.execution_date, task_instance._try_number
     )
 
     def on_success():
@@ -185,7 +185,7 @@ def on_task_instance_failed(previous_state, task_instance: "TaskInstance", sessi
     dagrun = task_instance.dag_run
 
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance.try_number - 1
+        task.task_id, task_instance.execution_date, task_instance._try_number
     )
 
     def on_failure():

--- a/integration/airflow/tests/integration/requests/failing/bash.json
+++ b/integration/airflow/tests/integration/requests/failing/bash.json
@@ -1,0 +1,72 @@
+[{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "name": "bash_dag.failing_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow": {
+                "dag": {
+                    "dag_id": "bash_dag",
+                    "timetable": {}
+                },
+                "dagRun": {
+                    "dag_id": "bash_dag"
+                },
+                "task": {
+                },
+                "taskInstance": {
+                    "try_number": 1
+                }
+            }
+        }
+    }
+},
+{
+    "eventType": "FAIL",
+    "inputs": [],
+    "job": {
+        "name": "bash_dag.failing_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": []
+},
+{
+    "eventType": "START",
+    "inputs": [],
+    "job": {
+        "name": "bash_dag.success_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": [],
+    "run": {
+        "facets": {
+            "airflow": {
+                "dag": {
+                    "dag_id": "bash_dag",
+                    "timetable": {}
+                },
+                "dagRun": {
+                    "dag_id": "bash_dag"
+                },
+                "task": {
+                },
+                "taskInstance": {
+                    "try_number": 1
+                }
+            }
+        }
+    }
+},
+{
+    "eventType": "COMPLETE",
+    "inputs": [],
+    "job": {
+        "name": "bash_dag.success_task",
+        "namespace": "food_delivery"
+    },
+    "outputs": []
+}]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -7,12 +7,15 @@ import os
 import sys
 import time
 import unittest
-from typing import List
+from collections import defaultdict
+from typing import Dict, List
 
 import psycopg2
 import pytest
 import requests
+from openlineage.client.run import RunState
 from openlineage.common.test import match, setup_jinja
+from openlineage.common.utils import get_from_nullable_chain
 from pkg_resources import parse_version
 from retrying import retry
 
@@ -208,6 +211,100 @@ def wait_for_dag(dag_id, airflow_db_conn, should_fail=False) -> bool:
     return True
 
 
+def check_run_id_matches(actual_events: List[Dict]) -> bool:
+    """Checks if the events have matching `runId` values for 'START' and 'COMPLETE'/'FAIL' states.
+
+    Each `runId` should have exactly one 'START' event and one 'COMPLETE' or 'FAIL' event.
+    If an unknown event type is encountered or the counts of event types do not match the expected pattern,
+    the function returns `False`.
+
+    :param actual_events: A list of event dictionaries.
+
+    :return: True if all `runId`s have matching event counts, False otherwise.
+
+    Examples:
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123"}},
+    ...     {"eventType": "COMPLETE", "run": {"runId": "run123"}}
+    ... ])
+    True
+
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123"}},
+    ... ])
+    False
+
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123"}},
+    ...     {"eventType": "COMPLETE", "run": {"runId": "run123"}},
+    ...     {"eventType": "FAIL", "run": {"runId": "run123"}}
+    ... ])
+    False
+
+    >>> mapped_task_facet = {"airflow": {"task": {"mapped": True}}}
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123", "facets": mapped_task_facet}},
+    ... ])
+    False
+
+    >>> mapped_task_facet = {"airflow": {"task": {"mapped": True}}}
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123", "facets": mapped_task_facet}},
+    ...     {"eventType": "COMPLETE", "run": {"runId": "run123", "facets": mapped_task_facet}},
+    ...     {"eventType": "START", "run": {"runId": "run123", "facets": mapped_task_facet}},
+    ...     {"eventType": "FAIL", "run": {"runId": "run123", "facets": mapped_task_facet}},
+    ... ])
+    True
+
+    >>> check_run_id_matches([
+    ...     {"eventType": "START", "run": {"runId": "run123"}},
+    ...     {"eventType": "COMPLETE", "run": {"runId": "run123"}},
+    ...     {"eventType": "FAIL", "run": {"runId": "run123"}}
+    ... ])
+    False
+    """
+    start = RunState.START.value
+    complete = RunState.COMPLETE.value
+    fail = RunState.FAIL.value
+
+    event_tracker = defaultdict(lambda: {start: 0, complete: 0, fail: 0, "is_mapped": False})
+
+    # Process each event in the list
+    for event in actual_events:
+        event_type = event["eventType"]
+        event_run_id = event["run"]["runId"]
+
+        is_dynamic_task = get_from_nullable_chain(event, ["run", "facets", "airflow", "task", "mapped"])
+        if is_dynamic_task is not None:
+            event_tracker[event_run_id]["is_mapped"] = is_dynamic_task
+
+        if event_type in [start, complete, fail]:
+            event_tracker[event_run_id][event_type] += 1
+        else:
+            log.info(f"Found unknown event_type: `{event_type}` for run_id: `{event_run_id}`")
+            return False
+
+    # Validate each run_id
+    failed_runs = {}
+    for run_id, events in event_tracker.items():
+        log.debug(f"{run_id} -> {events}")
+        if events["is_mapped"]:
+            # Dynamic tasks will have the same run_id, so we can allow more than one start and complete
+            if events[start] != (events[complete] + events[fail]):
+                failed_runs[run_id] = events
+        else:
+            if events[start] != 1 or (events[complete] + events[fail]) != 1:
+                failed_runs[run_id] = events
+
+    if failed_runs:
+        log_msg = "Validation failed for the following run_ids:\n"
+        for run_id, events in failed_runs.items():
+            log_msg += f"\t\t{run_id} -> {events}\n"
+        log.info(log_msg)
+        return False
+    return True
+
+
 def check_matches(expected_events, actual_events, check_duplicates: bool = None) -> bool:
     for expected in expected_events:
         expected_job_name = env.from_string(expected["job"]["name"]).render()
@@ -296,7 +393,11 @@ def test_integration(dag_id, request_path, check_duplicates, airflow_db_conn):
     # (3) Get actual events
     actual_events = get_events()
 
-    # (3) Verify events emitted
+    # (4) Verify run_id is constant across pairs of actual events for this dag
+    dag_events = [x for x in actual_events if dag_id in x["job"]["name"]]
+    assert check_run_id_matches(dag_events) is True
+
+    # (5) Verify events emitted
     assert check_matches(expected_events, actual_events, check_duplicates) is True
     log.info(f"Events for dag {dag_id} verified!")
 
@@ -307,6 +408,12 @@ def test_integration(dag_id, request_path, check_duplicates, airflow_db_conn):
         pytest.param(
             "async_dag",
             "requests/failing/async.json",
+            True,
+            marks=pytest.mark.skipif(not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"),
+        ),
+        pytest.param(
+            "bash_dag",
+            "requests/failing/bash.json",
             True,
             marks=pytest.mark.skipif(not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0"),
         ),
@@ -325,7 +432,11 @@ def test_failing_dag(dag_id, request_path, check_duplicates, airflow_db_conn):
     # (3) Get actual events
     actual_events = get_events()
 
-    # (3) Verify events emitted
+    # (4) Verify run_id is constant across pairs of actual events for this dag
+    dag_events = [x for x in actual_events if dag_id in x["job"]["name"]]
+    assert check_run_id_matches(dag_events) is True
+
+    # (5) Verify events emitted
     assert check_matches(expected_events, actual_events, check_duplicates) is True
     log.info(f"Events for dag {dag_id} verified!")
 
@@ -359,7 +470,10 @@ def test_integration_ordered(dag_id, request_dir: str, skip_jobs: List[str], air
     # (3) Get actual events with job names starting with dag_id
     actual_events = get_events(dag_id, False)
 
-    # (4) Filter jobs that we want to skip, which is
+    # # (4) Verify run_id is constant across pairs of actual events
+    assert check_run_id_matches(actual_events) is True
+
+    # (5) Filter jobs that we want to skip, which is
     #     used to skip dag events if we don't want to check them
     actual_events = [event for event in actual_events if event["job"]["name"] not in skip_jobs]
 
@@ -390,7 +504,7 @@ def test_airflow_run_facet(dag_id, request_path, airflow_db_conn):
     assert check_matches(expected_events, actual_events) is True
 
 
-@pytest.mark.skipif(not IS_AIRFLOW_VERSION_ENOUGH("2.4.0"), reason="Airflow < 2.4.0")
+@pytest.mark.skipif(not IS_AIRFLOW_VERSION_ENOUGH("2.3.0"), reason="Airflow < 2.3.0")
 def test_airflow_mapped_task_facet(airflow_db_conn):
     dag_id = "mapped_dag"
     task_id = "multiply"

--- a/integration/airflow/tests/integration/tests/airflow/dags/bash_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/bash_dag.py
@@ -1,0 +1,12 @@
+# Copyright 2018-2023 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+dag = DAG(dag_id="bash_dag", start_date=days_ago(7), schedule_interval="@once")
+
+failing_task = BashOperator(dag=dag, task_id="failing_task", bash_command="exit 1;")
+
+success_task = BashOperator(dag=dag, task_id="success_task", bash_command="exit 0;")

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -1,12 +1,12 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
-
 import logging
 import os
+import uuid
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from openlineage.airflow.adapter import OpenLineageAdapter
+from openlineage.airflow.adapter import _DAG_NAMESPACE, OpenLineageAdapter
 
 
 @patch.dict(os.environ, {"MARQUEZ_URL": "http://marquez:5000", "MARQUEZ_API_KEY": "api-key"})
@@ -70,3 +70,49 @@ def test_openlineage_adapter_stats_emit_failed(
 
     mock_stats_timer.assert_called_with("ol.emit.attempts")
     mock_stats_incr.assert_has_calls([mock.call("ol.emit.failed")])
+
+
+def test_build_dag_run_id_is_valid_uuid():
+    dag_id = "test_dag"
+    dag_run_id = "run_1"
+    result = OpenLineageAdapter.build_dag_run_id(dag_id, dag_run_id)
+    assert uuid.UUID(result)
+
+
+def test_build_dag_run_id_different_inputs_give_different_results():
+    result1 = OpenLineageAdapter.build_dag_run_id("dag1", "run1")
+    result2 = OpenLineageAdapter.build_dag_run_id("dag2", "run2")
+    assert result1 != result2
+
+
+def test_build_dag_run_id_uses_correct_methods_underneath():
+    dag_id = "test_dag"
+    dag_run_id = "run_1"
+    expected = str(uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}"))
+    actual = OpenLineageAdapter.build_dag_run_id(dag_id, dag_run_id)
+    assert actual == expected
+
+
+def test_build_task_instance_run_id_is_valid_uuid():
+    task_id = "task_1"
+    execution_date = "2023-01-01"
+    try_number = 1
+    result = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    assert uuid.UUID(result)
+
+
+def test_build_task_instance_run_id_different_inputs_gives_different_results():
+    result1 = OpenLineageAdapter.build_task_instance_run_id("task1", "2023-01-01", 1)
+    result2 = OpenLineageAdapter.build_task_instance_run_id("task2", "2023-01-02", 2)
+    assert result1 != result2
+
+
+def test_build_task_instance_run_id_uses_correct_methods_underneath():
+    task_id = "task_1"
+    execution_date = "2023-01-01"
+    try_number = 1
+    expected = str(
+        uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{task_id}.{execution_date}.{try_number}")
+    )
+    actual = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    assert actual == expected


### PR DESCRIPTION
### Problem
Starting from Airflow 2.6.0 FAIL event has different run_id than START event.

In Airflow 2.6 in this [PR](https://github.com/apache/airflow/pull/29289) there was a change regarding where the listener's `on_task_X` methods are called. As a result, the `on_task_failure` method is called before the `TaskIntstance.state` becomes FAILED and before the `try_number` is increased.

Here is [PR](https://github.com/apache/airflow/pull/36051) from OL provider package related to this issue (probably I will try to improve testing there in near future).

When building run_id for OL FAIL event [here](https://github.com/OpenLineage/OpenLineage/blob/8f473e9ea75fcab7517af4ecb4fe4bd716c1def1/integration/airflow/openlineage/airflow/listener.py#L188), we are subtracting 1 from `try_number` when we should take it as it is, starting from  Airflow version 2.6.0.

### Solution
To ensure compatibility across all supported Airflow versions, we should implement building run_id based on a `_try_number` (private) attribute of TaskInstance, which will remain unchanged regardless of the TaskInstance's state, leading to consistent run_ids for all task events.

I've also added integration tests that will verify if we receive exactly one START and one END (COMPLETE or FAIL) event for each run_id to make sure we can spot similar issues in the future . I've also added a DAG (`bash_dag`) in integration tests that will send both COMPLETE and FAIL events, and will run on all Airflow versions, to make sure there is at least one integration test always running and testing that test case.

#### One-line summary:
Run_id for FAIL event was different than in START event for Airflow 2.6+, this PR fixes it.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project