### PR TITLE
[SPARK] Fix a type incompatibility in RddExecutionContext between Scala 2.12 and 2.13

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -44,7 +44,6 @@ import org.apache.parquet.Strings;
 import org.apache.spark.Dependency;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkContext$;
-import org.apache.spark.TaskContext;
 import org.apache.spark.internal.io.HadoopMapRedWriteConfigUtil;
 import org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil;
 import org.apache.spark.rdd.HadoopRDD;
@@ -61,8 +60,6 @@ import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.apache.spark.util.SerializableJobConf;
-import scala.Function2;
-import scala.collection.Iterator;
 import scala.collection.Seq;
 import scala.runtime.AbstractFunction0;
 
@@ -107,11 +104,11 @@ class RddExecutionContext implements ExecutionContext {
     this.inputs = findInputs(rdds);
     Configuration jc = new JobConf();
     if (activeJob.finalStage() instanceof ResultStage) {
-      Function2<TaskContext, Iterator<?>, ?> fn = ((ResultStage) activeJob.finalStage()).func();
+      ResultStage resultStage = (ResultStage) activeJob.finalStage();
       try {
-        Field f = getConfigField(fn);
+        Field f = getConfigField(resultStage);
         f.setAccessible(true);
-        Object conf = f.get(fn);
+        Object conf = f.get(resultStage.func());
 
         if (conf instanceof HadoopMapRedWriteConfigUtil) {
           Field confField = HadoopMapRedWriteConfigUtil.class.getDeclaredField("conf");
@@ -143,16 +140,15 @@ class RddExecutionContext implements ExecutionContext {
    * In spark2 we can get it by "config$1" field.<br>
    * In spark3 we can get it by "arg$1" field
    *
-   * @param fn
+   * @param resultStage
    * @return HadoopMapRedWriteConfigUtil field
    * @throws NoSuchFieldException
    */
-  private Field getConfigField(Function2<TaskContext, Iterator<?>, ?> fn)
-      throws NoSuchFieldException {
+  private Field getConfigField(ResultStage resultStage) throws NoSuchFieldException {
     try {
-      return fn.getClass().getDeclaredField("config$1");
+      return resultStage.func().getClass().getDeclaredField("config$1");
     } catch (NoSuchFieldException e) {
-      return fn.getClass().getDeclaredField("arg$1");
+      return resultStage.func().getClass().getDeclaredField("arg$1");
     }
   }
 


### PR DESCRIPTION

### Problem

The function from the `ResultStage.func()` object change type in Spark between Scala 2.12 and 2.13 makes the compilation fail. 
```
incompatible types: Function2,CAP#1> cannot be converted to Function2,?> 

where CAP#1 is a fresh type-variable: CAP#1 extends Object from capture of ?
```

Issues: https://github.com/OpenLineage/OpenLineage/issues/2303 https://github.com/OpenLineage/OpenLineage/issues/2227

### Solution
Avoid getting the function with an explicit type; instead, get it every time it is needed from the `ResultStage` object. 

This PR is part of the effort to support Scala 2.13 in the Spark OpenLineage integration.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project