### PR TITLE
[SPARK] Migrated 'spark34' module to produce Scala 2.12 and Scala 2.13 variants

### DIFF
--- a/integration/spark/.gitignore
+++ b/integration/spark/.gitignore
@@ -2,3 +2,5 @@ bin/
 *.class
 */metastore_db
 */spark-warehouse
+
+.sdkmanrc

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -40,10 +40,16 @@ ext {
     versions = versionsMap[shortVersion]
 }
 
-configurations.all { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2
-    resolutionStrategy {
-        // https://github.com/FasterXML/jackson-databind/issues/3627
-        force "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
+// This is done, in order to prevent Jackson version conflicts during the tests in 'app'
+configurations.configureEach {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group.startsWith('com.fasterxml.jackson')) {
+            if (details.requested.name == 'jackson-databind') {
+                details.useVersion(jacksonDatabindVersion)
+            } else {
+                details.useVersion(jacksonVersion)
+            }
+        }
     }
 }
 

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -9,3 +9,4 @@ spark3.spark.version=3.2.4
 spark31.spark.version=3.1.2
 spark32.spark.version=3.2.4
 spark33.spark.version=3.3.4
+spark34.spark.version=3.4.2

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -7,3 +7,4 @@ scala.binary.version=2.12
 shared.spark.version=3.2.4
 spark3.spark.version=3.2.4
 spark31.spark.version=3.1.2
+spark32.spark.version=3.2.4

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -6,3 +6,4 @@ org.gradle.jvmargs=-Xmx1G
 scala.binary.version=2.12
 shared.spark.version=3.2.4
 spark3.spark.version=3.2.4
+spark31.spark.version=3.1.2

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -8,3 +8,4 @@ shared.spark.version=3.2.4
 spark3.spark.version=3.2.4
 spark31.spark.version=3.1.2
 spark32.spark.version=3.2.4
