### PR TITLE
[SPARK] Conform the 'spark31' module with the 'shared' and 'spark3'

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -40,10 +40,16 @@ ext {
     versions = versionsMap[shortVersion]
 }
 
-configurations.all { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2
-    resolutionStrategy {
-        // https://github.com/FasterXML/jackson-databind/issues/3627
-        force "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
+// This is done, in order to prevent Jackson version conflicts during the tests in 'app'
+configurations.configureEach {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group.startsWith('com.fasterxml.jackson')) {
+            if (details.requested.name == 'jackson-databind') {
+                details.useVersion(jacksonDatabindVersion)
+            } else {
+                details.useVersion(jacksonVersion)
+            }
+        }
     }
 }
 

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.jvmargs=-Xmx1G
 scala.binary.version=2.12
 shared.spark.version=3.2.4
 spark3.spark.version=3.2.4
+spark31.spark.version=3.1.2

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -1,61 +1,47 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+// We configure this variant build, because of convention. Apache Spark 3.1.x is only compiled
+// with Scala 2.12, however, this configuration adds important things for the broader project.
+scalaVariants {
+    create("2.12")
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.1.3'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
+    assertjVersion = "3.25.1"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
+    sparkVersion = project.findProperty("spark31.spark.version") ?: "3.1.2"
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    compileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
+    testFixturesApi(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    testFixturesApi("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.12 - we need this, because of convention. Its just duplication from the above for this specific module
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    scala212Implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
-
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    testScala212Implementation(project(path: ":shared"))
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }


### PR DESCRIPTION
### Summary: Conform the 'spark31' module with the rest of the migrated modules

### Problem

Spark 3.2.x, 3.3.x, 3.4.x, and 3.5.x are compiled using Scala 2.12 and Scala 2.13. Due to a change in the Scala Collections API in Scala 2.13, NoSuchMethodErrors are thrown when running the openlineage-spack connector in an Apache Spark runtime when the runtime was compiled using Scala 2.13.

Relates to: #2303 

### Solution

This PR is the **6th** of several PRs to support producing Scala 2.12 and Scala 2.13 variants of the OpenLineage Spark integration.

In this PR, we conform the spark31 module with the shared and spark3 modules

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project