### PR TITLE
[FLINK][BUG][ICEBERG] fix IcebergSourceWrapper for iceberg connector 1.17

### DIFF
--- a/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSourceWrapper.java
+++ b/integration/flink/src/main/java/io/openlineage/flink/visitor/wrapper/IcebergSourceWrapper.java
@@ -24,7 +24,11 @@ public class IcebergSourceWrapper<T> {
 
   public Table getTable() {
     return WrapperUtils.<TableLoader>getFieldValue(sourceClass, source, "tableLoader")
-        .map(TableLoader::loadTable)
+        .map(
+            loader -> {
+              loader.open();
+              return loader.loadTable();
+            })
         .get();
   }
 }


### PR DESCRIPTION
### Problem

in flink 1.17, iceberg catalogloader loads the catalog in the `open` function. 

https://github.com/apache/iceberg/blob/main/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java#L122

>    @Override
    public void open() {
      catalog = catalogLoader.loadCatalog();
    }

Need to call open first otherwise the `loadTable` method will throw an NPE


### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project