### PR TITLE
airflow: Add parent run facet to COMPLETE and FAIL events in Airflow integration

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -140,17 +140,19 @@ class OpenLineageAdapter:
         )
         if run_facets is None:
             run_facets = {}
+        if task:
+            run_facets = {**task.run_facets, **run_facets}
         run_facets["processing_engine"] = processing_engine_version_facet  # type: ignore
         event = RunEvent(
             eventType=RunState.START,
             eventTime=event_time,
             run=self._build_run(
-                run_id,
-                parent_job_name,
-                parent_run_id,
-                job_name,
-                nominal_start_time,
-                nominal_end_time,
+                run_id=run_id,
+                parent_job_name=parent_job_name,
+                parent_run_id=parent_run_id,
+                job_name=job_name,
+                nominal_start_time=nominal_start_time,
+                nominal_end_time=nominal_end_time,
                 run_facets=run_facets,
             ),
             job=self._build_job(
@@ -160,18 +162,29 @@ class OpenLineageAdapter:
                 owners=owners,
                 job_facets=task.job_facets if task else None,
             ),
-            inputs=task.inputs if task else None,
-            outputs=task.outputs if task else None,
+            inputs=task.inputs if task else [],
+            outputs=task.outputs if task else [],
             producer=_PRODUCER,
         )
         self.emit(event)
         return event.run.runId
 
-    def complete_task(self, run_id: str, job_name: str, end_time: str, task: TaskMetadata):
+    def complete_task(
+        self,
+        run_id: str,
+        parent_job_name: Optional[str],
+        parent_run_id: Optional[str],
+        job_name: str,
+        end_time: str,
+        task: TaskMetadata,
+    ):
         """
         Emits openlineage event of type COMPLETE
         :param run_id: globally unique identifier of task in dag run
         :param job_name: globally unique identifier of task between dags
+        :param parent_job_name: the name of the parent job (typically the DAG,
+                but possibly a task group)
+        :param parent_run_id: identifier of job spawning this task
         :param end_time: time of task completion
         :param task: metadata container with information extracted from operator
         """
@@ -179,7 +192,12 @@ class OpenLineageAdapter:
         event = RunEvent(
             eventType=RunState.COMPLETE,
             eventTime=end_time,
-            run=self._build_run(run_id, run_facets=task.run_facets),
+            run=self._build_run(
+                run_id=run_id,
+                parent_job_name=parent_job_name,
+                parent_run_id=parent_run_id,
+                run_facets=task.run_facets,
+            ),
             job=self._build_job(job_name, job_facets=task.job_facets),
             inputs=task.inputs,
             outputs=task.outputs,
@@ -187,19 +205,35 @@ class OpenLineageAdapter:
         )
         self.emit(event)
 
-    def fail_task(self, run_id: str, job_name: str, end_time: str, task: TaskMetadata):
+    def fail_task(
+        self,
+        run_id: str,
+        job_name: str,
+        parent_job_name: Optional[str],
+        parent_run_id: Optional[str],
+        end_time: str,
+        task: TaskMetadata,
+    ):
         """
         Emits openlineage event of type FAIL
         :param run_id: globally unique identifier of task in dag run
         :param job_name: globally unique identifier of task between dags
+        :param parent_job_name: the name of the parent job (typically the DAG,
+                but possibly a task group)
+        :param parent_run_id: identifier of job spawning this task
         :param end_time: time of task completion
         :param task: metadata container with information extracted from operator
         """
         event = RunEvent(
             eventType=RunState.FAIL,
             eventTime=end_time,
-            run=self._build_run(run_id, run_facets=task.run_facets),
-            job=self._build_job(job_name),
+            run=self._build_run(
+                run_id=run_id,
+                parent_job_name=parent_job_name,
+                parent_run_id=parent_run_id,
+                run_facets=task.run_facets,
+            ),
+            job=self._build_job(job_name, job_facets=task.job_facets),
             inputs=task.inputs,
             outputs=task.outputs,
             producer=_PRODUCER,

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -79,6 +79,8 @@ class Backend:
         self.adapter.complete_task(
             run_id=run_id,
             job_name=job_name,
+            parent_job_name=dag.dag_id,
+            parent_run_id=dag_run_id,
             end_time=DagUtils.to_iso_8601(self._now_ms()),
             task=task_metadata,
         )

--- a/integration/airflow/tests/integration/requests/failing/bash.json
+++ b/integration/airflow/tests/integration/requests/failing/bash.json
@@ -21,6 +21,20 @@
                 "taskInstance": {
                     "try_number": 1
                 }
+            },
+            "parent": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            },
+            "parentRun": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
             }
         }
     }
