### PR TITLE
[SPARK]Added the capability to publish Scala 2.12 and 2.13 variants of `openlineage-spark`

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -169,7 +169,8 @@ jobs:
           ./gradlew --no-daemon --console=plain publishToMavenLocal
           cd -
           # Publish *.jar
-          ./gradlew --no-daemon --console=plain publish
+          ./gradlew --no-daemon --console=plain clean publish -Pscala.binary.version=2.12
+          ./gradlew --no-daemon --console=plain clean publish -Pscala.binary.version=2.13
       - store_artifacts:
           path: ./build/libs
           destination: spark-client-artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * **SPARK: Build and test the Spark integration in the CI/CD pipelines with Scala 2.12 and Scala 2.13 (https://github.com/OpenLineage/OpenLineage/pull/2432) [@d-m-h](https://github.com/d-m-h)
     *Several new integration test steps were added*
 * **SPARK: Streamlined the testing of the 'app' module by removing unnecessary test types, such as 'beforeShadowJarTest' (https://github.com/OpenLineage/OpenLineage/pull/2432) [@d-m-h](https://github.com/d-m-h)
+* **SPARK: Added the capability to publish Scala 2.12 and 2.13 variants of `openlineage-spark`. (https://github.com/OpenLineage/OpenLineage/pull/2446) [@d-m-h](https://github.com/d-m-h)
+    *This means that the `openlineage-spark` integration can be run alongside Scala 2.12 and Scala 2.13 variants of Apache Spark.*
 
 ### Added
 * **FLINK: bump default Flink version to 1.18.1 (https://github.com/OpenLineage/OpenLineage/pull/2418) [@HuangZhenQiu](https://github.com/HuangZhenQiu)

--- a/integration/spark/README.md
+++ b/integration/spark/README.md
@@ -4,21 +4,43 @@ The OpenLineage Spark Agent uses jvm instrumentation to emit OpenLineage metadat
 
 ## Installation
 
+### Version 1.8.0 or earlier
+
 Maven:
 
 ```xml
 <dependency>
     <groupId>io.openlineage</groupId>
     <artifactId>openlineage-spark</artifactId>
-    <version>1.8.0</version>
+    <version>${OPEN_LINEAGE_VERSION}</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```groovy
-implementation 'io.openlineage:openlineage-spark:1.8.0'
+implementation("io.openlineage:openlineage-spark:${OPEN_LINEAGE_VERSION}")
 ```
+
+### Version 1.9.0 or later
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>io.openlineage</groupId>
+    <artifactId>openlineage-spark_${SCALA_BINARY_VERSION}</artifactId>
+    <version>${OPEN_LINEAGE_VERSION}</version>
+</dependency>
+```
+
+or Gradle:
+
+```groovy
+implementation("io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:${OPEN_LINEAGE_VERSION}")
+```
+
+**Replace `${SCALA_BINARY_VERSION}` with the appropriate Scala version, e.g., `2.12` or `2.13`.**
 
 ## Getting started
 

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -222,6 +222,11 @@ tasks.named("shadowJar", ShadowJar.class) {
         exclude(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
     }
 
+    dependencies {
+        exclude(dependency("org.slf4j::"))
+        exclude("org/apache/commons/logging/**")
+    }
+
     relocate 'com.github.ok2c.hc5', 'io.openlineage.spark.shaded.com.github.ok2c.hc5'
     relocate 'org.apache.httpcomponents.client5', 'io.openlineage.spark.shaded.org.apache.httpcomponents.client5'
     relocate 'javassist', 'io.openlineage.spark.shaded.javassist'
@@ -231,8 +236,6 @@ tasks.named("shadowJar", ShadowJar.class) {
     relocate 'org.apache.commons.beanutils', 'io.openlineage.spark.shaded.org.apache.commons.beanutils'
     relocate 'org.apache.http', 'io.openlineage.spark.shaded.org.apache.http'
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
-    // TODO: Why are we relocating slf4j?
-    // relocate 'org.slf4j', 'io.openlineage.spark.shaded.org.slf4j'
     relocate('com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson') {
         exclude 'com.fasterxml.jackson.annotation.JsonIgnore'
         exclude 'com.fasterxml.jackson.annotation.JsonIgnoreProperties'

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -2,54 +2,37 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id("java-library")
-    id("pmd")
-    id("com.diffplug.spotless")
-    id("io.freefair.lombok")
     id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
-    id 'maven-publish'
-    id 'signing'
-    id 'jacoco'
+    id("maven-publish")
+    id("signing")
+    id("jacoco")
 }
-
-archivesBaseName = 'openlineage-spark'
 
 ext {
-    isReleaseVersion = !version.endsWith('SNAPSHOT')
-    jacksonVersion = "2.13.2"
-    jacksonDatabindVersion = "2.13.2.2"
+    isReleaseVersion = !version.endsWith("SNAPSHOT")
+    scala = project.findProperty("scala.binary.version").toString()
+    scalaFmt = scala.replace(".", "")
 }
+
+final def archiveBaseName = "openlineage-spark_${scala}"
+final def activeRuntimeElementsConfiguration = "scala${scalaFmt}RuntimeElements"
 
 dependencies {
     implementation(project(path: ":app"))
-    implementation(project(path: ":shared"))
+    implementation(project(path: ":shared", configuration: activeRuntimeElementsConfiguration))
     implementation(project(path: ":spark2"))
-    implementation(project(path: ":spark3"))
+    implementation(project(path: ":spark3", configuration: activeRuntimeElementsConfiguration))
     implementation(project(path: ":spark31"))
-    implementation(project(path: ":spark32"))
-    implementation(project(path: ":spark33"))
-    implementation(project(path: ":spark34"))
-    implementation(project(path: ":spark35"))
+    implementation(project(path: ":spark32", configuration: activeRuntimeElementsConfiguration))
+    implementation(project(path: ":spark33", configuration: activeRuntimeElementsConfiguration))
+    implementation(project(path: ":spark34", configuration: activeRuntimeElementsConfiguration))
+    implementation(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
     implementation(project(path: ":snowflake"))
 }
 
-
-task sourceJar(type: Jar) {
-    archiveClassifier = 'sources'
-    from sourceSets.main.allJava
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-javadoc {
-    options.tags = ["apiNote"]
-}
-
-def reportsDir = "${buildDir}/reports";
-def coverageDir = "${reportsDir}/coverage";
+final def reportsDir = "${buildDir}/reports";
+final def coverageDir = "${reportsDir}/coverage";
 
 jacoco {
     toolVersion = '0.8.5'
@@ -68,52 +51,52 @@ jacocoTestReport {
     }
 }
 
-tasks.withType(GenerateModuleMetadata) {
+tasks.withType(Jar).configureEach {
+    it.archiveBaseName = archiveBaseName
+}
+
+tasks.withType(GenerateModuleMetadata.class).configureEach {
     enabled = false
 }
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'io.openlineage'
-            artifactId = 'openlineage-spark'
+            groupId = "io.openlineage"
+            artifactId = "openlineage-spark_${scala}"
 
             from components.java
 
-            artifact sourceJar
-            artifact javadocJar
-
             pom {
-                name = 'openlineage-spark'
-                description = 'OpenLineage Spark integration'
-                url = 'https://github.com/OpenLineage/OpenLineage'
+                name = "openlineage-spark_${scala}"
+                description = "OpenLineage Spark integration for Scala binary version ${scala}"
+                url = "https://github.com/OpenLineage/OpenLineage"
                 licenses {
                     license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
                 developers {
                     developer {
-                        id = 'openlineage'
-                        name = 'OpenLineage Project'
+                        id = "openlineage"
+                        name = "OpenLineage Project"
                     }
                 }
                 scm {
-                    connection = 'scm:git:git://github.com/OpenLineage/OpenLineage.git'
-                    developerConnection = 'scm:git:ssh://github.com:OpenLineage/OpenLineage.git'
-                    url = 'https://github.com/OpenLineage/OpenLineage'
+                    connection = "scm:git:git://github.com/OpenLineage/OpenLineage.git"
+                    developerConnection = "scm:git:ssh://github.com:OpenLineage/OpenLineage.git"
+                    url = "https://github.com/OpenLineage/OpenLineage"
                 }
             }
 
             pom.withXml {
-                asNode().dependencies.'*'.findAll() {
-                    it.groupId.text() == 'spark'
+                asNode().dependencies."*".findAll() {
+                    it.groupId.text() == "spark"
                 }.each() {
                     it.parent().remove(it)
                 }
             }
-
         }
     }
 
@@ -125,11 +108,12 @@ publishing {
 
     repositories {
         maven {
-            url = isReleaseVersion ? 'https://oss.sonatype.org/service/local/staging/deploy/maven2' :
-                    'https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot'
+            url = isReleaseVersion
+                    ? "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                    : "https://astronomer.jfrog.io/artifactory/maven-public-libs-snapshot"
             credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
+                username = System.getenv("RELEASE_USERNAME")
+                password = System.getenv("RELEASE_PASSWORD")
             }
         }
     }
@@ -144,61 +128,43 @@ signing {
 }
 
 shadowJar {
+    archiveClassifier = ""
+
     minimize() {
-        exclude(project(":shared"))
-        exclude(project(":spark2"))
-        exclude(project(":spark3"))
-        exclude(project(":spark31"))
-        exclude(project(":spark32"))
-        exclude(project(":spark33"))
-        exclude(project(":spark34"))
-        exclude(project(":spark35"))
-        exclude (project(":snowflake"))
-        exclude(project(":app"))
+        exclude(project(path: ":app"))
+        exclude(project(path: ":shared", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark2"))
+        exclude(project(path: ":spark3", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark31"))
+        exclude(project(path: ":spark32", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark33", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark34", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
+        exclude(project(path: ":snowflake"))
     }
+
     dependencies {
-        exclude(dependency('org.slf4j::'))
-        exclude('org/apache/commons/logging/**')
+        exclude(dependency("org.slf4j::"))
+        exclude("org/apache/commons/logging/**")
     }
-    archiveClassifier = ''
-    // avoid conflict with any client version of that lib
-    relocate 'com.github.ok2c.hc5', 'io.openlineage.spark.shaded.com.github.ok2c.hc5'
-    relocate 'org.apache.httpcomponents.client5', 'io.openlineage.spark.shaded.org.apache.httpcomponents.client5'
-    relocate 'javassist', 'io.openlineage.spark.shaded.javassist'
-    relocate 'org.apache.hc', 'io.openlineage.spark.shaded.org.apache.hc'
-    relocate 'org.apache.commons.codec', 'io.openlineage.spark.shaded.org.apache.commons.codec'
-    relocate 'org.apache.commons.lang3', 'io.openlineage.spark.shaded.org.apache.commons.lang3'
-    relocate 'org.apache.commons.beanutils', 'io.openlineage.spark.shaded.org.apache.commons.beanutils'
-    relocate 'org.apache.http', 'io.openlineage.spark.shaded.org.apache.http'
-    relocate 'com.fasterxml.jackson', 'io.openlineage.spark.shaded.com.fasterxml.jackson'
+
+    relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
+    relocate "org.apache.httpcomponents.client5", "io.openlineage.spark.shaded.org.apache.httpcomponents.client5"
+    relocate "javassist", "io.openlineage.spark.shaded.javassist"
+    relocate "org.apache.hc", "io.openlineage.spark.shaded.org.apache.hc"
+    relocate "org.apache.commons.codec", "io.openlineage.spark.shaded.org.apache.commons.codec"
+    relocate "org.apache.commons.lang3", "io.openlineage.spark.shaded.org.apache.commons.lang3"
+    relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
+    relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
+    relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
     manifest {
         attributes(
-                'Created-By': "Gradle ${gradle.gradleVersion}",
-                'Built-By': System.getProperty('user.name'),
-                'Build-Jdk': System.getProperty('java.version'),
-                'Implementation-Title': project.name,
-                'Implementation-Version': project.version
+                "Created-By": "Gradle ${gradle.gradleVersion}",
+                "Built-By": System.getProperty("user.name"),
+                "Build-Jdk": System.getProperty("java.version"),
+                "Implementation-Title": project.name,
+                "Implementation-Version": project.version
         )
     }
     zip64 true
-}
-
-assemble {
-    dependsOn shadowJar
-}
-
-task createVersionProperties(dependsOn: processResources) {
-    doLast {
-        File dir = new File("$buildDir/resources/main/io/openlineage/spark/agent/")
-        dir.mkdirs();
-        new File("$buildDir/resources/main/io/openlineage/spark/agent/version.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
-    }
-}
-
-classes {
-    dependsOn createVersionProperties
 }

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation(project(path: ":snowflake"))
 }
 
-final def reportsDir = "${buildDir}/reports";
-final def coverageDir = "${reportsDir}/coverage";
+def reportsDir = "${buildDir}/reports";
+def coverageDir = "${reportsDir}/coverage";
 
 jacoco {
     toolVersion = '0.8.5'


### PR DESCRIPTION
### Problem

Recent changes to the Spark integration have resulted us in being able to compile and test with Scala 2.12 and Scala 2.13.

Now, we need to publish things.

### Solution

Here, we add a new publish step to the `release-integration-spark` step.

First, we publish with `-Pscala.binary.version=2.12` and then `-Pscala.binary.version=2.13`.

We also modify the `integration/spark/build.gradle` file to source the correct variants of the modules.

We also updated the docs.

#### One-line summary: Added the capability to publish Scala 2.12 and 2.13 variants of `openlineage-spark`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project