### PR TITLE
client: add info from http response to client exception

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -147,11 +147,8 @@ public final class HttpTransport extends Transport implements Closeable {
   private void throwOnHttpError(@NonNull HttpResponse response) throws IOException {
     final int code = response.getStatusLine().getStatusCode();
     if (code >= 400 && code < 600) { // non-2xx
-      String message =
-          String.format(
-              "code: %d, response: %s", code, EntityUtils.toString(response.getEntity(), UTF_8));
-
-      throw new OpenLineageClientException(message);
+      throw new HttpTransportResponseException(
+          code, EntityUtils.toString(response.getEntity(), UTF_8));
     }
   }
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransportResponseException.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransportResponseException.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import io.openlineage.client.*;
+import lombok.*;
+
+/** An exception thrown to indicate a client error relating to a http response. */
+@Getter
+public class HttpTransportResponseException extends OpenLineageClientException {
+  private static final long serialVersionUID = 1L;
+
+  private final int statusCode;
+  private final String body;
+
+  public HttpTransportResponseException(int statusCode, String body) {
+    super(String.format("code: %d, response: %s", statusCode, body), null);
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+}


### PR DESCRIPTION
### Problem

When using the `HttpTransport` with the Java client, if the receiving service (Marquez or whatever) responds with a non-2xx status then an `OpenLineageClientException` is thrown with a descriptive message. The consuming code may want to do something different with that exception depending on the response - e.g. we might retry the operation for a 502 but not for a 400. Currently this information has to be parsed out of the exception message.

### Solution

This PR adds `HttpTransportResponseException`, a subclass of `OpenLineageClientException` that includes fields for status code and body - this is what is now thrown in the event of a non-2xx response. Note that other exception-raising scenarios like timeouts and bad config will behave as previously. Also, the `message` on the exception remains the same for backwards compatibility.

#### One-line summary:

Adds the status code and body as properties on the thrown exception when a non-success response is encountered in the HTTP transport.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project