### PR TITLE
[AIRFLOW] fix: Proceed without rendering templates if task_instance copy fails

### DIFF
--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -109,8 +109,15 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
 
     def on_running():
         nonlocal task_instance
-        ti = copy.deepcopy(task_instance)
-        ti.render_templates()
+        try:
+            ti = copy.deepcopy(task_instance)
+        except Exception as err:
+            log.debug(
+                f"Creating a task instance copy failed; proceeding without rendering templates. Error: {err}"
+            )
+            ti = task_instance
+        else:
+            ti.render_templates()
 
         task = ti.task
         dag = task.dag


### PR DESCRIPTION
### Problem

In listener's `on_task_instance_running` method, we are working on `task_instance` copy when rendering templates. Sometimes making a copy can fail, if there are some objects that cannot be pickled and copied with `copy.deepcopy()`.

### Solution

I think we have two options if copying fails:
1. Skip rendering templates
2. Render templates on task_instance and not the copy.

This PR implements the first one, as the second one can lead to [this](https://github.com/OpenLineage/OpenLineage/issues/1017) issue.

#### One-line summary:

Proceed without rendering templates if task_instance copy fails in listener.on_task_instance_running.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project