### PR TITLE
[SPARK] Refactor the CommonConfig Gradle plugin

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -1,9 +1,13 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
+    id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
     id 'java-test-fixtures'
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 configurations {

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -1,17 +1,15 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
+    id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id "com.github.johnrengelman.shadow" version "8.1.1"
-}
-
-commonConfig {
-    pmdEnabled = false
-    lombokEnabled = false
-    spotlessEnabled = false
 }
 
 archivesBaseName = 'openlineage-spark'

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -10,10 +10,12 @@ repositories {
 
 val downloadTaskVersion: String = "5.5.0"
 val lombokPluginVersion: String = "8.4"
+val shadowPluginVersion: String = "8.1.1"
 val spotlessVersion: String = "6.13.0"
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${spotlessVersion}")
+    implementation("com.github.johnrengelman:shadow:${shadowPluginVersion}")
     implementation("de.undercouch:gradle-download-task:${downloadTaskVersion}")
     implementation("io.freefair.gradle:lombok-plugin:${lombokPluginVersion}")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPluginExtension.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 
@@ -14,16 +14,10 @@ import org.gradle.api.provider.Property
  * Usage:
  * ```
  * commonConfig {
- *     pmdEnabled.set(true)
- *     lombokEnabled.set(true)
  *     lombokVersion.set("1.18.30")
- *     spotlessEnabled.set(true)
  * }
  * ```
  */
 interface CommonConfigPluginExtension {
-    val pmdEnabled: Property<Boolean>
-    val lombokEnabled: Property<Boolean>
     val lombokVersion: Property<String>
-    val spotlessEnabled: Property<Boolean>
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaBuildVariant.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaBuildVariant.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 
@@ -139,6 +139,7 @@ class ScalaVariantDelegate(
                 "Assembles a jar archive containing the main classes compiled using Scala $scalaBinaryVersion variants of the Apache Spark libraries"
             group = "build"
             from(sourceSets[sourceSetName].output)
+            destinationDirectory.set(target.file(target.layout.buildDirectory.file("libs/$sourceSetName")))
             archiveFileName.set(archiveName)
             includeEmptyDirs = false
         }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantsPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantsPlugin.kt
@@ -1,7 +1,7 @@
-/*
-* SPDX-License-Identifier: Apache-2.0
-* Copyright 2018-2023 contributors to the OpenLineage project
-*/
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 package io.openlineage.gradle.plugin
 

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("java-test-fixtures")

--- a/integration/spark/spark32/build.gradle
+++ b/integration/spark/spark32/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark33/build.gradle
+++ b/integration/spark/spark33/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark34/build.gradle
+++ b/integration/spark/spark34/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/spark35/build.gradle
+++ b/integration/spark/spark35/build.gradle
@@ -1,4 +1,8 @@
 plugins {
+    id("java-library")
+    id("pmd")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
     id("io.openlineage.scala-variants")
     id("idea")

--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -1,4 +1,7 @@
 plugins {
+    id("java-library")
+    id("com.diffplug.spotless")
+    id("io.freefair.lombok")
     id("io.openlineage.common-config")
 }
 


### PR DESCRIPTION
### Summary

This PR introduces an important refactor of the CommonConfig plugin to better align with Gradle best practices.

### Problem

The CommonConfig plugin was a "strong" opinion plugin. It applied plugins to projects, whether they needed it or not. 

### Solution

#### CommonConfig Plugin Refactor
- **Best Practices**: Modified to react to the application of plugins (Java library, PMD, Lombok, Spotless) rather than applying them directly, introducing a paradigm shift towards increased adherence to Gradle best practices.
- **Build Scripts Adjustment**: Ensured build integrity by explicitly applying the necessary plugins within each build script, following the refactor of the CommonConfig plugin.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project