### PR TITLE
[SPARK] Conform the 'spark2' module to the new build process

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,12 +93,12 @@ jobs:
           keys:
             - v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-client-java-{{ .Branch }}
-      - run: ./gradlew --no-daemon --stacktrace build
-      - run: ./gradlew --no-daemon jacocoTestReport
-      - run: ./gradlew --no-daemon --info check
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
+      - run: ./gradlew --no-daemon --console=plain --info check
       - run: bash <(curl -s https://codecov.io/bash)
-      - run: ./gradlew javadoc
-      - run: ./gradlew publishToMavenLocal --info
+      - run: ./gradlew --console=plain javadoc
+      - run: ./gradlew --console=plain publishToMavenLocal --info
       - persist_to_workspace:
           root: ~/.m2/repository/io/openlineage/
           paths:
@@ -115,7 +115,7 @@ jobs:
           key: v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
-  
+
   release-client-java:
     working_directory: ~/openlineage/client/java
     docker:
@@ -132,10 +132,10 @@ jobs:
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
           # publish jar to maven local so it can be found by dependents
-          ./gradlew publishToMavenLocal --info
+          ./gradlew --console=plain publishToMavenLocal --info
 
           # Publish *.jar
-          ./gradlew --no-daemon publish --info
+          ./gradlew --no-daemon --console=plain publish --info
       - store_artifacts:
           path: ./build/libs
           destination: java-client-artifacts
@@ -143,7 +143,7 @@ jobs:
           key: v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.m2
-  
+
   release-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:
@@ -166,14 +166,14 @@ jobs:
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
           cd ../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
+          ./gradlew --no-daemon --console=plain publishToMavenLocal
           cd -
           # Publish *.jar
-          ./gradlew --no-daemon publish
+          ./gradlew --no-daemon --console=plain publish
       - store_artifacts:
           path: ./build/libs
           destination: spark-client-artifacts
-  
+
   build-integration-spark:
     parameters:
       spark-version:
@@ -199,13 +199,13 @@ jobs:
       - run: |
           sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
           sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-      - run: ./gradlew --no-daemon --stacktrace build -Pspark.version=<< parameters.spark-version >>
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build -Pspark.version=<< parameters.spark-version >>
       - run:
           when: on_fail
           command: cat build/test-results/test/TEST-*.xml
-      - run: ./gradlew --no-daemon jacocoTestReport
-      - run: ./gradlew --no-daemon --info check -x test -Pspark.version=<< parameters.spark-version >>
-      - run: ./gradlew javadoc
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
+      - run: ./gradlew --no-daemon --console=plain --info check -x test -Pspark.version=<< parameters.spark-version >>
+      - run: ./gradlew --console=plain javadoc
       - store_test_results:
           path: build/test-results/test
       - store_artifacts:
@@ -218,7 +218,7 @@ jobs:
           key: v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
-  
+
   release-integration-flink:
     working_directory: ~/openlineage/integration/flink
     docker:
@@ -241,10 +241,10 @@ jobs:
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
           cd ../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
+          ./gradlew --no-daemon --console=plain publishToMavenLocal
           cd -
           # Publish *.jar
-          ./gradlew --no-daemon publish
+          ./gradlew --no-daemon --console=plain publish
       - store_artifacts:
           path: ./build/libs
           destination: flink-client-artifacts
@@ -270,13 +270,13 @@ jobs:
             - v1-integration-flink-{{ .Branch }}
       - attach_workspace:
           at: .
-      - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
-      - run: ./gradlew --no-daemon --stacktrace build -Pflink.version=<< parameters.flink-version >>
+      - run: (cd ./../../client/java/ && ./gradlew --no-daemon --console=plain --stacktrace publishToMavenLocal)
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build -Pflink.version=<< parameters.flink-version >>
       - run:
           when: on_fail
           command: cat build/test-results/test/TEST-*.xml
-      - run: ./gradlew --no-daemon jacocoTestReport
-      - run: ./gradlew javadoc
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
+      - run: ./gradlew --console=plain javadoc
       - store_test_results:
           path: build/test-results/test
       - store_artifacts:
@@ -286,7 +286,7 @@ jobs:
           key: v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
-  
+
   unit-test-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
@@ -300,7 +300,7 @@ jobs:
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
           path: test-results
-  
+
   build-integration-common:
     working_directory: ~/openlineage/integration/common
     docker:
@@ -314,7 +314,7 @@ jobs:
           paths:
             - ./dist/*.whl
             - ./dist/*.tar.gz
-  
+
   build-integration-sql:
     parameters:
       image:
@@ -345,7 +345,7 @@ jobs:
       - store_artifacts:
           path: ./iface-py/target/wheels
           destination: sql-artifacts
-  
+
   compile-integration-sql-java-linux:
     parameters:
       image:
@@ -367,7 +367,7 @@ jobs:
           path: ./target/debug/
           destination: sql-linux-artifacts
 
-  
+
   compile-integration-sql-java-macos:
     parameters:
       resource_class:
@@ -429,10 +429,10 @@ jobs:
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
           cd ../../../client/java
-          ./gradlew --no-daemon publishToMavenLocal
+          ./gradlew --no-daemon --console=plain publishToMavenLocal
           cd -
           # Publish *.jar
-          ./gradlew --no-daemon publish
+          ./gradlew --no-daemon --console=plain publish
 
   build-integration-sql-macos:
     working_directory: ~/openlineage/integration/sql
@@ -450,7 +450,7 @@ jobs:
       - store_artifacts:
           path: ./iface-py/target/wheels
           destination: sql-artifacts-macos
-  
+
   build-integration-dbt:
     working_directory: ~/openlineage/integration/dbt
     docker:
@@ -464,7 +464,7 @@ jobs:
           paths:
             - ./dist/*.whl
             - ./dist/*.tar.gz
-  
+
   integration-test-integration-spark:
     parameters:
       spark-version:
@@ -493,8 +493,8 @@ jobs:
       - run: |
           sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
           sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-      - run: ./gradlew --no-daemon integrationTest -x test   -Pspark.version=<< parameters.spark-version >>
-      - run: ./gradlew --no-daemon jacocoTestReport
+      - run: ./gradlew --no-daemon --console=plain integrationTest -x test   -Pspark.version=<< parameters.spark-version >>
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - store_test_results:
           path: app/build/test-results/integrationTest
       - store_artifacts:
@@ -534,8 +534,8 @@ jobs:
             - run: |
                 sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
                 sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-            - run: ./gradlew shadowJar -x test
-            - run: ./gradlew --no-daemon databricksIntegrationTest -x test   -Pspark.version=<< parameters.spark-version >> -PdatabricksHost=$DATABRICKS_HOST -PdatabricksToken=$DATABRICKS_TOKEN
+            - run: ./gradlew --console=plain shadowJar -x test
+            - run: ./gradlew --no-daemon --console=plain databricksIntegrationTest -x test   -Pspark.version=<< parameters.spark-version >> -PdatabricksHost=$DATABRICKS_HOST -PdatabricksToken=$DATABRICKS_TOKEN
             - store_test_results:
                 path: app/build/test-results/databricksIntegrationTest
             - store_artifacts:
@@ -568,14 +568,14 @@ jobs:
           keys:
             - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-integration-flink-{{ .Branch }}
-      - run: (cd ./../../client/java/ && ./gradlew --no-daemon --stacktrace publishToMavenLocal)
+      - run: (cd ./../../client/java/ && ./gradlew --no-daemon --console=plain --stacktrace publishToMavenLocal)
       - run: chmod -R 777 data/iceberg/db
-      - run: ./gradlew examples:stateful:build -Pflink.version=<< parameters.flink-version >>
-      - run: ./gradlew --no-daemon integrationTest --i -Pflink.version=<< parameters.flink-version >>
+      - run: ./gradlew --console=plain examples:stateful:build -Pflink.version=<< parameters.flink-version >>
+      - run: ./gradlew --no-daemon --console=plain integrationTest --i -Pflink.version=<< parameters.flink-version >>
       - run:
           when: on_fail
           command: cat build/test-results/integrationTest/TEST-*.xml
-      - run: ./gradlew --no-daemon jacocoTestReport
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - store_test_results:
           path: build/test-results/integrationTest
       - store_artifacts:
@@ -679,7 +679,7 @@ jobs:
       - run: python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
       - run: pytest --cov=openlineage tests/
       - run: bash <(curl -s https://codecov.io/bash)
-  
+
   build-integration-dagster:
     working_directory: ~/openlineage/integration/dagster
     docker:
@@ -716,7 +716,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "7d:bc:78:35:09:c9:25:04:63:f9:eb:4b:f1:f4:d1:91"
-      - run: ./gradlew javadoc
+      - run: ./gradlew --console=plain javadoc
       - run: ./release-javadoc.sh
 
   publish-spec:
@@ -752,8 +752,8 @@ jobs:
           keys:
             - v1-proxy-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
             - v1-proxy-{{ .Branch }}
-      - run: ./gradlew --no-daemon --stacktrace build
-      - run: ./gradlew --no-daemon jacocoTestReport
+      - run: ./gradlew --no-daemon --console=plain --stacktrace build
+      - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:
           path: proxy/build/test-results/test
@@ -789,10 +789,10 @@ jobs:
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
 
           # publish jar to maven local so it can be found by dependents
-          ./gradlew publishToMavenLocal
+          ./gradlew --console=plain publishToMavenLocal
 
           # Publish *.jar
-          ./gradlew publish
+          ./gradlew --console=plain publish
 
   release-docker-proxy-backend:
     working_directory: ~/openlineage/proxy/backend

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -40,6 +40,17 @@ ext {
     versions = versionsMap[shortVersion]
 }
 
+// This workaround is needed because the version of Snappy that Spark 2.4.x runs with,
+// cannot run on Apple Silicon. It fails with:
+// org.xerial.snappy.SnappyError: [FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Mac and os.arch=aarch64
+configurations.configureEach {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.xerial.snappy' && details.requested.name == 'snappy-java') {
+            details.useVersion("[1.1.8.4,)")
+        }
+    }
+}
+
 dependencies {
     implementation(project(path: ":shared"))
     implementation(project(path: ":spark2"))
@@ -50,7 +61,6 @@ dependencies {
     implementation(project(path: ":spark34"))
     implementation(project(path: ":spark35"))
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
-
 
     compileOnly "org.apache.spark:spark-core_${versions.scala}:${sparkVersion}"
     compileOnly "org.apache.spark:spark-sql_${versions.scala}:${sparkVersion}"
@@ -100,9 +110,9 @@ dependencies {
     if (versions.snowflake != "NA") {
         testFixturesApi("net.snowflake:spark-snowflake_${versions.scala}:${versions.snowflake}") {
             exclude group: 'com.google.guava:guava'
-            exclude group: 'org.apache.spark:spark-core_2.11'
-            exclude group: 'org.apache.spark:spark-sql_2.11'
-            exclude group: 'org.apache.spark:spark-catalyst_2.11'
+            exclude group: 'org.apache.spark:spark-core_${versions.scala}'
+            exclude group: 'org.apache.spark:spark-sql_${versions.scala}'
+            exclude group: 'org.apache.spark:spark-catalyst_${versions.scala}'
         }
     }
 
@@ -143,24 +153,18 @@ dependencies {
     pysparkContainerOnly("com.google.guava:guava:30.1-jre")
 
     if (versions.delta != "NA") {
-        testFixturesApi "io.delta:delta-core_2.12:${versions.delta}"
+        testFixturesApi "io.delta:delta-core_${versions.scala}:${versions.delta}"
     }
 
     if (versions.iceberg != "NA") {
         testFixturesApi "org.apache.iceberg:${versions.iceberg}"
     }
 
-    testImplementation(project(":${versions.module}"))
     if (versions.module != "spark2") {
         testImplementation("com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.9") {
             exclude group: 'com.google.guava', module: 'guava'
         }
         pysparkContainerOnly("com.google.guava:guava:30.1-jre")
-    }
-
-
-    testImplementation testFixtures(project(":${versions.module}")) {
-        exclude group: 'org.apache.avro'
     }
 }
 
@@ -183,8 +187,20 @@ def commonTestConfiguration = {
     classpath = project.sourceSets.test.runtimeClasspath
 }
 
+// These entries aren't considered "outputs" of any Gradle task, thus Gradle doesn't know about
+// them and won't clean them up when you run './gradlew clean'. This is a problem because
+// you may experience weird test failures, when running the tests using different versions of
+// Apache Spark. Thus this take is a workaround to clean up these file(s) and folder(s).
+tasks.register("cleanUp", Delete) {
+    delete("derby.log", "metastore_db", "spark-warehouse")
+}
+
+tasks.withType(Test).configureEach {
+    failFast = true
+}
+
 task nonParallelTest(type: Test) {
-    dependsOn shadowJar
+    dependsOn tasks.named("shadowJar"), tasks.named("cleanUp")
     group = 'verification'
     description = "Runs tests that cannot be run in parallel. For example test suites that require metastore_db"
 
@@ -198,7 +214,6 @@ task nonParallelTest(type: Test) {
 task beforeShadowJarTest(type: Test) {
     group = 'verification'
     description = "Tests that depend that have to be run before shadowJar"
-
     useJUnitPlatform {
         includeTags("beforeShadowJarTest")
     }
@@ -348,3 +363,4 @@ classes {
 tasks.named("pmdTest") {
     mustRunAfter("shadowJar")
 }
+

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -58,8 +58,8 @@ import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.apache.spark.util.SerializableJobConf;
+import scala.Option;
 import scala.collection.Seq;
-import scala.runtime.AbstractFunction0;
 
 @Slf4j
 class RddExecutionContext implements ExecutionContext {
@@ -72,17 +72,9 @@ class RddExecutionContext implements ExecutionContext {
 
   public RddExecutionContext(EventEmitter eventEmitter) {
     this.eventEmitter = eventEmitter;
+    Option<SparkContext> activeSessionOption = SparkContext$.MODULE$.getActive();
     sparkContextOption =
-        Optional.ofNullable(
-            SparkContext$.MODULE$
-                .getActive()
-                .getOrElse(
-                    new AbstractFunction0<SparkContext>() {
-                      @Override
-                      public SparkContext apply() {
-                        return null;
-                      }
-                    }));
+        activeSessionOption.isDefined() ? Optional.of(activeSessionOption.get()) : Optional.empty();
   }
 
   @Override

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -157,7 +157,7 @@ class SparkContainerIntegrationTest {
         admin.createTopics(
             Arrays.asList(
                 new NewTopic("topicA", 1, (short) 1), new NewTopic("topicB", 1, (short) 1)));
-    topicsResult.topicId("topicA").get();
+    topicsResult.all().get();
 
     SparkContainerUtils.runPysparkContainerWithDefaultConf(
         network,

--- a/integration/spark/app/src/test/resources/log4j.properties
+++ b/integration/spark/app/src/test/resources/log4j.properties
@@ -1,13 +1,13 @@
 # Set everything to be logged to the console
 log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
+log4j.appender.console.Target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
 # set the log level for the openlineage spark library
 log4j.logger.io.openlineage=DEBUG
 log4j.logger.io.openlineage.spark.shaded=WARN
 log4j.logger.org.apache.spark.storage=WARN
 log4j.logger.org.apache.spark.scheduler=WARN
-
+log4j.logger.org.testcontainers=WARN

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -49,6 +49,26 @@ javadoc {
     options.tags = ["apiNote"]
 }
 
+def reportsDir = "${buildDir}/reports";
+def coverageDir = "${reportsDir}/coverage";
+
+jacoco {
+    toolVersion = '0.8.5'
+    reportsDir = file(coverageDir)
+}
+
+jacocoTestReport {
+    reports {
+        xml {
+            enabled true
+        }
+        html {
+            enabled true
+            destination = file(coverageDir)
+        }
+    }
+}
+
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -1,10 +1,11 @@
 jdk8.build=true
 version=1.9.0-SNAPSHOT
-spark.version=3.5.0
+spark.version=2.4.6
 org.gradle.jvmargs=-Xmx1G
 
 scala.binary.version=2.12
 shared.spark.version=3.2.4
+spark2.spark.version=2.4.8
 spark3.spark.version=3.2.4
 spark31.spark.version=3.1.3
 spark32.spark.version=3.2.4

--- a/integration/spark/settings.gradle
+++ b/integration/spark/settings.gradle
@@ -7,4 +7,3 @@ include 'spark34'
 include 'spark35'
 include 'shared'
 include 'app'
-

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -1,70 +1,84 @@
 plugins {
     id("io.openlineage.common-config")
-    id 'java-test-fixtures'
-    id "com.adarshr.test-logger" version "3.2.0"
-    id "org.gradle.test-retry" version "1.5.8"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id("io.openlineage.scala-variants")
+    id("idea")
+    id("java-test-fixtures")
 }
 
-archivesBaseName = 'openlineage-spark-spark2'
+scalaVariants {
+    create("2.11")
+    create("2.12")
+}
+
+idea {
+    module {
+        testSources.from(sourceSets.testScala212.java.srcDirs)
+    }
+}
 
 ext {
-    assertjVersion = '3.25.1'
-    sparkVersion = '2.4.8'
-    junit5Version = '5.10.1'
-    mockitoVersion = '4.11.0'
-    lombokVersion = '1.18.20'
-    postgresqlVersion = '42.7.1'
+    assertjVersion = "3.25.1"
+    deltaVersion = "1.1.0"
+    icebergVersion = "0.14.1"
+    jacksonVersion = "2.15.3"
+    junit5Version = "5.10.1"
+    mockitoVersion = "4.11.0"
+    postgresqlVersion = "42.7.1"
+
+    sparkVersion = project.findProperty("spark2.spark.version")
+    scalaBinaryVersion = "2.11"
 }
 
 dependencies {
-    implementation(project(path: ":shared"))
+    compileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
-    compileOnly "com.fasterxml.jackson.module:jackson-module-scala_2.11:2.15.3"
-    compileOnly "org.apache.spark:spark-core_2.11:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql_2.11:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-hive_2.11:${sparkVersion}"
-    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.11:${sparkVersion}"
-    compileOnly "com.databricks:dbutils-api_2.11:0.0.5"
+    compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
 
-    testFixturesApi "org.apache.spark:spark-core_2.11:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-sql_2.11:${sparkVersion}"
-    testFixturesApi "org.apache.spark:spark-hive_2.11:${sparkVersion}"
-    testFixturesApi "com.fasterxml.jackson.module:jackson-module-scala_2.11:2.15.3"
-    testFixturesApi "org.apache.spark:spark-sql-kafka-0-10_2.11:${sparkVersion}"
+    // TODO: Replace 'testFixturesApi' with 'testImplementation'
+    // TODO: Remove the test dependency on 'shared'
+    testFixturesApi(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    testFixturesApi("com.fasterxml.jackson.module:jackson-module-scala_${scalaBinaryVersion}:${jacksonVersion}")
+    testFixturesApi("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
+    testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
+    testFixturesApi("org.postgresql:postgresql:${postgresqlVersion}")
 
-    testFixturesApi "org.junit.jupiter:junit-jupiter:${junit5Version}"
-    testFixturesApi "org.postgresql:postgresql:${postgresqlVersion}"
-    testFixturesApi "org.assertj:assertj-core:${assertjVersion}"
-    testFixturesApi "org.mockito:mockito-core:${mockitoVersion}"
-    testFixturesApi "org.mockito:mockito-inline:${mockitoVersion}"
-    testFixturesApi "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testFixturesApi "org.apache.kafka:kafka-clients:3.6.1"
-    testFixturesApi(project(path: ":shared"))
-}
+    // Scala 2.11
+    // This is intentionally left as 'scala212RuntimeElements' because the 'shared' project
+    // only has Scala 2.12 and 2.13 variants. Because this project is written in Java, this should
+    // not be a problem.
+    scala211CompileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
-def commonTestConfiguration = {
-    forkEvery 1
-    maxParallelForks 5
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
-    systemProperties = [
-            'junit.platform.output.capture.stdout': 'true',
-            'junit.platform.output.capture.stderr': 'true',
-            'spark.version'                       : "${sparkVersion}",
-            'openlineage.spark.jar'               : "${archivesBaseName}-${project.version}.jar",
-            'kafka.package.version'               : "org.apache.spark:spark-sql-kafka-0-10_2.11:${sparkVersion}",
-            'mockserver.logLevel'                 : 'ERROR'
-    ]
+    scala211CompileOnly("org.apache.spark:spark-sql_2.11:${sparkVersion}")
 
-    classpath = project.sourceSets.test.runtimeClasspath
-}
+    testScala211Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    testScala211Implementation("com.fasterxml.jackson.module:jackson-module-scala_2.11:${jacksonVersion}")
+    testScala211Implementation("org.apache.spark:spark-hive_2.11:${sparkVersion}")
+    testScala211Implementation("org.apache.spark:spark-sql_2.11:${sparkVersion}")
+    testScala211Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala211Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala211Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala211Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala211Implementation("org.mockito:mockito-inline:${mockitoVersion}")
+    testScala211Implementation("org.postgresql:postgresql:${postgresqlVersion}")
 
-test {
-    configure commonTestConfiguration
-    useJUnitPlatform {
-        excludeTags 'integration-test'
-    }
+    // Scala 2.12
+    scala212CompileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
+
+    scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+
+    testScala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
+    testScala212Implementation("com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}")
+    testScala212Implementation("org.apache.spark:spark-hive_2.12:${sparkVersion}")
+    testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
+    testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
+    testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
+    testScala212Implementation("org.postgresql:postgresql:${postgresqlVersion}")
 }

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -17,6 +17,7 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.spark.Partition;
@@ -70,10 +71,10 @@ class CreateHiveTableAsSelectCommandVisitorTest {
     CreateHiveTableAsSelectCommand command =
         new CreateHiveTableAsSelectCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("db")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.apply(URI.create("s3://bucket/directory")),
+                    Option.<URI>apply(URI.create("s3://bucket/directory")),
                     null,
                     null,
                     null,
@@ -82,9 +83,15 @@ class CreateHiveTableAsSelectCommandVisitorTest {
                 new StructType(
                     new StructField[] {
                       new StructField(
-                          KEY, IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+                          KEY,
+                          IntegerType$.MODULE$,
+                          false,
+                          new Metadata(new HashMap<String, Object>())),
                       new StructField(
-                          VALUE, StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+                          VALUE,
+                          StringType$.MODULE$,
+                          false,
+                          new Metadata(new HashMap<String, Object>()))
                     })),
             new LogicalRelation(
                 new JDBCRelation(
@@ -97,10 +104,9 @@ class CreateHiveTableAsSelectCommandVisitorTest {
                     new JDBCOptions(
                         "",
                         "temp",
-                        scala.collection.immutable.Map$.MODULE$
-                            .newBuilder()
-                            .$plus$eq(Tuple2.apply("driver", Driver.class.getName()))
-                            .result()),
+                        ScalaUtils.<String, String>fromTuples(
+                            Collections.singletonList(
+                                Tuple2.<String, String>apply("driver", Driver.class.getName())))),
                     session),
                 Seq$.MODULE$
                     .<AttributeReference>newBuilder()

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -17,6 +17,7 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.spark.Partition;
@@ -25,6 +26,7 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier$;
 import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat$;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
@@ -70,10 +72,10 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
     OptimizedCreateHiveTableAsSelectCommand command =
         new OptimizedCreateHiveTableAsSelectCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("db")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.apply(URI.create("s3://bucket/directory")),
+                    Option.<URI>apply(URI.create("s3://bucket/directory")),
                     null,
                     null,
                     null,
@@ -82,9 +84,15 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
                 new StructType(
                     new StructField[] {
                       new StructField(
-                          KEY, IntegerType$.MODULE$, false, new Metadata(new HashMap<>())),
+                          KEY,
+                          IntegerType$.MODULE$,
+                          false,
+                          new Metadata(new HashMap<String, Object>())),
                       new StructField(
-                          VALUE, StringType$.MODULE$, false, new Metadata(new HashMap<>()))
+                          VALUE,
+                          StringType$.MODULE$,
+                          false,
+                          new Metadata(new HashMap<String, Object>()))
                     })),
             new LogicalRelation(
                 new JDBCRelation(
@@ -97,10 +105,9 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
                     new JDBCOptions(
                         "",
                         "temp",
-                        scala.collection.immutable.Map$.MODULE$
-                            .newBuilder()
-                            .$plus$eq(Tuple2.apply("driver", Driver.class.getName()))
-                            .result()),
+                        ScalaUtils.<String, String>fromTuples(
+                            Collections.singletonList(
+                                Tuple2.<String, String>apply("driver", Driver.class.getName())))),
                     session),
                 Seq$.MODULE$
                     .<AttributeReference>newBuilder()
@@ -121,9 +128,9 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
                             ExprId.apply(2L),
                             Seq$.MODULE$.<String>empty()))
                     .result(),
-                Option.empty(),
+                Option.<CatalogTable>empty(),
                 false),
-            ScalaConversionUtils.fromList(Arrays.asList(KEY, VALUE)),
+            ScalaConversionUtils.<String>fromList(Arrays.asList(KEY, VALUE)),
             SaveMode.Overwrite);
 
     assertThat(visitor.isDefinedAt(command)).isTrue();

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/ScalaUtils.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/ScalaUtils.java
@@ -1,0 +1,19 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark2.agent.lifecycle.plan;
+
+import java.util.List;
+import scala.Tuple2;
+
+final class ScalaUtils {
+  public static <K, V> scala.collection.immutable.Map<K, V> fromTuples(List<Tuple2<K, V>> tuples) {
+    scala.collection.immutable.Map<K, V> map = scala.collection.immutable.Map$.MODULE$.empty();
+    for (Tuple2<K, V> tuple : tuples) {
+      map = map.$plus(Tuple2.apply(tuple._1(), tuple._2()));
+    }
+    return map;
+  }
+}


### PR DESCRIPTION
### Summary: Conform the 'spark2' module with the rest of the migrated modules

### Problem

Spark 3.2.x, 3.3.x, 3.4.x, and 3.5.x are compiled using Scala 2.12 and Scala 2.13. Due to a change in the Scala Collections API in Scala 2.13, NoSuchMethodErrors are thrown when running the openlineage-spack connector in an Apache Spark runtime when the runtime was compiled using Scala 2.13.

Relates to: #2303 

### Solution

This PR is the **11th** of several PRs to support producing Scala 2.12 and Scala 2.13 variants of the OpenLineage Spark integration.

In this PR, we conform the spark2 module with the other migrated modules

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project