### PR TITLE
[SQL] fix rust code due to failing CI

### DIFF
--- a/integration/sql/impl/tests/table_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_cte.rs
@@ -47,7 +47,7 @@ fn parse_bugged_cte() {
     let meta = parse_sql(sql, &PostgreSqlDialect {}, None).unwrap();
     assert_eq!(meta.errors.len(), 1);
     assert_eq!(
-        meta.errors.get(0).unwrap(),
+        meta.errors.first().unwrap(),
         &ExtractionError {
             index: 0,
             message: "Expected ), found: user_id".to_string(),


### PR DESCRIPTION
### Problem

CI is failing (like [here](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/8741/workflows/7c5d213e-23bb-4c53-9a95-6dd422655498)

due to:

```
error: accessing first element with `meta.errors.get(0)`
  --> impl/tests/table_lineage/tests_cte.rs:50:9
   |
50 |         meta.errors.get(0).unwrap(),
   |         ^^^^^^^^^^^^^^^^^^ help: try: `meta.errors.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
   = note: `-D clippy::get-first` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::get_first)]`
```
 

### Solution

Do what rust is asking for.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project