### PR TITLE
airflow: Add dag_id to task_run_id to avoid duplicates

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -81,11 +81,11 @@ class OpenLineageAdapter:
         return str(uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{dag_run_id}"))
 
     @staticmethod
-    def build_task_instance_run_id(task_id, execution_date, try_number):
+    def build_task_instance_run_id(dag_id, task_id, execution_date, try_number):
         return str(
             uuid.uuid3(
                 uuid.NAMESPACE_URL,
-                f"{_DAG_NAMESPACE}.{task_id}.{execution_date}.{try_number}",
+                f"{_DAG_NAMESPACE}.{dag_id}.{task_id}.{execution_date}.{try_number}",
             )
         )
 

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -122,7 +122,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
         parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
         task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            task.task_id, ti.execution_date, ti._try_number
+            dag.dag_id, task.task_id, ti.execution_date, ti._try_number
         )
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task, task_uuid=task_uuid)
@@ -161,7 +161,7 @@ def on_task_instance_success(previous_state, task_instance: "TaskInstance", sess
     parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance._try_number
+        dag.dag_id, task.task_id, task_instance.execution_date, task_instance._try_number
     )
 
     def on_success():
@@ -190,7 +190,7 @@ def on_task_instance_failed(previous_state, task_instance: "TaskInstance", sessi
     parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance._try_number
+        dag.dag_id, task.task_id, task_instance.execution_date, task_instance._try_number
     )
 
     def on_failure():

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -27,7 +27,7 @@ def lineage_run_id(task: "BaseOperator", task_instance: "TaskInstance"):
     )
     """
     return OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance.try_number
+        task_instance.dag_id, task.task_id, task_instance.execution_date, task_instance.try_number
     )
 
 
@@ -47,6 +47,6 @@ def lineage_parent_id(run_id: str, task: "BaseOperator", task_instance: "TaskIns
     )
     """
     job_name = OpenLineageAdapter.build_task_instance_run_id(
-        task.task_id, task_instance.execution_date, task_instance.try_number
+        task_instance.dag_id, task.task_id, task_instance.execution_date, task_instance.try_number
     )
     return f"{_JOB_NAMESPACE}/{job_name}/{run_id}"

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -53,7 +53,7 @@ class Backend:
         )
 
         task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            operator.task_id, task_instance.execution_date, task_instance.try_number
+            dag.dag_id, operator.task_id, task_instance.execution_date, task_instance.try_number
         )
         start, end = get_dagrun_start_end(dagrun, dag)
 

