### PR TITLE
spark: don't fail on exception of UnknownEntryFacet creation

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -147,7 +147,8 @@ class LogicalPlanSerializer {
     "canonicalized",
     "constraints",
     "data",
-    "deltaLog"
+    "deltaLog",
+    "limitExpr"
   })
   @SuppressWarnings("PMD")
   abstract class ChildMixIn {}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -53,6 +53,15 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
   }
 
   public Optional<UnknownEntryFacet> build(LogicalPlan root) {
+    try {
+      return buildFacet(root);
+    } catch (Exception exception) {
+      log.warn("Failed to serialize unknown entry facet: %s", exception);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<UnknownEntryFacet> buildFacet(LogicalPlan root) {
     Optional<UnknownEntryFacet.FacetEntry> output = mapEntry(root);
     List<UnknownEntryFacet.FacetEntry> inputs =
         ScalaConversionUtils.fromSeq(root.collectLeaves()).stream()


### PR DESCRIPTION
Failing to generate UnknownEntryFacet should not result in event not being send.