### PR TITLE
[SPARK] Support multiple Scala versions `LogicalPlan` implementation

### DIFF
--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializerTest.java
@@ -65,8 +65,8 @@ import org.junit.jupiter.api.Test;
 import org.postgresql.Driver;
 import scala.Option;
 import scala.collection.Seq;
-import scala.collection.Seq$;
 import scala.collection.immutable.HashMap;
+import scala.collection.immutable.IndexedSeq;
 
 class LogicalPlanSerializerTest {
   private static final String TEST_DATA = "test_data";
@@ -139,6 +139,7 @@ class LogicalPlanSerializerTest {
 
   @Test
   void testSerializeLogicalPlanReturnsAlwaysValidJson() throws IOException {
+
     LogicalPlan notSerializablePlan =
         new LogicalPlan() {
           @Override
@@ -146,8 +147,17 @@ class LogicalPlanSerializerTest {
             return null;
           }
 
+          public LogicalPlan withNewChildrenInternal(
+              scala.collection.IndexedSeq<LogicalPlan> newChildren) {
+            return null;
+          }
+
           @Override
           public Seq<LogicalPlan> children() {
+            return null;
+          }
+
+          public LogicalPlan withNewChildrenInternal(IndexedSeq<LogicalPlan> newChildren) {
             return null;
           }
 
@@ -355,7 +365,16 @@ class LogicalPlanSerializerTest {
 
           @Override
           public Seq<LogicalPlan> children() {
-            return Seq$.MODULE$.empty();
+            return ScalaConversionUtils.asScalaSeqEmpty();
+          }
+
+          public LogicalPlan withNewChildrenInternal(IndexedSeq<LogicalPlan> newChildren) {
+            return null;
+          }
+
+          public LogicalPlan withNewChildrenInternal(
+              scala.collection.IndexedSeq<LogicalPlan> newChildren) {
+            return null;
           }
 
           @Override
@@ -399,7 +418,16 @@ class LogicalPlanSerializerTest {
 
           @Override
           public Seq<LogicalPlan> children() {
-            return Seq$.MODULE$.empty();
+            return ScalaConversionUtils.asScalaSeqEmpty();
+          }
+
+          public LogicalPlan withNewChildrenInternal(IndexedSeq<LogicalPlan> newChildren) {
+            return null;
+          }
+
+          public LogicalPlan withNewChildrenInternal(
+              scala.collection.IndexedSeq<LogicalPlan> newChildren) {
+            return null;
           }
 
           @Override


### PR DESCRIPTION
### Problem

In the `LogicalPlanSerializerTest` class, the implementation of the `LogicalPlan` interface is different between Scala 2.12 and Scala 2.13. In detail, the `IndexedSeq` change package from the `scala.collection` to `scala.collection.immutable`.

Issues: https://github.com/OpenLineage/OpenLineage/issues/2303 https://github.com/OpenLineage/OpenLineage/issues/2227

### Solution

Implement both of the methods necessary in the two versions.

```
public LogicalPlan withNewChildrenInternal(
              scala.collection.IndexedSeq<LogicalPlan> newChildren) {
            return null;
          }
 public LogicalPlan withNewChildrenInternal(
              scala.collection.immutable.IndexedSeq<LogicalPlan> newChildren) {
            return null;
          }
```

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project