### PR TITLE
[SPARK] Add Gradle plugins to simplify the build process to support Scala 2.13

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -55,8 +49,7 @@ configurations {
     pysparkContainerOnly
 }
 
-archivesBaseName='openlineage-spark-app'
-
+archivesBaseName = 'openlineage-spark-app'
 
 ext {
     assertjVersion = '3.25.1'
@@ -66,7 +59,7 @@ ext {
     mockitoVersion = '4.11.0'
     testcontainersVersion = '1.19.3'
     junit5Version = '5.10.1'
-    shortVersion = sparkVersion.substring(0,3)
+    shortVersion = sparkVersion.substring(0, 3)
 
     versionsMap = [
             "3.5": ["module": "spark35", "scala": "2.12", "delta": "NA", "gcs": "hadoop3-2.2.9", "snowflake": "2.13.0-spark_3.4", "iceberg": "NA", "hadoopclient": "3.3.4"],
@@ -74,7 +67,7 @@ ext {
             "3.3": ["module": "spark33", "scala": "2.12", "delta": "2.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.3", "iceberg": "iceberg-spark-runtime-3.3_2.12:0.14.0", "hadoopclient": "3.3.4"],
             "3.2": ["module": "spark32", "scala": "2.12", "delta": "1.1.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.2", "iceberg": "iceberg-spark-runtime-3.2_2.12:0.14.0", "hadoopclient": "3.3.4"],
             "3.1": ["module": "spark31", "scala": "2.12", "delta": "1.0.0", "gcs": "hadoop3-2.2.9", "snowflake": "2.11.0-spark_3.1", "iceberg": "iceberg-spark-runtime-3.1_2.12:0.13.0", "hadoopclient": "3.3.4"],
-            "2.4": ["module": "spark2",  "scala": "2.11", "delta": "NA",    "gcs": "hadoop2-2.2.9", "snowflake": "2.9.3-spark_2.4",  "iceberg": "NA", "hadoopclient": "2.10.2"]
+            "2.4": ["module": "spark2", "scala": "2.11", "delta": "NA", "gcs": "hadoop2-2.2.9", "snowflake": "2.9.3-spark_2.4", "iceberg": "NA", "hadoopclient": "2.10.2"]
     ]
     versions = versionsMap[shortVersion]
 }
@@ -105,7 +98,7 @@ dependencies {
 
     compileOnly "org.apache.spark:spark-core_${versions.scala}:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_${versions.scala}:${sparkVersion}"
-    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_${versions.scala}:${bigqueryVersion}") {
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_${versions.scala}:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
         exclude group: 'com.sun.jmx'
@@ -113,7 +106,7 @@ dependencies {
         exclude group: 'javax.jms'
     }
 
-    compileOnly ("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
+    compileOnly("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
         exclude group: 'com.google.guava:guava'
         exclude group: 'org.apache.spark:spark-core_2.11'
         exclude group: 'org.apache.spark:spark-sql_2.11'
@@ -140,7 +133,7 @@ dependencies {
         exclude group: "org.apache.spark", module: "spark-graphx_${versions.scala}"
     }
     testFixturesApi 'commons-beanutils:commons-beanutils:1.9.4'
-    if(versions.module != "spark2") {
+    if (versions.module != "spark2") {
         testFixturesApi("org.apache.spark:spark-hadoop-cloud_${versions.scala}:${sparkVersion}") {
             exclude group: 'com.fasterxml.jackson.core'
             exclude group: 'org.apache.hadoop', module: 'hadoop-azure'
@@ -148,8 +141,8 @@ dependencies {
         }
     }
 
-    if(versions.snowflake != "NA") {
-        testFixturesApi ("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
+    if (versions.snowflake != "NA") {
+        testFixturesApi("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
             exclude group: 'com.google.guava:guava'
             exclude group: 'org.apache.spark:spark-core_2.11'
             exclude group: 'org.apache.spark:spark-sql_2.11'
@@ -188,29 +181,33 @@ dependencies {
     testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
     testFixturesApi "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
 
-    pysparkContainerOnly("com.google.cloud.bigdataoss:gcs-connector:${versions.gcs}:shaded"){
+    pysparkContainerOnly("com.google.cloud.bigdataoss:gcs-connector:${versions.gcs}:shaded") {
         exclude group: 'com.google.guava', module: 'guava'
     }
     pysparkContainerOnly("com.google.guava:guava:30.1-jre")
 
-    if(versions.delta != "NA") { testFixturesApi "io.delta:delta-core_2.12:${versions.delta}" }
+    if (versions.delta != "NA") {
+        testFixturesApi "io.delta:delta-core_2.12:${versions.delta}"
+    }
 
-    if(versions.iceberg != "NA") { testFixturesApi "org.apache.iceberg:${versions.iceberg}" }
+    if (versions.iceberg != "NA") {
+        testFixturesApi "org.apache.iceberg:${versions.iceberg}"
+    }
 
     testImplementation(project(":${versions.module}"))
-    if(versions.module != "spark2") {
-        testImplementation("com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.9"){
+    if (versions.module != "spark2") {
+        testImplementation("com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.9") {
             exclude group: 'com.google.guava', module: 'guava'
         }
         pysparkContainerOnly("com.google.guava:guava:30.1-jre")
     }
-    
-    
-    testImplementation testFixtures(project(":${versions.module}")){
+
+
+    testImplementation testFixtures(project(":${versions.module}")) {
         exclude group: 'org.apache.avro'
     }
 
-    lombok  "org.projectlombok:lombok:${lombokVersion}"
+    lombok "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
@@ -224,7 +221,7 @@ def commonTestConfiguration = {
     systemProperties = [
             'junit.platform.output.capture.stdout': 'true',
             'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       :  sparkVersion,
+            'spark.version'                       : sparkVersion,
             'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
             'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_${versions.scala}:${sparkVersion}",
             'mockserver.logLevel'                 : 'ERROR'
@@ -233,7 +230,7 @@ def commonTestConfiguration = {
     classpath = project.sourceSets.test.runtimeClasspath
 }
 
-task nonParallelTest (type: Test) {
+task nonParallelTest(type: Test) {
     dependsOn shadowJar
     group = 'verification'
     description = "Runs tests that cannot be run in parallel. For example test suites that require metastore_db"
@@ -245,7 +242,7 @@ task nonParallelTest (type: Test) {
     }
 }
 
-task beforeShadowJarTest (type: Test) {
+task beforeShadowJarTest(type: Test) {
     group = 'verification'
     description = "Tests that depend that have to be run before shadowJar"
 
@@ -257,10 +254,14 @@ task beforeShadowJarTest (type: Test) {
 // wrócić do jednego test z jakąś metodą zwracającą konfigurację żeby spark3 działał
 test {
     dependsOn nonParallelTest
-    useJUnitPlatform {i ->
-        excludeTags ('integration-test', 'nonParallelTest', 'beforeShadowJarTest' )
-        if(versions.delta == "NA") {excludeTags 'delta'}
-        if(versions.iceberg == "NA") {excludeTags 'iceberg'}
+    useJUnitPlatform { i ->
+        excludeTags('integration-test', 'nonParallelTest', 'beforeShadowJarTest')
+        if (versions.delta == "NA") {
+            excludeTags 'delta'
+        }
+        if (versions.iceberg == "NA") {
+            excludeTags 'iceberg'
+        }
     }
     configure commonTestConfiguration
     classpath = project.sourceSets.test.runtimeClasspath + configurations."${versions.module}"
@@ -269,7 +270,7 @@ test {
 task copyDependencies(type: Copy) {
     dependsOn shadowJar
     dependsOn(
-            ':spark2:shadowJar',':spark3:shadowJar', ':spark31:shadowJar',
+            ':spark2:shadowJar', ':spark3:shadowJar', ':spark31:shadowJar',
             ':spark32:shadowJar', ':spark33:shadowJar',
             ':spark34:shadowJar', ':spark35:shadowJar'
     )
@@ -307,9 +308,15 @@ task integrationTest(type: Test) {
     useJUnitPlatform {
         includeTags "integration-test"
         excludeTags "databricks"
-        if(!sparkVersion.startsWith('3')) {excludeTags 'spark3'}
-        if(versions.delta == "NA") {excludeTags 'delta'}
-        if(versions.iceberg == "NA") {excludeTags 'iceberg'}
+        if (!sparkVersion.startsWith('3')) {
+            excludeTags 'spark3'
+        }
+        if (versions.delta == "NA") {
+            excludeTags 'delta'
+        }
+        if (versions.iceberg == "NA") {
+            excludeTags 'iceberg'
+        }
     }
 }
 
@@ -328,22 +335,6 @@ task databricksIntegrationTest(type: Test) {
     }
 }
 
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
-}
-
 assemble {
     dependsOn shadowJar
 }
@@ -351,15 +342,15 @@ assemble {
 shadowJar {
     dependsOn beforeShadowJarTest
 
-    minimize(){
-        exclude (project(":shared"))
-        exclude (project(":spark2"))
-        exclude (project(":spark3"))
-        exclude (project(":spark31"))
-        exclude (project(":spark32"))
-        exclude (project(":spark33"))
-        exclude (project(":spark34"))
-        exclude (project(":spark35"))
+    minimize() {
+        exclude(project(":shared"))
+        exclude(project(":spark2"))
+        exclude(project(":spark3"))
+        exclude(project(":spark31"))
+        exclude(project(":spark32"))
+        exclude(project(":spark33"))
+        exclude(project(":spark34"))
+        exclude(project(":spark35"))
     }
     archiveClassifier = ''
     // avoid conflict with any client version of that lib

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'jacoco'
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
@@ -41,7 +41,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-archivesBaseName='openlineage-spark'
+archivesBaseName = 'openlineage-spark'
 
 ext {
     lombokVersion = '1.18.20'
@@ -51,7 +51,7 @@ ext {
 }
 
 dependencies {
-    implementation(project(path:    ":app"))
+    implementation(project(path: ":app"))
     implementation(project(path: ":shared", configuration: "shadow"))
     implementation(project(path: ":spark2"))
     implementation(project(path: ":spark3"))
@@ -71,12 +71,12 @@ dependencies {
 
 
 task sourceJar(type: Jar) {
-    archiveClassifier='sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allJava
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier='javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
 
@@ -103,23 +103,7 @@ task integrationTest(type: Test) {
 integrationTest.outputs.upToDateWhen { false }
 
 javadoc {
-    options.tags = [ "apiNote" ]
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
+    options.tags = ["apiNote"]
 }
 
 def reportsDir = "${buildDir}/reports";
@@ -220,16 +204,16 @@ signing {
 shadowJar {
     dependsOn test
 
-    minimize(){
-        exclude (project(":shared"))
-        exclude (project(":spark2"))
-        exclude (project(":spark3"))
-        exclude (project(":spark31"))
-        exclude (project(":spark32"))
-        exclude (project(":spark33"))
-        exclude (project(":spark34"))
-        exclude (project(":spark35"))
-        exclude (project(":app"))
+    minimize() {
+        exclude(project(":shared"))
+        exclude(project(":spark2"))
+        exclude(project(":spark3"))
+        exclude(project(":spark31"))
+        exclude(project(":spark32"))
+        exclude(project(":spark33"))
+        exclude(project(":spark34"))
+        exclude(project(":spark35"))
+        exclude(project(":app"))
     }
     dependencies {
         exclude(dependency('org.slf4j::'))

--- a/integration/spark/buildSrc/README.md
+++ b/integration/spark/buildSrc/README.md
@@ -1,0 +1,57 @@
+# OpenLineage Gradle Plugins
+
+This repository contains four Gradle plugins that are used to configure and manage the build process for OpenLineage projects. These plugins are written in Kotlin and are designed to work with Gradle.
+
+## Scala213VariantPlugin
+
+The `Scala213VariantPlugin` is a Gradle plugin that configures the project to use Scala 2.13. It sets up the necessary source sets, tasks, and configurations for building and testing Scala 2.13 code.
+
+To apply this plugin, add the following to your `build.gradle.kts` (or `build.gradle`):
+
+```kotlin
+plugins {
+    id("io.openlineage.scala213-variant")
+}
+```
+
+## StandardSpotlessPlugin
+
+The `StandardSpotlessPlugin` is a Gradle plugin that applies the Spotless code formatter to the project. It is configured to use the Google Java Format and to disallow wildcard imports.
+
+To apply this plugin, add the following to your `build.gradle.kts` (or `build.gradle`):
+
+```kotlin
+plugins {
+    id("io.openlineage.standard-spotless")
+}
+```
+
+## CommonJavaConfigPlugin
+
+The `CommonJavaConfigPlugin` is a Gradle plugin that applies common Java configurations to the project. It sets the source and target compatibility to Java 8 and configures the project to use Maven Central, Maven Local, and a custom Astronomer repository.
+
+To apply this plugin, add the following to your `build.gradle.kts` (or `build.gradle`):
+
+```kotlin
+plugins {
+    id("io.openlineage.common-java-config")
+}
+```
+
+## PrintSourceSetConfigurationPlugin
+
+The `PrintSourceSetConfigurationPlugin` is a Gradle plugin that registers a task named `printSourceSetConfiguration` to the project. This task, when executed, prints the configuration of the source sets in the project. This includes the name of each source set, its source directories, output directories, and compile classpath. This plugin can be useful for debugging and understanding how the source sets are configured in a project.
+
+To apply this plugin, add the following to your `build.gradle.kts` (or `build.gradle`):
+
+```kotlin
+plugins {
+    id("io.openlineage.print-source-set-configuration")
+}
+```
+
+To execute the `printSourceSetConfiguration` task, run the following command in your terminal:
+
+```bash
+./gradlew printSourceSetConfiguration
+```

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
+
+val spotlessVersion: String = "6.13.0"
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:${spotlessVersion}")
+}
+
+gradlePlugin {
+    plugins {
+        create("printSourceSetConfiguration") {
+            id = "io.openlineage.print-source-set-configuration"
+            implementationClass = "io.openlineage.gradle.plugin.PrintSourceSetConfigurationPlugin"
+        }
+
+        create("standardSpotless") {
+            id = "io.openlineage.standard-spotless"
+            implementationClass = "io.openlineage.gradle.plugin.StandardSpotlessPlugin"
+        }
+
+        create("scala213Variant") {
+            id = "io.openlineage.scala213-variant"
+            implementationClass = "io.openlineage.gradle.plugin.Scala213VariantPlugin"
+        }
+
+        create("commonJavaConfig") {
+            id = "io.openlineage.common-java-config"
+            implementationClass = "io.openlineage.gradle.plugin.CommonJavaConfigPlugin"
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonJavaConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonJavaConfigPlugin.kt
@@ -1,0 +1,54 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2018-2023 contributors to the OpenLineage project
+*/
+
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.maven
+
+/**
+ * A Gradle plugin that applies common Java configurations to the project.
+ *
+ * This plugin applies the "java-library" plugin, sets the source and target compatibility to Java 8,
+ * and configures the project to use Maven Central, Maven Local, and a custom Astronomer repository.
+ *
+ * To apply this plugin, add the following to your `build.gradle.kts`:
+ *
+ * ```kotlin
+ * plugins {
+ *     id("io.openlineage.common-java-config")
+ * }
+ * ```
+ *
+ * @see org.gradle.api.Plugin
+ */
+class CommonJavaConfigPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        configurePlugins(target)
+        configureJava(target)
+        configureRepositories(target)
+    }
+
+    private fun configurePlugins(target: Project) {
+        target.plugins.apply("java-library")
+    }
+
+    private fun configureJava(target: Project) {
+        target.extensions.getByType<JavaPluginExtension>().apply {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+
+    private fun configureRepositories(target: Project) {
+        target.repositories.mavenCentral()
+        target.repositories.mavenLocal()
+        target.repositories.maven("https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot")
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/PrintSourceSetConfigurationPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/PrintSourceSetConfigurationPlugin.kt
@@ -1,0 +1,51 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2018-2023 contributors to the OpenLineage project
+*/
+
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+
+/**
+ * A Gradle plugin that registers a task named `printSourceSetConfiguration` to the project.
+ *
+ * This task, when executed, prints the configuration of the source sets in the project. This includes the name of each source set, its source directories, output directories, and compile classpath. This plugin can be useful for debugging and understanding how the source sets are configured in a project.
+ *
+ * To apply this plugin, add the following to your `build.gradle.kts`:
+ *
+ * ```kotlin
+ * plugins {
+ *     id("io.openlineage.print-source-set-configuration")
+ * }
+ * ```
+ *
+ * To execute the `printSourceSetConfiguration` task, run the following command in your terminal:
+ *
+ * ```bash
+ * ./gradlew printSourceSetConfiguration
+ * ```
+ *
+ * @see org.gradle.api.Plugin
+ */
+class PrintSourceSetConfigurationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.tasks.register("printSourceSetConfiguration") {
+            doLast {
+                val sourceSets = target.extensions.getByType(SourceSetContainer::class.java)
+                sourceSets.forEach { srcSet ->
+                    println("[${srcSet.name}]")
+                    println("-->Source directories: ${srcSet.allJava.srcDirs}")
+                    println("-->Output directories: ${srcSet.output.classesDirs.files}")
+                    println("-->Compile classpath:")
+                    srcSet.compileClasspath.files.sortedBy { it.path }.forEach {
+                        println("  ${it.path}")
+                    }
+                    println("")
+                }
+            }
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/Scala213VariantPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/Scala213VariantPlugin.kt
@@ -1,0 +1,189 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2018-2023 contributors to the OpenLineage project
+*/
+
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.*
+
+/**
+ * An interface for the `Scala213VariantPlugin` extension.
+ *
+ * This extension provides a property for setting the archive base name for the plugin.
+ */
+interface Scala213VariantPluginExtension {
+    val archiveBaseName: Property<String>
+}
+
+/**
+ * A Gradle plugin that configures the project to use Scala 2.13.
+ *
+ * This plugin sets up the necessary source sets, tasks, and configurations for building and testing against libraries compiled using Scala 2.13. It also provides an extension for setting the archive base name.
+ *
+ * To apply this plugin, add the following to your `build.gradle.kts`:
+ *
+ * ```kotlin
+ * plugins {
+ *     id("io.openlineage.scala213-variant")
+ * }
+ * ```
+ *
+ * @see org.gradle.api.Plugin
+ */
+class Scala213VariantPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        configurePluginExtension(target)
+        configurePlugins(target)
+        configureSourceSets(target)
+        configureConfigurations(target)
+        configureTasks(target)
+        configureArtifacts(target)
+    }
+
+    private fun getSourceSetContainer(target: Project) = target.extensions.getByType<SourceSetContainer>()
+
+    private fun getPluginExtension(target: Project) = target.extensions.getByType<Scala213VariantPluginExtension>()
+
+    private fun configurePlugins(target: Project) {
+        target.plugins.apply("java-library")
+    }
+
+    private fun configurePluginExtension(target: Project) {
+        val extension = target.extensions.create<Scala213VariantPluginExtension>("scala213")
+        val moduleName = target.name
+        extension.archiveBaseName.convention("openlineage-spark-${moduleName}")
+    }
+
+    private fun configureSourceSets(target: Project) {
+        val sourceSets = getSourceSetContainer(target)
+
+        val scala213SourceSet = sourceSets.create("scala213") {
+            java {
+                srcDir("src/main/java")
+            }
+            resources {
+                srcDir("src/main/resources")
+            }
+        }
+
+        sourceSets.create("testScala213") {
+            compileClasspath += scala213SourceSet.output
+            runtimeClasspath += scala213SourceSet.output
+
+            java {
+                srcDir("src/test/java")
+            }
+            resources {
+                srcDir("src/test/resources")
+            }
+        }
+    }
+
+    private fun configureConfigurations(target: Project) {
+        val configurations = target.configurations
+
+        val scala213Api = configurations.create("scala213Api")
+
+        configurations.create("scala213ApiElements") {
+            extendsFrom(scala213Api)
+            isCanBeResolved = false
+            isCanBeConsumed = true
+        }
+
+        val scala213Implementation = configurations.named("scala213Implementation") {
+            extendsFrom(scala213Api)
+        }
+
+        val scala213RuntimeOnly = configurations.named("scala213RuntimeOnly")
+
+        val scala213CompileOnly = configurations.named("scala213CompileOnly")
+
+        configurations.create("scala213RuntimeElements") {
+            extendsFrom(scala213Implementation.get(), scala213RuntimeOnly.get())
+            isCanBeResolved = false
+            isCanBeConsumed = true
+        }
+
+        configurations.named("scala213CompileClasspath") {
+            extendsFrom(scala213CompileOnly.get(), scala213Implementation.get())
+            isCanBeResolved = true
+        }
+
+        configurations.named("scala213RuntimeClasspath") {
+            extendsFrom(scala213Implementation.get(), scala213RuntimeOnly.get())
+            isCanBeResolved = true
+        }
+
+        val testScala213Implementation = configurations.named("testScala213Implementation") {
+            extendsFrom(scala213Implementation.get())
+        }
+
+        val testScala213RuntimeOnly = configurations.named("testScala213RuntimeOnly") {
+            extendsFrom(scala213RuntimeOnly.get())
+        }
+
+        val testScala213CompileOnly = configurations.named("testScala213CompileOnly")
+
+        configurations.named("testScala213CompileClasspath") {
+            extendsFrom(testScala213CompileOnly.get(), testScala213Implementation.get())
+            isCanBeResolved = true
+        }
+
+        configurations.named("testScala213RuntimeClasspath") {
+            extendsFrom(testScala213Implementation.get(), testScala213RuntimeOnly.get())
+            isCanBeResolved = true
+        }
+    }
+
+    private fun configureTasks(target: Project) {
+        val tasks = target.tasks
+        val sourceSets = getSourceSetContainer(target)
+
+        tasks.withType<Test>().configureEach {
+            useJUnitPlatform()
+            testLogging {
+                events("passed", "skipped", "failed")
+                showStandardStreams = true
+            }
+        }
+
+        tasks.register<Test>("executeTestScala213") {
+            dependsOn(tasks.named("testScala213Classes"))
+            description = "Runs all tests in this module using Scala 2.13"
+            group = "verification"
+            testClassesDirs = sourceSets["testScala213"].output.classesDirs
+            classpath = sourceSets["testScala213"].runtimeClasspath
+        }
+
+        val archiveBaseName = getPluginExtension(target).archiveBaseName
+        tasks.register<Jar>("scala213Jar").configure {
+            dependsOn(tasks.named("scala213Classes"))
+            description = "Assembles a jar archive containing the main classes compiled using Scala 2.13 variants of the Apache Spark libraries"
+            group = "build"
+            from(sourceSets["scala213"].output)
+            archiveFileName.set("${archiveBaseName.get()}_2.13-${archiveVersion.get()}.${archiveExtension.get()}")
+            includeEmptyDirs = false
+        }
+
+        tasks.named("check") {
+            dependsOn(tasks.named("executeTestScala213"))
+        }
+
+        tasks.named("assemble").configure {
+            dependsOn(tasks.named("scala213Jar"), tasks.named("jar"))
+        }
+    }
+
+    private fun configureArtifacts(target: Project) {
+        target.artifacts {
+            add("scala213RuntimeElements", target.tasks.named("scala213Jar"))
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/StandardSpotlessPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/StandardSpotlessPlugin.kt
@@ -1,0 +1,50 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+* Copyright 2018-2023 contributors to the OpenLineage project
+*/
+
+package io.openlineage.gradle.plugin
+
+import com.diffplug.gradle.spotless.SpotlessExtension
+import com.diffplug.spotless.FormatterFunc
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+/**
+ * A Gradle plugin that applies the Spotless code formatter to the project.
+ *
+ * This plugin is configured to use the Google Java Format and to disallow wildcard imports.
+ *
+ * To apply this plugin, add the following to your `build.gradle.kts`:
+ *
+ * ```kotlin
+ * plugins {
+ *     id("io.openlineage.standard-spotless")
+ * }
+ * ```
+ *
+ * @see org.gradle.api.Plugin
+ */
+class StandardSpotlessPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply("com.diffplug.spotless")
+
+        val disallowWildcardImports = FormatterFunc { text ->
+            val regex = Regex("^import\\s+\\w+(\\.\\w+)*\\.*;$")
+            val m = regex.find(text)
+            if (m != null) {
+                throw RuntimeException("Wildcard imports are disallowed - ${m.groupValues}")
+            }
+            text
+        }
+
+        target.extensions.configure<SpotlessExtension> {
+            java {
+                googleJavaFormat()
+                removeUnusedImports()
+                custom("disallowWildcardImports", disallowWildcardImports)
+            }
+        }
+    }
+}

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.github.johnrengelman.shadow" version "8.1.1"
     id "pmd"
 }
@@ -33,8 +27,7 @@ pmdTest {
     dependsOn shadowJar
 }
 
-archivesBaseName='openlineage-spark-shared'
-
+archivesBaseName = 'openlineage-spark-shared'
 
 repositories {
     mavenLocal()
@@ -66,11 +59,11 @@ dependencies {
 
     compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
-    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:${bigqueryVersion}") {
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
     }
-    compileOnly ("net.snowflake:spark-snowflake_2.11:${snowflakeVersion}-spark_${sparkVersionShort}") {
+    compileOnly("net.snowflake:spark-snowflake_2.11:${snowflakeVersion}-spark_${sparkVersionShort}") {
         exclude group: 'com.google.guava:guava'
         exclude group: 'org.apache.spark:spark-core_2.11'
         exclude group: 'org.apache.spark:spark-sql_2.11'
@@ -131,7 +124,6 @@ def commonTestConfiguration = {
     classpath = project.sourceSets.test.runtimeClasspath
 }
 
-
 test {
     dependsOn shadowJar
     configure commonTestConfiguration
@@ -148,20 +140,4 @@ shadowJar {
     minimize()
     archiveClassifier = ''
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark2'
+archivesBaseName = 'openlineage-spark-spark2'
 
 ext {
     assertjVersion = '3.25.1'
@@ -125,20 +119,4 @@ shadowJar {
     minimize()
     archiveClassifier = ''
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -67,7 +61,7 @@ dependencies {
 
     implementation(project(path: ":shared", configuration: "shadow"))
 
-    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
     }
@@ -136,7 +130,6 @@ assemble {
     dependsOn shadowJar
 }
 
-
 shadowJar {
     minimize()
     archiveClassifier = ''
@@ -144,20 +137,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -126,20 +120,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -138,20 +132,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -102,12 +96,12 @@ def commonTestConfiguration = {
         showStandardStreams = true
     }
     systemProperties = [
-        'junit.platform.output.capture.stdout': 'true',
-        'junit.platform.output.capture.stderr': 'true',
-        'spark.version'                       : "${sparkVersion}",
-        'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-        'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-        'mockserver.logLevel'                 : 'ERROR'
+            'junit.platform.output.capture.stdout': 'true',
+            'junit.platform.output.capture.stderr': 'true',
+            'spark.version'                       : "${sparkVersion}",
+            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
+            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
+            'mockserver.logLevel'                 : 'ERROR'
     ]
 
     classpath = project.sourceSets.test.runtimeClasspath
@@ -143,20 +137,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -78,7 +72,7 @@ dependencies {
     compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.3.1"
     compileOnly "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
     compileOnly "io.delta:delta-core_2.12:2.4.0"
-    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
         exclude group: 'com.sun.jmx'
@@ -112,12 +106,12 @@ def commonTestConfiguration = {
         showStandardStreams = true
     }
     systemProperties = [
-        'junit.platform.output.capture.stdout': 'true',
-        'junit.platform.output.capture.stderr': 'true',
-        'spark.version'                       : "${sparkVersion}",
-        'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-        'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-        'mockserver.logLevel'                 : 'ERROR'
+            'junit.platform.output.capture.stdout': 'true',
+            'junit.platform.output.capture.stderr': 'true',
+            'spark.version'                       : "${sparkVersion}",
+            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
+            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
+            'mockserver.logLevel'                 : 'ERROR'
     ]
 
     classpath = project.sourceSets.test.runtimeClasspath
@@ -153,20 +147,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -1,14 +1,8 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-import groovy.io.FileType
-
-import java.nio.file.Files
-
-
 plugins {
     id 'java'
     id 'java-library'
     id 'java-test-fixtures'
-    id 'com.diffplug.spotless' version '6.12.0'
+    id("io.openlineage.standard-spotless")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
     id "com.github.johnrengelman.shadow" version "8.1.1"
@@ -43,7 +37,7 @@ repositories {
     }
 }
 
-archivesBaseName='openlineage-spark-spark3'
+archivesBaseName = 'openlineage-spark-spark3'
 
 ext {
     assertjVersion = '3.25.1'
@@ -69,7 +63,7 @@ dependencies {
     compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
     compileOnly "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
-    compileOnly ("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
         exclude group: 'com.sun.jmx'
@@ -103,12 +97,12 @@ def commonTestConfiguration = {
         showStandardStreams = true
     }
     systemProperties = [
-        'junit.platform.output.capture.stdout': 'true',
-        'junit.platform.output.capture.stderr': 'true',
-        'spark.version'                       : "${sparkVersion}",
-        'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-        'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-        'mockserver.logLevel'                 : 'ERROR'
+            'junit.platform.output.capture.stdout': 'true',
+            'junit.platform.output.capture.stderr': 'true',
+            'spark.version'                       : "${sparkVersion}",
+            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
+            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
+            'mockserver.logLevel'                 : 'ERROR'
     ]
 
     classpath = project.sourceSets.test.runtimeClasspath
@@ -145,20 +139,4 @@ shadowJar {
         exclude(dependency('org.slf4j::'))
     }
     zip64 true
-}
-
-spotless {
-    def disallowWildcardImports = {
-        String text = it
-        def regex = ~/import .*\.\*;/
-        def m = regex.matcher(text)
-        if (m.find()) {
-            throw new AssertionError("Wildcard imports disallowed - ${m.findAll()}")
-        }
-    }
-    java {
-        googleJavaFormat()
-        removeUnusedImports()
-        custom 'disallowWildcardImports', disallowWildcardImports
-    }
 }


### PR DESCRIPTION
### Problem

Spark 3.2.x, 3.3.x, 3.4.x, and 3.5.x are compiled using Scala 2.12 and Scala 2.13. Due to a change in the Scala Collections API in Scala 2.13, `NoSuchMethodErrors` are thrown when running the `openlineage-spack` connector in an Apache Spark runtime when the runtime was compiled using Scala 2.13.

### Solution

This PR is the first of several PRs to support producing Scala 2.12 and Scala 2.13 variants of the OpenLineage Spark integration.

First, we define a set of gradle plugins that when applied will configure the various builds.

#### One-line summary: Defines a set of Gradle plugins to configure the modules and reduce duplication.

#### Related issue: #2303

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project