### PR TITLE
[FLINK] Add the "isReleaseVersion" property back to integration/flink/build.gradle

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -51,6 +51,7 @@ archivesBaseName='openlineage-flink'
 ext {
     flinkVersion = project.getProperty('flink.version')
     flinkVersionShort = flinkVersion.substring(0,4)
+    isReleaseVersion = !version.endsWith('-SNAPSHOT')
 }
 
 dependencies {


### PR DESCRIPTION
### Problem

A release was cut (1.9.0), however a small item was missed during the review process of a PR that modified the structure of the flink integration. This resulted in the `isReleaseVersion` being deleted, and thus not being available for the signing of the JARs.

Closes: #2467 

### Solution

#### One-line summary: Added the 'isReleaseVersion' property back to the root build.gradle file for the Apache Flink integration. 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project