### PR TITLE
[SPARK] Add SparkVariantBuild Gradle plugin

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-test-fixtures'
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.github.johnrengelman.shadow"
 }
 
 configurations {

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.github.johnrengelman.shadow"
 }
 
 commonConfig {

--- a/integration/spark/buildSrc/README.md
+++ b/integration/spark/buildSrc/README.md
@@ -4,19 +4,6 @@ This repository hosts a suite of Gradle plugins designed for configuring and man
 process for OpenLineage projects. Written in Kotlin, these plugins are optimized for use with
 Gradle.
 
-## Scala213VariantPlugin
-
-Configures the project to support builds that use libraries compiled with Scala 2.13, setting up
-necessary source sets, tasks, and configurations for building and testing said code.
-
-To apply this plugin, add the following to your `build.gradle.kts` (or `build.gradle`):
-
-```kotlin
-plugins {
-    id("io.openlineage.scala213-variant")
-}
-```
-
 ## CommonConfigPlugin
 
 This versatile plugin combines the functionalities of the
@@ -47,3 +34,58 @@ To execute the `printSourceSetConfiguration` task, use the following command:
 ```bash
 ./gradlew printSourceSetConfiguration
 ```
+
+## SparkVariantBuild Plugin
+
+### Purpose
+
+The `SparkVariantBuild` plugin is a powerful tool designed to enhance the build process for projects that utilize Apache Spark and Scala. In environments where multiple versions of Spark and Scala are in use, ensuring compatibility and avoiding runtime failures can be challenging. The `SparkVariantBuild` plugin addresses these challenges head-on by enabling the creation of variant-specific source sets and configurations, facilitating a streamlined approach to compiling and testing code across different versions of the dependencies.
+
+#### Key Features
+
+- **Version-Specific Source Sets**: The plugin dynamically generates source sets for both main and test directories, named according to the pattern `mainSpark${sparkVersion}Scala${scalaBinaryVersion}` and `testSpark${sparkVersion}Scala${scalaBinaryVersion}`, where periods in version numbers are omitted. This ensures that each combination of Apache Spark and Scala versions has its compilation and testing environment, thereby improving codebase maintainability and readability.
+
+- **Aggregate Tasks Creation**: It simplifies the build process by creating aggregate tasks for compiling source codes, running tests (both unit and integration), and packaging compiled code into JAR files. This unified approach ensures consistency across the build process and reduces the manual effort associated with managing multiple versions.
+
+- **Utility Task for Source Set Details**: To further ease the development process, the plugin includes a utility task that prints detailed information about the created source sets. This feature provides developers with valuable insights into the configuration and setup of variant builds, aiding in troubleshooting and optimization.
+
+
+### Applying the SparkVariantBuild Plugin
+
+You can apply the plugin to your Gradle project by adding the following line to your `build.gradle.kts` script:
+
+```kotlin
+plugins {
+    id("io.openlineage.spark-variant-build")
+}
+```
+
+### Configuring SparkVariantBuild Plugin
+
+After applying the plugin, you can configure it by interacting with the exposed DSL to define variant builds, their respective Apache Spark and Scala versions, and to set common dependencies, if necessary. Below is an example of how to create different Spark and Scala variant builds and share common dependencies among them:
+
+```kotlin
+builds {
+    add("spark324Scala213", "3.2.4", "2.13") {
+      // Configure specific build variant settings if needed.
+    }
+
+    add("spark342Scala212", "3.4.2", "2.12") {
+      // Custom configurations for this variant.
+    }
+
+    commonDependencies {
+      // Define dependencies common to all variants here.
+      // For example, to add junit-jupiter for test implementation in all variants:
+      testImmplementation(dependencies.enforcedPlatform("org.junit:junit-bom:5.10.2"))
+      testImmplementation("org.junit.jupiter:junit-jupiter")
+    }
+
+    // Required, set a default build variant.
+    setDefaultBuild("spark342Scala212")
+}
+```
+
+In the above example, `builds` is a closure where you define multiple Spark and Scala combinations using the `add` method. Each variant can have its configurations adjusted within its block. The `commonDependencies` block is used to declare dependencies that are common across all variants, ensuring consistency and easing the management of dependencies.
+
+By adopting this setup, you facilitate building and testing your project against multiple versions of Spark and Scala, improving the compatibility and longevity of your application.

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -7,13 +7,16 @@ repositories {
     mavenCentral()
 }
 
+val downloadTaskVersion: String = "5.5.0"
 val lombokPluginVersion: String = "8.4"
+val shadowPluginVersion: String = "8.1.1"
 val spotlessVersion: String = "6.13.0"
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${spotlessVersion}")
+    implementation("com.github.johnrengelman:shadow:${shadowPluginVersion}")
     implementation("io.freefair.gradle:lombok-plugin:${lombokPluginVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }
 
 gradlePlugin {
@@ -26,6 +29,12 @@ gradlePlugin {
         create("scalaVariants") {
             id = "io.openlineage.scala-variants"
             implementationClass = "io.openlineage.gradle.plugin.ScalaVariantsPlugin"
+        }
+
+        create("sparkBuilds") {
+            id = "io.openlineage.spark-variant-build"
+            implementationClass =
+                "io.openlineage.gradle.plugin.variant.spark.SparkVariantsBuildPlugin"
         }
     }
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildConfigurerDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildConfigurerDsl.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+/**
+ * Provides a DSL for configuring a build variant within the SparkVariantsBuildPlugin.
+ * This DSL allows specifying dependencies and adjusting settings specific to the build variant,
+ * enabling fine-grained control over the configuration of build variant environments.
+ *
+ * @property build The internal representation of the build variant being configured.
+ */
+class BuildConfigurerDsl(private val build: InternalSparkVariantBuild) {
+
+    /**
+     * The version of Apache Spark used in this build variant.
+     */
+    val sparkVersion by build::sparkVersion
+
+    /**
+     * The version of Scala binary used in this build variant.
+     */
+    val scalaBinaryVersion by build::scalaBinaryVersion
+
+    /**
+     * Configures dependencies for this build variant. Provides a DSL for specifying the dependencies
+     * in different scopes such as implementation, compileOnly, runtimeOnly, etc.
+     *
+     * @param action A lambda expression providing a [DependencyHandlerDsl] to specify dependencies for this build variant.
+     */
+    fun dependencies(action: DependencyHandlerDsl.() -> Unit) {
+        val dsl = DependencyHandlerDsl(build)
+        action.invoke(dsl)
+    }
+
+    /**
+     * Adjusts the settings for this build variant. Through this method, tests can be enabled or disabled,
+     * and additional testing options can be configured.
+     *
+     * @param action A lambda expression providing a [BuildSettingsDsl] to adjust settings specific to this build variant.
+     */
+    fun settings(action: BuildSettingsDsl.() -> Unit) {
+        val dsl = BuildSettingsDsl(build)
+        action.invoke(dsl)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildSettingsDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/BuildSettingsDsl.kt
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+/**
+ * Provides a DSL for adjusting settings specific to a build variant. Through this,
+ * one can enable or disable certain test sets, or modify properties specific to how the tests are run.
+ * This allows for greater customization of the build process on a per-variant basis.
+ */
+class BuildSettingsDsl(private val build: InternalSparkVariantBuild) {
+    /**
+     * The version of Apache Spark used in this build variant.
+     */
+    val sparkVersion by build::sparkVersion
+
+    /**
+     * The version of Scala binary used in this build variant.
+     */
+    val scalaBinaryVersion by build::scalaBinaryVersion
+
+    /**
+     * Disables Delta tests for this build variant. This is useful if the variant
+     * doesn't support Delta or to speed up testing by skipping tests that are not relevant.
+     */
+    fun disableDeltaTests() {
+        build.prop(InternalSparkVariantBuild.DELTA_TESTS_ENABLED, false)
+    }
+
+    /**
+     * Disables Iceberg tests for this build variant. Similar to `disableDeltaTests`, this can be
+     * used to skip tests that are not applicable, or to reduce test time.
+     */
+    fun disableIcebergTests() {
+        build.prop(InternalSparkVariantBuild.ICEBERG_TESTS_ENABLED, false)
+    }
+
+    /**
+     * Configures integration test settings for this build variant by applying the specified
+     * configuration block to an instance of [IntegrationTestSettingsDsl].
+     *
+     * @param action The configuration block to adjust settings specific to integration tests.
+     */
+    fun integrationTest(action: IntegrationTestSettingsDsl.() -> Unit) {
+        val dsl = IntegrationTestSettingsDsl(build)
+        action.invoke(dsl)
+    }
+
+    /**
+     * Sets a custom system property to be used during test execution for this build variant.
+     * This is useful for controlling test behavior through system properties.
+     *
+     * Example usage:
+     * ```kotlin
+     * settings {
+     *     setSystemPropertyForTests("my.custom.property", "true")
+     * }
+     * ```
+     * This can then be checked in test code to modify the behavior based on the property value.
+     *
+     * @param key The system property key.
+     * @param value The value associated with the system property.
+     */
+    fun setSystemPropertyForTests(key: String, value: Any) {
+        build.prop(key, value)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/CommonDependenciesDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/CommonDependenciesDsl.kt
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.kotlin.dsl.project
+
+/**
+ * Provides a Domain-Specific Language (DSL) for configuring common dependencies across all variant builds created by the SparkVariantsBuildPlugin.
+ * This enables defining dependencies once and applying them across multiple variant builds, ensuring consistent dependency versions
+ * and configurations. This class is particularly useful when working with a project that needs to compile and test against multiple
+ * versions of Apache Spark and Scala, as it simplifies the management of dependencies common to all variants.
+ *
+ * @property builds A container of the internal representations of each build variant, allowing the common dependencies to be applied to each.
+ * @property dependencies The Gradle DependencyHandler used to declare dependencies. It provides a way to add or manipulate the dependencies of a project.
+ */
+class CommonDependenciesDsl(
+    private val builds: NamedDomainObjectContainer<InternalSparkVariantBuild>,
+    private val dependencies: DependencyHandler
+) {
+    fun project(path: String) = dependencies.project(path)
+
+    fun project(path: String, configuration: String) = dependencies.project(path, configuration)
+
+    fun implementation(dependency: Dependency) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependency)
+
+    fun implementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependency, configure)
+
+    fun implementation(dependencyNotation: String) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependencyNotation)
+
+    fun implementation(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.IMPLEMENTATION, dependencyNotation, configure)
+
+    fun compileOnly(dependency: Dependency) = addToAll(ConfigurationType.COMPILE_ONLY, dependency)
+
+    fun compileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependency, configure)
+
+    fun compileOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependencyNotation)
+
+    fun compileOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.COMPILE_ONLY, dependencyNotation, configure)
+
+    fun runtimeOnly(dependency: Dependency) = addToAll(ConfigurationType.RUNTIME_ONLY, dependency)
+
+    fun runtimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependency, configure)
+
+    fun runtimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependencyNotation)
+
+    fun runtimeOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun testImplementation(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependency)
+
+    fun testImplementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependency, configure)
+
+    fun testImplementation(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation)
+
+    fun testImplementation(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation, configure)
+
+    fun testCompileOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependency)
+
+    fun testCompileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependency, configure)
+
+    fun testCompileOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation)
+
+    fun testCompileOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation, configure)
+
+    fun testRuntimeOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependency)
+
+    fun testRuntimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun testRuntimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun testRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestRuntimeOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency)
+
+    fun integrationTestRuntimeOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun integrationTestRuntimeOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun integrationTestRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestMountOnly(dependency: Dependency) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency)
+
+    fun integrationTestMountOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency, configure)
+
+    fun integrationTestMountOnly(dependencyNotation: String) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation)
+
+    fun integrationTestMountOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        addToAll(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation, configure)
+
+    private fun addToAll(cfg: ConfigurationType, dependency: Dependency) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependency)
+            }
+        }
+    }
+
+    private fun addToAll(cfg: ConfigurationType, dependencyNotation: String) =
+        builds.forEach { build ->
+            build.configure {
+                dependencies {
+                    add(cfg, dependencyNotation)
+                }
+            }
+        }
+
+    private fun addToAll(
+        cfg: ConfigurationType,
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependency) {
+                    configure.invoke(this)
+                }
+            }
+        }
+    }
+
+    private fun addToAll(
+        cfg: ConfigurationType,
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) = builds.forEach { build ->
+        build.configure {
+            dependencies {
+                add(cfg, dependencyNotation) {
+                    configure.invoke(this)
+                }
+            }
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ConfigurationType.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ConfigurationType.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+/**
+ * Enumerates the types of Gradle configurations that are utilized within the SparkVariantsBuildPlugin to
+ * configure dependencies across various build variants. This includes configurations for compiling, testing,
+ * runtime, and integration testing, each tailored to the specifics of both Apache Spark and Scala versions.
+ *
+ * This enum is used internally by the plugin to streamline the assignment of dependencies to the respective
+ * configurations of each build variant, ensuring that all necessary dependencies are correctly applied according
+ * to their designated use case (e.g., compilation, runtime, testing).
+ */
+internal enum class ConfigurationType {
+    /** Configuration for dependencies that are necessary for compilation but not at runtime. */
+    COMPILE_ONLY,
+    /** Configuration for dependencies that are directly used in the code and are required at both compile-time and runtime. */
+    IMPLEMENTATION,
+    /** Configuration specifically for dependencies required at runtime during integration tests. */
+    INTEGRATION_TEST_RUNTIME_ONLY,
+    /** Configuration for additional dependencies that need to be uploaded for integration tests but are not part of the runtime classpath. */
+    INTEGRATION_TEST_UPLOAD_ONLY,
+    /** Configuration for dependencies needed at runtime but not for compilation. */
+    RUNTIME_ONLY,
+    /** Configuration for dependencies that are necessary to compile test sources but not required at runtime. */
+    TEST_COMPILE_ONLY,
+    /** Configuration for dependencies used in the test source set and required at both compile-time and runtime for testing. */
+    TEST_IMPLEMENTATION,
+    /** Configuration for dependencies required at runtime only when running tests. */
+    TEST_RUNTIME_ONLY,
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/DependencyHandlerDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/DependencyHandlerDsl.kt
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.kotlin.dsl.project
+
+/**
+ * Provides a Domain-Specific Language (DSL) for defining and managing dependencies within build variants
+ * in the SparkVariantsBuildPlugin. This DSL simplifies the process of adding various types of dependencies,
+ * such as implementation, compile-only, and runtime-only dependencies, specific to the Apache Spark and Scala
+ * version combination defined by the build variant.
+ *
+ * Dependency configurations can be catered to both the main source sets and test source sets, as well as providing
+ * additional granularity for integration testing setups. This allows a flexibly structured build that accommodates
+ * the complexities of varying Spark and Scala versions.
+ *
+ * @property b The internal representation of a build variant which encapsulates the details like Apache Spark version,
+ *             Scala binary version, and associated source sets for which the dependencies are being defined.
+ */
+class DependencyHandlerDsl(private val b: InternalSparkVariantBuild) {
+    private val dependencies = b.dependencies
+
+    val sparkVersion = b.sparkVersion
+    val scalaBinaryVersion = b.scalaBinaryVersion
+
+    fun project(path: String) = dependencies.project(path)
+
+    fun project(path: String, configuration: String) = dependencies.project(path, configuration)
+
+    fun implementation(dependency: Dependency) = add(ConfigurationType.IMPLEMENTATION, dependency)
+
+    fun implementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.IMPLEMENTATION, dependency, configure)
+
+    fun implementation(dependencyNotation: String) =
+        add(ConfigurationType.IMPLEMENTATION, dependencyNotation)
+
+    fun implementation(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.IMPLEMENTATION, dependencyNotation, configure)
+
+    fun implementation(dependency: Dependency, configuration: String) =
+        add(ConfigurationType.IMPLEMENTATION, dependency) {
+            this.targetConfiguration = configuration
+        }
+
+    fun compileOnly(dependency: Dependency) = add(ConfigurationType.COMPILE_ONLY, dependency)
+
+    fun compileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.COMPILE_ONLY, dependency, configure)
+
+    fun compileOnly(dependencyNotation: String) =
+        add(ConfigurationType.COMPILE_ONLY, dependencyNotation)
+
+    fun compileOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.COMPILE_ONLY, dependencyNotation, configure)
+
+    fun runtimeOnly(dependency: Dependency) = add(ConfigurationType.RUNTIME_ONLY, dependency)
+
+    fun runtimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.RUNTIME_ONLY, dependency, configure)
+
+    fun runtimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.RUNTIME_ONLY, dependencyNotation)
+
+    fun runtimeOnly(dependencyNotation: String, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun testImplementation(dependency: Dependency) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependency)
+
+    fun testImplementation(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependency, configure)
+
+    fun testImplementation(dependencyNotation: String) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation)
+
+    fun testImplementation(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_IMPLEMENTATION, dependencyNotation, configure)
+
+    fun testCompileOnly(dependency: Dependency) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependency)
+
+    fun testCompileOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependency, configure)
+
+    fun testCompileOnly(dependencyNotation: String) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation)
+
+    fun testCompileOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_COMPILE_ONLY, dependencyNotation, configure)
+
+    fun testRuntimeOnly(dependency: Dependency) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependency)
+
+    fun testRuntimeOnly(dependency: Dependency, configure: ExternalModuleDependency.() -> Unit) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun testRuntimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun testRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestRuntimeOnly(dependency: Dependency) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency)
+
+    fun integrationTestRuntimeOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependency, configure)
+
+    fun integrationTestRuntimeOnly(dependencyNotation: String) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation)
+
+    fun integrationTestRuntimeOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY, dependencyNotation, configure)
+
+    fun integrationTestMountOnly(dependency: Dependency) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency)
+
+    fun integrationTestMountOnly(
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependency, configure)
+
+    fun integrationTestMountOnly(dependencyNotation: String) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation)
+
+    fun integrationTestMountOnly(
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ) =
+        add(ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY, dependencyNotation, configure)
+
+    internal fun add(cfg: ConfigurationType, dependency: Dependency): Dependency =
+        doAdd(cfg, dependency)
+
+    internal fun add(
+        cfg: ConfigurationType,
+        dependency: Dependency,
+        configure: ExternalModuleDependency.() -> Unit
+    ): Dependency {
+        val dep = doAdd(cfg, dependency)
+        configure.invoke(dependency as ExternalModuleDependency)
+        return dep
+    }
+
+    internal fun add(cfg: ConfigurationType, dependencyNotation: String): Dependency =
+        doAdd(cfg, dependencyNotation)
+
+    internal fun add(
+        cfg: ConfigurationType,
+        dependencyNotation: String,
+        configure: ExternalModuleDependency.() -> Unit
+    ): Dependency {
+        val dep = doAdd(cfg, dependencyNotation)
+        configure.invoke(dep as ExternalModuleDependency)
+        return dep
+    }
+
+    private fun doAdd(cfg: ConfigurationType, dependencyNotation: Any): Dependency {
+        val configurationName = when (cfg) {
+            ConfigurationType.COMPILE_ONLY -> b.mainCompileOnly
+            ConfigurationType.RUNTIME_ONLY -> b.mainRuntimeOnly
+            ConfigurationType.IMPLEMENTATION -> b.mainImplementation
+            ConfigurationType.INTEGRATION_TEST_RUNTIME_ONLY -> b.integrationTestRuntimeOnly
+            ConfigurationType.INTEGRATION_TEST_UPLOAD_ONLY -> b.integrationTestAdditionalJars
+            ConfigurationType.TEST_COMPILE_ONLY -> b.testCompileOnly
+            ConfigurationType.TEST_RUNTIME_ONLY -> b.testRuntimeOnly
+            ConfigurationType.TEST_IMPLEMENTATION -> b.testImplementation
+        }
+
+        return dependencies.add(configurationName, dependencyNotation)!!
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/IntegrationTestSettingsDsl.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/IntegrationTestSettingsDsl.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+/**
+ * Provides a DSL for configuring integration test settings specific to a build variant. Through this DSL, users
+ * can customize aspects related to integration testing, such as specifying a custom Docker image to use during
+ * the tests. This allows for a more tailored and flexible setup when running integration tests against various
+ * Spark and Scala versions.
+ *
+ * @property build The [InternalSparkVariantBuild] instance for which the integration test settings are being configured.
+ */
+class IntegrationTestSettingsDsl(private val build: InternalSparkVariantBuild) {
+    /**
+     * Specifies a custom Docker image to be used for running integration tests. By default, the plugin uses a
+     * generated Docker image name based on Spark and Scala versions. This method allows overriding that image
+     * with any valid Docker image name, providing flexibility in the testing environment.
+     *
+     * Example of usage:
+     * ```kotlin
+     * integrationTests {
+     *      useDockerImage("my-custom-image:latest")
+     * }
+     * ```
+     *
+     * @param image The name of the Docker image to be used for integration tests, including the tag.
+     */
+    fun useDockerImage(image: String) {
+        build.prop(InternalSparkVariantBuild.DOCKER_IMAGE_NAME, image)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/InternalSparkVariantBuild.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/InternalSparkVariantBuild.kt
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+
+/**
+ * Represents an internally used variant of a build configured in the SparkVariantsBuildPlugin.
+ * It encapsulates the details of a specific build variant such as the Apache Spark version,
+ * Scala binary version, and associated source sets. Alongside, it handles the management of
+ * custom properties for build configurations and system properties for integration and unit tests.
+ *
+ * @property name The unique name of the build variant.
+ * @property sparkVersion The version of Apache Spark used in this build variant.
+ * @property scalaBinaryVersion The Scala binary version used in this build variant.
+ * @property project The Gradle [Project] instance this build variant belongs to.
+ * @property mainSourceSet The main source set for this build variant.
+ * @property testSourceSet The test source set for this build variant.
+ * @constructor Injects the necessary properties for initializing the build variant,
+ *              sets up default properties, and defines configurations for Docker, Derby, and Spark.
+ */
+abstract class InternalSparkVariantBuild @javax.inject.Inject constructor(
+    val name: String,
+    val sparkVersion: String,
+    val scalaBinaryVersion: String,
+    internal val project: Project,
+    val mainSourceSet: SourceSet,
+    val testSourceSet: SourceSet
+) {
+    companion object {
+        const val DOCKER_IMAGE_NAME = "docker.image.name"
+        const val DELTA_TESTS_ENABLED = "delta.tests.enabled"
+        const val ICEBERG_TESTS_ENABLED = "iceberg.tests.enabled"
+        const val DERBY_SYSTEM_HOME = "derby.system.home"
+        const val SPARK_WAREHOUSE = "spark.warehouse.dir"
+        const val JUNIT_CAPTURE_STD_OUT = "junit.platform.output.capture.stdout"
+        const val JUNIT_CAPTURE_STD_ERR = "junit.platform.output.capture.stderr"
+        const val SPARK_VERSION = "spark.version"
+        const val SCALA_BINARY_VERSION = "scala.binary.version"
+
+        /**
+         * This is used to specify the Kafka package in GAV (Group:Artifact:Version) format.
+         * The value of this will be supplied to the `--packages` argument of the `spark-submit` command.
+         *
+         * For example:
+         *
+         * ```shell
+         * spark-submit --packages org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.2 ...
+         * ```
+         */
+        const val KAFKA_PACKAGE_VERSION = "kafka.package.version"
+
+        const val ADDITIONAL_JARS_DIR = "additional.jars.dir"
+
+        const val FIXTURES_DIR = "fixtures.dir"
+    }
+
+    internal val dependencies = project.dependencies
+    private val properties = sortedMapOf<String, Any>()
+
+    init {
+        properties[DELTA_TESTS_ENABLED] = true
+
+        properties[ICEBERG_TESTS_ENABLED] = true
+
+        properties[JUNIT_CAPTURE_STD_OUT] = true
+
+        properties[JUNIT_CAPTURE_STD_ERR] = true
+
+        properties[DERBY_SYSTEM_HOME] =
+            project.layout.projectDirectory.file("build/var/run/${testSourceSet.name}/derby")
+
+        properties[SPARK_WAREHOUSE] =
+            project.layout.projectDirectory.dir("build/var/run/${testSourceSet.name}/spark-warehouse")
+
+        properties[SPARK_VERSION] = sparkVersion
+
+        properties[SCALA_BINARY_VERSION] = scalaBinaryVersion
+
+        properties[KAFKA_PACKAGE_VERSION] =
+            "org.apache.spark:spark-sql-kafka-0-10_${scalaBinaryVersion}:${sparkVersion}"
+
+        properties[ADDITIONAL_JARS_DIR] =
+            "build/deps/spark-${sparkVersion}/scala-${scalaBinaryVersion}"
+
+        properties[FIXTURES_DIR] =
+            "build/fixtures/spark-${sparkVersion}/scala-${scalaBinaryVersion}"
+
+        properties[DOCKER_IMAGE_NAME] =
+            "openlineage/spark:spark-${sparkVersion}-scala-${scalaBinaryVersion}"
+    }
+
+    val mainApi = mainSourceSet.apiConfigurationName
+    val mainApiElements = mainSourceSet.apiElementsConfigurationName
+    val mainCompileClassPath = mainSourceSet.compileClasspathConfigurationName
+    val mainCompileOnly = mainSourceSet.compileOnlyConfigurationName
+    val mainCompileOnlyApi = mainSourceSet.compileOnlyApiConfigurationName
+    val mainImplementation = mainSourceSet.implementationConfigurationName
+    val mainRuntimeClassPath = mainSourceSet.runtimeClasspathConfigurationName
+    val mainRuntimeElements = mainSourceSet.runtimeElementsConfigurationName
+    val mainRuntimeOnly = mainSourceSet.runtimeOnlyConfigurationName
+
+    val testCompileClasspath = testSourceSet.compileClasspathConfigurationName
+    val testCompileOnly = testSourceSet.compileOnlyConfigurationName
+    val testImplementation = testSourceSet.implementationConfigurationName
+    val testRuntimeClasspath = testSourceSet.runtimeClasspathConfigurationName
+    val testRuntimeOnly = testSourceSet.runtimeOnlyConfigurationName
+
+    val integrationTestRuntimeOnly = "integrationTest${mainSourceSet.name.capitalize()}RuntimeOnly"
+    val integrationTestRuntimeClasspath =
+        "integrationTest${mainSourceSet.name.capitalize()}RuntimeClasspath"
+
+    /**
+     * This is the name of a configuration that should be used for the explicit purpose of mounting JARs to a running Docker container.
+     */
+    val integrationTestAdditionalJars =
+        "integrationTest${mainSourceSet.name.capitalize()}Dependencies"
+
+    val integrationTestFixtures = "integrationTest${mainSourceSet.name.capitalize()}Fixtures"
+
+
+    val integrationTestTaskName = "executeIntegrationTestsFor${mainSourceSet.name.capitalize()}"
+
+    val integrationTestCopyAdditionalJarsTaskName =
+        "copyIntegrationTest${mainSourceSet.name.capitalize()}AdditionalJars"
+
+    val integrationTestCopyTestFixturesTaskName =
+        "copyIntegrationTest${mainSourceSet.name.capitalize()}Fixtures"
+
+    val shadowJarTaskName = "${mainSourceSet.name}ShadowJar"
+
+    /**
+     * Allows configuration of this build variant using a [BuildConfigurerDsl], enabling
+     * detailed setup of dependencies, and adjustment of settings like enabling or disabling tests, etc.
+     *
+     * @param configurer A lambda function that takes a [BuildConfigurerDsl] instance allowing
+     * configuration of various aspects of the build variant.
+     */
+    fun configure(configurer: BuildConfigurerDsl.() -> Unit) {
+        val dsl = BuildConfigurerDsl(this)
+        configurer.invoke(dsl)
+    }
+
+    /**
+     * Sets a custom property for this build variant.
+     *
+     * @param key The property key to set.
+     * @param value The property value to be set.
+     */
+    fun prop(key: String, value: Any) {
+        properties[key] = value
+    }
+
+    /**
+     * Retrieves the value of a custom property specified by the key.
+     *
+     * @param key The property key whose value is to be retrieved.
+     * @return The property value if the property is found, null otherwise.
+     */
+    fun prop(key: String) = properties[key]
+
+    /**
+     * Updates system properties with the properties defined in this build variant.
+     * This is typically used to propagate properties to the JVM environment used by
+     * tests or applications driven by Gradle tasks.
+     *
+     * @param systemProperties The mutable map of system properties to be updated.
+     */
+    fun updateSystemProperties(systemProperties: MutableMap<String, Any>) {
+        properties.forEach { (k, v) -> systemProperties[k] = v.toString() }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ProjectConfigurationFunctions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/ProjectConfigurationFunctions.kt
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+
+
+internal fun Project.configureBuild(sparkVariantBuild: SparkVariantBuild): InternalSparkVariantBuild {
+    val internalSparkVariantBuild = configureSourceSets(sparkVariantBuild)
+    configureConfigurations(internalSparkVariantBuild)
+    registerTasks(internalSparkVariantBuild)
+
+    return internalSparkVariantBuild
+}
+
+/**
+ * Configures the source sets for a given Spark and Scala build variants. It creates new source sets for the main
+ * and test code, based on the provided [SparkVariantBuild] instance. These source sets mirror the default
+ * 'main' and 'test' source sets but are named according to Spark and Scala versions.
+ *
+ * @receiver The Gradle [Project] within which the source sets are being configured.
+ * @param b The [SparkVariantBuild] instance representing the specific Spark and Scala version
+ * combination for which the source sets are being created.
+ * @return An [InternalSparkVariantBuild] instance containing details of the configured source sets.
+ */
+internal fun Project.configureSourceSets(b: SparkVariantBuild): InternalSparkVariantBuild {
+    val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+    val main = sourceSets.getByName("main")
+    val test = sourceSets.getByName("test")
+
+    val mainSourceSet = sourceSets.create(b.mainSourceSetName) {
+        java.setSrcDirs(main.java.srcDirs)
+        resources.setSrcDirs(main.resources.srcDirs)
+    }
+
+    val testSourceSet = sourceSets.create(b.testSourceSetName) {
+        java.setSrcDirs(test.java.srcDirs)
+        resources.setSrcDirs(test.resources.srcDirs)
+        compileClasspath += mainSourceSet.output
+        runtimeClasspath += mainSourceSet.output
+    }
+
+    val objects = project.objects
+    val internalVariant =
+        objects.newInstance(
+            InternalSparkVariantBuild::class.java,
+            b.name,
+            b.sparkVersion,
+            b.scalaBinaryVersion,
+            project,
+            mainSourceSet,
+            testSourceSet
+        )
+
+    return internalVariant
+}
+
+/**
+ * Configures the Gradle configurations required for the built variant represented by [InternalSparkVariantBuild].
+ * This includes setting up the compilations, runtime, and other necessary configurations for the build variant.
+ *
+ * @receiver The Gradle [Project] within which the configurations are being set up.
+ * @param b An instance of [InternalSparkVariantBuild] representing the build variant for which the configurations
+ * are being defined.
+ */
+internal fun Project.configureConfigurations(b: InternalSparkVariantBuild) {
+    val mainCompileOnlyApi = configurations.maybeCreate(b.mainCompileOnlyApi)
+    mainCompileOnlyApi.isCanBeConsumed = false
+    mainCompileOnlyApi.isCanBeResolved = false
+
+    val mainApi = configurations.maybeCreate(b.mainApi)
+    mainApi.isCanBeConsumed = false
+    mainApi.isCanBeResolved = false
+
+    val mainCompileOnly = configurations.maybeCreate(b.mainCompileOnly)
+    mainCompileOnly.isCanBeConsumed = false
+    mainCompileOnly.isCanBeResolved = false
+    mainCompileOnly.extendsFrom(mainCompileOnlyApi)
+
+    val mainApiElements = configurations.maybeCreate(b.mainApiElements)
+    mainApiElements.isCanBeConsumed = true
+    mainApiElements.isCanBeResolved = false
+    mainApiElements.extendsFrom(mainApi, mainCompileOnlyApi)
+
+    val mainImplementation = configurations.maybeCreate(b.mainImplementation)
+    mainImplementation.isCanBeConsumed = false
+    mainImplementation.isCanBeResolved = false
+    mainImplementation.extendsFrom(mainApi)
+
+    val mainRuntimeOnly = configurations.maybeCreate(b.mainRuntimeOnly)
+    mainImplementation.isCanBeConsumed = false
+    mainImplementation.isCanBeResolved = false
+
+    val mainCompileClassPath = configurations.maybeCreate(b.mainCompileClassPath)
+    mainCompileClassPath.isCanBeConsumed = false
+    mainCompileClassPath.isCanBeResolved = true
+    mainCompileClassPath.extendsFrom(mainCompileOnly, mainImplementation)
+
+    val mainRuntimeElements = configurations.maybeCreate(b.mainRuntimeElements)
+    mainRuntimeElements.isCanBeConsumed = true
+    mainRuntimeElements.isCanBeResolved = false
+    mainRuntimeElements.extendsFrom(mainImplementation, mainRuntimeOnly)
+
+    val mainRuntimeClasspath = configurations.maybeCreate(b.mainRuntimeClassPath)
+    mainRuntimeClasspath.isCanBeConsumed = false
+    mainRuntimeClasspath.isCanBeResolved = true
+    mainRuntimeClasspath.extendsFrom(mainImplementation, mainRuntimeOnly)
+
+    val testCompileOnly = configurations.maybeCreate(b.testCompileOnly)
+    testCompileOnly.extendsFrom(mainCompileOnlyApi)
+
+    val testImplementation = configurations.maybeCreate(b.testImplementation)
+    testImplementation.extendsFrom(mainImplementation)
+
+    val testRuntimeOnly = configurations.maybeCreate(b.testRuntimeOnly)
+    testRuntimeOnly.extendsFrom(mainRuntimeOnly)
+
+    val testCompileClasspath = configurations.maybeCreate(b.testCompileClasspath)
+    testCompileClasspath.isCanBeResolved = true
+    testCompileClasspath.extendsFrom(testCompileOnly, testImplementation)
+
+    val testRuntimeClasspath = configurations.maybeCreate(b.testRuntimeClasspath)
+    testRuntimeClasspath.isCanBeResolved = true
+    testRuntimeClasspath.extendsFrom(testRuntimeOnly, testImplementation)
+
+    // Now, we create four configurations meant for the integration test tasks
+    // The first one will define the dependencies that we need to run the integration tests, i.e., testcontainers.
+    // The second is the runtime classpath for the integration test task. This needs to be resolvable.
+    // The third is what we will mount to the container as additional runtime dependencies
+    // THe fourth is for test fixtures, that we will also mount to the counteiner
+    val integrationTestRuntimeOnly = configurations.maybeCreate(b.integrationTestRuntimeOnly)
+    integrationTestRuntimeOnly.isCanBeResolved = false
+    integrationTestRuntimeOnly.isCanBeConsumed = false
+
+    val integrationTestRuntimeClasspath =
+        configurations.maybeCreate(b.integrationTestRuntimeClasspath)
+    integrationTestRuntimeClasspath.extendsFrom(integrationTestRuntimeOnly, testImplementation)
+    integrationTestRuntimeClasspath.isCanBeResolved = true
+    integrationTestRuntimeClasspath.isCanBeConsumed = false
+
+    val integrationTestAdditionalJars = configurations.maybeCreate(b.integrationTestAdditionalJars)
+    integrationTestAdditionalJars.isCanBeResolved = true
+    integrationTestAdditionalJars.isCanBeConsumed = false
+
+    val integrationTestFixtures = configurations.maybeCreate(b.integrationTestFixtures)
+    integrationTestFixtures.isCanBeResolved = true
+    integrationTestFixtures.isCanBeConsumed = false
+}
+
+/**
+ * Configures the default configurations of the project to extend those of a specified internal Spark variant build.
+ * This essentially makes the specified build the default build, integrating its configurations with the project’s
+ * default ones.
+ *
+ * @receiver The Gradle [Project] in which the default configurations are being adjusted.
+ * @param b An instance of [InternalSparkVariantBuild] representing the build variant to be used as the default.
+ */
+internal fun Project.configureDefaultConfigurations(b: InternalSparkVariantBuild) {
+    configurations.named("implementation").configure {
+        extendsFrom(configurations.getByName(b.mainImplementation))
+    }
+    configurations.named("compileOnly").configure {
+        extendsFrom(configurations.getByName(b.mainCompileOnly))
+    }
+    configurations.named("runtimeOnly").configure {
+        extendsFrom(configurations.getByName(b.mainRuntimeOnly))
+    }
+    configurations.named("testImplementation").configure {
+        extendsFrom(configurations.getByName(b.testImplementation))
+    }
+    configurations.named("testCompileOnly").configure {
+        extendsFrom(configurations.getByName(b.testCompileOnly))
+    }
+    configurations.named("testRuntimeOnly").configure {
+        extendsFrom(configurations.getByName(b.testRuntimeOnly))
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantBuild.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantBuild.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+/**
+ * Represents a configuration for a specific Spark and Scala version combination.
+ * This class is used to define variant builds as per different combinations of
+ * Apache Spark and Scala binary versions.
+ *
+ * @property name The unique name given to this build variant.
+ * @property sparkVersion The version of Apache Spark this variant is targeting.
+ * @property scalaBinaryVersion The Scala binary version this variant is using.
+ * @constructor Initializes a variant build with the provided name, Spark version, and Scala binary version.
+ */
+abstract class SparkVariantBuild @javax.inject.Inject constructor(
+    val name: String,
+    val sparkVersion: String,
+    val scalaBinaryVersion: String
+) {
+    private val sparkVersionFmt = sparkVersion.removePeriods()
+    private val scalaBinaryVersionFmt = scalaBinaryVersion.removePeriods()
+
+    val mainSourceSetName = "mainSpark${sparkVersionFmt}Scala${scalaBinaryVersionFmt}"
+    val testSourceSetName = "testSpark${sparkVersionFmt}Scala${scalaBinaryVersionFmt}"
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPlugin.kt
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * This Gradle plugin enables the construction of source sets and tasks
+ * for multiple variants of Apache Spark and Scala versions. It aids in creating a unified build process
+ * that compiles and tests code across different Spark and Scala versions, mitigating runtime failures
+ * due to version discrepancies. This plugin operates within projects that apply the Java plugin.
+ *
+ * The plugin offers several key features:
+ * - Generation of variant-specific source sets for both main and test sources, named according to
+ *   the pattern 'mainSpark${sparkVersion}Scala${scalaBinaryVersion}' and
+ *   'testSpark${sparkVersion}Scala${scalaBinaryVersion}', with periods in versions removed.
+ * - Creation of aggregate tasks for compiling main and test sources, running unit and integration tests,
+ *   as well as packaging compiled code into JARs, including shadow JARs for creating fat JARs with all dependencies.
+ * - A utility task for printing the details of the created source sets.
+ *
+ * To leverage the plugin, a consumer must define the desired Apache Spark version, Scala Binary version,
+ * and a build name through the provided extension. This setup allows for compiling and testing against different
+ * versions, facilitating a broader compatibility range and reducing the potential for version-related runtime issues.
+ */
+class SparkVariantsBuildPlugin : Plugin<Project> {
+    /**
+     * Applies the SparkVariantsBuildPlugin to the given project. This method sets up the required tasks and extensions
+     * when the Java plugin is applied to the project.
+     *
+     * Specifically, it:
+     * - Creates an extension of type [SparkVariantsBuildPluginExtension] for configuring the plugin.
+     * - Registers tasks for compiling main and test sources, running unit and integration tests,
+     *   assembling JARs, including shadow JARs, and printing details of generated source sets.
+     *
+     * The functionality is only initiated if the Java plugin is already applied to the project, ensuring
+     * the necessary Java compilation, packaging, and testing infrastructure is in place.
+     *
+     * @param p The project to which the SparkVariantsBuildPlugin is applied.
+     */
+    override fun apply(p: Project) {
+        p.plugins.withType<JavaPlugin> {
+            p.extensions.create(
+                "builds", SparkVariantsBuildPluginExtension::class.java
+            )
+
+            p.registerAggregateCompileMainSourcesTask()
+            p.registerAggregateCompileTestSourcesTask()
+            p.registerAggregateUnitTestTask()
+            p.registerAggregateJarTask()
+            p.registerAggregateIntegrationTestTask()
+            p.registerAggregateShadowJarTasks()
+
+            p.registerPrintSourceSetDetailsTasks()
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/SparkVariantsBuildPluginExtension.kt
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import org.gradle.api.Project
+
+/**
+ * An extension for the [SparkVariantsBuildPlugin] allowing detailed configuration of variant builds.
+ * This includes adding new variant builds, specifying common dependencies across all builds,
+ * and selecting a default build configuration.
+ *
+ * @property p The Gradle [Project] that this extension is applied to, enabling access to project-specific functionalities and configurations.
+ * @constructor Creates a new instance of the extension, initialized with a specific Gradle [Project].
+ */
+abstract class SparkVariantsBuildPluginExtension @javax.inject.Inject constructor(private val p: Project) {
+    private val builds = p.objects.domainObjectContainer(InternalSparkVariantBuild::class.java)
+    private val objects = p.objects
+
+    private fun addBuild(build: SparkVariantBuild): InternalSparkVariantBuild {
+        val internalBuildVariant = p.configureBuild(build)
+        builds.add(internalBuildVariant)
+        return internalBuildVariant
+    }
+
+    /**
+     * Adds a new variant build configuration with the specified name, Apache Spark version, and Scala binary version.
+     * This variant is then initialized and registered within the plugin's extension for further configuration
+     * and usage in the build process.
+     *
+     * @param name The unique name of the build variant.
+     * @param sparkVersion The version of Apache Spark to be used in this build variant.
+     * @param scalaBinaryVersion The Scala binary version to be used in this build variant.
+     * @return The [InternalSparkVariantBuild] instance representing the added build variant,
+     *         allowing further configuration and use.
+     */
+    fun add(
+        name: String,
+        sparkVersion: String,
+        scalaBinaryVersion: String
+    ): InternalSparkVariantBuild {
+        val build =
+            objects.newInstance(
+                SparkVariantBuild::class.java,
+                name,
+                sparkVersion,
+                scalaBinaryVersion
+            )
+        return addBuild(build)
+    }
+
+    /**
+     * Configures a set of common dependencies for all variant builds defined within the extension. This allows
+     * for consistent dependency management across different Spark and Scala versions, ensuring that all variants
+     * are compiled and tested against the same set of dependencies.
+     *
+     * @param configure A lambda expression providing a DSL [CommonDependenciesDsl] for defining common dependencies.
+     */
+    fun commonDependencies(configure: CommonDependenciesDsl.() -> Unit) {
+        val dsl = CommonDependenciesDsl(builds, p.dependencies)
+        configure.invoke(dsl)
+    }
+
+    /**
+     * Specifies a default build variant by its name. This variant is used as the primary build configuration
+     * unless overridden. This method ensures that a specified default exists among the configured build variants.
+     *
+     * @param name The name of the build variant to be set as the default.
+     * @throws IllegalArgumentException if no build variant with the specified name is found.
+     */
+    fun setDefaultBuild(name: String) {
+        val build = builds.findByName(name)
+        check(build != null) { "No build found with name: $name" }
+        p.configureDefaultConfigurations(build)
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/StringExtensions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/StringExtensions.kt
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+internal fun String.removePeriods() = replace(".", "")

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/TaskRegistrationFunctions.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/variant/spark/TaskRegistrationFunctions.kt
@@ -1,0 +1,434 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin.variant.spark
+
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import java.util.*
+
+/**
+ * Registers all the necessary tasks for a given build variant within the project. This includes tasks for
+ * unit testing, JAR packaging, cleanup, integration tests, and others specifically configured for the [InternalSparkVariantBuild].
+ *
+ * @receiver The Gradle [Project] within which the tasks are being registered.
+ * @param b The [InternalSparkVariantBuild] instance representing the build variant for which the tasks are being defined.
+ */
+@Suppress("UNUSED_VARIABLE")
+internal fun Project.registerTasks(b: InternalSparkVariantBuild) {
+    val createVersionPropertiesTask = registerCreateVersionPropertiesTask(b)
+    val jarTask = registerJarTask(b)
+    val deleteSparkDirs = registerCleanupTask(b)
+    val unitTestTask = registerUnitTestTask(b, deleteSparkDirs)
+    val copyAdditionalJarsTask = registerCopyAdditionalIntegrationTestJars(b)
+    val copyFixturesTask = registerCopyIntegrationTestFixtures(b)
+    val integrationTestTask =
+        registerIntegrationTestTask(b, copyAdditionalJarsTask, copyFixturesTask)
+    val shadowJarTask = registerShadowJarTask(b, jarTask)
+}
+
+/**
+ * Registers a task for running unit tests specific to a [InternalSparkVariantBuild].
+ * This task relies on the standard JUnit platform setup to execute tests,
+ * excluding any tagged as 'integration-test'. It ensures that system properties
+ * defined by the build variant are propagated to the test execution environment.
+ *
+ * @param b The build variant configuration representing the specific Spark and Scala version.
+ * @param deleteSparkDirs A task provider for a task that cleans up Spark-related directories before executing tests.
+ * @return The task provider for the registered unit test task.
+ */
+internal fun Project.registerUnitTestTask(
+    b: InternalSparkVariantBuild,
+    deleteSparkDirs: TaskProvider<Delete>
+): TaskProvider<Test> {
+    val unitTestTaskName = "executeUnitTestsFor${b.name}"
+    val unitTestTask = tasks.register<Test>(unitTestTaskName)
+    unitTestTask.configure {
+        dependsOn(deleteSparkDirs)
+        group = "unitTests"
+        description = "Runs unit tests for Spark variant: ${b.name}"
+        testClassesDirs = b.testSourceSet.output.classesDirs
+        classpath = b.testSourceSet.runtimeClasspath
+        useJUnitPlatform {
+            excludeTags("integration-test")
+        }
+
+        doFirst {
+            b.updateSystemProperties(systemProperties)
+        }
+    }
+    return unitTestTask
+}
+
+/**
+ * Registers a cleanup task to delete Spark framework-related directories for a given [InternalSparkVariantBuild].
+ * This is useful for ensuring a clean state before or after test runs,
+ * particularly for integration tests that may modify these directories.
+ *
+ * @param b The build variant configuration.
+ * @return The task provider for the registered cleanup task.
+ */
+internal fun Project.registerCleanupTask(b: InternalSparkVariantBuild): TaskProvider<Delete> =
+    tasks.register<Delete>("cleanUpSparkDirsFor${b.name}") {
+        group = "aux"
+        description = "Cleans up the Spark directories for variant: ${b.name}"
+        delete(b.prop(InternalSparkVariantBuild.DERBY_SYSTEM_HOME))
+        delete(b.prop(InternalSparkVariantBuild.SPARK_WAREHOUSE))
+    }
+
+/**
+ * Registers a task to create a 'version.properties' file within the resources directory of a [InternalSparkVariantBuild].
+ * This properties file includes project version information that can be accessed at runtime,
+ * useful for logging or display purposes within the application.
+ *
+ * @param b The build variant configuration for which the properties file is created.
+ * @return The task provider for the registered properties file creation task.
+ */
+internal fun Project.registerCreateVersionPropertiesTask(b: InternalSparkVariantBuild): TaskProvider<Task> {
+    val task = tasks.register("createVersionPropertiesFor${b.name}") {
+        dependsOn(b.mainSourceSet.processResourcesTaskName)
+        group = "resources"
+        description = "Creates a version.properties file for Spark variant: ${b.name}"
+        outputs.file(layout.buildDirectory.file("resources/${b.mainSourceSet.name}/io/openlineage/spark/agent/version.properties"))
+        doLast {
+            val propertiesFile = outputs.files.first()
+            propertiesFile.writer().use { writer ->
+                val properties = Properties()
+                properties["version"] = project.version.toString()
+                properties.store(writer, null)
+            }
+        }
+    }
+    tasks.named(b.mainSourceSet.classesTaskName).configure {
+        dependsOn(task)
+    }
+    return task
+}
+
+/**
+ * Registers a JAR packaging task for the main source set of a [InternalSparkVariantBuild].
+ * This task assembles a JAR file containing the compiled classes and resources
+ * of the main source set, ready for distribution or further testing.
+ *
+ * @param b The build variant configuration being packaged into a JAR.
+ * @return The task provider for the registered JAR task.
+ */
+internal fun Project.registerJarTask(b: InternalSparkVariantBuild) =
+    tasks.register<Jar>(b.mainSourceSet.jarTaskName) {
+        dependsOn(b.mainSourceSet.classesTaskName)
+        group = "build"
+        description = "Assembles a jar archive for Spark variant: ${b.name}"
+        archiveBaseName = "openlineage-spark"
+        archiveAppendix = "app_${b.scalaBinaryVersion}"
+        from(b.mainSourceSet.output)
+        destinationDirectory.set(layout.buildDirectory.dir("libs/spark-${b.sparkVersion}/scala-${b.scalaBinaryVersion}"))
+    }
+
+/**
+ * Registers a shadow JAR task for a [InternalSparkVariantBuild], creating a fat JAR that includes
+ * all dependencies along with the build variant's compiled code. This is particularly useful for
+ * distribution or running standalone applications that require a complete package of all dependencies.
+ *
+ * @param b The build variant configuration being packaged into a shadow JAR.
+ * @param jarTask The task provider for the standard JAR task, which the shadow JAR task depends on.
+ * @return The task provider for the registered shadow JAR task.
+ */
+internal fun Project.registerShadowJarTask(
+    b: InternalSparkVariantBuild,
+    jarTask: TaskProvider<Jar>
+): TaskProvider<ShadowJar> {
+    return tasks.register<ShadowJar>(b.shadowJarTaskName) {
+        dependsOn(jarTask)
+        group = "shadow"
+        description = "Assembles a shadow jar archive for Spark variant: ${b.name}"
+        archiveBaseName = "openlineage-spark"
+        archiveAppendix = "app_${b.scalaBinaryVersion}"
+        archiveClassifier = "shadow"
+        from(b.mainSourceSet.output)
+        configurations = listOf(project.configurations[b.mainRuntimeClassPath])
+        isZip64 = true
+        destinationDirectory = jarTask.flatMap { it.destinationDirectory }
+
+        // This should be exposed in the build script. It's too deep here.
+        val prefix = "io.openlineage.spark.shaded"
+        relocate(
+            "com.github.ok2c.hc5",
+            "${prefix}.com.github.ok2c.hc5"
+        )
+        relocate(
+            "org.apache.httpcomponents.client5",
+            "${prefix}.org.apache.httpcomponents.client5"
+        )
+        relocate("javassist", "${prefix}.javassist")
+        relocate("org.apache.hc", "${prefix}.org.apache.hc")
+        relocate(
+            "org.apache.commons.codec",
+            "${prefix}.org.apache.commons.codec"
+        )
+        relocate(
+            "org.apache.commons.lang3",
+            "${prefix}.org.apache.commons.lang3"
+        )
+        relocate(
+            "org.apache.commons.beanutils",
+            "${prefix}.org.apache.commons.beanutils"
+        )
+        relocate("org.apache.http", "${prefix}.org.apache.http")
+        relocate("org.yaml.snakeyaml", "${prefix}.org.yaml.snakeyaml")
+        relocate(
+            "com.fasterxml.jackson",
+            "${prefix}.com.fasterxml.jackson"
+        ) {
+            exclude("com.fasterxml.jackson.annotation.JsonIgnore")
+            exclude("com.fasterxml.jackson.annotation.JsonIgnoreProperties")
+            exclude("com.fasterxml.jackson.annotation.JsonIgnoreType")
+        }
+
+        dependencies {
+            exclude(dependency("org.slf4j::"))
+            exclude("org/apache/commons/logging/**")
+        }
+
+        manifest {
+            attributes(
+                mapOf(
+                    "Created-By" to "Gradle ${project.gradle.gradleVersion}",
+                    "Built-By" to System.getProperty("user.name"),
+                    "Build-Jdk" to System.getProperty("java.version"),
+                    "Implementation-Title" to project.name,
+                    "Implementation-Version" to project.version
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Registers a task to copy additional JARs required for integration testing of a [InternalSparkVariantBuild].
+ * These include custom or third-party JARs not included in the project's declared dependencies
+ * but are necessary for integration tests to execute properly.
+ *
+ * @param b The build variant configuration.
+ * @return The task provider for the registered copy task.
+ */
+internal fun Project.registerCopyAdditionalIntegrationTestJars(b: InternalSparkVariantBuild): TaskProvider<Copy> {
+    val copyDependenciesTask = tasks.register<Copy>(b.integrationTestCopyAdditionalJarsTaskName) {
+        group = "integrationTests"
+        description =
+            "Copies additional jars needed for the integration tests for Spark variant: ${b.name}"
+        from(configurations[b.integrationTestAdditionalJars])
+        into(b.prop(InternalSparkVariantBuild.ADDITIONAL_JARS_DIR)!!)
+        include("*.jar")
+    }
+    return copyDependenciesTask
+}
+
+/**
+ * Registers a task to copy test fixtures necessary for integration testing of a [InternalSparkVariantBuild].
+ * These fixtures might include data files, configuration files, or other resources that are required
+ * for the setup or execution of integration tests.
+ *
+ * @param b The build variant configuration.
+ * @return The task provider for the registered copy task.
+ */
+internal fun Project.registerCopyIntegrationTestFixtures(b: InternalSparkVariantBuild): TaskProvider<Copy> {
+    val copyFixturesTask = tasks.register<Copy>(b.integrationTestCopyTestFixturesTaskName) {
+        group = "integrationTests"
+        description =
+            "Copies test fixtures needed for the integration tests for Spark variant: ${b.name}"
+        from(configurations[b.integrationTestAdditionalJars])
+        into(b.prop(InternalSparkVariantBuild.FIXTURES_DIR)!!)
+    }
+    return copyFixturesTask
+}
+
+/**
+ * Registers an integration test task for a [InternalSparkVariantBuild], configuring it to run
+ * tests tagged with 'integration-test'. This task setup includes the handling of system properties
+ * for test execution context and configuring the test runtime classpath to include necessary dependencies.
+ *
+ * @param b The build variant configuration.
+ * @param copyAdditionalJarsTask A task provider for copying additional JARs needed for integration testing.
+ * @param copyFixturesTask A task provider for copying test fixtures necessary for integration testing.
+ * @return The task provider for the registered integration test task.
+ */
+internal fun Project.registerIntegrationTestTask(
+    b: InternalSparkVariantBuild,
+    copyAdditionalJarsTask: TaskProvider<Copy>,
+    copyFixturesTask: TaskProvider<Copy>
+): TaskProvider<Test> {
+    val integrationTestTask = tasks.register<Test>(b.integrationTestTaskName)
+    integrationTestTask.configure {
+        dependsOn(b.shadowJarTaskName, copyAdditionalJarsTask, copyFixturesTask)
+        group = "integrationTests"
+        description = "Runs integration tests for Spark variant: ${b.name}"
+        testClassesDirs = b.testSourceSet.output.classesDirs
+        classpath = b.testSourceSet.runtimeClasspath
+        useJUnitPlatform {
+            includeTags("integration-test")
+            excludeTags("databricks")
+        }
+
+        doFirst {
+            b.updateSystemProperties(systemProperties)
+            systemProperties["project.version"] = project.version.toString()
+
+            tasks.getByName(b.shadowJarTaskName).outputs.files.first().let {
+                systemProperties["openlineage.spark.agent.jar"] = it.name
+                systemProperties["openlineage.spark.agent.jar.dir"] = it.parent
+                systemProperties["openlineage.spark.agent.jar.path"] = it.absolutePath
+            }
+            val additionalJarsDir =
+                copyAdditionalJarsTask.map { it.destinationDir }.get().absolutePath
+            systemProperties["openlineage.spark.agent.additional.jars.dir"] = additionalJarsDir
+            val fixturesDir = copyFixturesTask.map { it.destinationDir }.get().absolutePath
+            systemProperties["openlineage.spark.agent.fixtures.dir"] = fixturesDir
+        }
+    }
+    return integrationTestTask
+}
+
+/**
+ * Registers a task to print the details of all source sets in the project, providing insight into the Java and
+ * resource directories, as well as the compile and runtime classpaths for each source set. This function is
+ * beneficial for debugging and verifying the configuration of source sets.
+ *
+ * @receiver The Gradle [Project] within which the task is being registered.
+ */
+internal fun Project.registerPrintSourceSetDetailsTasks() {
+    val sourceSetContainer = extensions.getByType(SourceSetContainer::class.java)
+    sourceSetContainer.configureEach {
+        val taskName = "printSourceSetDetails${name.capitalize()}"
+        tasks.register(taskName) {
+            group = "debug"
+            description = "Prints details for source set: $name"
+            doLast {
+                println("Source set: $name\n")
+                println("> Java source dirs: ${java.srcDirs.joinToString(", ")}\n")
+                println("> Resources source dirs: ${resources.srcDirs.joinToString(", ")}\n")
+                println("> Output dirs: ${output.classesDirs.joinToString(", ")}\n")
+                val sortedCompileClassPath =
+                    compileClasspath.sortedBy { it.absolutePath }.joinToString("\n - ", " - ")
+
+                println("> Compile classpath:\n${sortedCompileClassPath}\n")
+
+                val sortedRuntimeClasspath =
+                    runtimeClasspath.sortedBy { it.absolutePath }.joinToString("\n - ", " - ")
+                println("> Runtime classpath:\n${sortedRuntimeClasspath}\n")
+            }
+        }
+    }
+}
+
+/**
+ * Registers an aggregate task to run unit tests for all Spark variants in the project. This task aggregates
+ * unit test tasks across all Spark variants, enabling a single command execution to run tests against all configurations.
+ *
+ * @receiver The Gradle [Project] in which the aggregate unit test task is being registered.
+ */
+internal fun Project.registerAggregateUnitTestTask() {
+    tasks.register("executeAllVariantsUnitTests") {
+        group = "aggregate"
+        description = "Aggregate task to run all Spark variant tests"
+        dependsOn(
+            tasks.withType<Test>().matching { it.group == "unitTests" && it.name != this.name })
+    }
+}
+
+/**
+ * Registers an aggregate task to assemble JARs for all Spark variants in the project. It aggregates the JAR tasks
+ * of all defined Spark variants into a single task that can be executed to package all variants at once.
+ *
+ * @receiver The Gradle [Project] in which the aggregate JAR task is being registered.
+ */
+internal fun Project.registerAggregateJarTask() {
+    tasks.register("executeAllVariantsJarTasks") {
+        group = "aggregate"
+        description = "Aggregate task to assemble all Spark variant jar archives"
+        dependsOn(
+            tasks.withType<Jar>().matching { it.group == "build" && it.name.endsWith("Jar") })
+    }
+}
+
+/**
+ * Registers an aggregate task for creating shadow JARs for all Spark variants that are configured in the project.
+ * This facilitates the creation of fat JARs, containing all dependencies, for each Spark and Scala version variant.
+ *
+ * @receiver The Gradle [Project] where the aggregate shadow JAR task is being registered.
+ */
+internal fun Project.registerAggregateShadowJarTasks() {
+    plugins.withType<ShadowPlugin> {
+        tasks.register("executeAllVariantsShadowJar") {
+            group = "aggregate"
+            description = "Aggregate task to create shadow jars for all Spark variants"
+            dependsOn(
+                tasks.withType<ShadowJar>()
+                    .filter { it.name.startsWith("mainSpark") && it.name.endsWith("ShadowJar") })
+        }
+    }
+}
+
+/**
+ * Registers an aggregate task to compile Java sources for all Spark variants in the project. It aggregates
+ * the compilation tasks of all defined Spark variants into a single task that can be executed to compile
+ * all variants at once.
+ *
+ * @receiver The Gradle [Project] in which the aggregate compile task is being registered.
+ */
+internal fun Project.registerAggregateCompileMainSourcesTask() {
+    tasks.register("compileAllVariantsJava") {
+        group = "aggregate"
+        description = "Aggregate task to compile all Spark variants"
+        dependsOn(
+            tasks.withType<JavaCompile>()
+                .filter { it.name.startsWith("compileSpark") })
+    }
+}
+
+/**
+ * Registers an aggregate task to compile Java test sources for all Spark variants in the project. It aggregates
+ * the test compilation tasks of all defined Spark variants into a single task that can be executed to compile
+ * test sources for all variants at once.
+ *
+ * @receiver The Gradle [Project] in which the aggregate test compile task is being registered.
+ */
+internal fun Project.registerAggregateCompileTestSourcesTask() {
+    tasks.register("compileAllVariantsTestJava") {
+        group = "aggregate"
+        description = "Aggregate task to compile all Spark test variants"
+        dependsOn(
+            tasks.withType<JavaCompile>()
+                .filter { it.name.startsWith("compileTestSpark") })
+    }
+}
+
+/**
+ * Registers an aggregate task to run integration tests for all Spark variants in the project. This task
+ * aggregates integration test tasks across all Spark variants, allowing execution of all integration tests with
+ * a single command.
+ *
+ * @receiver The Gradle [Project] in which the aggregate integration test task is being registered.
+ */
+internal fun Project.registerAggregateIntegrationTestTask() {
+    tasks.register("executeAllVariantsIntegrationTests") {
+        group = "aggregate"
+        description = "Aggregate task to run all Spark variant integration tests"
+        dependsOn(
+            tasks.withType<Test>().matching { it.group == "integrationTests" })
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces the SparkVariantBuild Gradle plugin to the Spark integration.

### Problem

Scala 2.12 and Scala 2.13 support is required for Apache Spark. This PR lays some groundwork for it.

### Solution

- **Spark Variants Build Plugin**: Enables definition of builds incorporating multiple Apache Spark and Scala versions, facilitating integration tests across various combinations.

### Implementation Details
- The introduction of the custom plugins addresses specific project needs, providing a tailored solution to our Spark and Scala versioning challenges, as well as our Docker image customization requirements.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project