@@ -31,6 +45,24 @@
     "job": {
         "name": "bash_dag.failing_task",
         "namespace": "food_delivery"
+    },
+    "run": {
+        "facets": {
+            "parent": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            },
+            "parentRun": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            }
+        }
     },
     "outputs": []
 },
@@ -57,6 +89,20 @@
                 "taskInstance": {
                     "try_number": 1
                 }
+            },
+            "parent": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            },
+            "parentRun": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
             }
         }
     }
@@ -67,6 +113,24 @@
     "job": {
         "name": "bash_dag.success_task",
         "namespace": "food_delivery"
+    },
+        "run": {
+        "facets": {
+            "parent": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            },
+            "parentRun": {
+                "job": {
+                    "name": "bash_dag",
+                    "namespace": "food_delivery"
+                },
+                "run": {}
+            }
+        }
     },
     "outputs": []
 }]

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -148,12 +148,47 @@ def test_task_instance_try_number_property(state):
     assert ti._try_number == start_try_number
 
 
+@patch("copy.deepcopy")
+@patch("openlineage.airflow.listener.extractor_manager")
+@patch("openlineage.airflow.listener.task_holder")
+@patch("openlineage.airflow.listener.OpenLineageAdapter")
+def test_running_task_correctly_calls_adapter_build_dag_run_id_method(
+    mock_adapter, mock_task_holder, mock_extractor, mock_copy, task_instance
+):
+    mock_task_holder.set_task.return_value = None
+    mock_extractor.extract_metadata.return_value = OperatorLineage()
+    mock_copy.return_value = task_instance
+
+    on_task_instance_running(None, task_instance, None)
+    mock_adapter.build_dag_run_id.assert_called_with("dag_id", "dag_run_run_id")
+
+
+@patch("openlineage.airflow.listener.task_holder")
+@patch("openlineage.airflow.listener.OpenLineageAdapter")
+def test_failed_task_correctly_calls_adapter_build_dag_run_id_method(
+    mock_adapter, mock_task_holder, task_instance
+):
+    mock_task_holder.get_task.return_value = None
+    on_task_instance_failed(None, task_instance, None)
+    mock_adapter.build_dag_run_id.assert_called_with("dag_id", "dag_run_run_id")
+
+
+@patch("openlineage.airflow.listener.task_holder")
+@patch("openlineage.airflow.listener.OpenLineageAdapter")
+def test_successful_task_correctly_calls_adapter_build_dag_run_id_method(
+    mock_adapter, mock_task_holder, task_instance
+):
+    mock_task_holder.get_task.return_value = None
+    on_task_instance_success(None, task_instance, None)
+    mock_adapter.build_dag_run_id.assert_called_with("dag_id", "dag_run_run_id")
+
+
 @pytest.mark.parametrize("state", TaskInstanceState)
 @patch("copy.deepcopy")
 @patch("openlineage.airflow.listener.extractor_manager")
 @patch("openlineage.airflow.listener.task_holder")
 @patch("openlineage.airflow.listener.OpenLineageAdapter")
