### PR TITLE
CI: Fix pre commit config to use current year.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
           - --license-filepath
           - .pre_commit/license-python.txt
           - --fuzzy-match-generates-todo
+          - --use-current-year
       - id: insert-license
         name: Add license for all Java files
         files: \.java$
@@ -20,6 +21,7 @@ repos:
           - --license-filepath
           - .pre_commit/license-java.txt
           - --fuzzy-match-generates-todo
+          - --use-current-year
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -48,17 +50,6 @@ repos:
       - id: ruff-format
         name: ruff-format
         files: ^client/python/|^dev/|^integration/airflow/|^integration/common/|^integration/dagster/|^integration/dbt/|^integration/spark/|^integration/sql/
-  - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
-    hooks:
-      - id: insert-license
-        files: ^client/python/.*\.py$
-        args:
-          - --detect-license-in-X-top-lines=2
-          - --license-filepath
-          - LICENSE.insert.txt
-          - --use-current-year
-          - --no-extra-eol
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"
     hooks:

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/SchemaParser.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/TypeResolver.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/ConfigPathProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/ConfigPathProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/DefaultConfigPathProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/DefaultConfigPathProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/Environment.java
+++ b/client/java/src/main/java/io/openlineage/client/Environment.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientException.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientException.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageYaml.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageYaml.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/ApiKeyTokenProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ApiKeyTokenProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/FacetsConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FacetsConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/FileConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TokenProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TokenProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportConfigTypeIdResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportConfigTypeIdResolver.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportResolver.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/Events.java
+++ b/client/java/src/test/java/io/openlineage/client/Events.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/transports/FileTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/FileTransportTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KinesisTransportTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/transports/TransportFactoryTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/TransportFactoryTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/java/src/test/java/io/openlineage/client/utils/DatasetIdentifierUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/DatasetIdentifierUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/constants.py
+++ b/client/python/openlineage/client/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from typing import Any, ClassVar, Dict, List, Optional

--- a/client/python/openlineage/client/filter.py
+++ b/client/python/openlineage/client/filter.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 import uuid
 from enum import Enum

