### PR TITLE
[FLINK] bump default Flink version to 1.18.1

### DIFF
--- a/.circleci/workflows/openlineage-flink.yml
+++ b/.circleci/workflows/openlineage-flink.yml
@@ -4,13 +4,13 @@ workflows:
       - build-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.0' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1' ]
           requires:
             - build-client-java
       - integration-test-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.0' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1' ]
           requires:
             - build-integration-flink
       - workflow_complete:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 
 ### Added
+* **FLINK: bump default Flink version to 1.18.1 (https://github.com/OpenLineage/OpenLineage/pull/2418) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
+  *Support Flink 1.18.1 as it is newly released 
+* **FLINK: support Flink Kafka dynamic source and sink (https://github.com/OpenLineage/OpenLineage/pull/2417) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
+  *Support Flink Kafka Table Connector use cases for topic and schema extraction
 * **Spark: integration now emits intermediate, application level events wrapping entire job execution** [`#1672`](https://github.com/OpenLineage/OpenLineage/issues/1672) [@mobuchowski](https://github.com/mobuchowski)  
     *Previously, Spark event model described only single actions, potentially linked only to some parent run.
 * **Flink: support multi topic Kafka Sink.** [`#2372`](https://github.com/OpenLineage/OpenLineage/pull/2372) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/README.md
+++ b/integration/README.md
@@ -5,7 +5,7 @@
 |Dagster| 0.13.8+                             |https://github.com/dagster-io/dagster/releases|[README](./dagster/README.md)| |
 |dbt| 0.20+, 1.3                          |https://github.com/dbt-labs/dbt-core/releases|[README](./dbt/README.md)| |
 |Apache Spark| 2.4.6, 3.1.2, 3.2.1+, 3.3.1+, 3.4.1, 3.5.0 |https://github.com/apache/spark/tags|[README](./spark/README.md)| |
-|Apache Flink| 1.15.4, 1.16.2, 1.17.1              |https://github.com/apache/flink/tags|[README](./spark/README.md)| Flink support is currently experimental |
+|Apache Flink| 1.15.4, 1.16.2, 1.17.1, 1.18.1            |https://github.com/apache/flink/tags|[README](./flink/README.md)|  |
 
 ----
 SPDX-License-Identifier: Apache-2.0\

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,4 +1,4 @@
 jdk8.build=true
 version=1.9.0-SNAPSHOT
-flink.version=1.18.0
+flink.version=1.18.1
 org.gradle.jvmargs=-Xmx1G


### PR DESCRIPTION
Bump default Flink version to 1.18.1 as it is newly released.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project