### PR TITLE
spec: fix inconsistency with redshift authority format

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -105,7 +105,7 @@ Identifier:
 
 - Namespace: redshift://{cluster_identifier}.{region_name}:{port} of the cluster instance.
   - Scheme = redshift
-  - Authority = {cluster_identifier}:{port}
+  - Authority = {cluster_identifier}.{region_name}:{port}
 - Unique name: {database}.{schema}.{table}
   - URI = redshift://{cluster_identifier}.{region_name}:{port}/{database}.{schema}.{table}
 


### PR DESCRIPTION
### Problem

The spec was a little inconsistent when discussing Redshift namespaces, with the "authority" format missing the region part that is included in other references in the same section.

### Solution

Amend the "authority" format accordingly.

#### One-line summary:

Fix inconsistency with redshift authority format

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project