### PR TITLE
[SPARK] fix unit tests in CI

### DIFF
--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -127,6 +127,9 @@ compileJava {
 test {
     mustRunAfter shadowJar
     configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
 }
 
 assemble {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap$;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.apache.spark.sql.types.IntegerType$;
@@ -28,6 +29,7 @@ import org.apache.spark.sql.types.Metadata$;
 import org.apache.spark.sql.types.StringType$;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import scala.collection.immutable.Map$;
 
 public class JdbcColumnLineageExpressionCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
@@ -54,6 +56,10 @@ public class JdbcColumnLineageExpressionCollectorTest {
   @BeforeEach
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
+
+    scala.collection.immutable.Map<String, String> properties = Map$.MODULE$.empty();
+    when(jdbcOptions.parameters())
+        .thenReturn(CaseInsensitiveMap$.MODULE$.<String>apply(properties));
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
@@ -20,10 +20,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap$;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import scala.collection.immutable.Map$;
 
 public class JdbcColumnLineageInputCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
@@ -32,8 +34,8 @@ public class JdbcColumnLineageInputCollectorTest {
   String jdbcQuery =
       "(select js1.k, CONCAT(js1.j1, js2.j2) as j from jdbc_source1 js1 join jdbc_source2 js2 on js1.k = js2.k) SPARK_GEN_SUBQ_0";
   String invalidJdbcQuery = "(INVALID) SPARK_GEN_SUBQ_0";
-  DatasetIdentifier datasetIdentifier1 = new DatasetIdentifier("jdbc_source1", "jdbc");
-  DatasetIdentifier datasetIdentifier2 = new DatasetIdentifier("jdbc_source2", "jdbc");
+  DatasetIdentifier datasetIdentifier1 = new DatasetIdentifier("test.jdbc_source1", "jdbc");
+  DatasetIdentifier datasetIdentifier2 = new DatasetIdentifier("test.jdbc_source2", "jdbc");
   String url = "jdbc:postgresql://localhost:5432/test";
 
   static ExprId exprId1 = ExprId.apply(1);
@@ -55,6 +57,10 @@ public class JdbcColumnLineageInputCollectorTest {
   @BeforeEach
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
+
+    scala.collection.immutable.Map<String, String> properties = Map$.MODULE$.empty();
+    when(jdbcOptions.parameters())
+        .thenReturn(CaseInsensitiveMap$.MODULE$.<String>apply(properties));
   }
 
   @Test

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -121,6 +121,9 @@ compileJava {
 test {
     mustRunAfter shadowJar
     configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
 }
 
 assemble {

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -116,6 +116,9 @@ def commonTestConfiguration = {
 test {
     dependsOn shadowJar
     configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
 }
 
 assemble {

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -126,6 +126,9 @@ def commonTestConfiguration = {
 test {
     dependsOn shadowJar
     configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
 }
 
 compileTestJava {

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -118,6 +118,9 @@ def commonTestConfiguration = {
 test {
     dependsOn shadowJar
     configure commonTestConfiguration
+    useJUnitPlatform {
+        excludeTags 'integration-test'
+    }
 }
 
 assemble {


### PR DESCRIPTION
### Problem

Unit tests were not properly run after upgrading Jackson in https://github.com/OpenLineage/OpenLineage/pull/2233


### Solution

make sure command ` ./gradlew clean :spark32:test` runs unit tests. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project