### PR TITLE
[SPARK] Add custom DockerBuild Gradle plugins

### DIFF
--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    kotlin("plugin.serialization") version "1.9.10"
 }
 
 repositories {
@@ -7,13 +8,17 @@ repositories {
     mavenCentral()
 }
 
+val downloadTaskVersion: String = "5.5.0"
 val lombokPluginVersion: String = "8.4"
 val spotlessVersion: String = "6.13.0"
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${spotlessVersion}")
+    implementation("de.undercouch:gradle-download-task:${downloadTaskVersion}")
     implementation("io.freefair.gradle:lombok-plugin:${lombokPluginVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 }
 
 gradlePlugin {
@@ -26,6 +31,11 @@ gradlePlugin {
         create("scalaVariants") {
             id = "io.openlineage.scala-variants"
             implementationClass = "io.openlineage.gradle.plugin.ScalaVariantsPlugin"
+        }
+
+        create("dockerBuild") {
+            id = "io.openlineage.docker-build"
+            implementationClass = "io.openlineage.gradle.plugin.docker.DockerBuildPlugin"
         }
     }
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/BuildDockerImageTask.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/BuildDockerImageTask.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class BuildDockerImageTask : DefaultTask() {
+
+    init {
+        group = "docker"
+        description = "Build the Docker image"
+    }
+
+    @get:Input
+    abstract val dockerImageName: Property<String>
+
+    @get:Input
+    abstract val dockerImageTag: Property<String>
+
+    @get:InputDirectory
+    abstract val dockerBuildContext: DirectoryProperty
+
+    @TaskAction
+    fun buildDockerImage() {
+        val dockerBuildContextDir = dockerBuildContext.get().asFile
+        val dockerImage = "${dockerImageName.get()}:${dockerImageTag.get()}"
+        logger.lifecycle("Building Docker image $dockerImage from $dockerBuildContextDir")
+        project.exec {
+            workingDir = dockerBuildContextDir
+            commandLine(
+                "docker",
+                "build",
+                "-t",
+                dockerImage,
+                "."
+            )
+        }
+    }
+
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPlugin.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class DockerBuildPlugin : Plugin<Project> {
+    override fun apply(p: Project) {
+        val extension = p.extensions.create("docker", DockerBuildPluginExtension::class.java)
+        val builder = DockerImageBuilder(p, extension)
+        builder.registerTasks()
+    }
+}
+

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerBuildPluginExtension.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+
+abstract class DockerBuildPluginExtension @javax.inject.Inject constructor(p: Project) {
+    internal val dockerFileTemplate: RegularFileProperty = p.objects.fileProperty().convention(
+        p.layout.projectDirectory.file("docker/Dockerfile.template")
+    )
+
+    internal val manifestFile: RegularFileProperty = p.objects.fileProperty().convention(
+        p.layout.projectDirectory.file("docker/manifest.json")
+    )
+
+    internal val downloadDir = p.objects.directoryProperty().convention(
+        p.layout.projectDirectory.dir("bin")
+    )
+
+    internal val destinationDir = p.objects.directoryProperty().convention(
+        p.layout.buildDirectory.dir("docker")
+    )
+
+    fun dockerfileTemplate(file: RegularFileProperty) {
+        dockerFileTemplate.set(file)
+    }
+
+    fun manifestFile(file: RegularFileProperty) {
+        manifestFile.set(file)
+    }
+
+    fun downloadDir(dir: DirectoryProperty) {
+        downloadDir.set(dir)
+    }
+
+    fun destinationDir(dir: DirectoryProperty) {
+        destinationDir.set(dir)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerImageBuilder.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerImageBuilder.kt
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import de.undercouch.gradle.tasks.download.Download
+import kotlinx.serialization.json.Json
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.register
+
+class DockerImageBuilder(
+    private val p: Project,
+    private val ext: DockerBuildPluginExtension
+) {
+    private val tasks = p.tasks
+
+    fun registerTasks() {
+        loadManifests().forEach {
+            registerTasks(it)
+        }
+
+        tasks.register("buildDockerImages") {
+            group = "docker"
+            description = "Build all Docker images"
+            dependsOn(tasks.withType(BuildDockerImageTask::class.java))
+        }
+    }
+
+    private fun registerTasks(m: DockerManifest) {
+        val downloadSparkBinariesTask = registerDownloadSparkBinaries(m)
+        val downloadSparkBinariesAscTask = registerDownloadSparkBinariesAsc(m)
+        val downloadSparkPgpKeysTask = registerDownloadSparkPgpKeys(m)
+        val copySparkBinariesTask = registerCopySparkBinaries(m, downloadSparkBinariesTask)
+        val copySparkBinariesAscTask = registerCopySparkBinariesAsc(m, downloadSparkBinariesAscTask)
+        val copySparkPgpKeysTask = registerCopySparkPgpKeys(m, downloadSparkPgpKeysTask)
+        val copyDependenciesTask = registerCopyDockerDependenciesTask(
+            m,
+            copySparkBinariesTask,
+            copySparkBinariesAscTask,
+            copySparkPgpKeysTask
+        )
+        val createDockerFileTask = registerCreateDockerFileTask(m)
+        registerBuildDockerImageTask(m, createDockerFileTask, copyDependenciesTask)
+    }
+
+    private fun formatName(m: DockerManifest) = formatName(m.sparkVersion, m.scalaBinaryVersion)
+
+    private fun formatName(sparkVersion: String, scalaBinaryVersion: String) =
+        "Spark${sparkVersion.replace(".", "")}Scala${scalaBinaryVersion.replace(".", "")}"
+
+    private fun registerDownloadSparkBinaries(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkBinaries${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkSourceBinaries)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/spark.tgz")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerDownloadSparkBinariesAsc(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkBinariesAsc${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkSourceBinariesAsc)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/spark.tgz.asc")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerDownloadSparkPgpKeys(m: DockerManifest): TaskProvider<Download> {
+        val taskName = "downloadSparkPgpKeys${formatName(m)}"
+        return tasks.register<Download>(taskName) {
+            group = "docker"
+            src(m.sparkPgpKeys)
+            dest(ext.downloadDir.map { dir ->
+                dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/KEYS")
+            })
+            overwrite(false)
+        }
+    }
+
+    private fun registerCopyFileTask(
+        taskName: String,
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> = tasks.register<Copy>(taskName) {
+        dependsOn(task)
+        group = "docker"
+        this.description = description
+        from(task.map { it.dest })
+        into(ext.destinationDir.map { dir ->
+            dir.dir("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}")
+        })
+    }
+
+    private fun registerCopySparkBinaries(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkBinaries${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopySparkBinariesAsc(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkBinariesAsc${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopySparkPgpKeys(
+        m: DockerManifest,
+        task: TaskProvider<Download>
+    ): TaskProvider<Copy> {
+        val taskName = "copySparkPgpKeys${formatName(m)}"
+        return registerCopyFileTask(taskName, m, task)
+    }
+
+    private fun registerCopyDockerDependenciesTask(
+        m: DockerManifest,
+        binariesTask: TaskProvider<Copy>,
+        ascTask: TaskProvider<Copy>,
+        pgpKeysTask: TaskProvider<Copy>
+    ): TaskProvider<Task> {
+        val taskName = "copyDockerDependencies${formatName(m)}"
+        return tasks.register(taskName) {
+            dependsOn(binariesTask, ascTask, pgpKeysTask)
+            group = "docker"
+            description =
+                "Aggregate task that triggers the copying of all necessary files " +
+                        "for the Docker Image for Spark ${m.sparkVersion} and " +
+                        "Scala ${m.scalaBinaryVersion} to be built"
+        }
+    }
+
+    private fun registerCreateDockerFileTask(m: DockerManifest): TaskProvider<MaterialiseDockerfileTask> {
+        val taskName = "createDockerFile${formatName(m)}"
+        return tasks.register<MaterialiseDockerfileTask>(taskName) {
+            baseDockerImage(m.baseDockerImage)
+            templateFile.set(ext.dockerFileTemplate)
+            destinationFile.set(
+                ext.destinationDir.map { dir ->
+                    dir.file("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}/Dockerfile")
+                }
+            )
+        }
+    }
+
+    private fun registerBuildDockerImageTask(
+        m: DockerManifest,
+        materialiseDockerFileTask: TaskProvider<MaterialiseDockerfileTask>,
+        copyDependenciesTask: TaskProvider<Task>
+    ): Provider<BuildDockerImageTask> {
+        val taskName = "buildDockerImage${formatName(m)}"
+        return tasks.register<BuildDockerImageTask>(taskName) {
+            dependsOn(materialiseDockerFileTask, copyDependenciesTask)
+            dockerImageName.set("openlineage/spark")
+            dockerImageTag.set("spark-${m.sparkVersion}-scala-${m.scalaBinaryVersion}")
+            dockerBuildContext.set(ext.destinationDir.map { dir ->
+                dir.dir("spark-${m.sparkVersion}/scala-${m.scalaBinaryVersion}")
+            })
+        }
+    }
+
+
+    private fun loadManifests(): List<DockerManifest> {
+        val file = ext.manifestFile.get()
+        val text = file.asFile.readText()
+        return Json.decodeFromString<List<DockerManifest>>(text)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerManifest.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/DockerManifest.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DockerManifest(
+    val sparkVersion: String,
+    val scalaBinaryVersion: String,
+    val sparkSourceBinaries: String,
+    val sparkSourceBinariesAsc: String,
+    val sparkPgpKeys: String,
+    val baseDockerImage: String
+)

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/MaterialiseDockerfileTask.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/docker/MaterialiseDockerfileTask.kt
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.docker
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class MaterialiseDockerfileTask : DefaultTask() {
+    private var baseDockerImage: String? = null
+
+    init {
+        group = "docker"
+        description = "Materialise the Dockerfile from the template"
+    }
+
+    @get:InputFile
+    abstract val templateFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val destinationFile: RegularFileProperty
+
+    fun baseDockerImage(baseDockerImage: String) {
+        this.baseDockerImage = baseDockerImage
+    }
+
+    @TaskAction
+    fun materialiseDockerfile() {
+        check(baseDockerImage != null) { "baseDockerImage must be set" }
+        val rawTemplate = loadDockerfileTemplate()
+        val appliedTemplate =
+            rawTemplate.replace("##BASE_DOCKER_IMAGE##", baseDockerImage!!)
+        val f = destinationFile.get()
+        f.asFile.writeText(appliedTemplate)
+    }
+
+    private fun loadDockerfileTemplate(): String = templateFile.get().asFile.readText()
+}


### PR DESCRIPTION
### Summary

This PR introduces significant enhancements to our build process by adding a custom Gradle plugin called 'DockerBuild; which is tailored to build Apache Spark Docker images.

### Problem

Scala 2.12 and Scala 2.13 support is required for Apache Spark. This PR lays some groundwork for it.

### Solution

#### Custom Gradle Plugins
- **Docker Build Plugin**: Automates Docker image preparation, including the downloading of Spark binaries and the adaptation of Bitnami Spark images to include required Scala variants.

### Implementation Details
- The introduction of the custom plugins addresses specific project needs, by providing the ability to create custom Docker images.
- 
### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project