### PR TITLE
airflow: Revert changes in Dockerfile from #2316 that broke the CI

### DIFF
--- a/integration/airflow/tests/integration/Dockerfile
+++ b/integration/airflow/tests/integration/Dockerfile
@@ -3,7 +3,7 @@ FROM $AIRFLOW_IMAGE AS airflow
 COPY integration/dbt /app/openlineage/integration/dbt
 COPY integration/common /app/openlineage/integration/common
 COPY integration/airflow /app/openlineage/integration/airflow
-COPY integration/sql/target /app/openlineage/integration/sql/target
+COPY integration/target /app/openlineage/integration/sql/target
 COPY client/python /app/openlineage/client/python
 USER root
 RUN mkdir -p /opt/data
@@ -34,7 +34,7 @@ RUN mkdir -p /app/openlineage
 RUN apt-get update && \
     apt-get install -y python3-dev default-libmysqlclient-dev build-essential pkg-config
 COPY integration/common /app/openlineage/integration/common
-COPY integration/sql/target /app/openlineage/integration/sql/target
+COPY integration/target /app/openlineage/integration/sql/target
 COPY integration/airflow /app/openlineage/integration/airflow
 COPY integration/airflow/integration-requirements.txt /app/openlineage/integration/integration-requirements.txt
 COPY client/python /app/openlineage/client/python


### PR DESCRIPTION
### Problem

PR #2316 broke the CI, this reverts some changes in Dockerfile that cause errors

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project