### PR TITLE
[FLINK] protobuf support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.13.1...HEAD)
 
+### Added
+* **Flink: support Protobuf format for sources and sinks** [`#2482`](https://github.com/OpenLineage/OpenLineage/pull/2482) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Extracts schema from Protobuf classes. Supports nested object types, `array` type, `map` type, `oneOf` and `any`.*
+
+
 ## [1.13.1](https://github.com/OpenLineage/OpenLineage/compare/1.12.0...1.13.1) - 2024-04-25
 ### Added
 * **Java: allow timeout for circuit breakers** [`#2609`](https://github.com/OpenLineage/OpenLineage/pull/2609) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -433,6 +433,18 @@ class ContainerTest {
             });
   }
 
+  @Test
+  void testProtobuf() {
+    Properties jobProperties = new Properties();
+    jobProperties.put("inputTopics", "io.openlineage.flink.kafka.protobuf_input");
+    jobProperties.put("outputTopics", "io.openlineage.flink.kafka.protobuf_output");
+    jobProperties.put("jobName", "flink_protobuf");
+    runUntilCheckpoint(
+        "io.openlineage.flink.FlinkProtobufApplication", jobProperties, generateEvents);
+
+    verify("events/expected_protobuf.json");
+  }
+
   @SneakyThrows
   private JsonBody readJson(Path path) {
     return json(new String(readAllBytes(path)), MatchType.ONLY_MATCHING_FIELDS);

--- a/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -24,9 +24,9 @@ import org.testcontainers.utility.MountableFile;
 
 public class FlinkContainerUtils {
 
-  private static final String CONFLUENT_VERSION = "6.2.1";
+  private static final String CONFLUENT_VERSION = "7.6.0";
   private static final String SCHEMA_REGISTRY_IMAGE = getRegistryImage();
-  private static final String KAFKA_IMAGE = "wurstmeister/kafka:2.13-2.8.1";
+  private static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.6.0";
   private static final String ZOOKEEPER_IMAGE = "confluentinc/cp-zookeeper:" + CONFLUENT_VERSION;
   private static final String CASSANDRA_IMAGE = "cassandra:3.11.16";
   private static final String POSTGRES_IMAGE = "postgres";
@@ -37,7 +37,6 @@ public class FlinkContainerUtils {
   static MockServerContainer makeMockServerContainer(Network network) {
     return new MockServerContainer(
             DockerImageName.parse("jamesdbloom/mockserver:mockserver-5.12.0"))
-        .withLogConsumer(of -> consumeOutput("mockserver", of))
         .withNetwork(network)
         .withNetworkAliases("openlineageclient");
   }
@@ -48,6 +47,7 @@ public class FlinkContainerUtils {
         .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
         .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
         .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://schema-registry:8081,http://0.0.0.0:28081")
+        .withEnv("SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL", "WARN")
         .dependsOn(startable);
   }
 
@@ -78,10 +78,12 @@ public class FlinkContainerUtils {
                 + "io.openlineage.flink.kafka.output:1:1,"
                 + "io.openlineage.flink.kafka.output1:1:1,"
                 + "io.openlineage.flink.kafka.output2:1:1,"
+                + "io.openlineage.flink.kafka.output_protobuf:1:1,"
                 + "io.openlineage.flink.kafka.input_no_schema_registry:1:1")
         .withEnv(
             "KAFKA_LOG4J_LOGGERS",
-            "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO")
+            "kafka.controller=WARN,kafka.producer.async.DefaultEventHandler=WARN,state.change.logger=INFO")
+        .withEnv("LOG4J_LOGGER_KAFKA", "WARN")
         .dependsOn(zookeeper);
   }
 
@@ -92,12 +94,19 @@ public class FlinkContainerUtils {
             MountableFile.forHostPath(Resources.getResource("InputEvent.avsc").getPath()),
             "/tmp/InputEvent.avsc")
         .withCopyFileToContainer(
+            MountableFile.forHostPath(Resources.getResource("InputEvent.proto").getPath()),
+            "/tmp/InputEvent.proto")
+        .withCopyFileToContainer(
             MountableFile.forHostPath(Resources.getResource("events.json").getPath()),
             "/tmp/events.json")
+        .withCopyFileToContainer(
+            MountableFile.forHostPath(Resources.getResource("events_proto.json").getPath()),
+            "/tmp/events_proto.json")
         .withCommand(
             "/bin/bash",
             "-c",
             Resources.toString(Resources.getResource("generate_events.sh"), StandardCharsets.UTF_8))
+        .withEnv("SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL", "WARN")
         .dependsOn(initTopics);
   }
 
