### PR TITLE
[SPARK] Bump BigQuery version from 0.26.0 to 0.29.0 in /integration/spark

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -59,7 +59,7 @@ archivesBaseName='openlineage-spark-app'
 
 ext {
     assertjVersion = '3.25.1'
-    bigqueryVersion = '0.26.0'
+    bigqueryVersion = '0.29.0'
     sparkVersion = project.getProperty('spark.version')
     postgresqlVersion = '42.7.1'
     mockitoVersion = '4.11.0'

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
@@ -114,7 +114,8 @@ public class MockBigQueryRelationProvider extends BigQueryRelationProvider {
                         }
                       })),
               DataSourceVersion.V1,
-              false));
+              false,
+              Optional.empty()));
     }
 
     public void setTestModule(Module testModule) {

--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/connector/common/MockBigQueryClientModule.java
@@ -32,6 +32,7 @@ public class MockBigQueryClientModule implements Module {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -52,7 +52,7 @@ ext {
     sparkVersion = '3.4.0'
     jacksonVersion = '2.15.3'
     lombokVersion = '1.18.30'
-    bigqueryVersion = '0.26.0'
+    bigqueryVersion = '0.29.0'
 }
 
 configurations.all { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -52,7 +52,7 @@ ext {
     sparkVersion = '3.5.0'
     jacksonVersion = '2.15.3'
     lombokVersion = '1.18.30'
-    bigqueryVersion = '0.26.0'
+    bigqueryVersion = '0.29.0'
 }
 
 dependencies {


### PR DESCRIPTION
### Problem

Align the `com.google.cloud.spark:spark-bigquery-with-dependencies_2.12` with the other projects `shared` and `spark3` and use a version that support Scala 2.13.

Issues: https://github.com/OpenLineage/OpenLineage/issues/2303 https://github.com/OpenLineage/OpenLineage/issues/2227

### Solution

Upgrade the `com.google.cloud.spark:spark-bigquery-with-dependencies_2.12` from `0.26.0` to `0.29.0` in the projects `spark35`, `spark34`, `app`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project