### PR TITLE
[DBT] Add a warning log instead of make the job fail in case of failed emit

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -207,15 +207,18 @@ def main():
             job_name=dbt_run_metadata.job_name,
             parent_run_metadata=parent_run_metadata,
         )
-
+    event: RunEvent
     for event in tqdm(
         events + [last_event],
         desc="Emitting OpenLineage events",
         initial=1,
         total=len(events) + 2,
     ):
-        client.emit(event)
-
+        try:
+            client.emit(event)
+        except Exception as e:
+            logger.warning("OpenLineage client failed to emit event %s runId %s. "
+                           "Exception: %s", event.eventType.value, event.run.runId, e, exc_info=True)
     logger.info(f"Emitted {len(events) + 2} openlineage events")
 
 

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -152,8 +152,10 @@ def main():
     )
 
     # Failed start event emit should not stop dbt command from running.
+    emitted_events = 0
     try:
         client.emit(start_event)
+        emitted_events += 1
     except Exception as e:
         logger.warning("OpenLineage client failed to emit start event. Exception: %s", e)
 
@@ -216,6 +218,7 @@ def main():
     ):
         try:
             client.emit(event)
+            emitted_events += 1
         except Exception as e:
             logger.warning(
                 "OpenLineage client failed to emit event %s runId %s. " "Exception: %s",
@@ -224,7 +227,7 @@ def main():
                 e,
                 exc_info=True,
             )
-    logger.info(f"Emitted {len(events) + 2} openlineage events")
+    logger.info(f"Emitted {emitted_events} openlineage events")
 
 
 if __name__ == "__main__":

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -209,7 +209,6 @@ def main():
             job_name=dbt_run_metadata.job_name,
             parent_run_metadata=parent_run_metadata,
         )
-    event: RunEvent
     for event in tqdm(
         events + [last_event],
         desc="Emitting OpenLineage events",

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -217,8 +217,13 @@ def main():
         try:
             client.emit(event)
         except Exception as e:
-            logger.warning("OpenLineage client failed to emit event %s runId %s. "
-                           "Exception: %s", event.eventType.value, event.run.runId, e, exc_info=True)
+            logger.warning(
+                "OpenLineage client failed to emit event %s runId %s. " "Exception: %s",
+                event.eventType.value,
+                event.run.runId,
+                e,
+                exc_info=True,
+            )
     logger.info(f"Emitted {len(events) + 2} openlineage events")
 
 


### PR DESCRIPTION
### Problem

In the DBT OL wrapper, in case of transport failure to emit the event, the whole job will fail even without failure. 
This behaviour adds another point of failure to the DBT job.

### Solution

Catch any exception from the `client.emit(event)` and log a warning to report the issue.
The transport must implement proper logic of retry with the Circuit Breaker pattern.

#### One-line summary:

Making the OL DBT wrapper more resilient and avoiding failure in case OL transport is unavailable.
### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project