### PR TITLE
[SPARK][FLINK][JAVA] http timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.9.1...HEAD)
+### Added
 * **Flink: improve Cassandra lineage metadata** (https://github.com/OpenLineage/OpenLineage/pull/2479) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
   *Use Cassandra cluster info as dataset namespace, and combine keyspace with table name as dataset name.*
 * **Flink: bump Flink JDBC connector version to 3.1.2-1.18 for Flink 1.18** (https://github.com/OpenLineage/OpenLineage/pull/2472) [@HuangZhenQiu](https://github.com/HuangZhenQiu)  
   *Bump Flink JDBC connector version to 3.1.2-1.18 for Flink 1.18.*
+
+### Fixed
+* **Spark: fix `HttpTransport` timeout.** [`#2475`](https://github.com/OpenLineage/OpenLineage/pull/2475) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Existing `timeout` config parameter is ambiguous: implementation treats value as double in seconds, although documentation claims it's milliseconds. New config param `timeoutInMillis` is added. Existing `timeout` gets removed from docs and will be deprecated in 1.13.*
+
 
 ## [1.9.1](https://github.com/OpenLineage/OpenLineage/compare/1.8.0...1.9.1) - 2024-02-26
 ### Added

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -22,7 +22,12 @@ import lombok.With;
 public final class HttpConfig implements TransportConfig {
   @Getter @Setter private URI url;
   @Getter @Setter private @Nullable String endpoint;
-  @Getter @Setter private @Nullable Double timeout;
+
+  @Getter @Setter
+  private @Nullable Double
+      timeout; // deprecated, will be removed in 1.13, assumes timeout is in seconds
+
+  @Getter @Setter private @Nullable Integer timeoutInMillis;
   @Getter @Setter private @Nullable TokenProvider auth;
   @Getter @Setter private @Nullable Map<String, String> urlParams;
   @Getter @Setter private @Nullable Map<String, String> headers;

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -47,15 +47,19 @@ public final class HttpTransport extends Transport implements Closeable {
   private final Map<String, String> headers;
 
   public HttpTransport(@NonNull final HttpConfig httpConfig) {
-    this(withTimeout(httpConfig.getTimeout()), httpConfig);
+    this(withTimeout(httpConfig), httpConfig);
   }
 
-  private static CloseableHttpClient withTimeout(Double timeout) {
+  private static CloseableHttpClient withTimeout(HttpConfig httpConfig) {
     int timeoutMs;
-    if (timeout == null) {
-      timeoutMs = 5000;
+    if (httpConfig.getTimeout() != null) {
+      // deprecated approach, value in seconds as double provided
+      timeoutMs = (int) (httpConfig.getTimeout() * 1000);
+    } else if (httpConfig.getTimeoutInMillis() != null) {
+      timeoutMs = httpConfig.getTimeoutInMillis();
     } else {
-      timeoutMs = (int) (timeout * 1000);
+      // default one
+      timeoutMs = 5000;
     }
 
     RequestConfig config =


### PR DESCRIPTION
### Problem

Documentation says timeout should be provided in millis
![Screenshot 2024-02-28 at 09 56 37](https://github.com/OpenLineage/OpenLineage/assets/1646950/0f8f2a33-187c-4da2-a126-6ee2145be598)

But the code treats it as if it was provided in seconds 

Fixes #2474

### Solution

 * Write failing test
 * Modify the code 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project