-def test_running_task_correctly_calls_adapter_run_id_method(
+def test_running_task_correctly_calls_adapter_build_ti_run_id_method(
     mock_adapter, mock_task_holder, mock_extractor, mock_copy, task_instance, state
 ):
     """Tests the OpenLineageListener's response when a task instance is in the running state.
@@ -176,7 +211,7 @@ def test_running_task_correctly_calls_adapter_run_id_method(
 @pytest.mark.parametrize("state", TaskInstanceState)
 @patch("openlineage.airflow.listener.task_holder")
 @patch("openlineage.airflow.listener.OpenLineageAdapter")
-def test_failed_task_correctly_calls_adapter_run_id_method(
+def test_failed_task_correctly_calls_adapter_build_ti_run_id_method(
     mock_adapter, mock_task_holder, task_instance, state
 ):
     mock_task_holder.get_task.return_value = None
@@ -191,7 +226,7 @@ def test_failed_task_correctly_calls_adapter_run_id_method(
 @pytest.mark.parametrize("state", TaskInstanceState)
 @patch("openlineage.airflow.listener.task_holder")
 @patch("openlineage.airflow.listener.OpenLineageAdapter")
-def test_successful_task_correctly_calls_adapter_run_id_method(
+def test_successful_task_correctly_calls_adapter_build_ti_run_id_method(
     mock_adapter, mock_task_holder, task_instance, state
 ):
     mock_task_holder.get_task.return_value = None

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -1,12 +1,26 @@
 # Copyright 2018-2023 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
+import datetime
+import datetime as dt
 import logging
 import os
 import uuid
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
-from openlineage.airflow.adapter import _DAG_NAMESPACE, OpenLineageAdapter
+from openlineage.airflow.adapter import _DAG_NAMESPACE, _PRODUCER, OpenLineageAdapter
+from openlineage.airflow.extractors import TaskMetadata
+from openlineage.client.facet import (
+    DocumentationJobFacet,
+    ExternalQueryRunFacet,
+    NominalTimeRunFacet,
+    OwnershipJobFacet,
+    OwnershipJobFacetOwners,
+    ParentRunFacet,
+    ProcessingEngineRunFacet,
+    SqlJobFacet,
+)
+from openlineage.client.run import Dataset, Job, Run, RunEvent, RunState
 
 
 @patch.dict(os.environ, {"MARQUEZ_URL": "http://marquez:5000", "MARQUEZ_API_KEY": "api-key"})
@@ -70,6 +84,302 @@ def test_openlineage_adapter_stats_emit_failed(
 
     mock_stats_timer.assert_called_with("ol.emit.attempts")
     mock_stats_incr.assert_has_calls([mock.call("ol.emit.failed")])
+
+
+def test_emit_start_event():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.start_task(
+        run_id=run_id,
+        job_name="job",
+        job_description="description",
+        event_time=event_time,
+        parent_job_name=None,
+        parent_run_id=None,
+        code_location=None,
+        nominal_start_time=datetime.datetime(2022, 1, 1).isoformat(),
+        nominal_end_time=datetime.datetime(2022, 1, 1).isoformat(),
+        owners=[],
+        task=None,
+        run_facets=None,
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.START,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={
+                    "nominalTime": NominalTimeRunFacet(
+                        nominalStartTime="2022-01-01T00:00:00",
+                        nominalEndTime="2022-01-01T00:00:00",
+                    ),
+                    "processing_engine": ProcessingEngineRunFacet(
+                        version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                    ),
+                },
+            ),
+            job=Job(
+                namespace="default",
+                name="job",
+                facets={"documentation": DocumentationJobFacet(description="description")},
+            ),
+            producer=_PRODUCER,
+            inputs=[],
+            outputs=[],
+        )
+    )
+
+
+def test_emit_start_event_with_additional_information():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = dt.datetime.now().isoformat()
+    adapter.start_task(
+        run_id=run_id,
+        job_name="job",
+        job_description="description",
+        event_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        code_location=None,
+        nominal_start_time=dt.datetime(2022, 1, 1).isoformat(),
+        nominal_end_time=dt.datetime(2022, 1, 1).isoformat(),
+        owners=["owner1", "owner2"],
+        task=TaskMetadata(
+            name="task_metadata",
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+            run_facets={"externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+        ),
+        run_facets={"externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source")},
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.START,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={
+                    "nominalTime": NominalTimeRunFacet(
+                        nominalStartTime="2022-01-01T00:00:00",
+                        nominalEndTime="2022-01-01T00:00:00",
+                    ),
+                    "processing_engine": ProcessingEngineRunFacet(
+                        version=ANY, name="Airflow", openlineageAdapterVersion=ANY
+                    ),
+                    "parent": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "parentRun": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                    "externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source"),
+                },
+            ),
+            job=Job(
+                namespace="default",
+                name="job",
+                facets={
+                    "documentation": DocumentationJobFacet(description="description"),
+                    "ownership": OwnershipJobFacet(
+                        owners=[
+                            OwnershipJobFacetOwners(name="owner1", type=None),
+                            OwnershipJobFacetOwners(name="owner2", type=None),
+                        ]
+                    ),
+                    "sql": SqlJobFacet(query="SELECT 1;"),
+                },
+            ),
+            producer=_PRODUCER,
+            inputs=[
+                Dataset(namespace="bigquery", name="a.b.c"),
+                Dataset(namespace="bigquery", name="x.y.z"),
+            ],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+        )
+    )
+
+
+def test_emit_complete_event():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.complete_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name=None,
+        parent_run_id=None,
+        job_name="job",
+        task=TaskMetadata(name="task_metadata"),
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.COMPLETE,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={},
+            ),
+            job=Job(
+                namespace="default",
+                name="job",
+                facets={},
+            ),
+            producer=_PRODUCER,
+            inputs=[],
+            outputs=[],
+        )
+    )
+
+
+def test_emit_complete_event_with_additional_information():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = dt.datetime.now().isoformat()
+    adapter.complete_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        job_name="job",
+        task=TaskMetadata(
+            name="task_metadata",
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+            run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+        ),
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.COMPLETE,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={
+                    "parent": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "parentRun": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                },
+            ),
+            job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+            producer=_PRODUCER,
+            inputs=[
+                Dataset(namespace="bigquery", name="a.b.c"),
+                Dataset(namespace="bigquery", name="x.y.z"),
+            ],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+        )
+    )
+
+
+def test_emit_fail_event():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = datetime.datetime.now().isoformat()
+    adapter.fail_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name=None,
+        parent_run_id=None,
+        job_name="job",
+        task=TaskMetadata(name="task_metadata"),
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.FAIL,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={},
+            ),
+            job=Job(
+                namespace="default",
+                name="job",
+                facets={},
+            ),
+            producer=_PRODUCER,
+            inputs=[],
+            outputs=[],
+        )
+    )
+
+
+def test_emit_fail_event_with_additional_information():
+    adapter = OpenLineageAdapter()
+    adapter.emit = mock.Mock()
+
+    run_id = str(uuid.uuid4())
+    event_time = dt.datetime.now().isoformat()
+    adapter.fail_task(
+        run_id=run_id,
+        end_time=event_time,
+        parent_job_name="parent_job_name",
+        parent_run_id="parent_run_id",
+        job_name="job",
+        task=TaskMetadata(
+            name="task_metadata",
+            inputs=[Dataset(namespace="bigquery", name="a.b.c"), Dataset(namespace="bigquery", name="x.y.z")],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+            job_facets={"sql": SqlJobFacet(query="SELECT 1;")},
+            run_facets={"externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source")},
+        ),
+    )
+
+    adapter.emit.assert_called_once_with(
+        RunEvent(
+            eventType=RunState.FAIL,
+            eventTime=event_time,
+            run=Run(
+                runId=run_id,
+                facets={
+                    "parent": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "parentRun": ParentRunFacet(
+                        run={"runId": "parent_run_id"},
+                        job={"namespace": "default", "name": "parent_job_name"},
+                    ),
+                    "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
+                },
+            ),
+            job=Job(namespace="default", name="job", facets={"sql": SqlJobFacet(query="SELECT 1;")}),
+            producer=_PRODUCER,
+            inputs=[
+                Dataset(namespace="bigquery", name="a.b.c"),
+                Dataset(namespace="bigquery", name="x.y.z"),
+            ],
+            outputs=[Dataset(namespace="gs://bucket", name="exported_folder")],
+        )
+    )
 
 
 def test_build_dag_run_id_is_valid_uuid():


### PR DESCRIPTION
### Problem

Occasionally, due to custom queue logic on their side, consumers may receive COMPLETE/FAIL events before a START event. Identifying the parent event requires waiting for the START event, which includes the parent run facet, to match it with other events using their run_id.

### Solution

Introduce a parent run facet to all events, enabling clear association of each event with its corresponding parent run.

Also added some smaller tweaks, with no changes in logic of the whole process. 

#### One-line summary:
Add parent run facet to all events in Airflow integration.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project