@@ -105,7 +114,8 @@ public class FlinkContainerUtils {
     return genericContainer(network, ZOOKEEPER_IMAGE, "zookeeper")
         .withExposedPorts(2181)
         .withEnv("ZOOKEEPER_CLIENT_PORT", "2181")
-        .withEnv("ZOOKEEPER_SERVER_ID", "1");
+        .withEnv("ZOOKEEPER_SERVER_ID", "1")
+        .withEnv("ZOOKEEPER_LOG4J_ROOT_LOGLEVEL", "WARN");
   }
 
   static GenericContainer<?> makeJdbcContainer(Network network) {
@@ -186,6 +196,10 @@ public class FlinkContainerUtils {
             .withCopyFileToContainer(
                 MountableFile.forHostPath(Resources.getResource("openlineage.yml").getPath()),
                 configPath)
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(
+                    Resources.getResource("log4j-console.properties").getPath()),
+                "/opt/flink/conf/log4j-console.properties")
             .withCommand(
                 "standalone-job "
                     + String.format("--job-classname %s ", entrypointClass)
@@ -209,6 +223,9 @@ public class FlinkContainerUtils {
         .withFileSystemBind(getOpenLineageJarPath(), "/opt/flink/lib/openlineage.jar")
         .withFileSystemBind(getExampleAppJarPath(), "/opt/flink/lib/example-app.jar")
         .withCopyFileToContainer(MountableFile.forHostPath("../data/iceberg"), "/tmp/warehouse/")
+        .withCopyFileToContainer(
+            MountableFile.forHostPath(Resources.getResource("log4j-console.properties").getPath()),
+            "/opt/flink/conf/log4j-console.properties")
         .withEnv(
             "FLINK_PROPERTIES",
             "jobmanager.rpc.address: jobmanager"
@@ -235,7 +252,9 @@ public class FlinkContainerUtils {
 
     // list of log entries that should stop the test
     return logs.contains("New checkpoint encountered")
-        || logs.contains("Shutting down remote daemon.");
+        || logs.contains("Shutting down remote daemon.")
+        || logs.contains(
+            "Terminating cluster entrypoint process StandaloneApplicationClusterEntryPoint with exit code 0.");
   }
 
   static GenericContainer<?> genericContainer(Network network, String image, String hostname) {
@@ -287,9 +306,6 @@ public class FlinkContainerUtils {
   }
 
   private static String getRegistryImage() {
-    if ("aarch64".equals(System.getProperty("os.arch"))) {
-      return "eugenetea/schema-registry-arm64:latest";
-    }
     return "confluentinc/cp-schema-registry:" + CONFLUENT_VERSION;
   }
 }

--- a/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -69,17 +69,9 @@ public class FlinkContainerUtils {
         .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
-        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+        .withEnv("TOPIC_AUTO_CREATE", "true")
+        .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
         .withEnv("KAFKA_BROKER_ID", "1")
-        .withEnv(
-            "KAFKA_CREATE_TOPICS",
-            "io.openlineage.flink.kafka.input1:1:1,"
-                + "io.openlineage.flink.kafka.input2:1:1,"
-                + "io.openlineage.flink.kafka.output:1:1,"
-                + "io.openlineage.flink.kafka.output1:1:1,"
-                + "io.openlineage.flink.kafka.output2:1:1,"
-                + "io.openlineage.flink.kafka.output_protobuf:1:1,"
-                + "io.openlineage.flink.kafka.input_no_schema_registry:1:1")
         .withEnv(
             "KAFKA_LOG4J_LOGGERS",
             "kafka.controller=WARN,kafka.producer.async.DefaultEventHandler=WARN,state.change.logger=INFO")

--- a/integration/flink/app/src/test/resources/InputEvent.proto
+++ b/integration/flink/app/src/test/resources/InputEvent.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package io.openlineage.flink.proto.event;
+option java_package = "io.openlineage.flink.proto.event";
+option java_multiple_files = true;
+
+message InputEvent {
+  string id = 1;
+  int64 version = 2;
+  SubInputEvent subEvent = 3;
+}
+
+message SubInputEvent {
+  string id = 1;
+  SubSubInputEvent subSubEvent = 2;
+  repeated int64 arr = 3;
+}
+
+message SubSubInputEvent {
+  string id = 1;
+  int64 version = 2;
+}

--- a/integration/flink/app/src/test/resources/events/expected_protobuf.json
+++ b/integration/flink/app/src/test/resources/events/expected_protobuf.json
@@ -1,0 +1,137 @@
+{
+  "eventType" : "START",
+  "eventTime": "${json-unit.any-string}",
+  "job" : {
+    "namespace" : "flink_job_namespace",
+    "name": "flink_protobuf",
+    "facets": {
+      "jobType": {
+        "processingType" : "STREAMING",
+        "jobType" : "JOB",
+        "integration": "FLINK"
+      }
+    }
+  },
+  "run": {
+    "runId": "${json-unit.any-string}"
+  },
+  "inputs": [
+    {
+      "namespace": "kafka://kafka:9092",
+      "name": "io.openlineage.flink.kafka.protobuf_input",
+      "facets" : {
+        "schema" : {
+          "fields" : [ {
+            "name" : "id",
+            "type" : "string",
+            "description" : "",
+            "fields" : [ ]
+          }, {
+            "name" : "version",
+            "type" : "int64",
+            "description" : "",
+            "fields" : [ ]
+          }, {
+            "name" : "subEvent",
+            "type" : "io.openlineage.flink.proto.event.SubInputEvent",
+            "description" : "",
+            "fields" : [ {
+              "name" : "id",
+              "type" : "string",
+              "description" : "",
+              "fields" : [ ]
+            }, {
+              "name" : "subSubEvent",
+              "type" : "io.openlineage.flink.proto.event.SubSubInputEvent",
+              "description" : "",
+              "fields" : [ {
+                "name" : "id",
+                "type" : "string",
+                "description" : "",
+                "fields" : [ ]
+              }, {
+                "name" : "version",
+                "type" : "int64",
+                "description" : "",
+                "fields" : [ ]
+              } ]
+            }, {
+              "name" : "arr",
+              "type" : "int64",
+              "description" : "",
+              "fields" : [ ]
+            } ]
+          } ]
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "kafka://kafka:9092",
+      "name": "io.openlineage.flink.kafka.protobuf_output",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "",
+              "fields": []
+            },
+            {
+              "name": "version",
+              "type": "int64",
+              "description": "",
+              "fields": []
+            },
+            {
+              "name": "counter",
+              "type": "int64",
+              "description": "",
+              "fields": []
+            },
+            {
+              "name": "subEvent",
+              "type": "io.openlineage.flink.proto.event.SubOutputEvent",
+              "description": "",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "string",
+                  "description": "",
+                  "fields": []
+                },
+                {
+                  "name": "subSubEvent",
+                  "type": "io.openlineage.flink.proto.event.SubSubOutputEvent",
+                  "description": "",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": "string",
+                      "description": "",
+                      "fields": []
+                    },
+                    {
+                      "name": "version",
+                      "type": "int64",
+                      "description": "",
+                      "fields": []
+                    }
+                  ]
+                },
+                {
+                  "name": "arr",
+                  "type": "int64",
+                  "description": "",
+                  "fields": []
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/flink/app/src/test/resources/events_proto.json
+++ b/integration/flink/app/src/test/resources/events_proto.json
@@ -1,0 +1,5 @@
+{ "id":  "some-id-1", "version":  7, "subEvent": {  "id": "sub-id-1", "subSubEvent": { "id": "sub-sub-1", "version":  1 }, "arr": [ 1, 2] } }
+{ "id":  "some-id-1", "version":  7, "subEvent": {  "id": "sub-id-1", "subSubEvent": { "id": "sub-sub-1", "version":  1 }, "arr": [ 1, 2] } }
+{ "id":  "some-id-1", "version":  7, "subEvent": {  "id": "sub-id-1", "subSubEvent": { "id": "sub-sub-1", "version":  1 }, "arr": [ 1, 2] } }
+{ "id":  "some-id-1", "version":  7, "subEvent": {  "id": "sub-id-1", "subSubEvent": { "id": "sub-sub-1", "version":  1 }, "arr": [ 1, 2] } }
+{ "id":  "some-id-1", "version":  7, "subEvent": {  "id": "sub-id-1", "subSubEvent": { "id": "sub-sub-1", "version":  1 }, "arr": [ 1, 2] } }

--- a/integration/flink/app/src/test/resources/generate_events.sh
+++ b/integration/flink/app/src/test/resources/generate_events.sh
@@ -8,6 +8,13 @@ kafka-avro-console-producer \
   --broker-list kafka:9092 \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema="$(< /tmp/InputEvent.avsc)" < /tmp/events.json &&
+echo 'input1 and input2 produced' &&
+kafka-protobuf-console-producer \
+  --topic io.openlineage.flink.kafka.protobuf_input \
+  --broker-list kafka:9092 \
+  --property schema.registry.url=http://schema-registry:8081 \
+  --property value.schema="$(< /tmp/InputEvent.proto)" < /tmp/events_proto.json &&
+echo 'input_protobuf produced' &&
 kafka-avro-console-producer \
   --topic io.openlineage.flink.kafka.input_no_schema_registry \
   --broker-list kafka:9092 \

--- a/integration/flink/app/src/test/resources/generate_events.sh
+++ b/integration/flink/app/src/test/resources/generate_events.sh
@@ -14,9 +14,4 @@ kafka-protobuf-console-producer \
   --broker-list kafka:9092 \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema="$(< /tmp/InputEvent.proto)" < /tmp/events_proto.json &&
-echo 'input_protobuf produced' &&
-kafka-avro-console-producer \
-  --topic io.openlineage.flink.kafka.input_no_schema_registry \
-  --broker-list kafka:9092 \
-  --property value.schema="$(< /tmp/InputEvent.avsc)" < /tmp/events.json &&
-echo 'Events emitted'
+echo 'input_protobuf produced'

--- a/integration/flink/app/src/test/resources/log4j-console.properties
+++ b/integration/flink/app/src/test/resources/log4j-console.properties
@@ -1,0 +1,59 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
+monitorInterval=30
+
+# This affects logging for both user code and Flink
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender
+rootLogger.appenderRef.rolling.ref = RollingFileAppender
+
+# Uncomment this if you want to _only_ change Flink's logging
+#logger.flink.name = org.apache.flink
+#logger.flink.level = INFO
+
+# The following lines keep the log level of common libraries/connectors on
+# log level INFO. The root logger does not override this. You have to manually
+# change the log levels here.
+logger.pekko.name = org.apache.pekko
+logger.pekko.level = WARN
+logger.kafka.name= org.apache.kafka
+logger.kafka.level = WARN
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = WARN
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = WARN
+logger.shaded_zookeeper.name = org.apache.flink.shaded.zookeeper3
+logger.shaded_zookeeper.level = WARN
+
+# Log all infos to the console
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = ${sys:console.log.level:-ALL}
+
+# Suppress the irrelevant (wrong) warnings from the Netty channel handler
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.level = OFF
+
+# Debug OpenLineage
+logger.openlineage.name = io.openlineage
+logger.openlineage.level = DEBUG

--- a/integration/flink/app/src/test/resources/log4j.properties
+++ b/integration/flink/app/src/test/resources/log4j.properties
@@ -1,9 +1,0 @@
-# Set everything to be logged to the console
-log4j.rootCategory=INFO, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-
-# set the log level for the openlineage spark library
-log4j.logger.io.openlineage=DEBUG

--- a/integration/flink/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/flink/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -79,6 +79,7 @@ class CommonConfigPlugin : Plugin<Project> {
 
         target.extensions.configure<SpotlessExtension> {
             java {
+                targetExclude("**/proto/**")
                 googleJavaFormat()
                 removeUnusedImports()
                 custom("disallowWildcardImports", disallowWildcardImports)

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id "com.github.johnrengelman.shadow"
     id 'io.openlineage.common-config'
     id "com.github.davidmc24.gradle.plugin.avro" version "1.9.1"
+    id "com.google.protobuf" version "0.9.4"
 }
 
 group 'io.openlineage.flink'
@@ -23,11 +24,11 @@ ext {
     hadoopVersion = '3.3.1'
 
     versionsMap = [
-            "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "jdbc": "1.15.4", "iceberg": "1.3.0", "alternativeShort": "1.15"],
-            "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "jdbc": "1.16.3", "iceberg": "1.3.0", "alternativeShort": "1.16"],
-            "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "jdbc": "3.1.1-1.17", "iceberg": "1.3.0", "alternativeShort": "1.17"],
-            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "iceberg": "1.5.0", "alternativeShort": "1.18"],
-            "1.19": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "iceberg": "1.5.0", "alternativeShort": "1.18"]
+            "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "jdbc": "1.15.4", "iceberg": "1.3.0", "alternativeShort": "1.15", "protobuf": "NA"],
+            "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "jdbc": "1.16.3", "iceberg": "1.3.0", "alternativeShort": "1.16", "protobuf": flinkVersion],
+            "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "jdbc": "3.1.1-1.17", "iceberg": "1.3.0", "alternativeShort": "1.17", "protobuf": flinkVersion],
+            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "iceberg": "1.5.0", "alternativeShort": "1.18", "protobuf": flinkVersion],
+            "1.19": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "iceberg": "1.5.0", "alternativeShort": "1.18", "protobuf": flinkVersion]
     ]
 
     versions = versionsMap[flinkVersionShort]
@@ -60,6 +61,9 @@ dependencies {
     implementation "org.apache.flink:flink-connector-cassandra_2.12:${versions.cassandra}"
     implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
     implementation "org.apache.flink:flink-avro:$flinkVersion"
+    if (versions.protobuf != "NA") {
+        implementation "org.apache.flink:flink-protobuf:${versions.protobuf}"
+    }
     compileOnly "org.apache.flink:flink-table:$flinkVersion"
     compileOnly "org.apache.flink:flink-table-api-java:$flinkVersion"
     compileOnly "org.apache.flink:flink-table-api-java-bridge:$flinkVersion"
@@ -70,6 +74,7 @@ dependencies {
     implementation "com.typesafe:config:1.4.3"
     implementation "org.apache.avro:avro:1.11.3"
     implementation 'io.confluent:kafka-avro-serializer:7.6.0'
+    implementation 'io.confluent:kafka-protobuf-serializer:7.6.0'
     implementation 'io.confluent:kafka-schema-registry-client:7.6.0'
     implementation 'com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.9.1'
     implementation 'org.postgresql:postgresql:42.7.2'
@@ -81,6 +86,7 @@ dependencies {
     implementation "org.apache.avro:avro"
 
     implementation "org.apache.iceberg:iceberg-flink-runtime-${versions.alternativeShort}:${versions.iceberg}"
+    implementation "com.google.protobuf:protobuf-java:3.25.3"
 }
 
 assemble {
@@ -104,6 +110,15 @@ avro {
     fieldVisibility = 'PUBLIC'
 }
 
+
+extractIncludeTestProto.enabled = false
+
 test {
     useJUnitPlatform()
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
 }

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkProtobufApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkProtobufApplication.java
@@ -1,0 +1,145 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+import static io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE;
+import static io.openlineage.common.config.ConfigWrapper.fromResource;
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
+import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.openlineage.flink.proto.event.InputEvent;
+import io.openlineage.flink.proto.event.OutputEvent;
+import io.openlineage.util.OpenLineageFlinkJobListenerBuilder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+public class FlinkProtobufApplication {
+
+  private static final String SCHEMA_REGISTRY_URL = "http://schema-registry:8081";
+  public static void main(String[] args) throws Exception {
+    ParameterTool parameters = ParameterTool.fromArgs(args);
+    StreamExecutionEnvironment env = setupEnv(args);
+
+    String inputTopic = parameters.getRequired("input-topics");
+    String outputTopic = parameters.getRequired("output-topics");
+
+    KafkaSource<InputEvent> source =
+        KafkaSource.<InputEvent>builder()
+            .setProperties(fromResource("kafka-consumer.conf").toProperties())
+            .setBootstrapServers("kafka:9092")
+            .setValueOnlyDeserializer(
+                new DeserializationSchema<InputEvent>() {
+                  @Override
+                  public InputEvent deserialize(byte[] bytes) throws IOException {
+                    CachedSchemaRegistryClient cachedSchemaRegistryClient = new CachedSchemaRegistryClient(
+                        SCHEMA_REGISTRY_URL,
+                        10,
+                        List.of(new AvroSchemaProvider(), new ProtobufSchemaProvider()),
+                        Collections.emptyMap()
+                    );
+                    KafkaProtobufDeserializer<InputEvent> deserializer = new KafkaProtobufDeserializer(
+                        cachedSchemaRegistryClient
+                    );
+
+                    Map<String, String> serdeConfig = new HashMap<>();
+                    serdeConfig.put(SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
+                    serdeConfig.put(SPECIFIC_PROTOBUF_VALUE_TYPE,InputEvent.class.getName());
+
+                    deserializer.configure(serdeConfig, false);
+                    return deserializer.deserialize(inputTopic, bytes);
+                  }
+
+                  @Override
+                  public boolean isEndOfStream(InputEvent simpleMessage) {
+                    return false;
+                  }
+
+                  @Override
+                  public TypeInformation<InputEvent> getProducedType() {
+                    return null;
+                  }
+                }
+            )
+            .setTopics(inputTopic)
+            .build();
+
+    KafkaSink<OutputEvent> sink = KafkaSink.<OutputEvent>builder()
+        .setKafkaProducerConfig(fromResource("kafka-producer.conf").toProperties())
+        .setBootstrapServers("kafka:9092")
+        .setRecordSerializer(
+            KafkaRecordSerializationSchema.builder()
+                .setValueSerializationSchema(
+                    new SerializationSchema<OutputEvent>() {
+                      @Override
+                      public byte[] serialize(OutputEvent outputEvent) {
+                        CachedSchemaRegistryClient cachedSchemaRegistryClient = new CachedSchemaRegistryClient(
+                            SCHEMA_REGISTRY_URL,
+                            10,
+                            List.of(new AvroSchemaProvider(), new ProtobufSchemaProvider()),
+                            Collections.emptyMap()
+                        );
+                        KafkaProtobufSerializer<OutputEvent> serializer = new KafkaProtobufSerializer(
+                            cachedSchemaRegistryClient
+                        );
+
+
+                        Map<String, String> serdeConfig = new HashMap<>();
+                        serdeConfig.put(SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
+                        serdeConfig.put(SPECIFIC_PROTOBUF_VALUE_TYPE,OutputEvent.class.getName());
+
+                        serializer.configure(serdeConfig, false);
+
+                        return serializer.serialize(outputTopic, outputEvent);
+                      }
+                    }
+                )
+                .setTopic(outputTopic)
+                .build())
+        .build();
+
+    env.fromSource(
+            source,
+            noWatermarks(),
+            "kafka-source")
+        .uid("kafka-source")
+        .returns(InputEvent.class)
+        .keyBy(InputEvent::getId)
+        .process(new StatefulProtoCounter())
+        .returns(OutputEvent.class)
+        .name("process")
+        .uid("process")
+        .sinkTo(sink)
+        .name("kafka-sink")
+        .uid("kafka-sink");
+
+    String jobName = parameters.get("job-name");
+    //env.getConfig().addDefaultKryoSerializer(InputEvent.class, ProtobufKryoSerializer.class);
+    env.registerJobListener(
+        OpenLineageFlinkJobListenerBuilder.create()
+            .executionEnvironment(env)
+            .jobName(jobName)
+            .build());
+    env.execute(jobName);
+  }
+
+}

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
@@ -11,13 +11,17 @@ import static io.openlineage.kafka.KafkaClientProvider.aKafkaSink;
 import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
 
 import io.openlineage.flink.avro.event.InputEvent;
+import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.util.OpenLineageFlinkJobListenerBuilder;
+import java.util.Collections;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
 
 /*
 /* Copyright 2018-2023 contributors to the OpenLineage project
@@ -26,6 +30,15 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 public class FlinkSourceWithGenericRecordApplication {
 
   public static void main(String[] args) throws Exception {
+    // create manually topic as
+    Admin admin = Admin.create(fromResource("kafka-consumer.conf").toProperties());
+    admin.createTopics(
+        Collections.singletonList(new NewTopic(
+            "io.openlineage.flink.kafka.input_no_schema_registry", 1, (short) 1)
+        )
+    );
+
+    // Then go with regular app
     ParameterTool parameters = ParameterTool.fromArgs(args);
     StreamExecutionEnvironment env = setupEnv(args);
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulProtoCounter.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/StatefulProtoCounter.java
@@ -1,0 +1,78 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import io.openlineage.flink.proto.event.InputEvent;
+import io.openlineage.flink.proto.event.OutputEvent;
+import io.openlineage.flink.avro.infrastructure.state.managed.Counter;
+import io.openlineage.flink.proto.event.OutputEvent;
+import io.openlineage.flink.proto.event.SubOutputEvent;
+import io.openlineage.flink.proto.event.SubOutputEvent.Builder;
+import io.openlineage.flink.proto.event.SubOutputEventOrBuilder;
+import io.openlineage.flink.proto.event.SubSubOutputEvent;
+import io.openlineage.util.StateUtils;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StatefulProtoCounter extends KeyedProcessFunction<String, InputEvent, OutputEvent> {
+
+  public static final long serialVersionUID = 1;
+  public static final ValueStateDescriptor<Counter> COUNTER_DESCRIPTOR;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StatefulProtoCounter.class);
+
+  static {
+    COUNTER_DESCRIPTOR = new ValueStateDescriptor<>("counter", Counter.class);
+    COUNTER_DESCRIPTOR.setQueryable(COUNTER_DESCRIPTOR.getName());
+  }
+
+  private transient ValueState<Counter> counterState;
+
+  @Override
+  public void open(Configuration parameters) {
+    counterState = getRuntimeContext().getState(COUNTER_DESCRIPTOR);
+  }
+
+  @Override
+  public void processElement(InputEvent inputEvent, Context ctx, Collector<OutputEvent> output)
+      throws Exception {
+    LOGGER.info("Processing InputEvent={}", inputEvent);
+    Counter counter = StateUtils.value(counterState, new Counter(0L, null));
+    counter.setCounter(counter.getCounter() + 1);
+    counter.setLastSeen(inputEvent.toString());
+    counterState.update(counter);
+
+    Builder builder = SubOutputEvent
+        .newBuilder()
+        .setId(inputEvent.getSubEvent().getId())
+        .setSubSubEvent(SubSubOutputEvent
+            .newBuilder()
+            .setId(inputEvent.getSubEvent().getSubSubEvent().getId())
+            .setVersion(inputEvent.getSubEvent().getSubSubEvent().getVersion())
+            .build()
+        );
+
+    inputEvent
+        .getSubEvent()
+        .getArrList()
+        .forEach(l -> builder.addArr(l));
+
+    OutputEvent outputEvent = OutputEvent
+        .newBuilder()
+        .setId(inputEvent.getId())
+        .setVersion(inputEvent.getVersion())
+        .setCounter(counter.getCounter())
+        .setSubEvent(builder)
+        .build();
+    LOGGER.info("Preparing OutputEvent={} to sent.", inputEvent);
+    output.collect(outputEvent);
+  }
+}

--- a/integration/flink/examples/stateful/src/main/proto/InputEvent.proto
+++ b/integration/flink/examples/stateful/src/main/proto/InputEvent.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package io.openlineage.flink.proto.event;
+option java_package = "io.openlineage.flink.proto.event";
+option java_multiple_files = true;
+
+message InputEvent {
+  string id = 1;
+  int64 version = 2;
+  SubInputEvent subEvent = 3;
+}
+
+message SubInputEvent {
+  string id = 1;
+  SubSubInputEvent subSubEvent = 2;
+  repeated int64 arr = 3;
+}
+
+message SubSubInputEvent {
+  string id = 1;
+  int64 version = 2;
+}

--- a/integration/flink/examples/stateful/src/main/proto/OutputEvent.proto
+++ b/integration/flink/examples/stateful/src/main/proto/OutputEvent.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+package io.openlineage.flink.proto.event;
+option java_package = "io.openlineage.flink.proto.event";
+option java_multiple_files = true;
+
+message OutputEvent {
+  string id = 1;
+  int64 version = 2;
+  int64 counter = 3;
+  SubOutputEvent subEvent = 4;
+}
+
+message SubOutputEvent {
+  string id = 1;
+  SubSubOutputEvent subSubEvent = 2;
+  repeated int64 arr = 3;
+}
+
+message SubSubOutputEvent {
+  string id = 1;
+  int64 version = 2;
+}

--- a/integration/flink/shared/build.gradle
+++ b/integration/flink/shared/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'com.github.johnrengelman.shadow'
     id 'io.franzbecker.gradle-lombok'
     id 'io.openlineage.common-config'
+    id "com.google.protobuf" version "0.9.4"
 }
 
 configurations {
@@ -35,7 +36,9 @@ task delombok(type: DelombokTask, dependsOn: compileJava) {
     ext.outputDir = file("$buildDir/delombok")
     outputs.dir(outputDir)
     sourceSets.main.java.srcDirs.each {
-        inputs.dir(it)
+        if (it.name =~ "/proto/") {
+            inputs.dir(it)
+        }
         args(it, "-d", outputDir)
     }
     doFirst {
@@ -100,6 +103,7 @@ dependencies {
     compileOnly "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
     compileOnly "org.apache.iceberg:iceberg-flink-runtime-${versions.alternativeShort}:${versions.iceberg}"
     compileOnly "org.apache.flink:flink-connector-jdbc:${versions.jdbc}"
+    compileOnly "com.google.protobuf:protobuf-java:3.25.3"
 
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
@@ -133,6 +137,13 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation "com.google.protobuf:protobuf-java:3.25.3"
 
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/TransformationUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/TransformationUtils.java
@@ -27,6 +27,7 @@ public class TransformationUtils {
   public List<SinkLineage> convertToVisitable(List<Transformation<?>> transformations) {
     List<SinkLineage> lineages = new ArrayList<>();
     for (Transformation<?> transformation : transformations) {
+      log.debug("convertToVisitable transformation: " + transformation);
       var sinkLineage = processSink(transformation);
       sinkLineage.ifPresent(lineages::add);
     }
@@ -37,10 +38,13 @@ public class TransformationUtils {
     List<Object> sources = new ArrayList<>();
     Object sink;
     if (transformation instanceof SinkTransformation) {
+      log.debug("Processing sink", transformation);
       sink = processSinkTransformation(transformation);
     } else if (transformation instanceof LegacySinkTransformation) {
+      log.debug("Processing legacy sink", transformation);
       sink = processLegacySinkTransformation(transformation);
     } else if (transformation instanceof OneInputTransformation) {
+      log.debug("Processing one input transformation", transformation);
       sink = transformation;
     } else {
       return Optional.empty();

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/CheckpointFacet.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/CheckpointFacet.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 
 /** Custom facet to contain counters from Flink checkpoints. */
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class CheckpointFacet extends OpenLineage.DefaultRunFacet {
 
   @JsonProperty("completed")

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -12,9 +12,11 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 
 /** Utility class for translating Avro schema into open lineage schema */
+@Slf4j
 public class AvroSchemaUtils {
 
   /**
@@ -31,6 +33,7 @@ public class AvroSchemaUtils {
     avroSchema.getFields().stream()
         .forEach(
             avroField -> {
+              log.debug("Converting avro field {} to OpenLineage field", avroField);
               fields.add(
                   openLineage
                       .newSchemaDatasetFacetFieldsBuilder()

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufFieldResolver.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufFieldResolver.java
@@ -1,0 +1,97 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.flink.utils;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
+import com.google.protobuf.Descriptors.OneofDescriptor;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+/** Class responsible for translating protbuf fields into {@link SchemaDatasetFacetFields} */
+@Slf4j
+public class ProtobufFieldResolver {
+
+  private final OpenLineage openLineage;
+
+  public ProtobufFieldResolver(OpenLineage openLineage) {
+    this.openLineage = openLineage;
+  }
+
+  public List<SchemaDatasetFacetFields> resolve(Descriptor descriptor) {
+    return descriptor.getFields().stream()
+        .map(protoField -> resolveField(protoField))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Resolves single Protobuf field into OpenLineage format.
+   *
+   * @param field
+   * @return returns a list as a single oneOf field should result in two separate OpenLineage fields
+   */
+  public SchemaDatasetFacetFields resolveField(FieldDescriptor field) {
+    log.debug("protoField: {} of type {}", field.getName(), field.getJavaType());
+    SchemaDatasetFacetFields facetField;
+    if (field.getType().getJavaType().equals(JavaType.MESSAGE)) {
+      // nested field encountered, array and map land here as well
+      if (field.isMapField()) {
+        facetField = resolveMapField(field);
+      } else if (field.isRepeated()) {
+        facetField = resolveArrayField(field);
+      } else {
+        facetField = resolveStructField(field);
+      }
+    } else {
+      facetField = resolvePrimitiveTypeField(field);
+    }
+
+    return facetField;
+  }
+
+  private SchemaDatasetFacetFields resolveMapField(FieldDescriptor field) {
+    return openLineage.newSchemaDatasetFacetFields(
+        field.getName(), "map", "", resolve(field.getMessageType()));
+  }
+
+  private SchemaDatasetFacetFields resolveArrayField(FieldDescriptor field) {
+    return openLineage.newSchemaDatasetFacetFields(
+        field.getName(),
+        "array",
+        "",
+        Collections.singletonList(
+            openLineage.newSchemaDatasetFacetFields(
+                "_element", getFieldType(field), "", resolve(field.getMessageType()))));
+  }
+
+  private SchemaDatasetFacetFields resolveStructField(FieldDescriptor field) {
+    return openLineage.newSchemaDatasetFacetFields(
+        field.getName(), getFieldType(field), "", resolve(field.getMessageType()));
+  }
+
+  private List<SchemaDatasetFacetFields> resolveOneOfField(OneofDescriptor oneofDescriptor) {
+    return oneofDescriptor.getFields().stream()
+        .map(f -> resolveField(f))
+        .collect(Collectors.toList());
+  }
+
+  private SchemaDatasetFacetFields resolvePrimitiveTypeField(FieldDescriptor field) {
+    return openLineage.newSchemaDatasetFacetFields(
+        field.getName(), getFieldType(field), "", Collections.emptyList());
+  }
+
+  private String getFieldType(FieldDescriptor field) {
+    if (field.getJavaType().equals(JavaType.MESSAGE)) {
+      return field.getMessageType().getFullName();
+    } else {
+      return field.getType().name().toLowerCase();
+    }
+  }
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufUtils.java
@@ -1,0 +1,180 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.utils;
+
+import com.google.protobuf.Descriptors.FileDescriptor;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+/** Utility methods to deal with Protobuf serialization schemas */
+@Slf4j
+public class ProtobufUtils {
+
+  /**
+   * Given a serialization schema, the method verifies if a produced output type extends Protobuf
+   * generated classes.
+   *
+   * @param serializationSchema
+   * @return
+   */
+  public static boolean isProtobufSerializationSchema(SerializationSchema serializationSchema) {
+    Optional<Class> messageClass = protobufMessageClass();
+    if (messageClass.isEmpty()) {
+      log.debug("Protobuf parent Message class not loaded");
+      return false;
+    }
+
+    return getProtobufSerializeClass(serializationSchema)
+        .map(t -> messageClass.get().isAssignableFrom(t))
+        .orElse(false);
+  }
+
+  /**
+   * Given a deserialization schema, the method verifies if a produced output type extends Protobuf
+   * generated classes.
+   *
+   * @param deserializationSchema
+   * @return
+   */
+  public static boolean isProtobufDeserializationSchema(
+      DeserializationSchema deserializationSchema) {
+    Optional<Class> messageClass = protobufMessageClass();
+    if (messageClass.isEmpty()) {
+      log.debug("Protobuf parent Message class not loaded");
+      return false;
+    }
+
+    return getProtobufDeserializeClass(deserializationSchema)
+        .map(t -> messageClass.get().isAssignableFrom(t))
+        .orElse(false);
+  }
+
+  public static Optional<OpenLineage.SchemaDatasetFacet> convert(
+      OpenLineage openLineage, SerializationSchema serializationSchema) {
+    Optional<Class> protobufSerializedClass = getProtobufSerializeClass(serializationSchema);
+
+    if (protobufSerializedClass.isEmpty()) {
+      return Optional.empty();
+    }
+
+    List<SchemaDatasetFacetFields> fields =
+        getSchemaDatasetFacetFields(openLineage, protobufSerializedClass.get());
+    if (!fields.isEmpty()) {
+      OpenLineage.SchemaDatasetFacetBuilder builder = openLineage.newSchemaDatasetFacetBuilder();
+      return Optional.of(builder.fields(fields).build());
+    }
+
+    return Optional.empty();
+  }
+
+  public static Optional<OpenLineage.SchemaDatasetFacet> convert(
+      OpenLineage openLineage, DeserializationSchema deserializationSchema) {
+    Optional<Class> protobufSerializedClass = getProtobufDeserializeClass(deserializationSchema);
+
+    if (protobufSerializedClass.isEmpty()) {
+      return Optional.empty();
+    }
+
+    List<SchemaDatasetFacetFields> fields =
+        getSchemaDatasetFacetFields(openLineage, protobufSerializedClass.get());
+    if (!fields.isEmpty()) {
+      OpenLineage.SchemaDatasetFacetBuilder builder = openLineage.newSchemaDatasetFacetBuilder();
+      return Optional.of(builder.fields(fields).build());
+    }
+
+    return Optional.empty();
+  }
+
+  static List<SchemaDatasetFacetFields> getSchemaDatasetFacetFields(
+      OpenLineage openLineage, Class protobufSerializedClass) {
+    try {
+      Class<?> staticDefintionClass =
+          Class.forName(protobufSerializedClass.getCanonicalName() + "OuterClass");
+
+      Field descriptorField = FieldUtils.getField(staticDefintionClass, "descriptor", true);
+      FileDescriptor fileDescriptor = (FileDescriptor) descriptorField.get(staticDefintionClass);
+
+      ProtobufFieldResolver fieldResolver = new ProtobufFieldResolver(openLineage);
+      return fileDescriptor.getMessageTypes().stream()
+          .flatMap(d -> d.getFields().stream())
+          .filter(d -> protobufSerializedClass.getName().contains(d.getContainingType().getName()))
+          .map(f -> fieldResolver.resolveField(f))
+          .collect(Collectors.toList());
+    } catch (ClassNotFoundException e) {
+      // swallow it
+      log.warn("Couldn't find OuterClass for {}: {}", protobufSerializedClass, e);
+      return Collections.emptyList();
+    } catch (IllegalAccessException e) {
+      // swallow it
+      log.warn("Couldn't find descriptor property in OuterClass", e);
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Given a serialization schema class, this method finds its serialize method which takes
+   * parameter different from {@link Object}. Having proper serialize method, the code identifies
+   * first parameter of the serialize method, which is the protobuf class we are looking for.
+   *
+   * @param serializationSchema
+   * @return
+   */
+  private static Optional<Class> getProtobufSerializeClass(
+      SerializationSchema serializationSchema) {
+    Optional<Class> parameterType =
+        Arrays.stream(serializationSchema.getClass().getMethods())
+            .filter(m -> m.getName().equalsIgnoreCase("serialize"))
+            .filter(m -> m.getParameterTypes()[0] != Object.class)
+            .findAny()
+            .map(m -> m.getParameterTypes()[0]);
+    log.debug("Serializer serializing {}", parameterType);
+    return parameterType;
+  }
+
+  /**
+   * Given a deserialization schema class, this method finds it deserialize method whose return type
+   * is different from {@link Object}. The return type of deserialize method is protobuf class we
+   * are looking for.
+   *
+   * @param deserializationSchema
+   * @return
+   */
+  private static Optional<Class> getProtobufDeserializeClass(
+      DeserializationSchema deserializationSchema) {
+    if (deserializationSchema.getProducedType() != null) {
+      return Optional.of(deserializationSchema.getProducedType().getTypeClass());
+    } else {
+      Optional<Class> parameterType =
+          Arrays.stream(deserializationSchema.getClass().getMethods())
+              .filter(m -> m.getName().equalsIgnoreCase("deserialize"))
+              .filter(m -> m.getReturnType() != Object.class)
+              .findAny()
+              .map(m -> m.getReturnType());
+      log.debug("Deserializer serializing {}", parameterType);
+      return parameterType;
+    }
+  }
+
+  private static Optional<Class> protobufMessageClass() {
+    try {
+      return Optional.of(
+          ProtobufUtils.class.getClassLoader().loadClass("com.google.protobuf.Message"));
+    } catch (ClassNotFoundException e) {
+      log.debug("Protobuf class not present");
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/KafkaSinkVisitor.java
@@ -35,8 +35,9 @@ public class KafkaSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
 
   @Override
   public List<OpenLineage.OutputDataset> apply(Object kafkaSink) {
-    KafkaSinkWrapper wrapper = KafkaSinkWrapper.of((KafkaSink) kafkaSink);
+    KafkaSinkWrapper wrapper = KafkaSinkWrapper.of((KafkaSink) kafkaSink, context);
     List<String> topics = wrapper.getTopicsOfMultiTopicSink();
+    log.debug("Extracting output dataset for KafkaSinkVisitor with topics {}", topics);
     if (topics != null && !topics.isEmpty()) {
       DatasetFacetsBuilder facetsBuilder = outputDataset().getDatasetFacetsBuilder();
       wrapper
@@ -64,14 +65,9 @@ public class KafkaSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
       OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
           outputDataset().getDatasetFacetsBuilder();
 
-      wrapper
-          .getAvroSchema()
-          .map(
-              schema ->
-                  datasetFacetsBuilder.schema(
-                      AvroSchemaUtils.convert(context.getOpenLineage(), schema)));
+      wrapper.getSchemaFacet().map(facet -> datasetFacetsBuilder.schema(facet));
 
-      log.debug("Kafka output topic: {}", di.getName());
+      log.debug("KafkaSinkVisitor extracted output topic: {}", di.getName());
       return Collections.singletonList(outputDataset().getDataset(di, datasetFacetsBuilder));
     } catch (IllegalAccessException | java.util.NoSuchElementException e) {
       log.error("Can't access the field. ", e);

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/KafkaSourceVisitor.java
@@ -8,7 +8,6 @@ package io.openlineage.flink.visitor;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
-import io.openlineage.flink.utils.AvroSchemaUtils;
 import io.openlineage.flink.utils.KafkaUtils;
 import io.openlineage.flink.visitor.wrapper.KafkaSourceWrapper;
 import java.util.Collections;
@@ -34,7 +33,7 @@ public class KafkaSourceVisitor extends Visitor<OpenLineage.InputDataset> {
   @Override
   public List<OpenLineage.InputDataset> apply(Object kafkaSource) {
     try {
-      KafkaSourceWrapper wrapper = KafkaSourceWrapper.of((KafkaSource<?>) kafkaSource);
+      KafkaSourceWrapper wrapper = KafkaSourceWrapper.of((KafkaSource<?>) kafkaSource, context);
       List<String> topics = wrapper.getTopics();
       Properties properties = wrapper.getProps();
 
@@ -48,12 +47,7 @@ public class KafkaSourceVisitor extends Visitor<OpenLineage.InputDataset> {
                     inputDataset().getDatasetFacetsBuilder();
                 // The issue here is that we assign dataset a schema that we're trying to read with.
                 // The read schema may be in mismatch with real dataset schema.
-                wrapper
-                    .getAvroSchema()
-                    .map(
-                        schema ->
-                            datasetFacetsBuilder.schema(
-                                AvroSchemaUtils.convert(context.getOpenLineage(), schema)));
+                wrapper.getSchemaFacet().map(facet -> datasetFacetsBuilder.schema(facet));
                 return inputDataset().getDataset(di, datasetFacetsBuilder);
               })
           .collect(Collectors.toList());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
@@ -1,0 +1,125 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.flink.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.flink.utils.ProtobufUtilsTest.ProtoDeserializationSchema;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class ProtobufFieldResolverTest {
+
+  OpenLineage openLineage = new OpenLineage(mock(URI.class));
+  SchemaDatasetFacet facet =
+      ProtobufUtils.convert(openLineage, new ProtoDeserializationSchema()).get();
+  SchemaDatasetFacetFields subEvent = getSubField(facet.getFields(), "subEvent").get();
+
+  @Test
+  void testConvertNestedDataType() {
+    // verify subEvent
+    assertThat(subEvent.getType())
+        .isEqualTo("io.openlineage.flink.proto.event.SubProtobufTestEvent");
+
+    assertThat(subEvent.getFields()).hasSize(4);
+    assertThat(getSubField(subEvent.getFields(), "id"))
+        .isPresent()
+        .map(f -> f.getType())
+        .hasValue("string");
+    assertThat(getSubField(subEvent.getFields(), "subSubEvent"))
+        .isPresent()
+        .map(f -> f.getType())
+        .hasValue("io.openlineage.flink.proto.event.SubSubProtobufTestEvent");
+
+    // verify subSubEvent
+    SchemaDatasetFacetFields subSubEvent = getSubField(subEvent.getFields(), "subSubEvent").get();
+
+    assertThat(subSubEvent.getFields()).hasSize(2);
+    assertThat(getSubField(subSubEvent.getFields(), "id"))
+        .isPresent()
+        .map(f -> f.getType())
+        .hasValue("string");
+    assertThat(getSubField(subSubEvent.getFields(), "version"))
+        .isPresent()
+        .map(f -> f.getType())
+        .hasValue("int64");
+  }
+
+  @Test
+  void testConvertVerifyArrayDataType() {
+    SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "arr").get();
+    assertThat(field.getFields()).hasSize(1);
+    assertThat("array").isEqualTo(field.getType());
+    assertThat("arr").isEqualTo(field.getName());
+
+    assertThat(field.getFields().get(0))
+        .hasFieldOrPropertyWithValue("name", "_element")
+        .hasFieldOrPropertyWithValue(
+            "type", "io.openlineage.flink.proto.event.SubSubProtobufTestEvent");
+
+    assertThat(field.getFields().get(0).getFields())
+        .hasSize(2); // fields of SubSubProtobufTestEvent
+  }
+
+  @Test
+  void testConvertVerifyMapDataType() {
+    SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "someMap").get();
+    assertThat(field.getFields()).hasSize(2);
+    assertThat("map").isEqualTo(field.getType());
+    assertThat("someMap").isEqualTo(field.getName());
+
+    assertThat(field.getFields().get(0))
+        .hasFieldOrPropertyWithValue("name", "key")
+        .hasFieldOrPropertyWithValue("type", "string");
+
+    assertThat(field.getFields().get(1))
+        .hasFieldOrPropertyWithValue("name", "value")
+        .hasFieldOrPropertyWithValue("type", "int32");
+  }
+
+  @Test
+  void testAny() {
+    SchemaDatasetFacetFields anyField = getSubField(facet.getFields(), "testAnyOf").get();
+    assertThat(anyField.getFields()).hasSize(2);
+    assertThat("google.protobuf.Any").isEqualTo(anyField.getType());
+    assertThat("testAnyOf").isEqualTo(anyField.getName());
+    assertThat(anyField.getFields().get(0))
+        .hasFieldOrPropertyWithValue("name", "type_url")
+        .hasFieldOrPropertyWithValue("type", "string");
+
+    assertThat(anyField.getFields().get(1))
+        .hasFieldOrPropertyWithValue("name", "value")
+        .hasFieldOrPropertyWithValue("type", "bytes");
+  }
+
+  /**
+   * One of field was introduced in protobuf to save memory. However, in OpenLineage schema it shall
+   * be represented by two separate fields.
+   */
+  @Test
+  void testOneOf() {
+    SchemaDatasetFacetFields oneOf1 = getSubField(facet.getFields(), "oneOf1").get();
+    SchemaDatasetFacetFields oneOf2 = getSubField(facet.getFields(), "oneOf2").get();
+
+    assertThat(oneOf1)
+        .hasFieldOrPropertyWithValue("name", "oneOf1")
+        .hasFieldOrPropertyWithValue("type", "string");
+    assertThat(oneOf2)
+        .hasFieldOrPropertyWithValue("name", "oneOf2")
+        .hasFieldOrPropertyWithValue(
+            "type", "io.openlineage.flink.proto.event.SubProtobufTestEvent");
+  }
+
+  private Optional<SchemaDatasetFacetFields> getSubField(
+      List<SchemaDatasetFacetFields> fields, String subfield) {
+    return fields.stream().filter(f -> subfield.equals(f.getName())).findAny();
+  }
+}

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufUtilsTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufUtilsTest.java
@@ -1,0 +1,195 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Message;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
+import io.openlineage.flink.proto.event.ProtobufTestEvent;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.junit.jupiter.api.Test;
+
+class ProtobufUtilsTest {
+
+  OpenLineage openLineage = new OpenLineage(mock(URI.class));
+
+  @Test
+  void testIsProtobufSerializationSchemaForProtoClass() {
+    assertThat(ProtobufUtils.isProtobufSerializationSchema(new ProtoSerializationSchema()))
+        .isTrue();
+  }
+
+  @Test
+  void testIsProtobufSerializationSchemaForNonProtoClass() {
+    assertThat(ProtobufUtils.isProtobufSerializationSchema(new NonProtoSerializationSchema()))
+        .isFalse();
+  }
+
+  @Test
+  void testConvertForOutputDataset() {
+    Optional<SchemaDatasetFacet> facet =
+        ProtobufUtils.convert(openLineage, new ProtoSerializationSchema());
+
+    List<String[]> fields =
+        facet.get().getFields().stream()
+            .map(f -> new String[] {f.getName(), f.getType()})
+            .collect(Collectors.toList());
+
+    assertThat(fields)
+        .hasSize(6)
+        .contains(
+            new String[] {"id", "string"},
+            new String[] {"version", "int64"},
+            new String[] {"subEvent", "io.openlineage.flink.proto.event.SubProtobufTestEvent"},
+            new String[] {"testAnyOf", "google.protobuf.Any"},
+            new String[] {"oneOf1", "string"},
+            new String[] {"oneOf2", "io.openlineage.flink.proto.event.SubProtobufTestEvent"});
+  }
+
+  @Test
+  void testConvertForInputDataset() {
+    SchemaDatasetFacet facet =
+        ProtobufUtils.convert(openLineage, new ProtoDeserializationSchema()).get();
+
+    List<String[]> fields =
+        facet.getFields().stream()
+            .map(f -> new String[] {f.getName(), f.getType()})
+            .collect(Collectors.toList());
+
+    assertThat(fields)
+        .hasSize(6)
+        .containsExactlyInAnyOrder(
+            new String[] {"id", "string"},
+            new String[] {"version", "int64"},
+            new String[] {"subEvent", "io.openlineage.flink.proto.event.SubProtobufTestEvent"},
+            new String[] {"testAnyOf", "google.protobuf.Any"},
+            new String[] {"oneOf1", "string"},
+            new String[] {"oneOf2", "io.openlineage.flink.proto.event.SubProtobufTestEvent"});
+  }
+
+  @Test
+  void testConvertSerializeWhenNoOuterClassFound() {
+    assertThat(ProtobufUtils.convert(openLineage, new NonProtoMessageSerializationSchema()))
+        .isEmpty();
+  }
+
+  @Test
+  void testIsProtobufDeserializationSchemaForProtoClass() {
+    assertThat(ProtobufUtils.isProtobufDeserializationSchema(new ProtoDeserializationSchema()))
+        .isTrue();
+  }
+
+  @Test
+  void testIsProtobufDeserializationSchemaForProtoClassWithProducedType() {
+    TypeInformation typeInformation = mock(TypeInformation.class);
+    when(typeInformation.getTypeClass()).thenReturn(ProtobufTestEvent.class);
+    assertThat(
+            ProtobufUtils.isProtobufDeserializationSchema(
+                new ProtoDeserializationSchema() {
+                  @Override
+                  public TypeInformation<ProtobufTestEvent> getProducedType() {
+                    return typeInformation;
+                  }
+                }))
+        .isTrue();
+  }
+
+  @Test
+  void testIsProtobufDeserializationSchemaForNonProtoClass() {
+    assertThat(ProtobufUtils.isProtobufDeserializationSchema(new NonProtoDeserializationSchema()))
+        .isFalse();
+  }
+
+  @Test
+  void testConvertDeserializeWhenNoOuterClassFound() {
+    assertThat(ProtobufUtils.convert(openLineage, new NonProtoMessageSerializationSchema()))
+        .isEmpty();
+  }
+
+  static class ProtoSerializationSchema implements SerializationSchema<ProtobufTestEvent> {
+    @Override
+    public byte[] serialize(ProtobufTestEvent o) {
+      return new byte[0];
+    }
+  }
+
+  static class NonProtoSerializationSchema implements SerializationSchema {
+    @Override
+    public byte[] serialize(Object o) {
+      return new byte[0];
+    }
+  }
+
+  static class NonProtoMessageSerializationSchema implements SerializationSchema<Message> {
+    @Override
+    public byte[] serialize(Message o) {
+      return new byte[0];
+    }
+  }
+
+  static class ProtoDeserializationSchema implements DeserializationSchema<ProtobufTestEvent> {
+    @Override
+    public ProtobufTestEvent deserialize(byte[] bytes) throws IOException {
+      return null;
+    }
+
+    @Override
+    public boolean isEndOfStream(ProtobufTestEvent inputEvent) {
+      return false;
+    }
+
+    @Override
+    public TypeInformation<ProtobufTestEvent> getProducedType() {
+      return null;
+    }
+  }
+
+  static class NonProtoDeserializationSchema implements DeserializationSchema {
+
+    @Override
+    public Object deserialize(byte[] bytes) throws IOException {
+      return null;
+    }
+
+    @Override
+    public boolean isEndOfStream(Object o) {
+      return false;
+    }
+
+    @Override
+    public TypeInformation getProducedType() {
+      return null;
+    }
+  }
+
+  static class NonProtoMessageDeserializationSchema implements DeserializationSchema<Message> {
+    @Override
+    public Message deserialize(byte[] bytes) throws IOException {
+      return null;
+    }
+
+    @Override
+    public boolean isEndOfStream(Message message) {
+      return false;
+    }
+
+    @Override
+    public TypeInformation<Message> getProducedType() {
+      return null;
+    }
+  }
+}

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -13,14 +13,15 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
 import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.utils.AvroSchemaUtils;
 import io.openlineage.flink.visitor.wrapper.KafkaSinkWrapper;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import lombok.SneakyThrows;
-import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,16 +36,18 @@ class KafkaSinkVisitorTest {
   Properties props = new Properties();
   KafkaSinkWrapper wrapper = mock(KafkaSinkWrapper.class);
   OpenLineage openLineage = new OpenLineage(mock(URI.class));
-  Schema schema =
-      SchemaBuilder.record("OutputEvent")
-          .namespace("io.openlineage.flink.avro.event")
-          .fields()
-          .name("a")
-          .type()
-          .nullable()
-          .longType()
-          .noDefault()
-          .endRecord();
+  SchemaDatasetFacet schemaFacet =
+      AvroSchemaUtils.convert(
+          openLineage,
+          SchemaBuilder.record("OutputEvent")
+              .namespace("io.openlineage.flink.avro.event")
+              .fields()
+              .name("a")
+              .type()
+              .nullable()
+              .longType()
+              .noDefault()
+              .endRecord());
 
   @BeforeEach
   @SneakyThrows
@@ -63,11 +66,11 @@ class KafkaSinkVisitorTest {
   @SneakyThrows
   void testApply() {
     try (MockedStatic<KafkaSinkWrapper> mockedStatic = mockStatic(KafkaSinkWrapper.class)) {
-      when(KafkaSinkWrapper.of(kafkaSink)).thenReturn(wrapper);
+      when(KafkaSinkWrapper.of(kafkaSink, context)).thenReturn(wrapper);
 
       when(wrapper.getKafkaTopic()).thenReturn("topic");
       when(wrapper.getKafkaProducerConfig()).thenReturn(props);
-      when(wrapper.getAvroSchema()).thenReturn(Optional.of(schema));
+      when(wrapper.getSchemaFacet()).thenReturn(Optional.of(schemaFacet));
 
       OpenLineage.OutputDataset outputDataset = visitor.apply(kafkaSink).get(0);
       List<OpenLineage.SchemaDatasetFacetFields> fields =
@@ -86,7 +89,7 @@ class KafkaSinkVisitorTest {
   @SneakyThrows
   void testApplyWhenIllegalAccessExceptionThrown() {
     try (MockedStatic<KafkaSinkWrapper> mockedStatic = mockStatic(KafkaSinkWrapper.class)) {
-      when(KafkaSinkWrapper.of(kafkaSink)).thenReturn(wrapper);
+      when(KafkaSinkWrapper.of(kafkaSink, context)).thenReturn(wrapper);
 
       when(wrapper.getKafkaProducerConfig()).thenReturn(props);
       when(wrapper.getKafkaTopic()).thenThrow(new IllegalAccessException(""));

--- a/integration/flink/shared/src/test/proto/ProtobufTestEvent.proto
+++ b/integration/flink/shared/src/test/proto/ProtobufTestEvent.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package io.openlineage.flink.proto.event;
+option java_package = "io.openlineage.flink.proto.event";
+option java_multiple_files = true;
+
+import "google/protobuf/any.proto";
+
+message ProtobufTestEvent {
+  string id = 1;
+  int64 version = 2;
+  SubProtobufTestEvent subEvent = 3;
+  // Oneof fields are like regular fields except all the fields
+  // in a oneof share memory, and at most one field can be set at the same time.
+  oneof testOneOf {
+    string oneOf1 = 4;
+    SubProtobufTestEvent oneOf2 = 5;
+  }
+  google.protobuf.Any testAnyOf = 6;
+}
+
+message SubProtobufTestEvent {
+  string id = 1;
+  SubSubProtobufTestEvent subSubEvent = 2;
+  repeated SubSubProtobufTestEvent arr = 3;
+  map<string, int32> someMap = 4;
+}
+
+message SubSubProtobufTestEvent {
+  string id = 1;
+  int64 version = 2;
+}


### PR DESCRIPTION
### Problem

Flink integration does not support Kafka topics in Protobuf format. 

### Solution

 * Prepare example application code that reads from protobuf topic and writes to protobuf topic.
 * Add integration test which verifies behaviour of such app (fill protobuf topic with some data).
 * Extend `KafkaSourceVisitor` and `KafkaSourceVistitor` to handle scenarios when serialization/deserialization is done with protobuf.
 * Create method to convert Protobuf generated classes into SchemaDatasetFacet. Make the method above support nested and repeated fields. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project