### PR TITLE
[SPARK] Migrated 'spark3' module to produce Scala 2.12 and Scala 2.13 variants

### DIFF
--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -5,3 +5,4 @@ org.gradle.jvmargs=-Xmx1G
 
 scala.binary.version=2.12
 shared.spark.version=3.2.4
+spark3.spark.version=3.2.4

--- a/integration/spark/spark3/README.md
+++ b/integration/spark/spark3/README.md
@@ -1,0 +1,10 @@
+# Spark3 Module
+
+This module contains common code for all variants of Apache Spark 3.x.y, where x >= 2.
+
+Concretely, this means:
+
+1. Spark 3.2.w
+2. Spark 3.3.x
+3. Spark 3.4.y
+4. Spark 3.5.z

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -1,77 +1,127 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("idea")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+scalaVariants {
+    create("2.12")
+    create("2.13")
+}
+
+idea {
+    module {
+        testSources.from(sourceSets.testScala212.java.srcDirs, sourceSets.testScala213.java.srcDirs)
+    }
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.1.3'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
+    assertjVersion = "3.25.1"
     bigqueryVersion = "0.29.0"
+    databricksVersion = "0.1.4"
+    deltaVersion = "1.1.0"
+    icebergVersion = "1.4.3"
+    jacksonVersion = "2.15.3"
+    junit5Version = "5.10.1"
+    lombokVersion = "1.18.30"
+    mockitoVersion = "4.11.0"
+
+    sparkVersion = project.findProperty("spark3.spark.version")
+    scalaBinaryVersion = project.findProperty("scala.binary.version")
+    configurationName = scalaBinaryVersion.replace(".", "")
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
+    implementation(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
 
-    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.module'
+    compileOnly("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
+    compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+
+    compileOnly("com.databricks:databricks-dbutils-scala_${scalaBinaryVersion}:${databricksVersion}")
+    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_${scalaBinaryVersion}:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
     }
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark3-runtime:0.12.1"
-    compileOnly "io.delta:delta-core_2.12:1.0.0"
-    compileOnly "com.databricks:dbutils-api_2.12:0.0.6"
+    compileOnly("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
+    compileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_${scalaBinaryVersion}:${icebergVersion}")
 
-    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark3-runtime:0.12.1"
-    testFixturesApi "io.delta:delta-core_2.12:1.0.0"
-    testFixturesApi "com.databricks:dbutils-api_2.12:0.0.6"
-
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi(project(path: ":shared"))
-}
-
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
+    // TODO: Convert this to testImplementation
+    testFixturesApi(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    testFixturesApi("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("com.databricks:databricks-dbutils-scala_${scalaBinaryVersion}:${databricksVersion}")
+    testFixturesApi("com.google.cloud.spark:spark-bigquery-with-dependencies_${scalaBinaryVersion}:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
     }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    testFixturesApi("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
+    testFixturesApi("org.apache.iceberg:iceberg-spark-runtime-3.2_${scalaBinaryVersion}:${icebergVersion}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
+    // Scala 2.12
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
+    scala212CompileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}")
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+
+    scala212CompileOnly("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}")
+    scala212CompileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
     }
+    scala212CompileOnly("io.delta:delta-core_2.12:${deltaVersion}")
+    scala212CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:${icebergVersion}")
+
+    testScala212Implementation("org.apache.spark:spark-hive_2.12:${sparkVersion}")
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+
+    testScala212Implementation("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}")
+    testScala212Implementation("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
+    }
+    testScala212Implementation("io.delta:delta-core_2.12:${deltaVersion}")
+    testScala212Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:${icebergVersion}")
+
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
+
+    // Scala 2.13
+    scala213Implementation(project(path: ":shared", configuration: "scala213RuntimeElements"))
+
+    scala213CompileOnly("org.apache.spark:spark-hive_2.13:${sparkVersion}")
+    scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+
+    scala213CompileOnly("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}")
+    scala213CompileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.13:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
+    }
+    scala213CompileOnly("io.delta:delta-core_2.13:${deltaVersion}")
+    scala213CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
+
+    testScala213Implementation("org.apache.spark:spark-hive_2.13:${sparkVersion}")
+    testScala213Implementation("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+
+    testScala213Implementation("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}")
+    testScala213Implementation("com.google.cloud.spark:spark-bigquery-with-dependencies_2.13:${bigqueryVersion}") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.module"
+    }
+    testScala213Implementation("io.delta:delta-core_2.13:${deltaVersion}")
+    testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
+
+    testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala213Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala213Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -7,6 +7,7 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -71,7 +72,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.properties()).thenReturn(commandProperties);
     verifyApply(
-        (LogicalPlan) logicalPlan,
+        logicalPlan,
         commandProperties,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
   }
@@ -84,7 +85,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.properties()).thenReturn(commandProperties);
     verifyApply(
-        (LogicalPlan) logicalPlan,
+        logicalPlan,
         commandProperties,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
   }
@@ -97,7 +98,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.properties()).thenReturn(commandProperties);
     verifyApply(
-        (LogicalPlan) logicalPlan,
+        logicalPlan,
         commandProperties,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE);
   }
