### PR TITLE
[FLINK] stick to dataset naming convention for kafka topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   *Fix potential NullPointerException in 1.17 when dealing with Iceberg sinks.*
 * **Spark: Fix `commons-logging` relocate in target jar.** [`#2319`](https://github.com/OpenLineage/OpenLineage/pull/2319) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
     *Avoid relocating dependency which gets excluded from the jar.*
+* **Flink: Name kafka datasets according to the naming convention.** [`#2321`](https://github.com/OpenLineage/OpenLineage/pull/2321) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Add `kafka://` prefix to kafka topic datasets namespaces.*
 
 ## [1.6.2](https://github.com/OpenLineage/OpenLineage/compare/1.5.0...1.6.2) - 2023-12-07
 ### Added

--- a/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
@@ -6,6 +6,7 @@
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 
 public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
   private final OpenLineage openLineage;
@@ -43,6 +44,10 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
 
   public OpenLineage.DatasetFacetsBuilder getDatasetFacetsBuilder() {
     return openLineage.newDatasetFacetsBuilder();
+  }
+
+  public D getDataset(DatasetIdentifier di, OpenLineage.DatasetFacetsBuilder facetsBuilder) {
+    return getDataset(di.getName(), di.getNamespace(), facetsBuilder.build());
   }
 
   public D getDataset(

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2023 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.flink.utils;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.util.Properties;
+
+public class KafkaUtils {
+
+  private static final String KAFKA_DATASET_PREFIX = "kafka://";
+
+  /**
+   * Generate dataset identifier based on bootstrap servers in properties and topic name
+   *
+   * @param properties
+   * @param topic
+   * @return
+   */
+  public static DatasetIdentifier datasetIdentifierOf(Properties properties, String topic) {
+    String bootstrapServers = properties.getProperty("bootstrap.servers");
+
+    return new DatasetIdentifier(topic, String.format(KAFKA_DATASET_PREFIX + bootstrapServers));
+  }
+}

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
@@ -6,12 +6,13 @@
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.utils.AvroSchemaUtils;
+import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.flink.visitor.wrapper.FlinkKafkaConsumerWrapper;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -33,26 +34,25 @@ public class FlinkKafkaConsumerVisitor extends Visitor<OpenLineage.InputDataset>
   public List<OpenLineage.InputDataset> apply(Object object) {
     try {
       FlinkKafkaConsumerWrapper wrapper = FlinkKafkaConsumerWrapper.of((FlinkKafkaConsumer) object);
-      Properties properties = wrapper.getKafkaProperties();
-      String bootstrapServers = properties.getProperty("bootstrap.servers");
 
       OpenLineage openLineage = context.getOpenLineage();
       return wrapper.getTopics().stream()
           .map(
               topic -> {
-                OpenLineage.InputDatasetBuilder builder =
-                    openLineage.newInputDatasetBuilder().namespace(bootstrapServers).name(topic);
+                DatasetIdentifier di =
+                    KafkaUtils.datasetIdentifierOf(wrapper.getKafkaProperties(), topic);
 
-                OpenLineage.DatasetFacetsBuilder facetsBuilder =
-                    openLineage.newDatasetFacetsBuilder();
+                OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
+                    inputDataset().getDatasetFacetsBuilder();
 
                 wrapper
                     .getAvroSchema()
                     .ifPresent(
                         schema ->
-                            facetsBuilder.schema(AvroSchemaUtils.convert(openLineage, schema)));
+                            datasetFacetsBuilder.schema(
+                                AvroSchemaUtils.convert(openLineage, schema)));
 
-                return builder.facets(facetsBuilder.build()).build();
+                return inputDataset().getDataset(di, datasetFacetsBuilder);
               })
           .collect(Collectors.toList());
     } catch (IllegalAccessException e) {

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
@@ -6,12 +6,13 @@
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.utils.AvroSchemaUtils;
+import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.flink.visitor.wrapper.FlinkKafkaProducerWrapper;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
@@ -31,9 +32,9 @@ public class FlinkKafkaProducerVisitor extends Visitor<OpenLineage.OutputDataset
   public List<OpenLineage.OutputDataset> apply(Object flinkKafkaProducer) {
     FlinkKafkaProducerWrapper wrapper =
         FlinkKafkaProducerWrapper.of((FlinkKafkaProducer) flinkKafkaProducer);
-    Properties properties = wrapper.getKafkaProducerConfig();
-    String bootstrapServers = properties.getProperty("bootstrap.servers");
-    String topic = wrapper.getKafkaTopic();
+
+    DatasetIdentifier di =
+        KafkaUtils.datasetIdentifierOf(wrapper.getKafkaProducerConfig(), wrapper.getKafkaTopic());
 
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         outputDataset().getDatasetFacetsBuilder();
@@ -45,9 +46,8 @@ public class FlinkKafkaProducerVisitor extends Visitor<OpenLineage.OutputDataset
                 datasetFacetsBuilder.schema(
                     AvroSchemaUtils.convert(context.getOpenLineage(), schema)));
 
-    log.debug("Kafka output topic: {}", topic);
+    log.debug("Kafka output topic: {}", di.getName());
 
-    return Collections.singletonList(
-        outputDataset().getDataset(topic, bootstrapServers, datasetFacetsBuilder));
+    return Collections.singletonList(outputDataset().getDataset(di, datasetFacetsBuilder));
   }
 }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -6,12 +6,13 @@
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.utils.AvroSchemaUtils;
+import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.flink.visitor.wrapper.KafkaSinkWrapper;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
@@ -32,9 +33,8 @@ public class KafkaSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
   public List<OpenLineage.OutputDataset> apply(Object kafkaSink) {
     KafkaSinkWrapper wrapper = KafkaSinkWrapper.of((KafkaSink) kafkaSink);
     try {
-      Properties properties = wrapper.getKafkaProducerConfig();
-      String bootstrapServers = properties.getProperty("bootstrap.servers");
-      String topic = wrapper.getKafkaTopic();
+      DatasetIdentifier di =
+          KafkaUtils.datasetIdentifierOf(wrapper.getKafkaProducerConfig(), wrapper.getKafkaTopic());
 
       OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
           outputDataset().getDatasetFacetsBuilder();
@@ -46,10 +46,9 @@ public class KafkaSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
                   datasetFacetsBuilder.schema(
                       AvroSchemaUtils.convert(context.getOpenLineage(), schema)));
 
-      log.debug("Kafka output topic: {}", topic);
+      log.debug("Kafka output topic: {}", di.getName());
 
-      return Collections.singletonList(
-          outputDataset().getDataset(topic, bootstrapServers, datasetFacetsBuilder));
+      return Collections.singletonList(outputDataset().getDataset(di, datasetFacetsBuilder));
     } catch (IllegalAccessException e) {
       log.error("Can't access the field. ", e);
     }

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -6,8 +6,10 @@
 package io.openlineage.flink.visitor;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.utils.AvroSchemaUtils;
+import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.flink.visitor.wrapper.KafkaSourceWrapper;
 import java.util.Collections;
 import java.util.List;
@@ -35,12 +37,13 @@ public class KafkaSourceVisitor extends Visitor<OpenLineage.InputDataset> {
       KafkaSourceWrapper wrapper = KafkaSourceWrapper.of((KafkaSource<?>) kafkaSource);
       List<String> topics = wrapper.getTopics();
       Properties properties = wrapper.getProps();
-      String bootstrapServers = properties.getProperty("bootstrap.servers");
 
       topics.forEach(topic -> log.debug("Kafka input topic: {}", topic));
       return topics.stream()
           .map(
               topic -> {
+                DatasetIdentifier di = KafkaUtils.datasetIdentifierOf(properties, topic);
+
                 OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
                     inputDataset().getDatasetFacetsBuilder();
                 // The issue here is that we assign dataset a schema that we're trying to read with.
@@ -51,7 +54,7 @@ public class KafkaSourceVisitor extends Visitor<OpenLineage.InputDataset> {
                         schema ->
                             datasetFacetsBuilder.schema(
                                 AvroSchemaUtils.convert(context.getOpenLineage(), schema)));
-                return inputDataset().getDataset(topic, bootstrapServers, datasetFacetsBuilder);
+                return inputDataset().getDataset(di, datasetFacetsBuilder);
               })
           .collect(Collectors.toList());
     } catch (IllegalAccessException e) {

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
@@ -79,7 +79,7 @@ class FlinkKafkaConsumerVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
@@ -78,7 +78,7 @@ class FlinkKafkaProducerVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -74,7 +74,7 @@ class KafkaSinkVisitorTest {
           outputDataset.getFacets().getSchema().getFields();
 
       assertEquals("topic", outputDataset.getName());
-      assertEquals("server1;server2", outputDataset.getNamespace());
+      assertEquals("kafka://server1;server2", outputDataset.getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
@@ -77,7 +77,7 @@ class KafkaSourceVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/src/test/resources/events/expected_flink_conf.json
+++ b/integration/flink/src/test/resources/events/expected_flink_conf.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -28,7 +28,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -48,7 +48,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_kafka.json
+++ b/integration/flink/src/test/resources/events/expected_kafka.json
@@ -16,7 +16,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -34,7 +34,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -54,7 +54,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_kafka_checkpoints.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_checkpoints.json
@@ -19,7 +19,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -57,7 +57,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_kafka_generic_record.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_generic_record.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input_no_schema_registry",
       "facets": {
         "schema": {
@@ -30,7 +30,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -28,7 +28,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -48,7 +48,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
@@ -19,7 +19,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -57,7 +57,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_legacy_kafka.json
+++ b/integration/flink/src/test/resources/events/expected_legacy_kafka.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -44,7 +44,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
+++ b/integration/flink/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -44,7 +44,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka:9092",
+      "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {


### PR DESCRIPTION
### Problem

[Naming convention for Kafka](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md#kafka) datasets assumes `kafka://` prefix which is currently missing within Flink integration. 

### Solution

* include prefix
* modify tests

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project