### PR TITLE
[SPARK] Enhancement of Custom Gradle Plugins

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -1,9 +1,13 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
+    id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
     id 'java-test-fixtures'
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 configurations {

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -1,17 +1,15 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id "com.github.johnrengelman.shadow" version "8.1.1"
-}
-
-commonConfig {
-    pmdEnabled = false
-    lombokEnabled = false
-    spotlessEnabled = false
+    id "com.github.johnrengelman.shadow"
 }
 
 archivesBaseName = 'openlineage-spark'

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    kotlin("plugin.serialization") version "1.9.10"
 }
 
 repositories {
@@ -7,13 +8,19 @@ repositories {
     mavenCentral()
 }
 
+val downloadTaskVersion: String = "5.5.0"
 val lombokPluginVersion: String = "8.4"
+val shadowPluginVersion: String = "8.1.1"
 val spotlessVersion: String = "6.13.0"
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${spotlessVersion}")
+    implementation("com.github.johnrengelman:shadow:${shadowPluginVersion}")
+    implementation("de.undercouch:gradle-download-task:${downloadTaskVersion}")
     implementation("io.freefair.gradle:lombok-plugin:${lombokPluginVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 }
 
 gradlePlugin {
@@ -26,6 +33,17 @@ gradlePlugin {
         create("scalaVariants") {
             id = "io.openlineage.scala-variants"
             implementationClass = "io.openlineage.gradle.plugin.ScalaVariantsPlugin"
+        }
+
+        create("sparkBuilds") {
+            id = "io.openlineage.spark-variant-build"
+            implementationClass =
+                "io.openlineage.gradle.plugin.variant.spark.SparkVariantsBuildPlugin"
+        }
+
+        create("dockerBuild") {
+            id = "io.openlineage.docker-build"
+            implementationClass = "io.openlineage.gradle.plugin.docker.DockerBuildPlugin"
         }
     }
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPluginExtension.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 
@@ -14,16 +14,10 @@ import org.gradle.api.provider.Property
  * Usage:
  * ```
  * commonConfig {
- *     pmdEnabled.set(true)
- *     lombokEnabled.set(true)
  *     lombokVersion.set("1.18.30")
- *     spotlessEnabled.set(true)
  * }
  * ```
  */
 interface CommonConfigPluginExtension {
-    val pmdEnabled: Property<Boolean>
-    val lombokEnabled: Property<Boolean>
     val lombokVersion: Property<String>
-    val spotlessEnabled: Property<Boolean>
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaBuildVariant.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaBuildVariant.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 
@@ -139,6 +139,7 @@ class ScalaVariantDelegate(
                 "Assembles a jar archive containing the main classes compiled using Scala $scalaBinaryVersion variants of the Apache Spark libraries"
             group = "build"
             from(sourceSets[sourceSetName].output)
+            destinationDirectory.set(target.file(target.layout.buildDirectory.file("libs/$sourceSetName")))
             archiveFileName.set(archiveName)
             includeEmptyDirs = false
         }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantsPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantsPlugin.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/BuildDockerImageTask.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/BuildDockerImageTask.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class BuildDockerImageTask : DefaultTask() {
+
+    init {
+        group = "docker"
+        description = "Build the Docker image"
+    }
+
+    @get:Input
+    abstract val dockerImageName: Property<String>
+
+    @get:Input
+    abstract val dockerImageTag: Property<String>
+
+    @get:InputDirectory
+    abstract val dockerBuildContext: DirectoryProperty
+
+    @TaskAction
+    fun buildDockerImage() {
+        val dockerBuildContextDir = dockerBuildContext.get().asFile
+        val dockerImage = "${dockerImageName.get()}:${dockerImageTag.get()}"
+        logger.lifecycle("Building Docker image $dockerImage from $dockerBuildContextDir")
+        project.exec {
+            workingDir = dockerBuildContextDir
+            commandLine(
+                "docker",
+                "build",
+                "-t",
+                dockerImage,
+                "."
+            )
+        }
+    }
+
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPlugin.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class DockerBuildPlugin : Plugin<Project> {
+    override fun apply(p: Project) {
+        val extension = p.extensions.create("docker", DockerBuildPluginExtension::class.java)
+        val builder = DockerImageBuilder(p, extension)
+        builder.registerTasks()
+    }
+}
+

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPluginExtension.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+
+abstract class DockerBuildPluginExtension @javax.inject.Inject constructor(p: Project) {
+    internal val dockerFileTemplate: RegularFileProperty = p.objects.fileProperty().convention(
+        p.layout.projectDirectory.file("docker/Dockerfile.template")
+    )
+
+    internal val manifestFile: RegularFileProperty = p.objects.fileProperty().convention(
+        p.layout.projectDirectory.file("docker/manifest.json")
+    )
+
+    internal val downloadDir = p.objects.directoryProperty().convention(
+        p.layout.projectDirectory.dir("bin")
+    )
+
+    internal val destinationDir = p.objects.directoryProperty().convention(
+        p.layout.buildDirectory.dir("docker")
+    )
+
+    fun dockerfileTemplate(file: RegularFileProperty) {
+        dockerFileTemplate.set(file)
+    }
+
+    fun manifestFile(file: RegularFileProperty) {
+        manifestFile.set(file)
+    }
+
+    fun downloadDir(dir: DirectoryProperty) {
+        downloadDir.set(dir)
+    }
+
+    fun destinationDir(dir: DirectoryProperty) {
+        destinationDir.set(dir)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerImageBuilder.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerImageBuilder.kt
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import de.undercouch.gradle.tasks.download.Download
+import kotlinx.serialization.json.Json
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+
+class DockerImageBuilder(
+    private val p: Project,
+    private val ext: DockerBuildPluginExtension
+) {
+    private val tasks = p.tasks
+
+    fun registerTasks() {
+        loadManifests().forEach {
+            registerTasks(it)
+        }
+
+        tasks.register("buildDockerImages") {
+            group = "docker"
+            description = "Build all Docker images"
+            dependsOn(tasks.withType(BuildDockerImageTask::class.java))
+        }
+    }
+
+    private fun registerTasks(m: DockerManifest) {
+        val downloadSparkBinariesTask = registerDownloadSparkBinaries(m)
+        val downloadSparkBinariesAscTask = registerDownloadSparkBinariesAsc(m)
+        val downloadSparkPgpKeysTask = registerDownloadSparkPgpKeys(m)
+        val copySparkBinariesTask = registerCopySparkBinaries(m, downloadSparkBinariesTask)
+        val copySparkBinariesAscTask = registerCopySparkBinariesAsc(m, downloadSparkBinariesAscTask)
+        val copySparkPgpKeysTask = registerCopySparkPgpKeys(m, downloadSparkPgpKeysTask)
+        val copyDependenciesTask = registerCopyDockerDependenciesTask(
+            m,
+            copySparkBinariesTask,
+            copySparkBinariesAscTask,
+            copySparkPgpKeysTask
+        )
+        val createDockerFileTask = registerCreateDockerFileTask(m)
+        registerBuildDockerImageTask(m, createDockerFileTask, copyDependenciesTask)
+    }
+
+    private fun formatName(m: DockerManifest) = formatName(m.sparkVersion, m.scalaBinaryVersion)
+
+    private fun formatName(sparkVersion: String, scalaBinaryVersion: String) =
+        "Spark${sparkVersion.replace(".", "")}Scala${scalaBinaryVersion.replace(".", "")}"
+
+    private fun registerDownloadSparkBinaries(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkBinaries${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkSourceBinaries)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/spark.tgz")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerDownloadSparkBinariesAsc(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkBinariesAsc${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkSourceBinariesAsc)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/spark.tgz.asc")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerDownloadSparkPgpKeys(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkPgpKeys${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkPgpKeys)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/KEYS")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerCopyFileTask(
+        taskName: String,
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> = tasks.register<Copy>(taskName) {
+        dependsOn(task)
+        group = "docker"
+        this.description = description
+        from(task.map { it.dest })
+        into(ext.destinationDir.map { dir ->
+            dir.dir("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}")
+        })
+    }
+
+    private fun registerCopySparkBinaries(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkBinaries${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopySparkBinariesAsc(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkBinariesAsc${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopySparkPgpKeys(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkPgpKeys${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopyDockerDependenciesTask(
+        m: DockerManifest,
+        binariesTask: TaskProvider<Copy>,
+        ascTask: TaskProvider<Copy>,
+        pgpKeysTask: TaskProvider<Copy>
+    ): TaskProvider<Task> {
+        val taskName = "copyDockerDependencies${formatName(m)}"
+        return tasks.register(taskName) {
+            dependsOn(binariesTask, ascTask, pgpKeysTask)
+            group = "docker"
+            description =
+                "Aggregate task that triggers the copying of all necessary files " +
+                        "for the Docker Image for Spark ${m.sparkVersion} and " +
+                        "Scala ${m.scalaBinaryVersion} to be built"
+        }
+    }
+
+    private fun registerCreateDockerFileTask(m: DockerManifest): TaskProvider<MaterialiseDockerfileTask> {
+        val taskName = "createDockerFile${formatName(m)}"
+        return tasks.register<MaterialiseDockerfileTask>(taskName) {
+            baseDockerImage(m.baseDockerImage)
+            templateFile.set(ext.dockerFileTemplate)
+            destinationFile.set(
+                ext.destinationDir.map { dir ->
+                    dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/Dockerfile")
+                }
+            )
+        }
+    }
+
+    private fun registerBuildDockerImageTask(
+        m: DockerManifest,
+        materialiseDockerFileTask: TaskProvider<MaterialiseDockerfileTask>,
+        copyDependenciesTask: TaskProvider<Task>
+    ): Provider<BuildDockerImageTask> {
+        val taskName = "buildDockerImage${formatName(m)}"
+        return tasks.register<BuildDockerImageTask>(taskName) {
+            dependsOn(materialiseDockerFileTask, copyDependenciesTask)
+            dockerImageName.set("openlineage/spark")
+            dockerImageTag.set("spark-${m.sparkVersion}-scala-${m.scalaBinaryVersion}")
+            dockerBuildContext.set(ext.destinationDir.map { dir ->
+                dir.dir("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}")
+            })
+        }
+    }
+
+
+    private fun loadManifests(): List<DockerManifest> {
+        val file = ext.manifestFile.get()
+        val text = file.asFile.readText()
+        return Json.decodeFromString<List<DockerManifest>>(text)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerManifest.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerManifest.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DockerManifest(
+    val sparkVersion: String,
+    val scalaBinaryVersion: String,
+    val sparkSourceBinaries: String,
+    val sparkSourceBinariesAsc: String,
+    val sparkPgpKeys: String,
+    val baseDockerImage: String
+)

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/MaterialiseDockerfileTask.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/MaterialiseDockerfileTask.kt
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class MaterialiseDockerfileTask : DefaultTask() {
+    private var baseDockerImage: String? = null
+
+    init {
+        group = "docker"
+        description = "Materialise the Dockerfile from the template"
+    }
+
+    @get:InputFile
+    abstract val templateFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val destinationFile: RegularFileProperty
+
+    fun baseDockerImage(baseDockerImage: String) {
+        this.baseDockerImage = baseDockerImage
+    }
+
+    @TaskAction
+    fun materialiseDockerfile() {
+        check(baseDockerImage != null) { "baseDockerImage must be set" }
+        val rawTemplate = loadDockerfileTemplate()
+        val appliedTemplate =
+            rawTemplate.replace("##BASE_DOCKER_IMAGE##", baseDockerImage!!)
+        val f = destinationFile.get()
+        f.asFile.writeText(appliedTemplate)
+    }
+
+    private fun loadDockerfileTemplate(): String = templateFile.get().asFile.readText()
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildConfigurerDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildConfigurerDsl.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+class BuildConfigurerDsl(private val build: InternalSparkVariantBuild) {
+    val sparkVersion by build::sparkVersion
+    val scalaBinaryVersion by build::scalaBinaryVersion
+
+    fun dependencies(action: DependencyHandlerDsl.() -> Unit) {
+        val dsl = DependencyHandlerDsl(build)
+        action.invoke(dsl)
+    }
+
+    fun settings(action: BuildSettingsDsl.() -> Unit) {
+        val dsl = BuildSettingsDsl(build)
+        action.invoke(dsl)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildSettingsDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildSettingsDsl.kt
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+class BuildSettingsDsl(private val build: InternalSparkVariantBuild) {
+    val sparkVersion by build::sparkVersion
+    val scalaBinaryVersion by build::scalaBinaryVersion
+
+    fun disableDeltaTests() {
+        build.prop(InternalSparkVariantBuild.DELTA_TESTS_ENABLED, false)
+    }
+
+    fun disableIcebergTests() {
+        build.prop(InternalSparkVariantBuild.ICEBERG_TESTS_ENABLED, false)
+    }
+
+    fun integrationTest(action: IntegrationTestSettingsDsl.() -> Unit) {
+        val dsl = IntegrationTestSettingsDsl(build)
+        action.invoke(dsl)
+    }
+
+    /**
+     * This particular method is to allow some flexibility when configuring the system properties for tests.
+     * The use case for this is if one test suite has a very specific configuration that is not shared by the rest
+     * then this method can be used to enable that bespoke configuration.
+     *
+     * Example:
+     *
+     * Suppose you have a test method that you want to guard behind a custom system property.
+     *
+     * ```java
+     * @Test
+     * @EnabledIfSystemProperty(named = "my.custom.property", matches = "true")
+     * void testSomeNewFeature() {
+     *   SparkSession spark = SparkSession.builder().getOrCreate();
+     *   // do some stuff, assert some things, etc
+     * }
+     * ```
+     *
+     * You can use this method whilst configuring a build to add that property, which will then be set. In your build script
+     * ```kotlin
+     * builds {
+     *     add(...).configure {
+     *          settings {
+     *              setSystemPropertyForTests("my.custom.property", "true")
+     *          }
+     *     }
+     * }
+     * ```
+     */
+    fun setSystemPropertyForTests(key: String, value: Any) {
+        build.prop(key, value)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/CommonDependenciesDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/CommonDependenciesDsl.kt
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.project
+
+class CommonDependenciesDsl(
+    private val builds: NamedDomainObjectContainer<InternalSparkVariantBuild>,
+    private val dependencies: DependencyHandler
+) {
+    fun project(path: String) = dependencies.project(path)
+
+    fun project(path: String, configuration: String) = dependencies.project(path, configuration)
+
+    fun implementation(dependency: Dependency) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependency)
+
+    fun implementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependency, configure)
+
+    fun implementation(dependencyNotation: String) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependencyNotation)
+
+    fun implementation(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependencyNotation, configure)
+
+    fun compileOnly(dependency: Dependency) = addToAll(ConfigurationType.COMPILE_ONLY, dependency)
+
+    fun compileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependency, configure)
+
+    fun compileOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependencyNotation)
+
+    fun compileOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependencyNotation, configure)
+
+    fun runtimeOnly(dependency: Dependency) = addToAll(ConfigurationType.RUNTIME_ONLY, dependency)
+
+    fun runtimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependency, configure)
+
+    fun runtimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependencyNotation)
+
+    fun runtimeOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun testImplementation(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependency)
+
+    fun testImplementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependency, configure)
+
+    fun testImplementation(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation)
+
+    fun testImplementation(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation, configure)
+
+    fun testCompileOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependency)
+
+    fun testCompileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependency, configure)
+
+    fun testCompileOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation)
+
+    fun testCompileOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation, configure)
+
+    fun testRuntimeOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependency)
+
+    fun testRuntimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun testRuntimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun testRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestRuntimeOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency)
+
+    fun integrationTestRuntimeOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun integrationTestRuntimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun integrationTestRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestMountOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency)
+
+    fun integrationTestMountOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency, configure)
+
+    fun integrationTestMountOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation)
+
+    fun integrationTestMountOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation, configure)
+
+    private fun addToAll(cfg: ConfigurationType, dependency: Dependency) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependency)
+            }
+        }
+    }
+
+    private fun addToAll(cfg: ConfigurationType, dependencyNotation: String) =
+        builds.forEach { build ->
+            build.configure {
+                dependencies {
+                    add(cfg, dependencyNotation)
+                }
+            }
+        }
+
+    private fun addToAll(
+        cfg: ConfigurationType,
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependency) {
+                    configure.invoke(this)
+                }
+            }
+        }
+    }
+
+    private fun addToAll(
+        cfg: ConfigurationType,
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependencyNotation) {
+                    configure.invoke(this)
+                }
+            }
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ConfigurationType.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ConfigurationType.kt
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+internal enum class ConfigurationType {
+    COMPILE_ONLY,
+    IMPLEMENTATION,
+    INTEGRATION_TEST_RUNTIME_ONLY,
+    INTEGRATION_TEST_UPLOAD_ONLY,
+    RUNTIME_ONLY,
+    TEST_COMPILE_ONLY,
+    TEST_IMPLEMENTATION,
+    TEST_RUNTIME_ONLY,
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/DependencyHandlerDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/DependencyHandlerDsl.kt
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.kotlin.dsl.project
+
+class DependencyHandlerDsl(private val b: InternalSparkVariantBuild) {
+    private val dependencies = b.dependencies
+
+    val sparkVersion = b.sparkVersion
+    val scalaBinaryVersion = b.scalaBinaryVersion
+
+    fun project(path: String) = dependencies.project(path)
+
+    fun project(path: String, configuration: String) = dependencies.project(path, configuration)
+
+    fun implementation(dependency: Dependency) = add(ConfigurationType.IMPLEMENTATION, dependency)
+
+    fun implementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.IMPLEMENTATION, dependency, configure)
+
+    fun implementation(dependencyNotation: String) =
+        add(ConfigurationType.IMPLEMENTATION, dependencyNotation)
+
+    fun implementation(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.IMPLEMENTATION, dependencyNotation, configure)
+
+    fun implementation(dependency: Dependency, configuration: String) =
+        add(ConfigurationType.IMPLEMENTATION, dependency) {
+            this.targetConfiguration = configuration
+        }
+
+    fun compileOnly(dependency: Dependency) = add(ConfigurationType.COMPILE_ONLY, dependency)
+
+    fun compileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.COMPILE_ONLY, dependency, configure)
+
+    fun compileOnly(dependencyNotation: String) =
+        add(ConfigurationType.COMPILE_ONLY, dependencyNotation)
+
+    fun compileOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.COMPILE_ONLY, dependencyNotation, configure)
+
+    fun runtimeOnly(dependency: Dependency) = add(ConfigurationType.RUNTIME_ONLY, dependency)
+
+    fun runtimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.RUNTIME_ONLY, dependency, configure)
+
+    fun runtimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.RUNTIME_ONLY, dependencyNotation)
+
+    fun runtimeOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun testImplementation(dependency: Dependency) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependency)
+
+    fun testImplementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependency, configure)
+
+    fun testImplementation(dependencyNotation: String) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation)
+
+    fun testImplementation(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation, configure)
+
+    fun testCompileOnly(dependency: Dependency) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependency)
+
+    fun testCompileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependency, configure)
+
+    fun testCompileOnly(dependencyNotation: String) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation)
+
+    fun testCompileOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation, configure)
+
+    fun testRuntimeOnly(dependency: Dependency) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependency)
+
+    fun testRuntimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun testRuntimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun testRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestRuntimeOnly(dependency: Dependency) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency)
+
+    fun integrationTestRuntimeOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun integrationTestRuntimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun integrationTestRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestMountOnly(dependency: Dependency) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency)
+
+    fun integrationTestMountOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency, configure)
+
+    fun integrationTestMountOnly(dependencyNotation: String) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation)
+
+    fun integrationTestMountOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation, configure)
+
+    internal fun add(cfg: ConfigurationType, dependency: Dependency): Dependency =
+        doAdd(cfg, dependency)
+
+    internal fun add(
+        cfg: ConfigurationType,
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ): Dependency {
+        val dep = doAdd(cfg, dependency)
+        configure.invoke(dependency as ExternalModuleDependency)
+        return dep
+    }
+
+    internal fun add(cfg: ConfigurationType, dependencyNotation: String): Dependency =
+        doAdd(cfg, dependencyNotation)
+
+    internal fun add(
+        cfg: ConfigurationType,
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ): Dependency {
+        val dep = doAdd(cfg, dependencyNotation)
+        configure.invoke(dep as ExternalModuleDependency)
+        return dep
+    }
+
+    private fun doAdd(cfg: ConfigurationType, dependencyNotation: Any): Dependency {
+        val configurationName = when (cfg) {
+            ConfigurationType.COMPILE_ONLY -> b.mainCompileOnly
+            ConfigurationType.RUNTIME_ONLY -> b.mainRuntimeOnly
+            ConfigurationType.IMPLEMENTATION -> b.mainImplementation
+            ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY -> b.integrationTestRuntimeOnly
+            ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY -> b.integrationTestAdditionalJars
+            ConfigurationType.TEST_COMPILE_ONLY -> b.testCompileOnly
+            ConfigurationType.TEST_RUNTIME_ONLY -> b.testRuntimeOnly
+            ConfigurationType.TEST_IMPLEMENTATION -> b.testImplementation
+        }
+
+        return dependencies.add(configurationName, dependencyNotation)!!
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/IntegrationTestSettingsDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/IntegrationTestSettingsDsl.kt
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+class IntegrationTestSettingsDsl(private val build: InternalSparkVariantBuild) {
+    /**
+     * Use a specific docker image for integration tests. This should be the fully qualified form of the image.
+     *
+     * That is, supply the image name (with its repository, if applicable) and the image tag.
+     *
+     * For example:
+     *
+     * ```kotlin
+     * integrationTests {
+     *      useDockerImage("bitnami/spark:3.5.0")
+     * }
+     * ```
+     *
+     * Defaults to `openlineage/spark:spark-${sparkVersion}-scala-${scalaBinaryVersion}`
+     */
+    fun useDockerImage(image: String) {
+        build.prop(InternalSparkVariantBuild.DOCKER_IMAGE_NAME, image)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/InternalSparkVariantBuild.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/InternalSparkVariantBuild.kt
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+
+abstract class InternalSparkVariantBuild @javax.inject.Inject constructor(
+    val name: String,
+    val sparkVersion: String,
+    val scalaBinaryVersion: String,
+    internal val project: Project,
+    val mainSourceSet: SourceSet,
+    val testSourceSet: SourceSet
+) {
+    companion object {
+        const val DOCKER_IMAGE_NAME = "docker.image.name"
+        const val DELTA_TESTS_ENABLED = "delta.tests.enabled"
+        const val ICEBERG_TESTS_ENABLED = "iceberg.tests.enabled"
+        const val DERBY_SYSTEM_HOME = "derby.system.home"
+        const val SPARK_WAREHOUSE = "spark.warehouse.dir"
+        const val JUNIT_CAPTURE_STD_OUT = "junit.platform.output.capture.stdout"
+        const val JUNIT_CAPTURE_STD_ERR = "junit.platform.output.capture.stderr"
+        const val SPARK_VERSION = "spark.version"
+        const val SCALA_BINARY_VERSION = "scala.binary.version"
+
+        /**
+         * This is used to specify the Kafka package in GAV (Group:Artifact:Version) format.
+         * The value of this will be supplied to the `--packages` argument of the `spark-submit` command.
+         *
+         * For example:
+         *
+         * ```shell
+         * spark-submit --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.2 ...
+         * ```
+         */
+        const val KAFKA_PACKAGE_VERSION = "kafka.package.version"
+
+        const val ADDITIONAL_JARS_DIR = "additional.jars.dir"
+
+        const val FIXTURES_DIR = "fixtures.dir"
+    }
+
+    internal val dependencies = project.dependencies
+    private val properties = sortedMapOf<String, Any>()
+
+    init {
+        properties[DELTA_TESTS_ENABLED] = true
+
+        properties[ICEBERG_TESTS_ENABLED] = true
+
+        properties[JUNIT_CAPTURE_STD_OUT] = true
+
+        properties[JUNIT_CAPTURE_STD_ERR] = true
+
+        properties[DERBY_SYSTEM_HOME] =
+            project.layout.projectDirectory.file("build/var/run/${testSourceSet.name}/derby")
+
+        properties[SPARK_WAREHOUSE] =
+            project.layout.projectDirectory.dir("build/var/run/${testSourceSet.name}/spark-warehouse")
+
+        properties[SPARK_VERSION] = sparkVersion
+
+        properties[SCALA_BINARY_VERSION] = scalaBinaryVersion
+
+        properties[KAFKA_PACKAGE_VERSION] =
+            "org.apache.spark:spark-sql-kafka-0-10_${scalaBinaryVersion}:${sparkVersion}"
+
+        properties[ADDITIONAL_JARS_DIR] =
+            "build/deps/spark-${sparkVersion}/scala-${scalaBinaryVersion}"
+
+        properties[FIXTURES_DIR] =
+            "build/fixtures/spark-${sparkVersion}/scala-${scalaBinaryVersion}"
+
+        properties[DOCKER_IMAGE_NAME] =
+            "openlineage/spark:spark-${sparkVersion}-scala-${scalaBinaryVersion}"
+    }
+
+    val mainApi = mainSourceSet.apiConfigurationName
+    val mainApiElements = mainSourceSet.apiElementsConfigurationName
+    val mainCompileClassPath = mainSourceSet.compileClasspathConfigurationName
+    val mainCompileOnly = mainSourceSet.compileOnlyConfigurationName
+    val mainCompileOnlyApi = mainSourceSet.compileOnlyApiConfigurationName
+    val mainImplementation = mainSourceSet.implementationConfigurationName
+    val mainRuntimeClassPath = mainSourceSet.runtimeClasspathConfigurationName
+    val mainRuntimeElements = mainSourceSet.runtimeElementsConfigurationName
+    val mainRuntimeOnly = mainSourceSet.runtimeOnlyConfigurationName
+
+    val testCompileClasspath = testSourceSet.compileClasspathConfigurationName
+    val testCompileOnly = testSourceSet.compileOnlyConfigurationName
+    val testImplementation = testSourceSet.implementationConfigurationName
+    val testRuntimeClasspath = testSourceSet.runtimeClasspathConfigurationName
+    val testRuntimeOnly = testSourceSet.runtimeOnlyConfigurationName
+
+    val integrationTestRuntimeOnly = "integrationTest${mainSourceSet.name.capitalize()}RuntimeOnly"
+    val integrationTestRuntimeClasspath =
+        "integrationTest${mainSourceSet.name.capitalize()}RuntimeClasspath"
+
+    /**
+     * This is the name of a configuration that should be used for the explicit purpose of mounting JARs to a running Docker container.
+     */
+    val integrationTestAdditionalJars =
+        "integrationTest${mainSourceSet.name.capitalize()}Dependencies"
+
+    val integrationTestFixtures = "integrationTest${mainSourceSet.name.capitalize()}Fixtures"
+
+
+    val integrationTestTaskName = "executeIntegrationTestsFor${mainSourceSet.name.capitalize()}"
+
+    val integrationTestCopyAdditionalJarsTaskName =
+        "copyIntegrationTest${mainSourceSet.name.capitalize()}AdditionalJars"
+
+    val integrationTestCopyTestFixturesTaskName =
+        "copyIntegrationTest${mainSourceSet.name.capitalize()}Fixtures"
+
+    val shadowJarTaskName = "${mainSourceSet.name}ShadowJar"
+
+    fun configure(configurer: BuildConfigurerDsl.() -> Unit) {
+        val dsl = BuildConfigurerDsl(this)
+        configurer.invoke(dsl)
+    }
+
+    fun prop(key: String, value: Any) {
+        properties[key] = value
+    }
+
+    fun prop(key: String) = properties[key]
+
+    fun updateSystemProperties(systemProperties: MutableMap<String, Any>) {
+        properties.forEach { (k, v) -> systemProperties[k] = v.toString() }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ProjectConfigurationFunctions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ProjectConfigurationFunctions.kt
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+
+internal fun Project.configureBuild(sparkVariantBuild: SparkVariantBuild): InternalSparkVariantBuild {
+    val internalSparkVariantBuild = configureSourceSets(sparkVariantBuild)
+    configureConfigurations(internalSparkVariantBuild)
+    registerTasks(internalSparkVariantBuild)
+
+    return internalSparkVariantBuild
+}
+
+internal fun Project.configureSourceSets(b: SparkVariantBuild): InternalSparkVariantBuild {
+    val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+    val main = sourceSets.getByName("main")
+    val test = sourceSets.getByName("test")
+
+    val mainSourceSet = sourceSets.create(b.mainSourceSetName) {
+        java.setSrcDirs(main.java.srcDirs)
+        resources.setSrcDirs(main.resources.srcDirs)
+    }
+
+    val testSourceSet = sourceSets.create(b.testSourceSetName) {
+        java.setSrcDirs(test.java.srcDirs)
+        resources.setSrcDirs(test.resources.srcDirs)
+        compileClasspath += mainSourceSet.output
+        runtimeClasspath += mainSourceSet.output
+    }
+
+    val objects = project.objects
+    val internalVariant =
+        objects.newInstance(
+            InternalSparkVariantBuild::class.java,
+            b.name,
+            b.sparkVersion,
+            b.scalaBinaryVersion,
+            project,
+            mainSourceSet,
+            testSourceSet
+        )
+
+    return internalVariant
+}
+
+internal fun Project.configureConfigurations(b: InternalSparkVariantBuild) {
+    val mainCompileOnlyApi = configurations.maybeCreate(b.mainCompileOnlyApi)
+    mainCompileOnlyApi.isCanBeConsumed = false
+    mainCompileOnlyApi.isCanBeResolved = false
+
+    val mainApi = configurations.maybeCreate(b.mainApi)
+    mainApi.isCanBeConsumed = false
+    mainApi.isCanBeResolved = false
+
+    val mainCompileOnly = configurations.maybeCreate(b.mainCompileOnly)
+    mainCompileOnly.isCanBeConsumed = false
+    mainCompileOnly.isCanBeResolved = false
+    mainCompileOnly.extendsFrom(mainCompileOnlyApi)
+
+    val mainApiElements = configurations.maybeCreate(b.mainApiElements)
+    mainApiElements.isCanBeConsumed = true
+    mainApiElements.isCanBeResolved = false
+    mainApiElements.extendsFrom(mainApi, mainCompileOnlyApi)
+
+    val mainImplementation = configurations.maybeCreate(b.mainImplementation)
+    mainImplementation.isCanBeConsumed = false
+    mainImplementation.isCanBeResolved = false
+    mainImplementation.extendsFrom(mainApi)
+
+    val mainRuntimeOnly = configurations.maybeCreate(b.mainRuntimeOnly)
+    mainImplementation.isCanBeConsumed = false
+    mainImplementation.isCanBeResolved = false
+
+    val mainCompileClassPath = configurations.maybeCreate(b.mainCompileClassPath)
+    mainCompileClassPath.isCanBeConsumed = false
+    mainCompileClassPath.isCanBeResolved = true
+    mainCompileClassPath.extendsFrom(mainCompileOnly, mainImplementation)
+
+    val mainRuntimeElements = configurations.maybeCreate(b.mainRuntimeElements)
+    mainRuntimeElements.isCanBeConsumed = true
+    mainRuntimeElements.isCanBeResolved = false
+    mainRuntimeElements.extendsFrom(mainImplementation, mainRuntimeOnly)
+
+    val mainRuntimeClasspath = configurations.maybeCreate(b.mainRuntimeClassPath)
+    mainRuntimeClasspath.isCanBeConsumed = false
+    mainRuntimeClasspath.isCanBeResolved = true
+    mainRuntimeClasspath.extendsFrom(mainImplementation, mainRuntimeOnly)
+
+    val testCompileOnly = configurations.maybeCreate(b.testCompileOnly)
+    testCompileOnly.extendsFrom(mainCompileOnlyApi)
+
+    val testImplementation = configurations.maybeCreate(b.testImplementation)
+    testImplementation.extendsFrom(mainImplementation)
+
+    val testRuntimeOnly = configurations.maybeCreate(b.testRuntimeOnly)
+    testRuntimeOnly.extendsFrom(mainRuntimeOnly)
+
+    val testCompileClasspath = configurations.maybeCreate(b.testCompileClasspath)
+    testCompileClasspath.isCanBeResolved = true
+    testCompileClasspath.extendsFrom(testCompileOnly, testImplementation)
+
+    val testRuntimeClasspath = configurations.maybeCreate(b.testRuntimeClasspath)
+    testRuntimeClasspath.isCanBeResolved = true
+    testRuntimeClasspath.extendsFrom(testRuntimeOnly, testImplementation)
+
+    // Now, we create four configurations meant for the integration test tasks
+    // The first one will define the dependencies that we need to run the integration tests, i.e., testcontainers.
+    // The second is the runtime classpath for the integration test task. This needs to be resolvable.
+    // The third is what we will mount to the container as additional runtime dependencies
+    // THe fourth is for test fixtures, that we will also mount to the counteiner
+    val integrationTestRuntimeOnly = configurations.maybeCreate(b.integrationTestRuntimeOnly)
+    integrationTestRuntimeOnly.isCanBeResolved = false
+    integrationTestRuntimeOnly.isCanBeConsumed = false
+
+    val integrationTestRuntimeClasspath =
+        configurations.maybeCreate(b.integrationTestRuntimeClasspath)
+    integrationTestRuntimeClasspath.extendsFrom(integrationTestRuntimeOnly, testImplementation)
+    integrationTestRuntimeClasspath.isCanBeResolved = true
+    integrationTestRuntimeClasspath.isCanBeConsumed = false
+
+    val integrationTestAdditionalJars = configurations.maybeCreate(b.integrationTestAdditionalJars)
+    integrationTestAdditionalJars.isCanBeResolved = true
+    integrationTestAdditionalJars.isCanBeConsumed = false
+
+    val integrationTestFixtures = configurations.maybeCreate(b.integrationTestFixtures)
+    integrationTestFixtures.isCanBeResolved = true
+    integrationTestFixtures.isCanBeConsumed = false
+}
+
+internal fun Project.configureDefaultConfigurations(b: InternalSparkVariantBuild) {
+    configurations.named("implementation").configure {
+        extendsFrom(configurations.getByName(b.mainImplementation))
+    }
+    configurations.named("compileOnly").configure {
+        extendsFrom(configurations.getByName(b.mainCompileOnly))
+    }
+    configurations.named("runtimeOnly").configure {
+        extendsFrom(configurations.getByName(b.mainRuntimeOnly))
+    }
+    configurations.named("testImplementation").configure {
+        extendsFrom(configurations.getByName(b.testImplementation))
+    }
+    configurations.named("testCompileOnly").configure {
+        extendsFrom(configurations.getByName(b.testCompileOnly))
+    }
+    configurations.named("testRuntimeOnly").configure {
+        extendsFrom(configurations.getByName(b.testRuntimeOnly))
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantBuild.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantBuild.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+abstract class SparkVariantBuild @javax.inject.Inject constructor(
+    val name: String,
+    val sparkVersion: String,
+    val scalaBinaryVersion: String
+) {
+    private val sparkVersionFmt = sparkVersion.removePeriods()
+    private val scalaBinaryVersionFmt = scalaBinaryVersion.removePeriods()
+
+    val mainSourceSetName = "mainSpark${sparkVersionFmt}Scala${scalaBinaryVersionFmt}"
+    val testSourceSetName = "testSpark${sparkVersionFmt}Scala${scalaBinaryVersionFmt}"
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPlugin.kt
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.kotlin.dsl.withType
+
+class SparkVariantsBuildPlugin : Plugin<Project> {
+    override fun apply(p: Project) {
+        p.plugins.withType<JavaPlugin> {
+            p.extensions.create(
+                "builds", SparkVariantsBuildPluginExtension::class.java
+            )
+
+            p.registerAggregateCompileMainSourcesTask()
+            p.registerAggregateCompileTestSourcesTask()
+            p.registerAggregateUnitTestTask()
+            p.registerAggregateJarTask()
+            p.registerAggregateIntegrationTestTask()
+            p.registerAggregateShadowJarTasks()
+
+            p.registerPrintSourceSetDetailsTasks()
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPluginExtension.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+
+abstract class SparkVariantsBuildPluginExtension @javax.inject.Inject constructor(private val p: Project) {
+    private val builds = p.objects.domainObjectContainer(InternalSparkVariantBuild::class.java)
+    private val objects = p.objects
+
+    private fun addBuild(build: SparkVariantBuild): InternalSparkVariantBuild {
+        val internalBuildVariant = p.configureBuild(build)
+        builds.add(internalBuildVariant)
+        return internalBuildVariant
+    }
+
+    fun add(
+        name: String,
+        sparkVersion: String,
+        scalaBinaryVersion: String
+    ): InternalSparkVariantBuild {
+        val build =
+            objects.newInstance(
+                SparkVariantBuild::class.java,
+                name,
+                sparkVersion,
+                scalaBinaryVersion
+            )
+        return addBuild(build)
+    }
+
+    fun commonDependencies(configure: CommonDependenciesDsl.() -> Unit) {
+        val dsl = CommonDependenciesDsl(builds, p.dependencies)
+        configure.invoke(dsl)
+    }
+
+    fun setDefaultBuild(name: String) {
+        val build = builds.findByName(name)
+        check(build != null) { "No build found with name: $name" }
+        p.configureDefaultConfigurations(build)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/StringExtensions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/StringExtensions.kt
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+internal fun String.removePeriods() = replace(".", "")

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/TaskRegistrationFunctions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/TaskRegistrationFunctions.kt
@@ -1,0 +1,313 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import java.util.*
+
+@Suppress("UNUSED_VARIABLE")
+internal fun Project.registerTasks(b: InternalSparkVariantBuild) {
+    val createVersionPropertiesTask = registerCreateVersionPropertiesTask(b)
+    val jarTask = registerJarTask(b)
+    val deleteSparkDirs = registerCleanupTask(b)
+    val unitTestTask = registerUnitTestTask(b, deleteSparkDirs)
+    val copyAdditionalJarsTask = registerCopyAdditionalIntegrationTestJars(b)
+    val copyFixturesTask = registerCopyIntegrationTestFixtures(b)
+    val integrationTestTask =
+        registerIntegrationTestTask(b, copyAdditionalJarsTask, copyFixturesTask)
+    val shadowJarTask = registerShadowJarTask(b, jarTask)
+}
+
+internal fun Project.registerUnitTestTask(
+    b: InternalSparkVariantBuild,
+    deleteSparkDirs: TaskProvider<Delete>
+): TaskProvider<Test> {
+    val unitTestTaskName = "executeUnitTestsFor${b.name}"
+    val unitTestTask = tasks.register<Test>(unitTestTaskName)
+    unitTestTask.configure {
+        dependsOn(deleteSparkDirs)
+        group = "unitTests"
+        description = "Runs unit tests for Spark variant: ${b.name}"
+        testClassesDirs = b.testSourceSet.output.classesDirs
+        classpath = b.testSourceSet.runtimeClasspath
+        useJUnitPlatform {
+            excludeTags("nonParallelTest", "integration-test")
+        }
+
+        doFirst {
+            b.updateSystemProperties(systemProperties)
+        }
+    }
+    return unitTestTask
+}
+
+internal fun Project.registerCleanupTask(b: InternalSparkVariantBuild): TaskProvider<Delete> =
+    tasks.register<Delete>("cleanUpSparkDirsFor${b.name}") {
+        group = "aux"
+        description = "Cleans up the Spark directories for variant: ${b.name}"
+        delete(b.prop(InternalSparkVariantBuild.DERBY_SYSTEM_HOME))
+        delete(b.prop(InternalSparkVariantBuild.SPARK_WAREHOUSE))
+    }
+
+internal fun Project.registerCreateVersionPropertiesTask(b: InternalSparkVariantBuild): TaskProvider<Task> {
+    val task = tasks.register("createVersionPropertiesFor${b.name}") {
+        dependsOn(b.mainSourceSet.processResourcesTaskName)
+        group = "resources"
+        description = "Creates a version.properties file for Spark variant: ${b.name}"
+        outputs.file(layout.buildDirectory.file("resources/${b.mainSourceSet.name}/io/openlineage/spark/agent/version.properties"))
+        doLast {
+            val propertiesFile = outputs.files.first()
+            propertiesFile.writer().use { writer ->
+                val properties = Properties()
+                properties["version"] = project.version.toString()
+                properties.store(writer, null)
+            }
+        }
+    }
+    tasks.named(b.mainSourceSet.classesTaskName).configure {
+        dependsOn(task)
+    }
+    return task
+}
+
+internal fun Project.registerJarTask(b: InternalSparkVariantBuild) =
+    tasks.register<Jar>(b.mainSourceSet.jarTaskName) {
+        dependsOn(b.mainSourceSet.classesTaskName)
+        group = "build"
+        description = "Assembles a jar archive for Spark variant: ${b.name}"
+        archiveBaseName = "openlineage-spark"
+        archiveAppendix = "app_${b.scalaBinaryVersion}"
+        from(b.mainSourceSet.output)
+        destinationDirectory.set(layout.buildDirectory.dir("libs/spark-${b.sparkVersion}/scala-${b.scalaBinaryVersion}"))
+    }
+
+internal fun Project.registerShadowJarTask(
+    b: InternalSparkVariantBuild,
+    jarTask: TaskProvider<Jar>
+): TaskProvider<ShadowJar> {
+    return tasks.register<ShadowJar>(b.shadowJarTaskName) {
+        dependsOn(jarTask)
+        group = "shadow"
+        description = "Assembles a shadow jar archive for Spark variant: ${b.name}"
+        archiveBaseName = "openlineage-spark"
+        archiveAppendix = "app_${b.scalaBinaryVersion}"
+        archiveClassifier = "shadow"
+        from(b.mainSourceSet.output)
+        configurations = listOf(project.configurations[b.mainRuntimeClassPath])
+        isZip64 = true
+        destinationDirectory = jarTask.flatMap { it.destinationDirectory }
+
+        // This should be exposed in the build script. It's too deep here.
+        val prefix = "io.openlineage.spark.shaded"
+        relocate(
+            "com.github.ok2c.hc5",
+            "${prefix}.com.github.ok2c.hc5"
+        )
+        relocate(
+            "org.apache.httpcomponents.client5",
+            "${prefix}.org.apache.httpcomponents.client5"
+        )
+        relocate("javassist", "${prefix}.javassist")
+        relocate("org.apache.hc", "${prefix}.org.apache.hc")
+        relocate(
+            "org.apache.commons.codec",
+            "${prefix}.org.apache.commons.codec"
+        )
+        relocate(
+            "org.apache.commons.lang3",
+            "${prefix}.org.apache.commons.lang3"
+        )
+        relocate(
+            "org.apache.commons.beanutils",
+            "${prefix}.org.apache.commons.beanutils"
+        )
+        relocate("org.apache.http", "${prefix}.org.apache.http")
+        relocate("org.yaml.snakeyaml", "${prefix}.org.yaml.snakeyaml")
+        relocate(
+            "com.fasterxml.jackson",
+            "${prefix}.com.fasterxml.jackson"
+        ) {
+            exclude("com.fasterxml.jackson.annotation.JsonIgnore")
+            exclude("com.fasterxml.jackson.annotation.JsonIgnoreProperties")
+            exclude("com.fasterxml.jackson.annotation.JsonIgnoreType")
+        }
+
+        dependencies {
+            exclude(dependency("org.slf4j::"))
+            exclude("org/apache/commons/logging/**")
+        }
+
+        manifest {
+            attributes(
+                mapOf(
+                    "Created-By" to "Gradle ${project.gradle.gradleVersion}",
+                    "Built-By" to System.getProperty("user.name"),
+                    "Build-Jdk" to System.getProperty("java.version"),
+                    "Implementation-Title" to project.name,
+                    "Implementation-Version" to project.version
+                )
+            )
+        }
+    }
+}
+
+internal fun Project.registerCopyAdditionalIntegrationTestJars(b: InternalSparkVariantBuild): TaskProvider<Copy> {
+    val copyDependenciesTask = tasks.register<Copy>(b.integrationTestCopyAdditionalJarsTaskName) {
+        group = "integrationTests"
+        description =
+            "Copies additional jars needed for the integration tests for Spark variant: ${b.name}"
+        from(configurations[b.integrationTestAdditionalJars])
+        into(b.prop(InternalSparkVariantBuild.ADDITIONAL_JARS_DIR)!!)
+        include("*.jar")
+    }
+    return copyDependenciesTask
+}
+
+internal fun Project.registerCopyIntegrationTestFixtures(b: InternalSparkVariantBuild): TaskProvider<Copy> {
+    val copyFixturesTask = tasks.register<Copy>(b.integrationTestCopyTestFixturesTaskName) {
+        group = "integrationTests"
+        description =
+            "Copies test fixtures needed for the integration tests for Spark variant: ${b.name}"
+        from(configurations[b.integrationTestAdditionalJars])
+        into(b.prop(InternalSparkVariantBuild.FIXTURES_DIR)!!)
+    }
+    return copyFixturesTask
+}
+
+internal fun Project.registerIntegrationTestTask(
+    b: InternalSparkVariantBuild,
+    copyAdditionalJarsTask: TaskProvider<Copy>,
+    copyFixturesTask: TaskProvider<Copy>
+): TaskProvider<Test> {
+    val integrationTestTask = tasks.register<Test>(b.integrationTestTaskName)
+    integrationTestTask.configure {
+        dependsOn(b.shadowJarTaskName, copyAdditionalJarsTask, copyFixturesTask)
+        group = "integrationTests"
+        description = "Runs integration tests for Spark variant: ${b.name}"
+        testClassesDirs = b.testSourceSet.output.classesDirs
+        classpath = b.testSourceSet.runtimeClasspath
+        useJUnitPlatform {
+            includeTags("integration-test")
+            excludeTags("databricks")
+        }
+
+        doFirst {
+            b.updateSystemProperties(systemProperties)
+            systemProperties["project.version"] = project.version.toString()
+
+            tasks.getByName(b.shadowJarTaskName).outputs.files.first().let {
+                systemProperties["openlineage.spark.agent.jar"] = it.name
+                systemProperties["openlineage.spark.agent.jar.dir"] = it.parent
+                systemProperties["openlineage.spark.agent.jar.path"] = it.absolutePath
+            }
+            val additionalJarsDir =
+                copyAdditionalJarsTask.map { it.destinationDir }.get().absolutePath
+            systemProperties["openlineage.spark.agent.additional.jars.dir"] = additionalJarsDir
+            val fixturesDir = copyFixturesTask.map { it.destinationDir }.get().absolutePath
+            systemProperties["openlineage.spark.agent.fixtures.dir"] = fixturesDir
+        }
+    }
+    return integrationTestTask
+}
+
+
+internal fun Project.registerPrintSourceSetDetailsTasks() {
+    val sourceSetContainer = extensions.getByType(SourceSetContainer::class.java)
+    sourceSetContainer.configureEach {
+        val taskName = "printSourceSetDetails${name.capitalize()}"
+        tasks.register(taskName) {
+            group = "debug"
+            description = "Prints details for source set: $name"
+            doLast {
+                println("Source set: $name\n")
+                println("> Java source dirs: ${java.srcDirs.joinToString(", ")}\n")
+                println("> Resources source dirs: ${resources.srcDirs.joinToString(", ")}\n")
+                println("> Output dirs: ${output.classesDirs.joinToString(", ")}\n")
+                val sortedCompileClassPath =
+                    compileClasspath.sortedBy { it.absolutePath }.joinToString("\n - ", " - ")
+
+                println("> Compile classpath:\n${sortedCompileClassPath}\n")
+
+                val sortedRuntimeClasspath =
+                    runtimeClasspath.sortedBy { it.absolutePath }.joinToString("\n - ", " - ")
+                println("> Runtime classpath:\n${sortedRuntimeClasspath}\n")
+            }
+        }
+    }
+}
+
+internal fun Project.registerAggregateUnitTestTask() {
+    tasks.register("executeAllVariantsUnitTests") {
+        group = "aggregate"
+        description = "Aggregate task to run all Spark variant tests"
+        dependsOn(
+            tasks.withType<Test>().matching { it.group == "unitTests" && it.name != this.name })
+    }
+}
+
+internal fun Project.registerAggregateJarTask() {
+    tasks.register("executeAllVariantsJarTasks") {
+        group = "aggregate"
+        description = "Aggregate task to assemble all Spark variant jar archives"
+        dependsOn(
+            tasks.withType<Jar>().matching { it.group == "build" && it.name.endsWith("Jar") })
+    }
+}
+
+internal fun Project.registerAggregateShadowJarTasks() {
+    plugins.withType<ShadowPlugin> {
+        tasks.register("executeAllVariantsShadowJar") {
+            group = "aggregate"
+            description = "Aggregate task to create shadow jars for all Spark variants"
+            dependsOn(
+                tasks.withType<ShadowJar>()
+                    .filter { it.name.startsWith("mainSpark") && it.name.endsWith("ShadowJar") })
+        }
+    }
+}
+
+internal fun Project.registerAggregateCompileMainSourcesTask() {
+    tasks.register("compileAllVariantsJava") {
+        group = "aggregate"
+        description = "Aggregate task to compile all Spark variants"
+        dependsOn(
+            tasks.withType<JavaCompile>()
+                .filter { it.name.startsWith("compileSpark") })
+    }
+}
+
+internal fun Project.registerAggregateCompileTestSourcesTask() {
+    tasks.register("compileAllVariantsTestJava") {
+        group = "aggregate"
+        description = "Aggregate task to compile all Spark test variants"
+        dependsOn(
+            tasks.withType<JavaCompile>()
+                .filter { it.name.startsWith("compileTestSpark") })
+    }
+}
+
+internal fun Project.registerAggregateIntegrationTestTask() {
+    tasks.register("executeAllVariantsIntegrationTests") {
+        group = "aggregate"
+        description = "Aggregate task to run all Spark variant integration tests"
+        dependsOn(
+            tasks.withType<Test>().matching { it.group == "integrationTests" })
+    }
+}

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("java-test-fixtures")

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
 }
 


### PR DESCRIPTION
### Summary

This PR introduces significant enhancements to our build process by adding custom Gradle plugins tailored for Apache Spark and Docker builds, along with a crucial refactor of the CommonConfig plugin to better align with Gradle best practices.

### Problem

Scala 2.12 and Scala 2.13 support is required for Apache Spark. This PR lays some groundwork for it.

### Solution

#### Custom Gradle Plugins
- **Spark Variants Build Plugin**: Enables definition of builds incorporating multiple Apache Spark and Scala versions, facilitating integration tests across various combinations.
- **Docker Build Plugin**: Automates Docker image preparation, including the downloading of Spark binaries and the adaptation of Bitnami Spark images to include required Scala variants.

#### CommonConfig Plugin Refactor
- **Best Practices**: Modified to react to the application of plugins (Java library, PMD, Lombok, Spotless) rather than applying them directly, introducing a paradigm shift towards reduced temporal coupling and increased adherence to Gradle best practices.
- **Build Scripts Adjustment**: Ensured build integrity by explicitly applying the necessary plugins within each build script, following the refactor of the CommonConfig plugin.

### Motivation
The motivation behind these changes is to enhance our development and deployment efficiency, ensure our builds are robust and flexible, and maintain our code and infrastructure in line with industry best practices.

### Implementation Details
- The introduction of the custom plugins addresses specific project needs, providing a tailored solution to our Spark and Scala versioning challenges, as well as our Docker image customization requirements.
- The refactor of the CommonConfig plugin represents a significant improvement in our build process's architecture, ensuring a more modular and best-practice-oriented approach to plugin management.

### Future Work
- Full integration of the new plugins and refactored CommonConfig into our CI/CD pipeline.
- Continuous evaluation and refinement of these tools to meet evolving project needs.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project