### PR TITLE
[FLINK] support flink 1.18

### DIFF
--- a/.circleci/workflows/openlineage-flink.yml
+++ b/.circleci/workflows/openlineage-flink.yml
@@ -4,13 +4,13 @@ workflows:
       - build-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.0' ]
           requires:
             - build-client-java
       - integration-test-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.0' ]
           requires:
             - build-integration-flink
       - workflow_complete:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 * **Spark: Support `MERGE INTO` queries on Databricks** [`#2283`](https://github.com/OpenLineage/OpenLineage/pull/2283) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Support custom plan nodes used when running `MERGE INTO` queries on Databricks runtime.*
+* **Flink: Support Flink 1.18.0**
+  *Add Flink 1.8.0 as default flink version and introduce it into integration test*
 
 ### Fixed
 * **Spark: Fix `removePathPattern` feature** [`#2350`](https://github.com/OpenLineage/OpenLineage/pull/2350) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -66,9 +66,10 @@ ext {
     icebergVersion = "1.3.0"
 
     versionsMap = [
-            "1.15": ["cassandra": "1.15.4"],
-            "1.16": ["cassandra": "3.0.0-1.16"],
-            "1.17": ["cassandra": "3.1.0-1.17"]
+            "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "alternativeShort": "1.15"],
+            "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "alternativeShort": "1.16"],
+            "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "alternativeShort": "1.17"],
+            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "alternativeShort": "1.17"]
     ]
 
     versions = versionsMap[flinkVersionShort]
@@ -82,10 +83,10 @@ dependencies {
     compileOnly "org.apache.flink:flink-streaming-java:$flinkVersion"
     compileOnly "org.apache.flink:flink-runtime-web:$flinkVersion"
     compileOnly "org.apache.flink:flink-table-common:$flinkVersion"
-    compileOnly "org.apache.flink:flink-connector-kafka:$flinkVersion"
+    compileOnly "org.apache.flink:flink-connector-kafka:${versions.kafka}"
     compileOnly "org.apache.flink:flink-avro:$flinkVersion"
     compileOnly "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
-    compileOnly "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:$icebergVersion"
+    compileOnly "org.apache.iceberg:iceberg-flink-runtime-${versions.alternativeShort}:$icebergVersion"
     compileOnly "org.apache.flink:flink-connector-cassandra_2.12:${versions.cassandra}"
 
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
@@ -96,12 +97,13 @@ dependencies {
     testImplementation "org.apache.flink:flink-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-streaming-java:$flinkVersion"
     testImplementation "org.apache.flink:flink-runtime-web:$flinkVersion"
-    testImplementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
+    testImplementation "org.apache.flink:flink-connector-base:$flinkVersion"
+    testImplementation "org.apache.flink:flink-connector-kafka:${versions.kafka}"
     testImplementation "org.apache.flink:flink-connector-cassandra_2.12:${versions.cassandra}"
     testImplementation "org.apache.flink:flink-table-common:$flinkVersion"
     testImplementation "org.apache.flink:flink-avro:$flinkVersion"
     testImplementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
-    testImplementation "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:$icebergVersion"
+    testImplementation "org.apache.iceberg:iceberg-flink-runtime-${versions.alternativeShort}:$icebergVersion"
     testImplementation platform('org.junit:junit-bom:5.10.1')
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation "org.testcontainers:mockserver:${testcontainersVersion}"

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -58,9 +58,10 @@ ext {
     icebergVersion = "1.3.0"
 
     versionsMap = [
-            "1.15": ["cassandra": "1.15.4"],
-            "1.16": ["cassandra": "3.0.0-1.16"],
-            "1.17": ["cassandra": "3.1.0-1.17"]
+            "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "alternativeShort": "1.15"],
+            "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "alternativeShort": "1.16"],
+            "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "alternativeShort": "1.17"],
+            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "alternativeShort": "1.17"]
     ]
 
     versions = versionsMap[flinkVersionShort]
@@ -84,8 +85,9 @@ dependencies {
     compileOnly "org.apache.flink:flink-streaming-java:$flinkVersion"
     compileOnly "org.apache.flink:flink-runtime-web:$flinkVersion"
     compileOnly "org.apache.flink:flink-core:$flinkVersion"
+    compileOnly "org.apache.flink:flink-connector-base:$flinkVersion"
     implementation "org.apache.flink:flink-runtime:$flinkVersion"
-    implementation "org.apache.flink:flink-connector-kafka:$flinkVersion"
+    implementation "org.apache.flink:flink-connector-kafka:${versions.kafka}"
     implementation "org.apache.flink:flink-connector-cassandra_2.12:${versions.cassandra}"
     implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
     implementation "org.apache.flink:flink-avro:$flinkVersion"
@@ -108,7 +110,7 @@ dependencies {
     }
     implementation "org.apache.avro:avro"
 
-    implementation "org.apache.iceberg:iceberg-flink-runtime-$flinkVersionShort:$icebergVersion"
+    implementation "org.apache.iceberg:iceberg-flink-runtime-${versions.alternativeShort}:$icebergVersion"
 }
 
 assemble {

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
 version=1.8.0-SNAPSHOT
-flink.version=1.17.1
+flink.version=1.18.0
 org.gradle.jvmargs=-Xmx1G


### PR DESCRIPTION
### Problem
Support Open lineage for Flink 1.18.0

### Solution
Flink 1.18.0 has been released for more than 3 months. Flink 1.18.1 is on its way. As more and more users are using Flink 1.18 in production, Open lineage want to support Flink 1.18.0 for potential needs. Currently, there are some blockers to support it cleanly.

1. Iceberg Flink runtime module for Flink 1.18 is not released
2. Cassandra connector Flink 1.18 is not released.

As a workaround, we use 1.17 version for these two libs as public interfaces needed for Open Lineage visitor for them  are not changed.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project