### PR TITLE
upgrade spotless

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.adarshr.test-logger" version "3.2.0"
-    id 'com.diffplug.spotless' version '6.13.0'
+    id 'com.diffplug.spotless' version '6.21.0'
     id "org.openapi.generator" version "6.6.0"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"

--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
@@ -13,8 +13,10 @@ import java.util.regex.Pattern;
 public class DatasetIdentifierUtils {
 
   private static final String DEFAULT_SCHEME = "file";
+
   /** The directory separator, a slash, as a character. */
   public static final char SEPARATOR_CHAR = '/';
+
   /** The directory separator, a slash. */
   public static final String SEPARATOR = "/";
 


### PR DESCRIPTION
### Problem

the current version of spotless we use does not work with jdk 21
https://github.com/diffplug/spotless/issues/1819

### Solution

upgrade spotless plugin
