### PR TITLE
[SPARK] fix bigquery test to recreate table every time

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java
@@ -121,16 +121,18 @@ public class GoogleCloudIntegrationTest {
 
     spark.sparkContext().setLogLevel("info");
 
-    // TODO: would love to avoid this in future
-    // # # ran this once to create source table
-    // # df = spark.createDataFrame([
-    // #     {'a': 1, 'b': 2},
-    // #     {'a': 3, 'b': 4}
-    // # ])
-    // # df.write.format('bigquery') \
-    // #     .option('table', source_table) \
-    // #     .mode('overwrite') \
-    // #     .save()
+    Dataset<Row> dataset =
+        spark
+            .createDataFrame(
+                ImmutableList.of(RowFactory.create(1L, 2L), RowFactory.create(3L, 4L)),
+                new StructType(
+                    new StructField[] {
+                      new StructField("a", LongType$.MODULE$, false, Metadata.empty()),
+                      new StructField("b", LongType$.MODULE$, false, Metadata.empty())
+                    }))
+            .repartition(1);
+
+    dataset.write().format("bigquery").option("table", source_table).mode("overwrite").save();
 
     Dataset<Row> first = spark.read().format("bigquery").option("table", source_table).load();
 


### PR DESCRIPTION
### Problem

`GoogleCloudIntegrationTest` is failing for new spark versions as it relies on BigQuery tables with spark version suffixes. 

### Solution

Assure tables are recreated with each test. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project