### PR TITLE
[SPARK] Use ScalaConversionUtils to convert Scala and Java collections.

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -5,8 +5,6 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
-import static scala.collection.JavaConversions.asJavaCollection;
-
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.EventEmitter;
@@ -370,7 +368,7 @@ class RddExecutionContext implements ExecutionContext {
   }
 
   protected void printRDDs(String prefix, RDD<?> rdd) {
-    Collection<Dependency<?>> deps = asJavaCollection(rdd.dependencies());
+    Collection<Dependency<?>> deps = ScalaConversionUtils.fromSeq(rdd.dependencies());
     for (Dependency<?> dep : deps) {
       printRDDs(prefix + "  ", dep.rdd());
     }

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
@@ -23,6 +23,7 @@ import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Guice;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Injector;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Key;
 import com.google.cloud.spark.bigquery.repackaged.com.google.inject.Module;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
@@ -37,7 +38,6 @@ import org.apache.spark.sql.sources.TableScan;
 import org.apache.spark.sql.types.StructType;
 import org.mockito.Mockito;
 import scala.Option;
-import scala.collection.JavaConversions;
 import scala.collection.immutable.Map;
 import scala.runtime.AbstractFunction0;
 
@@ -103,7 +103,7 @@ public class MockBigQueryRelationProvider extends BigQueryRelationProvider {
           bqModule,
           new SparkBigQueryConnectorModule(
               sparkSession,
-              JavaConversions.<String, String>mapAsJavaMap(parameters),
+              ScalaConversionUtils.<String, String>fromMap(parameters),
               Collections.emptyMap(),
               Optional.ofNullable(
                   schema.getOrElse(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -20,6 +20,7 @@ import io.openlineage.spark.agent.lifecycle.ContextFactory;
 import io.openlineage.spark.agent.lifecycle.ExecutionContext;
 import io.openlineage.spark.agent.lifecycle.StaticExecutionContextFactory;
 import io.openlineage.spark.agent.lifecycle.plan.InsertIntoHadoopFsRelationVisitor;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -46,8 +47,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import scala.Option;
-import scala.collection.Map$;
-import scala.collection.Seq$;
 
 class OpenLineageSparkListenerTest {
 
@@ -86,15 +85,15 @@ class OpenLineageSparkListenerTest {
                 new Path("file:///tmp/dir"),
                 null,
                 false,
-                Seq$.MODULE$.empty(),
+                ScalaConversionUtils.asScalaSeqEmpty(),
                 Option.empty(),
                 null,
-                Map$.MODULE$.empty(),
+                ScalaConversionUtils.asScalaMapEmpty(),
                 query,
                 SaveMode.Overwrite,
                 Option.empty(),
                 Option.empty(),
-                Seq$.MODULE$.<String>empty()));
+                ScalaConversionUtils.<String>asScalaSeqEmpty()));
 
     when(qe.executedPlan()).thenReturn(plan);
 
@@ -111,9 +110,9 @@ class OpenLineageSparkListenerTest {
             new SparkPlanInfo(
                 "name",
                 "string",
-                Seq$.MODULE$.empty(),
-                Map$.MODULE$.empty(),
-                Seq$.MODULE$.empty()));
+                ScalaConversionUtils.asScalaSeqEmpty(),
+                ScalaConversionUtils.asScalaMapEmpty(),
+                ScalaConversionUtils.asScalaSeqEmpty()));
     when(event.executionId()).thenReturn(1L);
     try (MockedStatic<EventFilterUtils> utils = mockStatic(EventFilterUtils.class)) {
       utils.when(() -> EventFilterUtils.isDisabled(olContext, event)).thenReturn(false);
@@ -137,7 +136,8 @@ class OpenLineageSparkListenerTest {
       OpenLineageSparkListener listener = new OpenLineageSparkListener();
 
       listener.onJobStart(
-          new SparkListenerJobStart(0, 2L, Seq$.MODULE$.<StageInfo>empty(), new Properties()));
+          new SparkListenerJobStart(
+              0, 2L, ScalaConversionUtils.<StageInfo>asScalaSeqEmpty(), new Properties()));
 
       verify(contextFactory, never()).createSparkSQLExecutionContext(anyLong());
     }
@@ -156,15 +156,15 @@ class OpenLineageSparkListenerTest {
                 new Path("file:///tmp/dir"),
                 null,
                 false,
-                Seq$.MODULE$.empty(),
+                ScalaConversionUtils.asScalaSeqEmpty(),
                 Option.empty(),
                 null,
-                Map$.MODULE$.empty(),
+                ScalaConversionUtils.asScalaMapEmpty(),
                 query,
                 SaveMode.Overwrite,
                 Option.empty(),
                 Option.empty(),
-                Seq$.MODULE$.<String>empty()));
+                ScalaConversionUtils.asScalaSeqEmpty()));
 
     when(qe.executedPlan()).thenReturn(plan);
     when(qe.sparkSession()).thenReturn(sparkSession);

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -5,11 +5,13 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -52,7 +54,7 @@ public class CatalogTableTestUtils {
               new StructField("name", StringType$.MODULE$, false, Metadata.empty())
             }));
     params.add(Option.empty());
-    params.add(Seq$.MODULE$.<String>newBuilder().$plus$eq("name").result());
+    params.add(ScalaConversionUtils.fromList(Collections.singletonList("name")));
     params.add(Option.empty());
     params.add("");
     params.add(Instant.now().getEpochSecond());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitorTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
