### PR TITLE
[SPARK] Ensure that we only release Scala 2.12 variants for now

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -169,7 +169,7 @@ jobs:
           ./gradlew --no-daemon --console=plain publishToMavenLocal
           cd -
           # Publish *.jar
-          ./gradlew --no-daemon --console=plain publish
+          ./gradlew --no-daemon --console=plain publish -Pscala.binary.version=2.12
       - store_artifacts:
           path: ./build/libs
           destination: spark-client-artifacts


### PR DESCRIPTION
### Problem

Recent changes to the Spark integration have resulted us in being able to compile and test with Scala 2.12 and Scala 2.13. However, we still need to create explicit publish steps for Scala 2.12 and Scala 2.13 to prevent runtime failures.

### Solution

Here, we force the `release-integration-spark` to set the `scala.binary.version` property to 2.12, via `-Pscala.binary.version=2.12`

#### One-line summary: Ensure the CI/CD `release-integration-spark` step in the CI/CD pipeline only publishes the Scala 2.12 variant for now.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project