+spark33.spark.version=3.3.4

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -1,61 +1,47 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+// We configure this variant build, because of convention. Apache Spark 3.1.x is only compiled
+// with Scala 2.12, however, this configuration adds important things for the broader project.
+scalaVariants {
+    create("2.12")
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.1.3'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
+    assertjVersion = "3.25.1"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
+    sparkVersion = project.findProperty("spark31.spark.version") ?: "3.1.2"
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
+    compileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
+    testFixturesApi(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    testFixturesApi("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.12 - we need this, because of convention. Its just duplication from the above for this specific module
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    scala212Implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
-
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    testScala212Implementation(project(path: ":shared"))
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -1,73 +1,84 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("idea")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+scalaVariants {
+    create("2.12")
+    create("2.13")
+}
+
+idea {
+    module {
+        testSources.from(sourceSets.testScala212.java.srcDirs, sourceSets.testScala213.java.srcDirs)
+    }
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.2.2'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
+    assertjVersion = "3.25.1"
+    deltaVersion = "1.1.0"
+    icebergVersion = "0.14.1"
+    jacksonVersion = "2.15.3"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
+
+    sparkVersion = project.findProperty("spark32.spark.version")
+    scalaBinaryVersion = project.findProperty("scala.binary.version")
+    configurationName = scalaBinaryVersion.replace(".", "")
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    implementation(project(path: ":spark3", configuration: "scala${configurationName}RuntimeElements"))
 
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark3-runtime:0.13.0"
-    compileOnly "io.delta:delta-core_2.12:1.1.0"
-    compileOnly "com.databricks:dbutils-api_2.12:0.0.6"
+    compileOnly("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
+    compileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_${scalaBinaryVersion}:${icebergVersion}")
+    compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
 
-    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.13.0"
-    testFixturesApi "io.delta:delta-core_2.12:1.1.0"
-    testFixturesApi "com.databricks:dbutils-api_2.12:0.0.6"
+    // TODO: Remove this. Test Fixtures are not needed.
+    testFixturesApi(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    testFixturesApi("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
+    testFixturesApi("org.apache.iceberg:iceberg-spark-runtime-3.2_${scalaBinaryVersion}:${icebergVersion}")
+    testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.12
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    scala212Implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala212CompileOnly("io.delta:delta-core_2.12:${deltaVersion}")
+    scala212CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:${icebergVersion}")
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
+    testScala212Implementation("io.delta:delta-core_2.12:${deltaVersion}")
+    testScala212Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:${icebergVersion}")
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    // Scala 2.13
+    scala213Implementation(project(path: ":shared", configuration: "scala213RuntimeElements"))
+    scala213Implementation(project(path: ":spark3", configuration: "scala213RuntimeElements"))
+
+    scala213CompileOnly("io.delta:delta-core_2.13:${deltaVersion}")
+    scala213CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
+    scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+
+    testScala213Implementation("io.delta:delta-core_2.13:${deltaVersion}")
+    testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
+    testScala213Implementation("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala213Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala213Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -1,22 +1,34 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("idea")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+scalaVariants {
+    create("2.12")
+    create("2.13")
+}
+
+idea {
+    module {
+        testSources.from(sourceSets.testScala212.java.srcDirs, sourceSets.testScala213.java.srcDirs)
+    }
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.3.1'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
+    assertjVersion = "3.25.1"
+    icebergVersion = "0.14.1"
+    jacksonVersion = "2.15.3"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
+
+    sparkVersion = project.findProperty("spark33.spark.version") ?: "3.3.2"
+    scalaBinaryVersion = project.findProperty("scala.binary.version") ?: "2.12"
+    configurationName = scalaBinaryVersion.replace(".", "")
 }
 
-configurations.all { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2
+configurations.configureEach { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2
     resolutionStrategy {
         // https://github.com/FasterXML/jackson-databind/issues/3627
         force "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
@@ -24,55 +36,49 @@ configurations.all { // https://github.com/apache/spark/pull/38355 - can be remo
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    implementation(project(path: ":spark3", configuration: "scala${configurationName}RuntimeElements"))
 
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
-    compileOnly "io.delta:delta-core_2.12:2.1.0"
+    compileOnly("org.apache.iceberg:iceberg-spark-runtime-3.3_${scalaBinaryVersion}:${icebergVersion}")
+    compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
 
-    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:0.14.0"
-    testFixturesApi "io.delta:delta-core_2.12:2.1.0"
+    // TODO: Replace these with 'testImplementation'
+    testFixturesApi(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    testFixturesApi("org.apache.iceberg:iceberg-spark-runtime-3.3_${scalaBinaryVersion}:${icebergVersion}")
+    testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.12
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    scala212Implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala212CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:${icebergVersion}")
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
+    testScala212Implementation("org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:${icebergVersion}")
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    // Scala 2.13
+    scala213Implementation(project(path: ":shared", configuration: "scala213RuntimeElements"))
+    scala213Implementation(project(path: ":spark3", configuration: "scala213RuntimeElements"))
+
+    scala213CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.3_2.13:${icebergVersion}")
+    scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+
+    testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.3_2.13:${icebergVersion}")
+    testScala213Implementation("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala213Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala213Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -1,88 +1,85 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
+    id("io.openlineage.scala-variants")
+    id("idea")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark3'
+scalaVariants {
+    create("2.12")
+    create("2.13")
+}
+
+idea {
+    module {
+        testSources.from(sourceSets.testScala212.java.srcDirs, sourceSets.testScala213.java.srcDirs)
+    }
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    sparkVersion = '3.4.0'
-    jacksonVersion = '2.15.3'
-    lombokVersion = '1.18.30'
-    bigqueryVersion = '0.29.0'
-}
+    assertjVersion = "3.25.1"
+    deltaVersion = "2.4.0"
+    icebergVersion = "1.3.1"
+    jacksonVersion = "2.15.3"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
 
-configurations.all { // https://github.com/apache/spark/pull/38355 - can be remove for Spark 3.3.2
-    resolutionStrategy {
-        // https://github.com/FasterXML/jackson-databind/issues/3627
-        force "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
-    }
+    sparkVersion = project.findProperty("spark34.spark.version")
+    scalaBinaryVersion = project.findProperty("scala.binary.version")
+    configurationName = scalaBinaryVersion.replace(".", "")
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    implementation(project(path: ":spark3", configuration: "scala${configurationName}RuntimeElements"))
 
-    compileOnly "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    compileOnly "org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.3.1"
-    compileOnly "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
-    compileOnly "io.delta:delta-core_2.12:2.4.0"
-    compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.module'
-        exclude group: 'com.sun.jmx'
-        exclude group: 'com.sun.jdmk'
-        exclude group: 'javax.jms'
-    }
+    compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    compileOnly("org.apache.iceberg:iceberg-spark-runtime-3.4_${scalaBinaryVersion}:${icebergVersion}")
+    compileOnly("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
 
-    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}"
-    testFixturesApi "org.apache.spark:spark-core_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-hive_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-catalyst_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}"
-    testFixturesApi "org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:1.3.1"
-    testFixturesApi "org.scala-lang.modules:scala-collection-compat_2.12:2.11.0"
-    testFixturesApi "io.delta:delta-core_2.12:2.4.0"
+    // TODO: Replace this with 'testImplementation'
+    testFixturesApi(project(path: ":shared", configuration: "scala${configurationName}RuntimeElements"))
+    testFixturesApi("io.delta:delta-core_${scalaBinaryVersion}:${deltaVersion}")
+    testFixturesApi("org.apache.iceberg:iceberg-spark-runtime-3.4_${scalaBinaryVersion}:${icebergVersion}")
+    testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.12
+    scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    scala212Implementation(project(path: ":spark3", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    scala212CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:${icebergVersion}")
+    scala212CompileOnly("io.delta:delta-core_2.12:${deltaVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
+    testScala212Implementation("io.delta:delta-core_2.12:${deltaVersion}")
+    testScala212Implementation("org.apache.iceberg:iceberg-spark-runtime-3.4_2.12:${icebergVersion}")
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    // Scala 2.13
+    scala213Implementation(project(path: ":shared", configuration: "scala213RuntimeElements"))
+    scala213Implementation(project(path: ":spark3", configuration: "scala213RuntimeElements"))
+
+    scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    scala213CompileOnly("org.apache.iceberg:iceberg-spark-runtime-3.4_2.13:${icebergVersion}")
+    scala213CompileOnly("io.delta:delta-core_2.13:${deltaVersion}")
+
+    // Replace 'testFixturesApi' with 'testScala213TestImplementation'
+    testScala213Implementation("io.delta:delta-core_2.13:${deltaVersion}")
+    testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.4_2.13:${icebergVersion}")
+    testScala213Implementation("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala213Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala213Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala213Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -32,6 +33,7 @@ import org.apache.spark.sql.catalyst.plans.logical.TableSpec;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
@@ -53,7 +55,7 @@ public class CreateReplaceInputDatasetBuilderTest {
           catalog,
           mock(Identifier.class),
           mock(Table.class),
-          ScalaConversionUtils.asScalaSeqEmpty());
+          ScalaConversionUtils.<Attribute>asScalaSeqEmpty());
 
   TableSpec tableSpec = mock(TableSpec.class);
 
@@ -85,12 +87,12 @@ public class CreateReplaceInputDatasetBuilderTest {
     CreateTableAsSelect node =
         new CreateTableAsSelect(
             namePlan,
-            ScalaConversionUtils.asScalaSeqEmpty(),
+            ScalaConversionUtils.<Transform>asScalaSeqEmpty(),
             query,
             tableSpec,
             null,
             false,
-            Option.empty());
+            Option.<LogicalPlan>empty());
     when(query.collect(any()))
         .thenReturn(
             ScalaConversionUtils.fromList(


### PR DESCRIPTION
### Summary: Migrated 'spark34' module to produce Scala 2.12 and Scala 2.13 variants

### Problem

Spark 3.2.x, 3.3.x, 3.4.x, and 3.5.x are compiled using Scala 2.12 and Scala 2.13. Due to a change in the Scala Collections API in Scala 2.13, NoSuchMethodErrors are thrown when running the openlineage-spack connector in an Apache Spark runtime when the runtime was compiled using Scala 2.13.

Relates to: #2303 

### Solution

This PR is the **9th** of several PRs to support producing Scala 2.12 and Scala 2.13 variants of the OpenLineage Spark integration.

In this PR, we migrate the 'spark34' module to use the refactored Gradle plugins.

The module now produces 3 JARS; one default one, one compiled using the Scala 2.12 variant of Apache Spark, and one compiled using the Scala 2.13 variant of Apache Spark.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project