### PR TITLE
airflow: Add database information to SnowflakeExtractor

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/snowflake_extractor.py
@@ -20,6 +20,7 @@ class SnowflakeExtractor(SqlExtractor):
         "column_name",
         "ordinal_position",
         "data_type",
+        "table_catalog",
     ]
     _is_information_schema_cross_db = True
     _is_uppercase_names = True

--- a/integration/airflow/tests/extractors/test_snowflake_extractor.py
+++ b/integration/airflow/tests/extractors/test_snowflake_extractor.py
@@ -183,7 +183,7 @@ def test_information_schema_query(get_connection):
     ]
 
     same_db_explicit_sql = (
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM DB.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A','TABLE_B') );"
     )
@@ -191,7 +191,7 @@ def test_information_schema_query(get_connection):
     same_db_implicit = [DbTableMeta("SCHEMA.TABLE_A"), DbTableMeta("SCHEMA.TABLE_B")]
 
     same_db_implicit_sql = (
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM FOOD_DELIVERY.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A','TABLE_B') );"
     )
@@ -202,11 +202,11 @@ def test_information_schema_query(get_connection):
     ]
 
     different_databases_explicit_sql = (
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM DB_1.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A') ) "
         "UNION ALL "
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM DB_2.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_B') );"
     )
@@ -217,11 +217,11 @@ def test_information_schema_query(get_connection):
     ]
 
     different_databases_mixed_sql = (
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM FOOD_DELIVERY.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_A') ) "
         "UNION ALL "
-        "SELECT table_schema, table_name, column_name, ordinal_position, data_type "
+        "SELECT table_schema, table_name, column_name, ordinal_position, data_type, table_catalog "
         "FROM DB_2.information_schema.columns "
         "WHERE ( table_schema = 'SCHEMA' AND table_name IN ('TABLE_B') );"
     )


### PR DESCRIPTION
### Problem

SnowflakeExtractor is not extracting database name from Snowflake. When no database is extracted the one from connection is used, which can cause having wrong dataset names in OL events.

F.e.
If database provided in connection is `DB_CONN`, and the query looks like this: `INSERT INTO X.Y.Z (var1) values ('test')` we can still end up with Dataset name `DB_CONN.Y.Z` in OL event, so the database specified in query is not taken into consideration.

### Solution

I added a database name (`table_catalog `) to the list of columns that are selected when looking for schema information in Snowflake.

#### One-line summary:
Fixes missing database information in SnowflakeExtractor

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project