### PR TITLE
Flink/multi topic sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.8.0...HEAD)
 
+### Added
+* **Flink: support multi topic Kafka Sink.** [`#2372`](https://github.com/OpenLineage/OpenLineage/pull/2372) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Support multi topic kafka sinks. Limitations: `recordSerializer` need to implement `KafkaTopicsDescriptor`. Please refer to [limitations](https://openlineage.io/docs/integrations/flink/#limitations) sections in documentation.*
+
 ## [1.8.0](https://github.com/OpenLineage/OpenLineage/compare/1.7.0...1.8.0) - 2024-01-19
 
 * **Flink: support Flink 1.18** [`#2366`](https://github.com/OpenLineage/OpenLineage/pull/2366) [@HuangZhenQiu](https://github.com/HuangZhenQiu)  

--- a/integration/flink/examples/stateful/src/docker/docker-compose.yml
+++ b/integration/flink/examples/stateful/src/docker/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     container_name: jobmanager
     ports:
       - "18081:8081"
-    command: standalone-job --job-classname io.openlineage.flink.FlinkStatefulApplication --input-topics "io.openlineage.flink.kafka.input" --output-topic "io.openlineage.flink.kafka.output"
+    command: standalone-job --job-classname io.openlineage.flink.FlinkStatefulApplication --input-topics "io.openlineage.flink.kafka.input" --output-topics "io.openlineage.flink.kafka.output"
     volumes:
       - ../../build/libs:/opt/flink/usrlib
     environment:

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkLegacyKafkaApplication.java
@@ -30,7 +30,7 @@ public class FlinkLegacyKafkaApplication {
         .process(new StatefulCounter())
         .name("process")
         .uid("process")
-        .addSink(legacyKafkaSink(parameters.getRequired("output-topic")))
+        .addSink(legacyKafkaSink(parameters.getRequired("output-topics")))
         .name("kafka-sink")
         .uid("kafka-sink");
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkMultiTopicSinkApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkMultiTopicSinkApplication.java
@@ -5,23 +5,31 @@
 
 package io.openlineage.flink;
 
+import static io.openlineage.common.config.ConfigWrapper.fromResource;
 import static io.openlineage.flink.StreamEnvironment.setupEnv;
-import static io.openlineage.kafka.KafkaClientProvider.aKafkaSink;
 import static io.openlineage.kafka.KafkaClientProvider.aKafkaSource;
 import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
 
 import io.openlineage.flink.avro.event.InputEvent;
+import io.openlineage.flink.avro.event.OutputEvent;
 import io.openlineage.util.OpenLineageFlinkJobListenerBuilder;
+import java.util.Map;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.formats.avro.AvroSerializationSchema;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
-public class FlinkStatefulApplication {
+public class FlinkMultiTopicSinkApplication {
 
   private static final String TOPIC_PARAM_SEPARATOR = ",";
 
   public static void main(String[] args) throws Exception {
     ParameterTool parameters = ParameterTool.fromArgs(args);
     StreamExecutionEnvironment env = setupEnv(args);
+    String[] topics = parameters.getRequired("output-topics").split(TOPIC_PARAM_SEPARATOR);
 
     env.fromSource(
             aKafkaSource(parameters.getRequired("input-topics").split(TOPIC_PARAM_SEPARATOR)),
@@ -32,11 +40,17 @@ public class FlinkStatefulApplication {
         .process(new StatefulCounter())
         .name("process")
         .uid("process")
-        .sinkTo(aKafkaSink(parameters.getRequired("output-topics")))
+        .sinkTo(
+            KafkaSink.<OutputEvent>builder()
+                .setRecordSerializer(new MultiTopicSerializationSchema(topics))
+                .setKafkaProducerConfig(fromResource("kafka-producer.conf").toProperties())
+                .setBootstrapServers("kafka:9092")
+                .build()
+        )
         .name("kafka-sink")
         .uid("kafka-sink");
 
-    String jobName = parameters.get("job-name", "flink_examples_stateful");
+    String jobName = parameters.get("job-name", "flink_multi_topic_sink");
     env.registerJobListener(
         OpenLineageFlinkJobListenerBuilder.create()
             .executionEnvironment(env)

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
@@ -49,7 +49,7 @@ public class FlinkSourceWithGenericRecordApplication {
         .process(new StatefulCounter())
         .name("process")
         .uid("process")
-        .sinkTo(aKafkaSink(parameters.getRequired("output-topic")))
+        .sinkTo(aKafkaSink(parameters.getRequired("output-topics")))
         .name("kafka-sink")
         .uid("kafka-sink");
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStoppableApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkStoppableApplication.java
@@ -54,7 +54,7 @@ public class FlinkStoppableApplication {
         .process(new StatefulCounter())
         .name("process")
         .uid("process")
-        .sinkTo(aKafkaSink(parameters.getRequired("output-topic")))
+        .sinkTo(aKafkaSink(parameters.getRequired("output-topics")))
         .name("kafka-sink")
         .uid("kafka-sink");
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/MultiTopicSerializationSchema.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/MultiTopicSerializationSchema.java
@@ -1,0 +1,45 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import io.openlineage.flink.avro.event.OutputEvent;
+import java.util.Arrays;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.formats.avro.AvroSerializationSchema;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+public class MultiTopicSerializationSchema extends KafkaTopicsDescriptor implements
+    KafkaRecordSerializationSchema<OutputEvent> {
+
+  public MultiTopicSerializationSchema(String[] topics) {
+    super(Arrays.asList(topics), null);
+  }
+
+  @Override
+  public void open(
+      SerializationSchema.InitializationContext context,
+      KafkaSinkContext sinkContext)
+      throws Exception {
+    KafkaRecordSerializationSchema.super.open(context, sinkContext);
+  }
+
+  @Override
+  public ProducerRecord<byte[], byte[]> serialize(
+      OutputEvent t, KafkaSinkContext kafkaSinkContext, Long aLong) {
+    AvroSerializationSchema<OutputEvent> serializer = AvroSerializationSchema.forSpecific(OutputEvent.class);
+    return new ProducerRecord<>(getTopic(t), serializer.serialize(t));
+  }
+
+  public String getTopic(OutputEvent outputEvent) {
+    if (outputEvent.counter % 2 == 0) {
+      return getFixedTopics().get(0);
+    } else {
+      return getFixedTopics().get(1);
+    }
+  }
+}

--- a/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
+++ b/integration/flink/examples/stateful/src/test/groovy/io/openlineage/flink/FlinkStatefulApplicationRunner.groovy
@@ -7,7 +7,7 @@ package io.openlineage.flink
 
 class FlinkStatefulApplicationRunner {
     private static String[] PARAMETERS = ["--input-topics", "io.openlineage.flink.kafka.input",
-                                          "--output-topic", "io.openlineage.flink.kafka.output",
+                                          "--output-topics", "io.openlineage.flink.kafka.output",
                                           "--flink.openlineage.url", "http://localhost:5000/api/v1/namespaces/flink_integration/"]
 
     static void main(String[] args) {

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapper.java
@@ -5,13 +5,21 @@
 
 package io.openlineage.flink.visitor.wrapper;
 
+import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
+import org.apache.commons.lang3.reflect.TypeUtils;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.formats.avro.AvroSerializationSchema;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 
 /**
  * Wrapper class to extract hidden fields and call hidden methods on {@link KafkaSink} object. It
@@ -38,6 +46,28 @@ public class KafkaSinkWrapper {
   public Properties getKafkaProducerConfig() {
     return WrapperUtils.<Properties>getFieldValue(KafkaSink.class, kafkaSink, "kafkaProducerConfig")
         .get();
+  }
+
+  public List<String> getTopicsOfMultiTopicSink() {
+    return Optional.of(serializationSchema)
+        .filter(serializationSchema -> serializationSchema instanceof KafkaTopicsDescriptor)
+        .map(serializationSchema -> (KafkaTopicsDescriptor) serializationSchema)
+        .filter(descriptor -> descriptor.isFixedTopics())
+        .map(descriptor -> descriptor.getFixedTopics())
+        .orElse(Collections.emptyList());
+  }
+
+  public Optional<SerializationSchema> getSchemaOfMultiTopicSink() {
+    return Arrays.stream(serializationSchema.getClass().getGenericInterfaces())
+        .filter(t -> TypeUtils.isAssignable(t, KafkaRecordSerializationSchema.class))
+        .findFirst()
+        .filter(t -> t instanceof ParameterizedType)
+        .map(t -> (ParameterizedType) t)
+        .map(t -> t.getActualTypeArguments())
+        .filter(t -> t != null || t.length > 0)
+        .map(t -> t[0])
+        .filter(t -> t instanceof Class)
+        .map(t -> AvroSerializationSchema.forSpecific((Class) t));
   }
 
   public String getKafkaTopic() throws IllegalAccessException {

--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapper.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
@@ -69,7 +70,6 @@ public class KafkaSourceWrapper {
         WrapperUtils.<Pattern>getFieldValue(
             kafkaSubscriber.getClass(), kafkaSubscriber, "topicPattern");
 
-    // TODO: write some unit test to this
     if (topicPattern.isPresent()) {
       KafkaTopicsDescriptor descriptor = new KafkaTopicsDescriptor(null, topicPattern.get());
 
@@ -79,7 +79,10 @@ public class KafkaSourceWrapper {
           KafkaPartitionDiscoverer.class, partitionDiscoverer, "initializeConnections");
       return WrapperUtils.<List<String>>invoke(
               KafkaPartitionDiscoverer.class, partitionDiscoverer, "getAllTopics")
-          .get();
+          .get()
+          .stream()
+          .filter(topic -> descriptor.isMatchingTopic(topic))
+          .collect(Collectors.toList());
     }
     return Collections.emptyList();
   }

--- a/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -16,6 +16,8 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.JsonBody.json;
 
 import com.google.common.io.Resources;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -185,6 +187,29 @@ class ContainerTest {
 
   @Test
   @SneakyThrows
+  void testMultiTopicSinkJob() {
+    Properties jobProperties = new Properties();
+    jobProperties.put("inputTopics", "io.openlineage.flink.kafka.input[0-9].*");
+    jobProperties.put(
+        "outputTopics", "io.openlineage.flink.kafka.output1,io.openlineage.flink.kafka.output2");
+    jobProperties.put("jobName", "flink_multi_topic_sink");
+    runUntilCheckpoint(
+        "io.openlineage.flink.FlinkMultiTopicSinkApplication", jobProperties, generateEvents);
+    verify("events/expected_kafka_multi_topic_sink.json");
+
+    HttpRequest[] httpRequests =
+        mockServerClient.retrieveRecordedRequests(request().withPath("/api/v1/lineage"));
+
+    RunEvent lastEvent =
+        OpenLineageClientUtils.runEventFromJson(
+            httpRequests[httpRequests.length - 1].getBodyAsString());
+
+    assertThat(lastEvent.getOutputs()).hasSize(2);
+    assertThat(lastEvent.getInputs()).hasSize(2);
+  }
+
+  @Test
+  @SneakyThrows
   void testOpenLineageEventSentForKafkaSourceWithGenericRecord() {
     runUntilCheckpoint(
         "io.openlineage.flink.FlinkSourceWithGenericRecordApplication",
@@ -294,7 +319,7 @@ class ContainerTest {
                         "--job-classname %s ", "io.openlineage.flink.FlinkStatefulApplication")
                     + "--input-topics "
                     + inputTopics
-                    + " --output-topic io.openlineage.flink.kafka.output --job-name flink_conf_job")
+                    + " --output-topics io.openlineage.flink.kafka.output --job-name flink_conf_job")
             .withEnv(
                 "FLINK_PROPERTIES",
                 "jobmanager.rpc.address: jobmanager\n"

--- a/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -72,7 +72,12 @@ public class FlinkContainerUtils {
         .withEnv("KAFKA_BROKER_ID", "1")
         .withEnv(
             "KAFKA_CREATE_TOPICS",
-            "io.openlineage.flink.kafka.input1:1:1,io.openlineage.flink.kafka.input2:1:1,io.openlineage.flink.kafka.output:1:1,io.openlineage.flink.kafka.input_no_schema_registry:1:1")
+            "io.openlineage.flink.kafka.input1:1:1,"
+                + "io.openlineage.flink.kafka.input2:1:1,"
+                + "io.openlineage.flink.kafka.output:1:1,"
+                + "io.openlineage.flink.kafka.output1:1:1,"
+                + "io.openlineage.flink.kafka.output2:1:1,"
+                + "io.openlineage.flink.kafka.input_no_schema_registry:1:1")
         .withEnv(
             "KAFKA_LOG4J_LOGGERS",
             "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO")
@@ -140,6 +145,8 @@ public class FlinkContainerUtils {
     String inputTopics =
         jobProperties.getProperty(
             "inputTopics", "io.openlineage.flink.kafka.input1,io.openlineage.flink.kafka.input2");
+    String outputTopics =
+        jobProperties.getProperty("outputTopics", "io.openlineage.flink.kafka.output");
     String jobNameParam = "";
     if (jobProperties.getProperty("jobName") != null) {
       jobNameParam = "--job-name " + jobProperties.get("jobName") + " ";
@@ -159,7 +166,9 @@ public class FlinkContainerUtils {
                     + String.format("--job-classname %s ", entrypointClass)
                     + "--input-topics "
                     + inputTopics
-                    + " --output-topic io.openlineage.flink.kafka.output "
+                    + " --output-topics "
+                    + outputTopics
+                    + " "
                     + jobNameParam)
             .withEnv(
                 "FLINK_PROPERTIES", "jobmanager.rpc.address: jobmanager\nexecution.attached: true")

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSinkWrapperTest.java
@@ -5,12 +5,16 @@
 
 package io.openlineage.flink.visitor.wrapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -22,9 +26,11 @@ import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.formats.avro.AvroSerializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.testcontainers.shaded.org.apache.commons.lang3.reflect.FieldUtils;
 
 class KafkaSinkWrapperTest {
 
@@ -128,6 +134,37 @@ class KafkaSinkWrapperTest {
           .thenReturn(Optional.empty());
 
       assertFalse(wrapper.getAvroSchema().isPresent());
+    }
+  }
+
+  @Test
+  void testGetTopicsOfMultiTopicSink() throws IllegalAccessException {
+    KafkaRecordSerializationSchema serializer =
+        (KafkaRecordSerializationSchema)
+            mock(
+                KafkaTopicsDescriptor.class,
+                withSettings().extraInterfaces(KafkaRecordSerializationSchema.class));
+
+    when(((KafkaTopicsDescriptor) serializer).isFixedTopics()).thenReturn(true);
+    when(((KafkaTopicsDescriptor) serializer).getFixedTopics())
+        .thenReturn(Arrays.asList("topic1", "topic2"));
+
+    FieldUtils.writeField(wrapper, "serializationSchema", serializer, true);
+
+    assertThat(wrapper.getTopicsOfMultiTopicSink()).containsExactlyInAnyOrder("topic1", "topic2");
+  }
+
+  @Test
+  void testGetSchemaOfMultiTopicSink() throws IllegalAccessException {
+    KafkaRecordSerializationSchema serializer =
+        new MultiTopicSerializationSchema(new String[] {"t1"});
+    FieldUtils.writeField(wrapper, "serializationSchema", serializer, true);
+
+    try (MockedStatic<AvroSerializationSchema> mockedStatic =
+        mockStatic(AvroSerializationSchema.class)) {
+      AvroSerializationSchema<SomeEvent> schema = mock(AvroSerializationSchema.class);
+      when(AvroSerializationSchema.<SomeEvent>forSpecific(eq(SomeEvent.class))).thenReturn(schema);
+      assertThat(wrapper.getSchemaOfMultiTopicSink().get()).isEqualTo(schema);
     }
   }
 }

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/MultiTopicSerializationSchema.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/MultiTopicSerializationSchema.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.wrapper;
+
+import java.util.Arrays;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+public class MultiTopicSerializationSchema extends KafkaTopicsDescriptor
+    implements KafkaRecordSerializationSchema<SomeEvent> {
+
+  public MultiTopicSerializationSchema(String[] topics) {
+    super(Arrays.asList(topics), null);
+  }
+
+  @Override
+  public void open(SerializationSchema.InitializationContext context, KafkaSinkContext sinkContext)
+      throws Exception {
+    KafkaRecordSerializationSchema.super.open(context, sinkContext);
+  }
+
+  @Override
+  public ProducerRecord<byte[], byte[]> serialize(
+      SomeEvent t, KafkaSinkContext kafkaSinkContext, Long aLong) {
+    throw new RuntimeException("unimplemented");
+  }
+}

--- a/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/SomeEvent.java
+++ b/integration/flink/src/test/java/io/openlineage/flink/visitor/wrapper/SomeEvent.java
@@ -1,0 +1,25 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.wrapper;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecord;
+
+public class SomeEvent implements SpecificRecord {
+
+  @Override
+  public void put(int i, Object v) {}
+
+  @Override
+  public Object get(int i) {
+    return null;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return null;
+  }
+}

--- a/integration/flink/src/test/resources/events/expected_kafka_multi_topic_sink.json
+++ b/integration/flink/src/test/resources/events/expected_kafka_multi_topic_sink.json
@@ -1,0 +1,64 @@
+{
+  "eventType" : "START",
+  "eventTime": "${json-unit.any-string}",
+  "job" : {
+    "namespace" : "flink_job_namespace",
+    "name": "flink_multi_topic_sink",
+    "facets": {
+      "jobType": {
+        "processingType" : "STREAMING",
+        "jobType" : "JOB",
+        "integration": "FLINK"
+      }
+    }
+  },
+  "run": {
+    "runId": "${json-unit.any-string}"
+  },
+  "outputs": [
+    {
+      "namespace": "kafka://kafka:9092",
+      "name": "io.openlineage.flink.kafka.output1",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "long"
+            },
+            {
+              "name": "counter",
+              "type": "long"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "namespace": "kafka://kafka:9092",
+      "name": "io.openlineage.flink.kafka.output2",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "long"
+            },
+            {
+              "name": "counter",
+              "type": "long"
+            }
+          ]
+        }
+      }
+    }
+  ]
+},


### PR DESCRIPTION
### Problem

A single `KafkaSink` can write to multiple topics. Topic names can be generated dynamically based on event content. We want to have multiple output datasets with each topic, a job can write to, being a dataset. 

### Solution

The problem cannot be solved in general as a logic choosing which topic to write to can be any code and we can't predict its output upfront. We are also not able to cover which topics are written to, as Openlineage integration code runs on `TaskManagers` while a logic to write to topics is executed on worker nodes.

We decided to have this feature working under the following assumptions: 
 * Each output topic has the same schema which is extracted from generic parameter type of `KafkaRecordSerializationSchema` 
 * Implementation of `KafkaRecordSerializationSchema` needs to extend `KafkaTopicsDescriptor` class and its constructor takes a list of allowed output topics in advance. 

Limitations are also mentioned within the documentation  -> PR https://github.com/OpenLineage/docs/pull/273

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project