--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 """
 To implement custom Transport implement Config and Transport classes.

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/__init__.py
+++ b/client/python/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/client/python/tests/conftest.py
+++ b/client/python/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_file.py
+++ b/client/python/tests/test_file.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import json

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/client/python/tests/transport.py
+++ b/client/python/tests/transport.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/dev/create_release_doc.py
+++ b/dev/create_release_doc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import rich_click as click

--- a/dev/get_changes.py
+++ b/dev/get_changes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import date

--- a/dev/get_contributor_stats.py
+++ b/dev/get_contributor_stats.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import csv

--- a/integration/airflow/openlineage/airflow/__init__.py
+++ b/integration/airflow/openlineage/airflow/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 #

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/openlineage/airflow/extractors/__init__.py
+++ b/integration/airflow/openlineage/airflow/extractors/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata

--- a/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import traceback

--- a/integration/airflow/openlineage/airflow/extractors/converters.py
+++ b/integration/airflow/openlineage/airflow/extractors/converters.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional, Tuple, cast

--- a/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbapi_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/openlineage/airflow/extractors/dbt_cloud_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/dbt_cloud_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio

--- a/integration/airflow/openlineage/airflow/extractors/example_dag.py
+++ b/integration/airflow/openlineage/airflow/extractors/example_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/openlineage/airflow/extractors/extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/openlineage/airflow/extractors/ftp_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/ftp_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import socket

--- a/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/gcs_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/great_expectations_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/mysql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List

--- a/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/postgres_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect

--- a/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_sql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, List

--- a/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/s3_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/sagemaker_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sagemaker_extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional

--- a/integration/airflow/openlineage/airflow/extractors/sftp_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sftp_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import socket

--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, List, Mapping, Optional

--- a/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_check_extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/integration/airflow/openlineage/airflow/extractors/sql_execute_query.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_execute_query.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 sql_extractors = {

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import abstractmethod

--- a/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/trino_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import ClassVar, Dict, List

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/integration/airflow/openlineage/airflow/version.py
+++ b/integration/airflow/openlineage/airflow/version.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 __version__ = "1.8.0"

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/setup.py
+++ b/integration/airflow/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/integration/airflow/tests/__init__.py
+++ b/integration/airflow/tests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/extractors/__init__.py
+++ b/integration/airflow/tests/extractors/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 

--- a/integration/airflow/tests/extractors/test_athena_extractor.py
+++ b/integration/airflow/tests/extractors/test_athena_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/extractors/test_base.py
+++ b/integration/airflow/tests/extractors/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from urllib.parse import parse_qs, urlparse

--- a/integration/airflow/tests/extractors/test_bash_extractor.py
+++ b/integration/airflow/tests/extractors/test_bash_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/extractors/test_converters.py
+++ b/integration/airflow/tests/extractors/test_converters.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/integration/airflow/tests/extractors/test_dbapi_utils.py
+++ b/integration/airflow/tests/extractors/test_dbapi_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest.mock import MagicMock

--- a/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
+++ b/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/extractors/test_default_extractor.py
+++ b/integration/airflow/tests/extractors/test_default_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/integration/airflow/tests/extractors/test_extractor_manager.py
+++ b/integration/airflow/tests/extractors/test_extractor_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, List, Optional

--- a/integration/airflow/tests/extractors/test_extractors.py
+++ b/integration/airflow/tests/extractors/test_extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/extractors/test_ftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_ftp_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import socket

--- a/integration/airflow/tests/extractors/test_gcs_extractor.py
+++ b/integration/airflow/tests/extractors/test_gcs_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/extractors/test_mysql_extractor.py
+++ b/integration/airflow/tests/extractors/test_mysql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock

--- a/integration/airflow/tests/extractors/test_postgres_extractor.py
+++ b/integration/airflow/tests/extractors/test_postgres_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock

--- a/integration/airflow/tests/extractors/test_python_extractor.py
+++ b/integration/airflow/tests/extractors/test_python_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_sql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock

--- a/integration/airflow/tests/extractors/test_s3_extractor.py
+++ b/integration/airflow/tests/extractors/test_s3_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/extractors/test_sagemaker_extractors.py
+++ b/integration/airflow/tests/extractors/test_sagemaker_extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/extractors/test_sftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_sftp_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import socket

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock

--- a/integration/airflow/tests/extractors/test_sql_check_extractors.py
+++ b/integration/airflow/tests/extractors/test_sql_check_extractors.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.airflow.extractors.postgres_extractor import PostgresExtractor

--- a/integration/airflow/tests/extractors/test_sql_extractor.py
+++ b/integration/airflow/tests/extractors/test_sql_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.airflow.extractors.sql_extractor import SqlExtractor

--- a/integration/airflow/tests/extractors/test_trino_extractor.py
+++ b/integration/airflow/tests/extractors/test_trino_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import mock

--- a/integration/airflow/tests/integration/__init__.py
+++ b/integration/airflow/tests/integration/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 

--- a/integration/airflow/tests/integration/failures/airflow/__init__.py
+++ b/integration/airflow/tests/integration/failures/airflow/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/airflow/tests/integration/failures/airflow/dags/__init__.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from time import sleep

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/integration/failures/airflow/dags/run_test_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/run_test_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/failures/airflow/dags/wait_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/wait_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/server/app.py
+++ b/integration/airflow/tests/integration/server/app.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/integration/test_failure.py
+++ b/integration/airflow/tests/integration/test_failure.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/integration/tests/airflow/__init__.py
+++ b/integration/airflow/tests/integration/tests/airflow/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/airflow/tests/integration/tests/airflow/config/__init__.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/airflow/tests/integration/tests/airflow/config/log_config.py
+++ b/integration/airflow/tests/integration/tests/airflow/config/log_config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy

--- a/integration/airflow/tests/integration/tests/airflow/dags/__init__.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 

--- a/integration/airflow/tests/integration/tests/airflow/dags/async_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/async_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import timedelta

--- a/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/athena_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/integration/tests/airflow/dags/bash_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/bash_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from airflow import DAG

--- a/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional, Union

--- a/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/custom_extractor_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/integration/tests/airflow/dags/dag_event_order.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dag_event_order.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/dbt_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dbt_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/dynamic_task_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime

--- a/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from openlineage.client import set_producer
 from pkg_resources import parse_version

--- a/integration/airflow/tests/integration/tests/airflow/dags/ftp_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/ftp_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from airflow import DAG

--- a/integration/airflow/tests/integration/tests/airflow/dags/gcs_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/gcs_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 import os
 from urllib.parse import urlparse

--- a/integration/airflow/tests/integration/tests/airflow/dags/greatexpectations_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/greatexpectations_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from great_expectations_provider.operators.great_expectations import (

--- a/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/mysql_orders_popular_day_of_week.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/redshift_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/redshift_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3copy_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from airflow import DAG

--- a/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/s3transform_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from airflow import DAG

--- a/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/secrets.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/integration/tests/airflow/dags/sftp_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/sftp_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from airflow import DAG

--- a/integration/airflow/tests/integration/tests/airflow/dags/snowflake_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/snowflake_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/source_extractor_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/source_extractor_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/task_group_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/task_group_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/airflow/tests/integration/tests/airflow/dags/trino_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/trino_orders_popular_day_of_week.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer

--- a/integration/airflow/tests/integration/tests/airflow/dags/unknown_operator_dag.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/unknown_operator_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/integration/airflow/tests/log_config.py
+++ b/integration/airflow/tests/log_config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy

--- a/integration/airflow/tests/mocks/__init__.py
+++ b/integration/airflow/tests/mocks/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/airflow/tests/mocks/git_mock.py
+++ b/integration/airflow/tests/mocks/git_mock.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/test_dags/test_dummy_dag.py
+++ b/integration/airflow/tests/test_dags/test_dummy_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime as dt

--- a/integration/airflow/tests/test_location.py
+++ b/integration/airflow/tests/test_location.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 import datetime
 import datetime as dt

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/integration/common/openlineage/common/__init__.py
+++ b/integration/common/openlineage/common/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 __version__ = "1.8.0"

--- a/integration/common/openlineage/common/dataset.py
+++ b/integration/common/openlineage/common/dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import ClassVar, Dict, List, Optional

--- a/integration/common/openlineage/common/models.py
+++ b/integration/common/openlineage/common/models.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, ClassVar, List, Optional

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/openlineage/common/provider/dbt/__init__.py
+++ b/integration/common/openlineage/common/provider/dbt/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.provider.dbt.cloud import DbtCloudArtifactProcessor

--- a/integration/common/openlineage/common/provider/dbt/cloud.py
+++ b/integration/common/openlineage/common/provider/dbt/cloud.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/common/openlineage/common/provider/dbt/local.py
+++ b/integration/common/openlineage/common/provider/dbt/local.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import collections

--- a/integration/common/openlineage/common/provider/great_expectations/__init__.py
+++ b/integration/common/openlineage/common/provider/great_expectations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.provider.great_expectations.action import (

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/integration/common/openlineage/common/provider/great_expectations/facets.py
+++ b/integration/common/openlineage/common/provider/great_expectations/facets.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, List, Optional, Union

--- a/integration/common/openlineage/common/provider/great_expectations/results.py
+++ b/integration/common/openlineage/common/provider/great_expectations/results.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Optional

--- a/integration/common/openlineage/common/provider/redshift_data.py
+++ b/integration/common/openlineage/common/provider/redshift_data.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/common/openlineage/common/provider/snowflake.py
+++ b/integration/common/openlineage/common/provider/snowflake.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from urllib.parse import quote, urlparse, urlunparse

--- a/integration/common/openlineage/common/schema/__init__.py
+++ b/integration/common/openlineage/common/schema/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 GITHUB_LOCATION = (

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Optional

--- a/integration/common/script/match.py
+++ b/integration/common/script/match.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/setup.py
+++ b/integration/common/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/integration/common/tests/bigquery/test_bigquery.py
+++ b/integration/common/tests/bigquery/test_bigquery.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
+++ b/integration/common/tests/great_expectations/test_great_expectations_validation_action.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/integration/common/tests/redshift_data/test_redshift_data.py
+++ b/integration/common/tests/redshift_data/test_redshift_data.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/common/tests/sql/test_column.py
+++ b/integration/common/tests/sql/test_column.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.sql import ColumnLineage, ColumnMeta, DbTableMeta, parse

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/common/tests/sql/test_tpcds.py
+++ b/integration/common/tests/sql/test_tpcds.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.sql import DbTableMeta, parse

--- a/integration/common/tests/test_dataset.py
+++ b/integration/common/tests/test_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/integration/common/tests/test_models.py
+++ b/integration/common/tests/test_models.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.sql import DbTableMeta

--- a/integration/common/tests/test_snowflake.py
+++ b/integration/common/tests/test_snowflake.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/integration/common/tests/test_utils.py
+++ b/integration/common/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.common.utils import get_from_nullable_chain, parse_single_arg

--- a/integration/dagster/openlineage/dagster/__init__.py
+++ b/integration/dagster/openlineage/dagster/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 __version__ = "1.8.0"

--- a/integration/dagster/openlineage/dagster/adapter.py
+++ b/integration/dagster/openlineage/dagster/adapter.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/dagster/openlineage/dagster/cursor.py
+++ b/integration/dagster/openlineage/dagster/cursor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/dagster/openlineage/dagster/sensor.py
+++ b/integration/dagster/openlineage/dagster/sensor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid

--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/integration/dagster/tests/__init__.py
+++ b/integration/dagster/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import time

--- a/integration/dagster/tests/test_adapter_client.py
+++ b/integration/dagster/tests/test_adapter_client.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/dagster/tests/test_adapter_pipeline.py
+++ b/integration/dagster/tests/test_adapter_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import time

--- a/integration/dagster/tests/test_adapter_step.py
+++ b/integration/dagster/tests/test_adapter_step.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import time

--- a/integration/dagster/tests/test_sensor_cursor.py
+++ b/integration/dagster/tests/test_sensor_cursor.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/integration/dagster/tests/test_sensor_evaluation.py
+++ b/integration/dagster/tests/test_sensor_evaluation.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import tempfile

--- a/integration/dagster/tests/test_utils.py
+++ b/integration/dagster/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid

--- a/integration/dbt/setup.py
+++ b/integration/dbt/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 #
 # -*- coding: utf-8 -*-

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/cassandra/Event.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/cassandra/Event.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/common/config/ConfigWrapper.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/common/config/ConfigWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCassandraApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCassandraApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkCrashingLineageProviderApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFailedApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkFakeApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergSourceApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkIcebergSourceApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStatefulApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStatefulApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStoppableApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStoppableApplication.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulCounter.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulCounter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StreamEnvironment.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/util/OpenLineageFlinkJobListenerBuilder.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/util/OpenLineageFlinkJobListenerBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/util/StateUtils.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/util/StateUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/SinkLineage.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/DatasetFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/api/LineageProvider.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/LineageProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/client/CheckpointFacet.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/client/CheckpointFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/client/EventEmitter.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/client/EventEmitter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/Checkpoints.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/Checkpoints.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/CheckpointsCounts.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/tracker/restapi/CheckpointsCounts.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/CassandraUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/CassandraUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/JobTypeUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/JobTypeUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 package io.openlineage.flink.utils;

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/CassandraSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/CassandraSinkVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/CassandraSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/CassandraSourceVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSinkVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/IcebergSourceVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/LineageProviderVisitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/LineageProviderVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/Visitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/ExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/AvroUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/AvroUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/CassandraSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/CassandraSinkWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/CassandraSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/CassandraSourceWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/FlinkKafkaConsumerWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/FlinkKafkaConsumerWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/FlinkKafkaProducerWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/FlinkKafkaProducerWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSinkWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSourceWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/WrapperUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerFailureTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/JobListenerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/pojo/Event.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/pojo/Event.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/tracker/OpenLineageContinousJobTrackerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/CassandraSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/CassandraSinkVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/CassandraSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/CassandraSourceVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/ExampleLineageProvider.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/ExampleLineageProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSinkVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/IcebergSourceVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/WrapperUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/UrlParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/UrlParser.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark2DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark2VisitorFactoryImpl.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark2VisitorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32VisitorFactoryImpl.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32VisitorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark33DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/VisitorFactoryProvider.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/VisitorFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive2Test.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive2Test.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive3Test.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive3Test.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreTestUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MockServerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MockServerUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkOpenLineageFailuresTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkOpenLineageFailuresTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageDeltaTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageDeltaTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageHiveTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageHiveTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageTestUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/ClusterLogConf.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/ClusterLogConf.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/CreateCluster.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/CreateCluster.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/InitScript.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/InitScript.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/WorkspaceDestination.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/databricks/WorkspaceDestination.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactoryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkEventFilterTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkReadWriteIntegTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/VisitorFactoryProviderTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/VisitorFactoryProviderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JDBCRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JDBCRelationVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/LastQueryExecutionSparkEventListener.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/LastQueryExecutionSparkEventListener.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/TestOpenLineageEventHandlerFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/TestOpenLineageEventHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/app/src/test/resources/databricks_notebooks/ctas.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/ctas.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/databricks_notebooks/dataset_names.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/dataset_names.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/databricks_notebooks/narrow_transformation.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/narrow_transformation.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/databricks_notebooks/wide_transformation.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/wide_transformation.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/overwrite_appname.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/overwrite_appname.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_alter_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_alter_table.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_bigquery.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_bigquery.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from pyspark.sql import SparkSession

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_cached.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_cached.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_create_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_create_table.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_ctas_load.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_ctas_load.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_drop_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_drop_table.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_facets_disable.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_facets_disable.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hive.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hive.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hive_catalog.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hive_catalog.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_kafk_assign_read.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_kafk_assign_read.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from pyspark.sql import SparkSession

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_kafka.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_kafka.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from pyspark.sql import SparkSession

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_octas_load.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_octas_load.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_overwrite_hive.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_overwrite_hive.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_to_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_to_table.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import random

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from pyspark.sql import SparkSession

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_test_failures.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_test_failures.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_truncate_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_truncate_table.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_word_count.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_word_count.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from pyspark.sql import SparkSession

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/Versions.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/Versions.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/ErrorFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/ErrorFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/LogicalPlanFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/LogicalPlanFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkPropertyFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkPropertyFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkVersionFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/UnknownEntryFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/UnknownEntryFacet.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/CustomEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/CustomEnvironmentFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/HookUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/HookUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/RunEventBuilderHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/RunEventBuilderHook.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/DatasetBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/VisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/VisitorFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AppendDataVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeOutputVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CommandPlanVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/ExternalRDDVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceDirVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDataSourceVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoDirVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveDirVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHiveTableVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRDDVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlDWDatabricksVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SqlExecutionRDDVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/CustomColumnLineageVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/CustomColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/JdbcRelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/JdbcRelationHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/models/DatabricksMountpoint.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/models/DatabricksMountpoint.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/BigQueryUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/BigQueryUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetFacetsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetFacetsUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetIdentifier.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DeltaUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DeltaUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/FacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/FacetUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkConfUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractDatasetFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractGenericArgPartialFunction.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractGenericArgPartialFunction.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractInputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractInputDatasetFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractJobFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractOutputDatasetFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractPartial.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractPartial.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractRunFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/CustomFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/CustomFacetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageEventHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/QueryPlanVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/QueryPlanVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/ErrorFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/CreateViewFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/CreateViewFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/SparkNodesFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/SparkNodesFilterTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/ExecutionContextTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/ExecutionContextTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/MatchesMapRecursively.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListenerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListenerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/SparkConfUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/SparkConfUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/TestOpenLineageEventHandlerFactory.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/TestOpenLineageEventHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/main/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/spark2/src/main/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/SparkUtils.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/SparkUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/MergeIntoCommandInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/MergeIntoCommandInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/MergeIntoCommandOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/MergeIntoCommandOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/AbstractDatabricksHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/RelationHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/UnsupportedCatalogException.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/UnsupportedCatalogException.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageCollector.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollector.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/ExpressionDependencyVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/ExpressionDependencyVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionDependencyVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionDependencyVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtils.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CustomColumnLineageVisitorTestImpl.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CustomColumnLineageVisitorTestImpl.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/InMemoryRelationInputDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3Test.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3Test.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DatasetVersionDatasetFacetUtilsTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitor.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitor.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
+++ b/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitorTest.java
+++ b/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitorTest.java
+++ b/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitor.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitor.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 package io.openlineage.spark34.agent.lifecycle.plan.column;

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitorTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitorTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnLineage.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnLineage.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ColumnMeta.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/DbTableMeta.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/ExtractionError.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/ExtractionError.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/QuoteStyle.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/QuoteStyle.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/SqlMeta.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/test/integration/TestParser.java
+++ b/integration/sql/iface-java/src/test/integration/TestParser.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
+++ b/integration/sql/iface-java/src/test/java/io/openlineage/sql/OpenLineageSqlTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/sql/iface-py/openlineage_sql.pyi
+++ b/integration/sql/iface-py/openlineage_sql.pyi
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/integration/sql/iface-py/tests/python/sql_tester.py
+++ b/integration/sql/iface-py/tests/python/sql_tester.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/integration/sql/iface-py/tests/python/test_small.py
+++ b/integration/sql/iface-py/tests/python/test_small.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 contributors to the OpenLineage project
+# Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage_sql import parse

--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyApp.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyApp.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyAppException.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyAppException.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/ProxyResource.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/ProxyResource.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/ConsoleConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/ConsoleConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/ConsoleLineageStream.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/HttpConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/HttpLineageStream.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/HttpLineageStream.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaLineageStream.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaLineageStream.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/LineageStream.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/proxy/backend/src/main/java/io/openlineage/proxy/service/ProxyService.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/service/ProxyService.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2023 contributors to the OpenLineage project
+/* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 


### PR DESCRIPTION
Update licenses.

### Problem

`--use-current-year` argument was not passed in pre commit config.

### Solution

Add argument and update licenses per pre-commit hooks.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project