@@ -24,8 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
-import scala.collection.JavaConversions;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -64,7 +63,7 @@ class AlterTableAddColumnsCommandVisitorTest {
               new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
 
-    session.catalog().createTable(TABLE_1, "csv", schema, Map$.MODULE$.empty());
+    session.catalog().createTable(TABLE_1, "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
     database = session.catalog().currentDatabase();
     visitor = new AlterTableAddColumnsCommandVisitor(SparkAgentTestExtension.newContext(session));
   }
@@ -74,13 +73,12 @@ class AlterTableAddColumnsCommandVisitorTest {
     AlterTableAddColumnsCommand command =
         new AlterTableAddColumnsCommand(
             new TableIdentifier(TABLE_1, Option.apply(database)),
-            JavaConversions.asScalaIterator(
+            ScalaConversionUtils.fromList(
                     Arrays.asList(
-                            new StructField(
-                                "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>())),
-                            new StructField(
-                                "col3", StringType$.MODULE$, false, new Metadata(new HashMap<>())))
-                        .iterator())
+                        new StructField(
+                            "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>())),
+                        new StructField(
+                            "col3", StringType$.MODULE$, false, new Metadata(new HashMap<>()))))
                 .toSeq());
 
     command.run(session);
@@ -99,11 +97,10 @@ class AlterTableAddColumnsCommandVisitorTest {
     AlterTableAddColumnsCommand command =
         new AlterTableAddColumnsCommand(
             new TableIdentifier(TABLE_1, Option.apply(database)),
-            JavaConversions.asScalaIterator(
+            ScalaConversionUtils.fromList(
                     Arrays.asList(
-                            new StructField(
-                                "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>())))
-                        .iterator())
+                        new StructField(
+                            "col2", StringType$.MODULE$, false, new Metadata(new HashMap<>()))))
                 .toSeq());
 
     // command is not run

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitorTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.spark.sql.SparkSession;
@@ -24,8 +26,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import scala.Option;
 import scala.Tuple2;
-import scala.collection.Seq;
-import scala.collection.Seq$;
 import scala.collection.immutable.Map;
 
 @Tag("nonParallelTest")
@@ -82,16 +82,12 @@ class AlterTableAddPartitionCommandVisitorTest {
   void testAlterTableAddPartition() {
 
     scala.collection.immutable.Map<String, String> params =
-        scala.collection.immutable.Map$.MODULE$
-            .<String, String>newBuilder()
-            .$plus$eq(Tuple2.apply("col1", "aaa"))
-            .result();
+        ScalaConversionUtils.<String, String>fromJavaMap(Collections.singletonMap("col1", "aaa"));
 
-    Seq<Tuple2<Map<String, String>, Option<String>>> partitionSpecsAndLocs =
-        Seq$.MODULE$
-            .<Tuple2<Map<String, String>, Option<String>>>newBuilder()
-            .$plus$eq(Tuple2.apply(params, Option.apply("file:///tmp/dir")))
-            .result();
+    scala.collection.immutable.Seq<Tuple2<Map<String, String>, Option<String>>>
+        partitionSpecsAndLocs =
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(Tuple2.apply(params, Option.apply("file:///tmp/dir"))));
 
     AlterTableAddPartitionCommand command =
         new AlterTableAddPartitionCommand(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitorTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.hadoop.fs.FileSystem;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -76,7 +76,7 @@ class AlterTableRenameCommandVisitorTest {
               new StructField("a", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
 
-    session.catalog().createTable(OLD_TABLE, "csv", schema, Map$.MODULE$.empty());
+    session.catalog().createTable(OLD_TABLE, "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
     visitor = new AlterTableRenameCommandVisitor(SparkAgentTestExtension.newContext(session));
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -62,7 +62,7 @@ class AlterTableSetLocationCommandVisitorTest {
               new StructField("col1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
 
-    session.catalog().createTable(TABLE_1, "csv", schema, Map$.MODULE$.empty());
+    session.catalog().createTable(TABLE_1, "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
     database = session.catalog().currentDatabase();
     visitor = new AlterTableSetLocationCommandVisitor(SparkAgentTestExtension.newContext(session));
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -71,7 +71,9 @@ class DropTableCommandVisitorTest {
             new StructField[] {
               new StructField("field1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
-    session.catalog().createTable("drop_table", "csv", schema, Map$.MODULE$.empty());
+    session
+        .catalog()
+        .createTable("drop_table", "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
 
     // apply the visitor before running the command
     List<OpenLineage.OutputDataset> datasets = visitor.apply(command);

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +35,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import scala.Option;
-import scala.collection.Seq$;
 
 /**
  * This unit test tests the apply method of KustoRelationVisitor. Therefore it only tests Kusto read
@@ -125,17 +126,15 @@ class KustoRelationVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockKustoRelation(inputQuery, url, database),
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.<String>asScalaSeqEmpty()))),
             Option.empty(),
             false);
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitorTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier$;
@@ -20,7 +21,6 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import scala.Option;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 class LoadDataCommandVisitorTest {
@@ -40,7 +40,7 @@ class LoadDataCommandVisitorTest {
               new StructField("value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
 
-    session.catalog().createTable("table", "csv", schema, Map$.MODULE$.empty());
+    session.catalog().createTable("table", "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
 
     LoadDataCommandVisitor visitor =
         new LoadDataCommandVisitor(SparkAgentTestExtension.newContext(session));

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
 import java.util.List;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
@@ -29,7 +31,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
-import scala.collection.Seq$;
 
 class SqlDwRelationParams {
 
@@ -140,17 +141,15 @@ class SQLDWDatabricksVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
 
@@ -178,17 +177,15 @@ class SQLDWDatabricksVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockSpark2SqlDWBaseRelation(inputName, inputJdbcUrl),
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
 
@@ -216,17 +213,15 @@ class SQLDWDatabricksVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
 
@@ -250,17 +245,15 @@ class SQLDWDatabricksVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
@@ -29,9 +29,7 @@ import org.apache.spark.sql.sources.CreatableRelationProvider;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.StringType$;
 import org.junit.jupiter.api.Test;
-import scala.Predef;
-import scala.Tuple2;
-import scala.collection.Map;
+import scala.collection.immutable.Map;
 
 class SaveIntoDataSourceCommandVisitorTest {
 
@@ -54,21 +52,20 @@ class SaveIntoDataSourceCommandVisitorTest {
     when(attr2.name()).thenReturn("b");
 
     Map<String, String> options =
-        scala.collection.JavaConversions$.MODULE$.mapAsScalaMap(
-            Collections.singletonMap("path", "some-path"));
+        ScalaConversionUtils.fromJavaMap(Collections.singletonMap("path", "some-path"));
 
     command = mock(SaveIntoDataSourceCommand.class);
     DeltaDataSource deltaDataSource = mock(DeltaDataSource.class);
     LocalRelation localRelation = mock(LocalRelation.class);
     when(localRelation.output())
-        .thenReturn(Arrays.asList(attr1, attr2).stream().collect(ScalaConversionUtils.toSeq()));
+        .thenReturn(ScalaConversionUtils.fromList(Arrays.asList(attr1, attr2)).toSeq());
     when(command.dataSource()).thenReturn(deltaDataSource);
     when(command.schema()).thenReturn(null);
     when(command.mode()).thenReturn(SaveMode.Overwrite);
     when(command.query()).thenReturn(localRelation);
-    when(command.options()).thenReturn(options.toMap(Predef.<Tuple2<String, String>>conforms()));
+    when(command.options()).thenReturn(options);
     when(localRelation.output())
-        .thenReturn(Arrays.asList(attr1, attr2).stream().collect(ScalaConversionUtils.toSeq()));
+        .thenReturn(ScalaConversionUtils.fromList(Arrays.asList(attr1, attr2)).toSeq());
     when(datasetFactory.getDataset(any(), any(), eq(OVERWRITE))).thenReturn(dataset);
 
     List<OpenLineage.OutputDataset> datasets =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SnowflakeRelationVisitorTest.java
@@ -13,8 +13,10 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import net.snowflake.spark.snowflake.SnowflakeRelation;
@@ -30,7 +32,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
-import scala.collection.Seq$;
 
 @Slf4j
 public class SnowflakeRelationVisitorTest {
@@ -74,17 +75,15 @@ public class SnowflakeRelationVisitorTest {
     LogicalRelation lr =
         new LogicalRelation(
             relation,
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         FIELD_NAME,
                         StringType$.MODULE$,
                         false,
                         null,
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.<String>asScalaSeqEmpty()))),
             Option.empty(),
             false);
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitorTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.List;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
@@ -79,7 +79,9 @@ class TruncateTableCommandVisitorTest {
             new StructField[] {
               new StructField("field1", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
             });
-    session.catalog().createTable("truncate_table", "csv", schema, Map$.MODULE$.empty());
+    session
+        .catalog()
+        .createTable("truncate_table", "csv", schema, ScalaConversionUtils.asScalaMapEmpty());
 
     // apply the visitor before running the command
     List<OpenLineage.OutputDataset> datasets = visitor.apply(command);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -9,6 +9,7 @@ import com.databricks.backend.daemon.dbutils.MountInfo;
 import com.databricks.dbutils_v1.DbfsUtils;
 import io.openlineage.spark.agent.facets.EnvironmentFacet;
 import io.openlineage.spark.agent.models.DatabricksMountpoint;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.lang.reflect.Constructor;
@@ -23,7 +24,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerJobStart;
-import scala.collection.JavaConversions;
 
 /**
  * {@link CustomFacetBuilder} that generates a {@link EnvironmentFacet} when using OpenLineage on
@@ -139,7 +139,7 @@ public class DatabricksEnvironmentFacetBuilder
 
   private static List<DatabricksMountpoint> getDatabricksMountpoints(DbfsUtils dbutils) {
     List<DatabricksMountpoint> mountpoints = new ArrayList<>();
-    List<MountInfo> mountsList = JavaConversions.seqAsJavaList(dbutils.mounts());
+    List<MountInfo> mountsList = ScalaConversionUtils.fromSeq(dbutils.mounts());
     for (MountInfo mount : mountsList) {
       mountpoints.add(new DatabricksMountpoint(mount.mountPoint(), mount.source()));
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import static io.openlineage.client.OpenLineageClientUtils.mergeFacets;
-import static io.openlineage.spark.agent.util.ScalaConversionUtils.fromSeq;
 import static io.openlineage.spark.agent.util.ScalaConversionUtils.toScalaFn;
 
 import io.openlineage.client.OpenLineage;
@@ -342,7 +341,8 @@ class OpenLineageRunEventBuilder {
                     .getQueryExecution()
                     .map(
                         qe ->
-                            fromSeq(qe.optimizedPlan().map(inputVisitor)).stream()
+                            ScalaConversionUtils.fromSeq(qe.optimizedPlan().map(inputVisitor))
+                                .stream()
                                 .flatMap(Collection::stream)
                                 .map(((Class<InputDataset>) InputDataset.class)::cast))
                     .orElse(Stream.empty()))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
@@ -21,7 +21,6 @@ import org.apache.spark.scheduler.StageInfo;
 import org.apache.spark.sql.execution.ShuffledRowRDD;
 import org.apache.spark.sql.execution.datasources.FileScanRDD;
 import org.apache.spark.storage.RDDInfo;
-import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
 public class Rdds {
@@ -32,7 +31,8 @@ public class Rdds {
     if (rdd instanceof ShuffledRowRDD) {
       rdds.addAll(flattenRDDs(((ShuffledRowRDD) rdd).dependency().rdd()));
     }
-    Collection<Dependency<?>> deps = JavaConversions.asJavaCollection(rdd.dependencies());
+    Seq<Dependency<?>> dependencies = rdd.dependencies();
+    Collection<Dependency<?>> deps = ScalaConversionUtils.fromSeq(dependencies);
     for (Dependency<?> dep : deps) {
       rdds.addAll(flattenRDDs(dep.rdd()));
     }
@@ -42,7 +42,7 @@ public class Rdds {
   static String toString(SparkListenerJobStart jobStart) {
     StringBuilder sb = new StringBuilder();
     sb.append("start: ").append(jobStart.properties().toString()).append("\n");
-    List<StageInfo> stageInfos = JavaConversions.seqAsJavaList(jobStart.stageInfos());
+    List<StageInfo> stageInfos = ScalaConversionUtils.fromSeq(jobStart.stageInfos());
     for (StageInfo stageInfo : stageInfos) {
       sb.append("  ")
           .append("stageInfo: ")
@@ -50,7 +50,7 @@ public class Rdds {
           .append(" ")
           .append(stageInfo.name())
           .append("\n");
-      List<RDDInfo> rddInfos = JavaConversions.seqAsJavaList(stageInfo.rddInfos());
+      List<RDDInfo> rddInfos = ScalaConversionUtils.fromSeq(stageInfo.rddInfos());
       for (RDDInfo rddInfo : rddInfos) {
         sb.append("    ").append("rddInfo: ").append(rddInfo).append("\n");
       }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -6,11 +6,10 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import static java.util.Optional.ofNullable;
-import static scala.collection.JavaConversions.mapAsJavaMap;
-import static scala.collection.JavaConversions.seqAsJavaList;
 
 import io.openlineage.spark.agent.facets.LogicalPlanFacet;
 import io.openlineage.spark.agent.facets.UnknownEntryFacet;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -23,7 +22,6 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.AttributeSet;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.types.DataType;
-import scala.collection.JavaConversions;
 
 /**
  * Holds information about visited nodes in {@link LogicalPlan}, using {@link LogicalPlanSerializer}
@@ -57,7 +55,7 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
   public Optional<UnknownEntryFacet> build(LogicalPlan root) {
     Optional<UnknownEntryFacet.FacetEntry> output = mapEntry(root);
     List<UnknownEntryFacet.FacetEntry> inputs =
-        seqAsJavaList(root.collectLeaves()).stream()
+        ScalaConversionUtils.fromSeq(root.collectLeaves()).stream()
             .map(this::mapEntry)
             .filter(Optional::isPresent)
             .map(Optional::get)
@@ -80,7 +78,7 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
   }
 
   private List<UnknownEntryFacet.AttributeField> attributeFields(AttributeSet set) {
-    return JavaConversions.<AttributeReference>asJavaCollection(set.toSet()).stream()
+    return ScalaConversionUtils.<AttributeReference>fromSet(set.toSet()).stream()
         .map(this::mapAttributeReference)
         .collect(Collectors.toList());
   }
@@ -89,6 +87,6 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
     return new UnknownEntryFacet.AttributeField(
         ar.name(),
         ofNullable(ar.dataType()).map(DataType::typeName).orElse(null),
-        new HashMap<>(mapAsJavaMap(ar.metadata().map())));
+        new HashMap<>(ScalaConversionUtils.fromMap(ar.metadata().map())));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Arrays;
@@ -17,7 +18,6 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.AlterTableAddColumnsCommand;
 import org.apache.spark.sql.types.StructField;
-import scala.collection.JavaConversions;
 
 public class AlterTableAddColumnsCommandVisitor
     extends QueryPlanVisitor<AlterTableAddColumnsCommand, OpenLineage.OutputDataset> {
@@ -36,7 +36,7 @@ public class AlterTableAddColumnsCommandVisitor
 
     List<StructField> tableColumns = Arrays.asList(catalogTable.schema().fields());
     List<StructField> addedColumns =
-        JavaConversions.seqAsJavaList(((AlterTableAddColumnsCommand) x).colsToAdd());
+        ScalaConversionUtils.fromSeq(((AlterTableAddColumnsCommand) x).colsToAdd());
 
     if (tableColumns.containsAll(addedColumns)) {
       return Collections.singletonList(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -11,6 +11,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -31,7 +32,6 @@ import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
-import scala.collection.JavaConversions;
 
 /**
  * {@link LogicalPlan} visitor that attempts to extract a {@link OpenLineage.Dataset} from a {@link
@@ -146,7 +146,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                                 context.getOpenLineage().newDatasetVersionDatasetFacet(version)));
 
                 Collection<Path> rootPaths =
-                    JavaConversions.asJavaCollection(relation.location().rootPaths());
+                    ScalaConversionUtils.fromSeq(relation.location().rootPaths());
 
                 if (isSingleFileRelation(rootPaths, hadoopConfig)) {
                   return Collections.singletonList(
@@ -182,7 +182,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
         // Datasets
         List<D> inputDatasets = new ArrayList<D>();
         List<Path> paths =
-            new ArrayList<>(JavaConversions.asJavaCollection(relation.location().rootPaths()));
+            new ArrayList<>(ScalaConversionUtils.fromSeq(relation.location().rootPaths()));
         for (Path p : paths) {
           inputDatasets.add(datasetFactory.getDataset(p.toUri(), relation.schema()));
         }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -36,7 +36,6 @@ import org.apache.spark.sql.sources.RelationProvider;
 import org.apache.spark.sql.sources.SchemaRelationProvider;
 import org.apache.spark.sql.types.StructType;
 import scala.Option;
-import scala.collection.Seq$;
 
 /**
  * {@link LogicalPlan} visitor that matches an {@link SaveIntoDataSourceCommand} and extracts the
@@ -155,7 +154,11 @@ public class SaveIntoDataSourceCommandVisitor
       throw ex;
     }
     LogicalRelation logicalRelation =
-        new LogicalRelation(relation, Seq$.MODULE$.empty(), Option.empty(), command.isStreaming());
+        new LogicalRelation(
+            relation,
+            ScalaConversionUtils.asScalaSeqEmpty(),
+            Option.empty(),
+            command.isStreaming());
     return delegate(
             context.getOutputDatasetQueryPlanVisitors(), context.getOutputDatasetBuilders(), event)
         .applyOrElse(

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
@@ -107,8 +107,7 @@ public class DebugRunFacetBuilderDelegateTest {
   void testBuildClasspathDebugFacet() {
     when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
     when(sparkContext.listJars())
-        .thenReturn(
-            Collections.singletonList("oneJar").stream().collect(ScalaConversionUtils.toSeq()));
+        .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList("oneJar")));
     when(openLineageContext.getSparkVersion()).thenReturn("3.3.0");
 
     ClasspathDebugFacet facet = delegate.buildFacet().getClasspath();
@@ -134,9 +133,8 @@ public class DebugRunFacetBuilderDelegateTest {
 
     when(queryExecution.optimizedPlan()).thenReturn(root);
     when(root.children())
-        .thenReturn(Collections.singletonList(node).stream().collect(ScalaConversionUtils.toSeq()));
-    when(node.children())
-        .thenReturn(Arrays.asList(leaf1, leaf2).stream().collect(ScalaConversionUtils.toSeq()));
+        .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList(node)));
+    when(node.children()).thenReturn(ScalaConversionUtils.fromList(Arrays.asList(leaf1, leaf2)));
 
     LogicalPlanDebugFacet facet = delegate.buildFacet().getLogicalPlan();
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/LogicalPlanRunFacetBuilderTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,7 +34,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq$;
 
 class LogicalPlanRunFacetBuilderTest {
 
@@ -91,7 +91,8 @@ class LogicalPlanRunFacetBuilderTest {
 
     assertThat(
             builder.isDefinedAt(
-                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
         .isTrue();
   }
 
@@ -108,7 +109,8 @@ class LogicalPlanRunFacetBuilderTest {
     sparkContext.conf().set("spark.openlineage.facets.disabled", "[spark.logicalPlan]");
     assertThat(
             builder.isDefinedAt(
-                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
         .isFalse();
 
     sparkContext.conf().remove("spark.openlineage.facets.disabled");
@@ -132,7 +134,8 @@ class LogicalPlanRunFacetBuilderTest {
 
     assertThat(
             builder.isDefinedAt(
-                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
         .isFalse();
   }
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +25,6 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import scala.collection.Seq$;
 
 class SparkProcessingEngineFacetBuilderTest {
   private static SparkContext sparkContext;
@@ -51,7 +51,8 @@ class SparkProcessingEngineFacetBuilderTest {
         .isTrue();
     assertThat(
             builder.isDefinedAt(
-                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
         .isTrue();
     assertThat(builder.isDefinedAt(new SparkListenerJobEnd(1, 1L, JobSucceeded$.MODULE$))).isTrue();
     assertThat(builder.isDefinedAt(new SparkListenerStageSubmitted(null, new Properties())))

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.facets.SparkPropertyFacet;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +22,6 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq$;
 
 public class SparkPropertyFacetBuilderTest {
 
@@ -79,7 +79,8 @@ public class SparkPropertyFacetBuilderTest {
 
     Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
     builder.build(
-        new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties()), runFacetMap::put);
+        new SparkListenerJobStart(1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties()),
+        runFacetMap::put);
 
     assertThat(runFacetMap).hasEntrySatisfying("spark_properties", runFacetConsumer);
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkVersionFacetBuilderTest.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.facets.SparkVersionFacet;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +28,6 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq$;
 
 class SparkVersionFacetBuilderTest {
 
@@ -60,7 +60,8 @@ class SparkVersionFacetBuilderTest {
         .isTrue();
     assertThat(
             builder.isDefinedAt(
-                new SparkListenerJobStart(1, 1L, Seq$.MODULE$.empty(), new Properties())))
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
         .isTrue();
     assertThat(builder.isDefinedAt(new SparkListenerJobEnd(1, 1L, JobSucceeded$.MODULE$))).isTrue();
     assertThat(builder.isDefinedAt(new SparkListenerStageSubmitted(null, new Properties())))

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Optional;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -20,7 +21,6 @@ import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.WholeStageCodegenExec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq$;
 
 public class DatabricksEventFilterTest {
 
@@ -55,7 +55,7 @@ public class DatabricksEventFilterTest {
   @Test
   public void testSerializeFromObjectIsDisabled() {
     SerializeFromObject serializeFromObject = mock(SerializeFromObject.class);
-    when(serializeFromObject.collectLeaves()).thenReturn(Seq$.MODULE$.empty());
+    when(serializeFromObject.collectLeaves()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(queryExecution.optimizedPlan()).thenReturn(serializeFromObject);
 
     assertTrue(filter.isDisabled(sparkListenerEvent));

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.apache.spark.SparkConf;
@@ -33,8 +34,7 @@ import org.apache.spark.sql.execution.QueryExecution;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import scala.collection.Seq;
-import scala.collection.Seq$;
+import scala.collection.immutable.Seq;
 
 public class DeltaEventFilterTest {
 
@@ -90,8 +90,7 @@ public class DeltaEventFilterTest {
   void testDisabledForLocalRelationOnly() {
     try (MockedStatic mocked = mockStatic(SparkSession.class)) {
       LocalRelation localRelation = mock(LocalRelation.class);
-      when(localRelation.children())
-          .thenReturn((Seq<LogicalPlan>) Seq$.MODULE$.<LogicalPlan>empty());
+      when(localRelation.children()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
       when(SparkSession.active()).thenReturn(sparkSession);
       when(sparkConf.get("spark.sql.extensions", ""))
           .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
@@ -132,18 +131,17 @@ public class DeltaEventFilterTest {
       LogicalPlan logicalPlan = mock(LogicalPlan.class);
       LogicalRDD logicalRDD = mock(LogicalRDD.class);
       when(logicalPlan.collectLeaves())
-          .thenReturn(Arrays.asList(logicalRDD).stream().collect(ScalaConversionUtils.toSeq()));
+          .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList(logicalRDD)));
       Seq<Attribute> outputs =
-          Arrays.asList(
+          ScalaConversionUtils.fromList(
+              Arrays.asList(
                   attributeWithName("txn"),
                   attributeWithName("add"),
                   attributeWithName("remove"),
                   attributeWithName("metaData"),
                   attributeWithName("cdc"),
                   attributeWithName("protocol"),
-                  attributeWithName("commitInfo"))
-              .stream()
-              .collect(ScalaConversionUtils.toSeq());
+                  attributeWithName("commitInfo")));
       when(logicalRDD.output()).thenReturn(outputs);
 
       when(SparkSession.active()).thenReturn(sparkSession);
@@ -160,14 +158,13 @@ public class DeltaEventFilterTest {
     try (MockedStatic mocked = mockStatic(SparkSession.class)) {
       LogicalPlan project = mock(Project.class);
       Seq<Attribute> attributeSeq =
-          Arrays.asList(
+          ScalaConversionUtils.fromList(
+              Arrays.asList(
                   attributeWithName("protocol"),
                   attributeWithName("metaData"),
-                  attributeWithName("action_sort_column"))
-              .stream()
-              .collect(ScalaConversionUtils.toSeq());
+                  attributeWithName("action_sort_column")));
       when(project.output()).thenReturn(attributeSeq);
-      when(project.collectLeaves()).thenReturn(Seq$.MODULE$.empty());
+      when(project.collectLeaves()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
 
       when(SparkSession.active()).thenReturn(sparkSession);
       when(sparkConf.get("spark.sql.extensions", ""))
@@ -182,13 +179,12 @@ public class DeltaEventFilterTest {
   void testDisabledForSerializeFromObject() {
     try (MockedStatic mocked = mockStatic(SparkSession.class)) {
       LocalRelation localRelation = mock(LocalRelation.class);
-      when(localRelation.children())
-          .thenReturn((Seq<LogicalPlan>) Seq$.MODULE$.<LogicalPlan>empty());
+      when(localRelation.children()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
       when(SparkSession.active()).thenReturn(sparkSession);
       when(sparkConf.get("spark.sql.extensions", ""))
           .thenReturn("io.delta.sql.DeltaSparkSessionExtension");
       SerializeFromObject serializeFromObject = mock(SerializeFromObject.class);
-      when(serializeFromObject.collectLeaves()).thenReturn(Seq$.MODULE$.empty());
+      when(serializeFromObject.collectLeaves()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
       when(queryExecution.optimizedPlan()).thenReturn(serializeFromObject);
 
       assertTrue(filter.isDisabled(sparkListenerEvent));

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/CatalogTableTestUtils.java
@@ -5,11 +5,13 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -52,7 +54,7 @@ public class CatalogTableTestUtils {
               new StructField("name", StringType$.MODULE$, false, Metadata.empty())
             }));
     params.add(Option.empty());
-    params.add(Seq$.MODULE$.<String>newBuilder().$plus$eq("name").result());
+    params.add(ScalaConversionUtils.fromList(Collections.singletonList("name")));
     params.add(Option.empty());
     params.add("");
     params.add(Instant.now().getEpochSecond());

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.Tabl
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.TableId;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.spark.bigquery.repackaged.com.google.common.collect.ImmutableMap;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
@@ -44,8 +45,6 @@ import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
-import org.apache.spark.sql.catalyst.expressions.Expression;
-import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.CatalogFileIndex;
@@ -65,11 +64,9 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.postgresql.Driver;
 import scala.Option;
-import scala.Tuple2;
 import scala.collection.Seq;
 import scala.collection.Seq$;
 import scala.collection.immutable.HashMap;
-import scala.collection.immutable.Map$;
 
 class LogicalPlanSerializerTest {
   private static final String TEST_DATA = "test_data";
@@ -89,11 +86,8 @@ class LogicalPlanSerializerTest {
     String jdbcUrl = "jdbc:postgresql://postgreshost:5432/sparkdata";
     String sparkTableName = "my_spark_table";
     scala.collection.immutable.Map<String, String> map =
-        (scala.collection.immutable.Map<String, String>)
-            Map$.MODULE$
-                .<String, String>newBuilder()
-                .$plus$eq(Tuple2.apply("driver", Driver.class.getName()))
-                .result();
+        ScalaConversionUtils.fromJavaMap(
+            Collections.singletonMap("driver", Driver.class.getName()));
     JDBCRelation relation =
         new JDBCRelation(
             new StructType(
@@ -106,23 +100,21 @@ class LogicalPlanSerializerTest {
     LogicalRelation logicalRelation =
         new LogicalRelation(
             relation,
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         NAME,
                         StringType$.MODULE$,
                         false,
                         Metadata.empty(),
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
     Aggregate aggregate =
         new Aggregate(
-            Seq$.MODULE$.<Expression>empty(),
-            Seq$.MODULE$.<NamedExpression>empty(),
+            ScalaConversionUtils.asScalaSeqEmpty(),
+            ScalaConversionUtils.asScalaSeqEmpty(),
             logicalRelation);
 
     Map<String, Object> aggregateActualNode =
@@ -211,17 +203,15 @@ class LogicalPlanSerializerTest {
     LogicalRelation logicalRelation =
         new LogicalRelation(
             hadoopFsRelation,
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         NAME,
                         StringType$.MODULE$,
                         false,
                         Metadata.empty(),
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
     InsertIntoHadoopFsRelationCommand command =
@@ -229,17 +219,15 @@ class LogicalPlanSerializerTest {
             new org.apache.hadoop.fs.Path("/tmp"),
             new HashMap<>(),
             false,
-            Seq$.MODULE$
-                .<Attribute>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         NAME,
                         StringType$.MODULE$,
                         false,
                         Metadata.empty(),
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             new TextFileFormat(),
             new HashMap<>(),
@@ -247,7 +235,7 @@ class LogicalPlanSerializerTest {
             SaveMode.Overwrite,
             Option.empty(),
             Option.empty(),
-            Seq$.MODULE$.<String>newBuilder().$plus$eq(NAME).result());
+            ScalaConversionUtils.fromList(Collections.singletonList(NAME)));
 
     Map<String, Object> commandActualNode =
         objectMapper.readValue(logicalPlanSerializer.serialize(command), mapTypeReference);
@@ -303,17 +291,15 @@ class LogicalPlanSerializerTest {
     LogicalRelation logicalRelation =
         new LogicalRelation(
             bigQueryRelation,
-            Seq$.MODULE$
-                .<AttributeReference>newBuilder()
-                .$plus$eq(
+            ScalaConversionUtils.fromList(
+                Collections.singletonList(
                     new AttributeReference(
                         NAME,
                         StringType$.MODULE$,
                         false,
                         Metadata.empty(),
                         ExprId.apply(1L),
-                        Seq$.MODULE$.<String>empty()))
-                .result(),
+                        ScalaConversionUtils.asScalaSeqEmpty()))),
             Option.empty(),
             false);
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListenerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListenerTest.java
@@ -8,6 +8,8 @@ package io.openlineage.spark.agent.lifecycle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openlineage.spark.agent.facets.UnknownEntryFacet;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.Collections;
 import java.util.Optional;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
@@ -36,10 +38,11 @@ class UnknownEntryFacetListenerTest {
             Seq$.MODULE$.<String>newBuilder().result());
 
     ListFilesCommand logicalPlan =
-        new ListFilesCommand(Seq$.MODULE$.<String>newBuilder().$plus$eq("./test.file").result());
+        new ListFilesCommand(
+            ScalaConversionUtils.fromList(Collections.singletonList("./test.file")));
     Project project =
         new Project(
-            Seq$.MODULE$.<NamedExpression>newBuilder().$plus$eq(reference).result(), logicalPlan);
+            ScalaConversionUtils.fromList(Collections.singletonList(reference)), logicalPlan);
 
     UnknownEntryFacet facet = underTest.build(project).get();
 
@@ -85,13 +88,13 @@ class UnknownEntryFacetListenerTest {
             false,
             Metadata$.MODULE$.fromJson("{\"__CHAR_VARCHAR_TYPE_STRING\":\"varchar(64)\"}"),
             ExprId.apply(1L),
-            Seq$.MODULE$.<String>newBuilder().result());
+            ScalaConversionUtils.asScalaSeqEmpty());
 
     ListFilesCommand logicalPlan =
-        new ListFilesCommand(Seq$.MODULE$.<String>newBuilder().$plus$eq("./test").result());
+        new ListFilesCommand(ScalaConversionUtils.fromList(Collections.singletonList("./test")));
     Project project =
         new Project(
-            Seq$.MODULE$.<NamedExpression>newBuilder().$plus$eq(reference).result(), logicalPlan);
+            ScalaConversionUtils.fromList(Collections.singletonList(reference)), logicalPlan);
     underTest.accept(project);
     underTest.accept(logicalPlan);
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
+import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap;
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap$;
@@ -26,7 +28,6 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.Tuple2;
 import scala.collection.immutable.Map$;
 
 public class JdbcRelationHandlerTest {
@@ -76,10 +77,8 @@ public class JdbcRelationHandlerTest {
   void testHandlingJdbcTable() {
     CaseInsensitiveMap params =
         CaseInsensitiveMap$.MODULE$.apply(
-            Map$.MODULE$
-                .<String, String>newBuilder()
-                .$plus$eq(Tuple2.apply(JDBCOptions$.MODULE$.JDBC_TABLE_NAME(), jdbcTable))
-                .result());
+            ScalaConversionUtils.fromJavaMap(
+                Collections.singletonMap(JDBCOptions$.MODULE$.JDBC_TABLE_NAME(), jdbcTable)));
     when(jdbcOptions.parameters()).thenReturn(params);
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcTable);
     when(relation.schema()).thenReturn(schema);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -15,12 +15,14 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -50,9 +52,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.postgresql.Driver;
 import scala.Option;
-import scala.Tuple2;
-import scala.collection.Seq$;
-import scala.collection.immutable.Map$;
 
 class LogicalRelationDatasetBuilderTest {
 
@@ -87,29 +86,25 @@ class LogicalRelationDatasetBuilderTest {
             new JDBCOptions(
                 connectionUri,
                 sparkTableName,
-                Map$.MODULE$
-                    .<String, String>newBuilder()
-                    .$plus$eq(Tuple2.apply("driver", Driver.class.getName()))
-                    .result()),
+                ScalaConversionUtils.fromJavaMap(
+                    Collections.singletonMap("driver", Driver.class.getName()))),
             session);
     QueryExecution qe = mock(QueryExecution.class);
     when(qe.optimizedPlan())
         .thenReturn(
             new Project(
-                Seq$.MODULE$.<String>empty(),
+                ScalaConversionUtils.asScalaSeqEmpty(),
                 new LogicalRelation(
                     relation,
-                    Seq$.MODULE$
-                        .<AttributeReference>newBuilder()
-                        .$plus$eq(
+                    ScalaConversionUtils.fromList(
+                        Collections.singletonList(
                             new AttributeReference(
                                 "name",
                                 StringType$.MODULE$,
                                 false,
                                 null,
                                 ExprId.apply(1L),
-                                Seq$.MODULE$.<String>empty()))
-                        .result(),
+                                ScalaConversionUtils.asScalaSeqEmpty()))),
                     Option.empty(),
                     false)));
     OpenLineageContext context =
@@ -122,7 +117,8 @@ class LogicalRelationDatasetBuilderTest {
         new LogicalRelationDatasetBuilder<>(
             context, DatasetFactory.output(openLineageContext), true);
     List<OutputDataset> datasets =
-        visitor.apply(new SparkListenerJobStart(1, 1, Seq$.MODULE$.empty(), null));
+        visitor.apply(
+            new SparkListenerJobStart(1, 1, ScalaConversionUtils.asScalaSeqEmpty(), null));
     assertEquals(1, datasets.size());
     OutputDataset ds = datasets.get(0);
     assertEquals(targetUri, ds.getNamespace());

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
@@ -21,7 +21,6 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.org.apache.commons.lang3.reflect.FieldUtils;
 import scala.Tuple2;
-import scala.collection.JavaConversions;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
@@ -36,7 +35,7 @@ public class RddPathUtilsTest {
 
     when(mapPartitions.prev()).thenReturn(fileScanRDD);
     when(fileScanRDD.filePartitions())
-        .thenReturn(JavaConversions.asScalaBuffer(Collections.singletonList(filePartition)));
+        .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList(filePartition)));
     when(filePartition.files()).thenReturn(new PartitionedFile[] {partitionedFile});
     when(partitionedFile.filePath()).thenReturn("/some-path/sub-path");
 
@@ -95,7 +94,7 @@ public class RddPathUtilsTest {
     when(filePartition.files()).thenReturn(new PartitionedFile[] {partitionedFile});
     when(partitionedFile.filePath()).thenReturn("");
     when(fileScanRDD.filePartitions())
-        .thenReturn(JavaConversions.asScalaBuffer(Collections.singletonList(filePartition)));
+        .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList(filePartition)));
 
     List rddPaths = PlanUtils.findRDDPaths(Collections.singletonList(fileScanRDD));
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -42,7 +42,6 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
-import scala.collection.JavaConversions;
 
 /** Traverses LogicalPlan and collect input fields with the corresponding ExprId. */
 @Slf4j
@@ -181,7 +180,7 @@ public class InputFieldsCollector {
   private static List<DatasetIdentifier> extractDatasetIdentifier(HadoopFsRelation relation) {
     List<DatasetIdentifier> inputDatasets = new ArrayList<DatasetIdentifier>();
     List<Path> paths =
-        JavaConversions.asJavaCollection(relation.location().rootPaths()).stream()
+        ScalaConversionUtils.fromSeq(relation.location().rootPaths()).stream()
             .collect(Collectors.toList());
 
     for (Path p : paths) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AlterTableDatasetBuilderTest.java
@@ -13,11 +13,12 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
-import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.spark.SparkContext;
@@ -32,8 +33,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import scala.collection.immutable.HashMap;
-import scala.collection.immutable.Map;
 
 class AlterTableDatasetBuilderTest {
 
@@ -76,10 +75,7 @@ class AlterTableDatasetBuilderTest {
     when(tableCatalog.loadTable(identifier)).thenReturn(table);
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(
-              openLineageContext,
-              tableCatalog,
-              identifier,
-              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+              openLineageContext, tableCatalog, identifier, tableProperties))
           .thenReturn(Optional.empty());
 
       List<OpenLineage.OutputDataset> outputDatasets =
@@ -94,10 +90,7 @@ class AlterTableDatasetBuilderTest {
     when(tableCatalog.loadTable(identifier)).thenReturn(table);
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(
-              openLineageContext,
-              tableCatalog,
-              identifier,
-              ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+              openLineageContext, tableCatalog, identifier, tableProperties))
           .thenReturn(Optional.of(di));
 
       List<OpenLineage.OutputDataset> outputDatasets =
@@ -116,17 +109,11 @@ class AlterTableDatasetBuilderTest {
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
       try (MockedStatic mockCatalog = mockStatic(CatalogUtils3.class)) {
         when(CatalogUtils3.getDatasetVersion(
-                openLineageContext,
-                tableCatalog,
-                identifier,
-                ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+                openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(Optional.of("v2"));
 
         when(PlanUtils3.getDatasetIdentifier(
-                openLineageContext,
-                tableCatalog,
-                identifier,
-                ScalaConversionUtils.<String, String>fromMap(tableProperties)))
+                openLineageContext, tableCatalog, identifier, tableProperties))
             .thenReturn(Optional.of(di));
 
         List<OpenLineage.OutputDataset> outputDatasets =

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.List;
@@ -34,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import scala.Option;
 import scala.Option$;
-import scala.collection.Map$;
 import scala.collection.immutable.HashMap;
 
 class CreateTableLikeCommandVisitorTest {
@@ -82,7 +82,7 @@ class CreateTableLikeCommandVisitorTest {
             sourceTableIdentifier,
             CatalogStorageFormat.empty(),
             Option$.MODULE$.empty(),
-            Map$.MODULE$.empty(),
+            ScalaConversionUtils.asScalaMapEmpty(),
             false);
 
     assertThat(visitor.isDefinedAt(command)).isTrue();

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
@@ -11,20 +11,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import scala.collection.Seq;
-import scala.collection.Seq$;
 
 @Slf4j
 public class CustomCollectorsUtilsTest {
@@ -50,9 +48,9 @@ public class CustomCollectorsUtilsTest {
                 .toSeq());
     when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
     when(queryExecution.optimizedPlan()).thenReturn(plan);
-    when(child.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
-    when(plan.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
-    when(child.children()).thenReturn((Seq<LogicalPlan>) Seq$.MODULE$.empty());
+    when(child.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
+    when(plan.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
+    when(child.children()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(context.getOpenLineage()).thenReturn(openLineage);
 
     Mockito.doCallRealMethod().when(plan).foreach(any());

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -11,9 +11,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Collections;
 import org.apache.spark.sql.catalyst.expressions.Alias;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.BinaryExpression;
@@ -30,8 +31,7 @@ import org.apache.spark.sql.types.Metadata$;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import scala.Option;
-import scala.collection.Seq;
-import scala.collection.Seq$;
+import scala.collection.immutable.Seq;
 
 class ExpressionDependencyCollectorTest {
 
@@ -56,24 +56,25 @@ class ExpressionDependencyCollectorTest {
           (Expression) expression1,
           "name1",
           aliasExprId1,
-          (Seq<String>) Seq$.MODULE$.empty(),
+          ScalaConversionUtils.asScalaSeqEmpty(),
           Option.empty(),
-          (Seq<String>) Seq$.MODULE$.empty());
+          ScalaConversionUtils.asScalaSeqEmpty());
 
   Alias alias2 =
       new Alias(
           (Expression) expression2,
           "name2",
           aliasExprId2,
-          (Seq<String>) Seq$.MODULE$.empty(),
+          ScalaConversionUtils.asScalaSeqEmpty(),
           Option.empty(),
-          (Seq<String>) Seq$.MODULE$.empty());
+          ScalaConversionUtils.asScalaSeqEmpty());
 
   @Test
   void testCollectFromProjectPlan() {
     Project project =
         new Project(
-            toScalaSeq(Arrays.asList((NamedExpression) alias1, (NamedExpression) alias2)),
+            ScalaConversionUtils.fromList(
+                Arrays.asList((NamedExpression) alias1, (NamedExpression) alias2)),
             mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
 
@@ -87,8 +88,8 @@ class ExpressionDependencyCollectorTest {
   void testCollectFromAggregatePlan() {
     Aggregate aggregate =
         new Aggregate(
-            (Seq<Expression>) Seq$.MODULE$.empty(),
-            toScalaSeq(Arrays.asList((NamedExpression) alias1)),
+            ScalaConversionUtils.asScalaSeqEmpty(),
+            ScalaConversionUtils.fromList(Collections.singletonList((NamedExpression) alias1)),
             mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, aggregate, null, null, false);
 
@@ -108,10 +109,7 @@ class ExpressionDependencyCollectorTest {
 
     // BinaryExpression
     Seq<Expression> children =
-        scala.collection.JavaConverters.collectionAsScalaIterableConverter(
-                Arrays.asList((Expression) aggr1, aggr2))
-            .asScala()
-            .toSeq();
+        ScalaConversionUtils.fromList(Arrays.asList((Expression) aggr1, aggr2)).toSeq();
     BinaryExpression binaryExpression = mock(BinaryExpression.class);
     when(binaryExpression.children()).thenReturn(children);
 
@@ -121,22 +119,19 @@ class ExpressionDependencyCollectorTest {
             (Expression) binaryExpression,
             "name2",
             rootAliasExprId,
-            (Seq<String>) Seq$.MODULE$.empty(),
+            ScalaConversionUtils.asScalaSeqEmpty(),
             Option.empty(),
-            (Seq<String>) Seq$.MODULE$.empty());
+            ScalaConversionUtils.asScalaSeqEmpty());
 
-    Project project = new Project(toScalaSeq(Arrays.asList(rootAlias)), mock(LogicalPlan.class));
+    Project project =
+        new Project(
+            ScalaConversionUtils.fromList(Collections.singletonList(rootAlias)),
+            mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, project, null, null, false);
 
     ExpressionDependencyCollector.collect(context, plan, builder);
 
     verify(builder, times(1)).addDependency(rootAliasExprId, exprId1);
     verify(builder, times(1)).addDependency(rootAliasExprId, exprId2);
-  }
-
-  private Seq<NamedExpression> toScalaSeq(Collection<NamedExpression> expressions) {
-    return scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions)
-        .asScala()
-        .toSeq();
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.agent.lifecycle.Rdds;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.net.URI;
@@ -47,8 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
+import scala.collection.immutable.Seq;
 
 class InputFieldsCollectorTest {
 
@@ -236,8 +236,7 @@ class InputFieldsCollectorTest {
     when(logicalRelation.relation()).thenReturn(relation);
 
     Path p = new Path("abfss://tmp@storage.dfs.core.windows.net/path");
-    Seq<Path> expected_path_seq =
-        JavaConverters.asScalaBufferConverter(Collections.singletonList(p)).asScala();
+    Seq<Path> expected_path_seq = ScalaConversionUtils.fromList(Collections.singletonList(p));
 
     when(relation.location().rootPaths()).thenReturn(expected_path_seq);
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.sql.ColumnMeta;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,7 +30,6 @@ import org.apache.spark.sql.types.Metadata$;
 import org.apache.spark.sql.types.StringType$;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.collection.immutable.Map$;
 
 public class JdbcColumnLineageExpressionCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
@@ -57,7 +57,8 @@ public class JdbcColumnLineageExpressionCollectorTest {
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
 
-    scala.collection.immutable.Map<String, String> properties = Map$.MODULE$.empty();
+    scala.collection.immutable.Map<String, String> properties =
+        ScalaConversionUtils.<String, String>asScalaMapEmpty();
     when(jdbcOptions.parameters())
         .thenReturn(CaseInsensitiveMap$.MODULE$.<String>apply(properties));
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.sql.ColumnMeta;
 import io.openlineage.sql.DbTableMeta;
 import java.util.Arrays;
@@ -25,7 +26,6 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import scala.collection.immutable.Map$;
 
 public class JdbcColumnLineageInputCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
@@ -58,7 +58,8 @@ public class JdbcColumnLineageInputCollectorTest {
   void setup() {
     when(relation.jdbcOptions()).thenReturn(jdbcOptions);
 
-    scala.collection.immutable.Map<String, String> properties = Map$.MODULE$.empty();
+    scala.collection.immutable.Map<String, String> properties =
+        ScalaConversionUtils.<String, String>asScalaMapEmpty();
     when(jdbcOptions.parameters())
         .thenReturn(CaseInsensitiveMap$.MODULE$.<String>apply(properties));
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/OutputFieldsCollectorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
@@ -21,8 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Project;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import scala.collection.Seq;
-import scala.collection.Seq$;
+import scala.collection.immutable.Seq;
 
 class OutputFieldsCollectorTest {
 
@@ -35,11 +35,7 @@ class OutputFieldsCollectorTest {
   ExprId exprId1 = mock(ExprId.class);
   ExprId exprId2 = mock(ExprId.class);
 
-  Seq<Attribute> attrs =
-      scala.collection.JavaConverters.collectionAsScalaIterableConverter(
-              Arrays.asList(attr1, attr2))
-          .asScala()
-          .toSeq();
+  Seq<Attribute> attrs = ScalaConversionUtils.fromList(Arrays.asList(attr1, attr2)).toSeq();
 
   @BeforeEach
   void setup() {
@@ -49,7 +45,7 @@ class OutputFieldsCollectorTest {
     when(attr2.name()).thenReturn("name2");
     when(attr2.exprId()).thenReturn(exprId2);
 
-    when(plan.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(plan.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(builder.hasOutputs()).thenReturn(true);
   }
 
@@ -72,7 +68,7 @@ class OutputFieldsCollectorTest {
     when(namedExpression.exprId()).thenReturn(exprId);
 
     Aggregate aggregate = mock(Aggregate.class);
-    when(aggregate.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(aggregate.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(aggregate.aggregateExpressions())
         .thenReturn(
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(
@@ -94,7 +90,7 @@ class OutputFieldsCollectorTest {
     when(namedExpression.exprId()).thenReturn(exprId);
 
     Project project = mock(Project.class);
-    when(project.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(project.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(project.projectList())
         .thenReturn(
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(
@@ -112,7 +108,7 @@ class OutputFieldsCollectorTest {
     LogicalPlan childPlan = mock(LogicalPlan.class);
     when(childPlan.output()).thenReturn(attrs);
 
-    when(plan.output()).thenReturn((Seq<Attribute>) Seq$.MODULE$.empty());
+    when(plan.output()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(builder.hasOutputs()).thenReturn(false).thenReturn(true);
     when(plan.children())
         .thenReturn(

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
@@ -12,8 +12,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.expressions.NamedExpression;
@@ -50,15 +52,18 @@ class UnionFieldDependencyCollectorTest {
   void testCollect() {
     Union union =
         new Union(
-            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
+            ScalaConversionUtils.fromList(
                     Arrays.asList(
                         (LogicalPlan)
                             new Project(
-                                toScalaSeq(Arrays.asList(expression1)), mock(LogicalPlan.class)),
+                                ScalaConversionUtils.fromList(
+                                    Collections.singletonList(expression1)),
+                                mock(LogicalPlan.class)),
                         (LogicalPlan)
                             new Project(
-                                toScalaSeq(Arrays.asList(expression2)), mock(LogicalPlan.class))))
-                .asScala()
+                                ScalaConversionUtils.fromList(
+                                    Collections.singletonList(expression2)),
+                                mock(LogicalPlan.class))))
                 .toSeq(),
             true,
             true);

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -37,8 +37,6 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import scala.collection.Seq;
-import scala.collection.Seq$;
 import scala.collection.immutable.HashMap;
 import scala.collection.immutable.Map;
 
@@ -60,7 +58,7 @@ public class CreateReplaceVisitorDatasetBuilderTest {
   Identifier tableName = Identifier.of(new String[] {"db"}, TABLE);
 
   ResolvedDBObjectName namePlan =
-      new ResolvedDBObjectName(catalog, (Seq<String>) Seq$.MODULE$.empty());
+      new ResolvedDBObjectName(catalog, ScalaConversionUtils.asScalaSeqEmpty());
   TableSpec tableSpec = mock(TableSpec.class);
 
   @BeforeEach

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
-import scala.collection.Seq$;
 
 public class MergeIntoDelta24ColumnLineageVisitorTest {
 
@@ -67,8 +66,8 @@ public class MergeIntoDelta24ColumnLineageVisitorTest {
 
     when(command.source()).thenReturn(source);
     when(command.target()).thenReturn(target);
-    when(command.matchedClauses()).thenReturn(Seq$.MODULE$.empty());
-    when(command.notMatchedClauses()).thenReturn(Seq$.MODULE$.empty());
+    when(command.matchedClauses()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
+    when(command.notMatchedClauses()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
 
     try (MockedStatic mocked = mockStatic(InputFieldsCollector.class)) {
       visitor.collectInputs(command, builder);

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
-import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -40,10 +39,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
-import scala.collection.Seq;
 import scala.collection.immutable.HashMap;
 import scala.collection.immutable.Map;
-import scala.collection.immutable.Seq$;
 
 public class CreateReplaceDatasetBuilderTest {
 
@@ -68,7 +65,7 @@ public class CreateReplaceDatasetBuilderTest {
           catalog,
           mock(Identifier.class),
           mock(Table.class),
-          (Seq<Attribute>) Seq$.MODULE$.empty());
+          ScalaConversionUtils.asScalaSeqEmpty());
 
   TableSpec tableSpec = mock(TableSpec.class);
 


### PR DESCRIPTION
### Problem

This initial step is to start supporting compilation for Scala 2.13 in the 3.2+ Spark versions.

Scala 2.13 changed the default collection to immutable, the methods to create an empty collection, and the conversion between Java and Scala. This causes the code to not compile between 2.12 and 2.13.

Issues: #2303 #2227

### Solution

Replace the usage of direct Scala collection methods (like creating an empty object) and conversions utils with `ScalaConversionUtils` methods that will support cross-compilation.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project