@@ -110,7 +111,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.tableSchema()).thenReturn(schema);
     when(logicalPlan.properties()).thenReturn(commandProperties);
     verifyApply(
-        (LogicalPlan) logicalPlan,
+        logicalPlan,
         commandProperties,
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE);
   }
@@ -124,8 +125,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.properties()).thenReturn(commandProperties);
 
     DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+    try (MockedStatic<PlanUtils3> ignored = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic<CatalogUtils3> ignored1 = mockStatic(CatalogUtils3.class)) {
         when(CatalogUtils3.getDatasetVersion(
                 openLineageContext,
                 catalogTable,
@@ -158,8 +159,8 @@ class CreateReplaceVisitorDatasetBuilderTest {
     when(logicalPlan.properties()).thenReturn(commandProperties);
 
     DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      try (MockedStatic mockedCatalog = mockStatic(CatalogUtils3.class)) {
+    try (MockedStatic<PlanUtils3> ignored = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic<CatalogUtils3> ignored1 = mockStatic(CatalogUtils3.class)) {
         when(CatalogUtils3.getDatasetVersion(
                 openLineageContext,
                 catalogTable,
@@ -178,7 +179,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
             visitor.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
         assertEquals(1, outputDatasets.size());
-        assertEquals(null, outputDatasets.get(0).getFacets().getVersion());
+        assertNull(outputDatasets.get(0).getFacets().getVersion());
       }
     }
   }
@@ -188,7 +189,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
       Map<String, String> tableProperties,
       OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange) {
     DatasetIdentifier di = new DatasetIdentifier(TABLE, "db");
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic<PlanUtils3> ignored = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(
               openLineageContext,
               catalogTable,
@@ -211,7 +212,7 @@ class CreateReplaceVisitorDatasetBuilderTest {
   @Test
   void testApplyWhenNoDatasetIdentifierReturned() {
     CreateTableAsSelect logicalPlan = mock(CreateTableAsSelect.class);
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic<PlanUtils3> ignored = mockStatic(PlanUtils3.class)) {
       when(PlanUtils3.getDatasetIdentifier(
               openLineageContext,
               catalogTable,


### PR DESCRIPTION
### Summary: Migrated 'spark3' module to produce Scala 2.12 and Scala 2.13 variants

### Problem

Spark 3.2.x, 3.3.x, 3.4.x, and 3.5.x are compiled using Scala 2.12 and Scala 2.13. Due to a change in the Scala Collections API in Scala 2.13, NoSuchMethodErrors are thrown when running the openlineage-spack connector in an Apache Spark runtime when the runtime was compiled using Scala 2.13.

Relates to: #2303 

### Solution

This PR is the **fifth** of several PRs to support producing Scala 2.12 and Scala 2.13 variants of the OpenLineage Spark integration.

In this PR, we migrate the 'spark3' module to use the refactored Gradle plugins.

The module now produces 3 JARS; one default one, one compiled using the Scala 2.12 variant of Apache Spark, and one compiled using the Scala 2.13 variant of Apache Spark.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project