### PR TITLE
spark: use prebuild Spark images from quay.io

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id("io.freefair.lombok")
     id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
-    id("io.openlineage.docker-build")
+//    id("io.openlineage.docker-build")
     id "com.adarshr.test-logger" version "3.2.0"
     id "org.gradle.test-retry" version "1.5.8"
 }
@@ -168,7 +168,7 @@ def testSystemProperties = { String spark, String scala ->
             "mockserver.logLevel"                 : "ERROR",
             "resources.dir"                       : testResourcesDir.get().asFile.absolutePath,
             "scala.fixtures.jar.name"             : scalaFixturesJarName.toString(),
-            "spark.docker.image"                  : "openlineage/spark:spark-${spark}-scala-${scala}",
+            "spark.docker.image"                  : "quay.io/openlineage/spark:spark-${spark}-scala-${scala}",
             "spark.home.dir"                      : "/opt/bitnami/spark",
             "spark.sql.warehouse.dir"             : sparkWarehouseDir.get().asFile.absolutePath,
             "spark.version"                       : spark,
@@ -354,14 +354,14 @@ tasks.register("createVersionProperties") {
     }
 }
 
-tasks.register("buildDockerImage") {
-    group = "docker"
-    description = "Selects the appropriate docker image build task based on the values of spark version and scala binary version"
-    def sparkFmt = spark.replace(".", "")
-    def scalaFmt = scala.replace(".", "")
-    def taskName = "buildDockerImageSpark${sparkFmt}Scala${scalaFmt}"
-    dependsOn(tasks.named(taskName))
-}
+//tasks.register("buildDockerImage") {
+//    group = "docker"
+//    description = "Selects the appropriate docker image build task based on the values of spark version and scala binary version"
+//    def sparkFmt = spark.replace(".", "")
+//    def scalaFmt = scala.replace(".", "")
+//    def taskName = "buildDockerImageSpark${sparkFmt}Scala${scalaFmt}"
+//    dependsOn(tasks.named(taskName))
+//}
 
 def integrationTestDependencies = [
         tasks.named("shadowJar"),
@@ -369,7 +369,7 @@ def integrationTestDependencies = [
         tasks.named("copyIntegrationTestFixtures"),
         tasks.named("copyAdditionalJars"),
         tasks.named("copyAdditionalConfiguration"),
-        tasks.named("buildDockerImage"),
+//        tasks.named("buildDockerImage"),
 ]
 
 tasks.register("integrationTest", Test.class) {

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -35,9 +35,9 @@ gradlePlugin {
             implementationClass = "io.openlineage.gradle.plugin.ScalaVariantsPlugin"
         }
 
-        create("dockerBuild") {
-            id = "io.openlineage.docker-build"
-            implementationClass = "io.openlineage.gradle.plugin.docker.DockerBuildPlugin"
-        }
+//        create("dockerBuild") {
+//            id = "io.openlineage.docker-build"
+//            implementationClass = "io.openlineage.gradle.plugin.docker.DockerBuildPlugin"
+//        }
     }
 }

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -1,6 +1,6 @@
 jdk8.build=true
 version=1.9.0-SNAPSHOT
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx4G
 
 spark.version=3.3.4
 scala.binary.version=2.12


### PR DESCRIPTION
**PROBLEM**

The CI/CD pipeline sometimes times out when building the docker images needed for the integration test, due to throttling that the Apache archive applies to the downloads of the Spark binaries.

**SOLUTION**

We built and pushed Spark images to `quay.io` under the `openlineage/spark` repository. We now use those images in the integration tests.