--- a/integration/airflow/tests/test_listener.py
+++ b/integration/airflow/tests/test_listener.py
@@ -205,7 +205,7 @@ def test_running_task_correctly_calls_adapter_build_ti_run_id_method(
     task_instance.state = state
 
     on_task_instance_running(None, task_instance, None)
-    mock_adapter.build_task_instance_run_id.assert_called_once_with("task_id", "execution_date", 1)
+    mock_adapter.build_task_instance_run_id.assert_called_once_with("dag_id", "task_id", "execution_date", 1)
 
 
 @pytest.mark.parametrize("state", TaskInstanceState)
@@ -220,7 +220,7 @@ def test_failed_task_correctly_calls_adapter_build_ti_run_id_method(
     task_instance.state = state
 
     on_task_instance_failed(None, task_instance, None)
-    mock_adapter.build_task_instance_run_id.assert_called_with("task_id", "execution_date", 1)
+    mock_adapter.build_task_instance_run_id.assert_called_with("dag_id", "task_id", "execution_date", 1)
 
 
 @pytest.mark.parametrize("state", TaskInstanceState)
@@ -235,4 +235,4 @@ def test_successful_task_correctly_calls_adapter_build_ti_run_id_method(
     task_instance.state = state
 
     on_task_instance_success(None, task_instance, None)
-    mock_adapter.build_task_instance_run_id.assert_called_with("task_id", "execution_date", 1)
+    mock_adapter.build_task_instance_run_id.assert_called_with("dag_id", "task_id", "execution_date", 1)

--- a/integration/airflow/tests/test_macros.py
+++ b/integration/airflow/tests/test_macros.py
@@ -1,0 +1,42 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+import uuid
+from unittest import mock
+
+from openlineage.airflow.adapter import _DAG_NAMESPACE
+from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+
+
+def test_lineage_run_id():
+    task_instance = mock.MagicMock(
+        dag_id="dag_id",
+        execution_date="execution_date",
+        try_number=1,
+    )
+    task = mock.MagicMock(task_id="task_id")
+    actual = lineage_run_id(task=task, task_instance=task_instance)
+    expected = str(
+        uuid.uuid3(
+            uuid.NAMESPACE_URL,
+            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
+        )
+    )
+    assert actual == expected
+
+
+def test_lineage_parent_id():
+    task_instance = mock.MagicMock(
+        dag_id="dag_id",
+        execution_date="execution_date",
+        try_number=1,
+    )
+    task = mock.MagicMock(task_id="task_id")
+    actual = lineage_parent_id(run_id="run_id", task_instance=task_instance, task=task)
+    job_name = str(
+        uuid.uuid3(
+            uuid.NAMESPACE_URL,
+            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
+        )
+    )
+    expected = f"{_DAG_NAMESPACE}/{job_name}/run_id"
+    assert actual == expected

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -404,25 +404,23 @@ def test_build_dag_run_id_uses_correct_methods_underneath():
 
 
 def test_build_task_instance_run_id_is_valid_uuid():
-    task_id = "task_1"
-    execution_date = "2023-01-01"
-    try_number = 1
-    result = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    result = OpenLineageAdapter.build_task_instance_run_id("dag_id", "task_id", "execution_date", 1)
     assert uuid.UUID(result)
 
 
 def test_build_task_instance_run_id_different_inputs_gives_different_results():
-    result1 = OpenLineageAdapter.build_task_instance_run_id("task1", "2023-01-01", 1)
-    result2 = OpenLineageAdapter.build_task_instance_run_id("task2", "2023-01-02", 2)
+    result1 = OpenLineageAdapter.build_task_instance_run_id("dag_id", "task1", "2023-01-01", 1)
+    result2 = OpenLineageAdapter.build_task_instance_run_id("dag_id", "task2", "2023-01-02", 2)
     assert result1 != result2
 
 
 def test_build_task_instance_run_id_uses_correct_methods_underneath():
+    dag_id = "dag_id"
     task_id = "task_1"
     execution_date = "2023-01-01"
     try_number = 1
     expected = str(
-        uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{task_id}.{execution_date}.{try_number}")
+        uuid.uuid3(uuid.NAMESPACE_URL, f"{_DAG_NAMESPACE}.{dag_id}.{task_id}.{execution_date}.{try_number}")
     )
-    actual = OpenLineageAdapter.build_task_instance_run_id(task_id, execution_date, try_number)
+    actual = OpenLineageAdapter.build_task_instance_run_id(dag_id, task_id, execution_date, try_number)
     assert actual == expected


### PR DESCRIPTION
### Problem
Reference [PR](https://github.com/apache/airflow/pull/36659) in Airflow provider package.

We might get the same run_id for the corresponding tasks even though they come from different dags. This happens when two dags are almost identical (same task ids, same schedules).

F.e., in this case we have the same dag copied twice, but i changed the name of one of them. When we allow dags to run backfill, we will receive events from two dags, but the run_id for task events will be the same in both cases.
```
from airflow import DAG
from airflow.operators.bash import BashOperator
from airflow.utils.dates import days_ago

with DAG(
    dag_id='test',
    start_date=days_ago(2),
    schedule_interval="@daily",
    catchup=True
) as dag1:
    task1 = BashOperator(
        task_id='run',
        bash_command="echo 'test'; "
    )


with DAG(
    dag_id='test_1',
    start_date=days_ago(2),
    schedule_interval="@daily",
    catchup=True
) as dag2:
    task2 = BashOperator(
        task_id='run',
        bash_command="echo 'test'; "
    )
```

### Solution

To fix that, I added a dag_id to the function that generates run_id for the task. I also added some macros tests and adjusted all other tests.

#### One-line summary:
Lack of dag_id in task_run_id can cause duplicates in run_id across different dags.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project