### PR TITLE
metrics, java: add support for Micrometer metrics

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -46,6 +46,7 @@ ext {
     junit5Version = '5.10.2'
     lombokVersion = '1.18.32'
     mockitoVersion = '5.2.0'
+    micrometerVersion = '1.12.4'
     isReleaseVersion = !version.endsWith('SNAPSHOT')
 }
 
@@ -63,10 +64,13 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'commons-logging:commons-logging:1.3.0'
     implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation "io.micrometer:micrometer-core:${micrometerVersion}"
+
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'org.apache.kafka:kafka-clients:3.7.0'
     compileOnly 'com.amazonaws:amazon-kinesis-producer:0.15.10'
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "io.micrometer:micrometer-registry-statsd:${micrometerVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     codeGenerator project(':generator')
@@ -77,6 +81,7 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation "io.micrometer:micrometer-registry-statsd:${micrometerVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -45,8 +45,8 @@ public final class OpenLineageClientUtils {
 
   private static final ObjectMapper MAPPER = newObjectMapper();
 
-  private static final ObjectMapper YML = new ObjectMapper(new YAMLFactory());
-  private static final ObjectMapper JSON = new ObjectMapper(new JsonFactory());
+  private static final ObjectMapper YML = newObjectMapper(new YAMLFactory());
+  private static final ObjectMapper JSON = newObjectMapper();
 
   @JsonFilter("disabledFacets")
   public class DisabledFacetsMixin {}
@@ -58,7 +58,17 @@ public final class OpenLineageClientUtils {
    * @return A configured {@link ObjectMapper} instance.
    */
   public static ObjectMapper newObjectMapper() {
-    final ObjectMapper mapper = new ObjectMapper();
+    return newObjectMapper(new JsonFactory());
+  }
+
+  /**
+   * Creates a new {@link ObjectMapper} instance configured with modules for JDK8 and JavaTime,
+   * including settings to ignore unknown properties and to not write dates as timestamps.
+   *
+   * @return A configured {@link ObjectMapper} instance.
+   */
+  public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {
+    final ObjectMapper mapper = new ObjectMapper(jsonFactory);
     mapper.registerModule(new Jdk8Module());
     mapper.registerModule(new JavaTimeModule());
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageYaml.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageYaml.java
@@ -5,23 +5,27 @@
 
 package io.openlineage.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
+import java.util.Map;
 import lombok.Getter;
 
 /** Configuration for {@link OpenLineageClient}. */
+@JsonIgnoreProperties
+@Getter
 public class OpenLineageYaml {
-  @Getter
   @JsonProperty("transport")
   private TransportConfig transportConfig;
 
-  @Getter
   @JsonProperty("facets")
   private FacetsConfig facetsConfig;
 
-  @Getter
   @JsonProperty("circuitBreaker")
   private CircuitBreakerConfig circuitBreaker;
+
+  @JsonProperty("metrics")
+  private Map<String, Object> metricsConfig;
 }

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreaker.java
@@ -5,10 +5,10 @@
 
 package io.openlineage.client.circuitBreaker;
 
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.freeMemory;
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.getGarbageCollectorMXBeans;
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.maxMemory;
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.totalMemory;
+import static io.openlineage.client.utils.RuntimeUtils.freeMemory;
+import static io.openlineage.client.utils.RuntimeUtils.getGarbageCollectorMXBeans;
+import static io.openlineage.client.utils.RuntimeUtils.maxMemory;
+import static io.openlineage.client.utils.RuntimeUtils.totalMemory;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreaker.java
@@ -5,9 +5,9 @@
 
 package io.openlineage.client.circuitBreaker;
 
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.freeMemory;
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.maxMemory;
-import static io.openlineage.client.circuitBreaker.RuntimeUtils.totalMemory;
+import static io.openlineage.client.utils.RuntimeUtils.freeMemory;
+import static io.openlineage.client.utils.RuntimeUtils.maxMemory;
+import static io.openlineage.client.utils.RuntimeUtils.totalMemory;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;

--- a/client/java/src/main/java/io/openlineage/client/metrics/CompositeMeterRegistryFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/CompositeMeterRegistryFactory.java
@@ -1,0 +1,51 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A builder class that provides implementations to build composite meter registries. This class
+ * implements the MetricsBuilder interface with CompositeMeterRegistry as its type.
+ *
+ * <p>CompositeMeterRegistry is a type of MeterRegistry, that encapsulates two or more meter
+ * registries into one, and manages unified functionalities across all registries.
+ */
+public class CompositeMeterRegistryFactory implements MeterRegistryFactory<CompositeMeterRegistry> {
+
+  /**
+   * Constructs a CompositeMeterRegistry from a given map of configuration options. The "registries"
+   * key in the map is expected to provide a list of meter registry configurations. Each
+   * configuration is parsed and, if parsed successfully, added to the CompositeMeterRegistry.
+   *
+   * @param config The map containing the configurations for composite meter registry.
+   * @return A CompositeMeterRegistry built from the provided configuration. An empty
+   *     CompositeMeterRegistry is returned if the the map doesn't contain a list of configurations
+   *     extended by registries.
+   */
+  @Override
+  public CompositeMeterRegistry registry(Map<String, Object> config) {
+    CompositeMeterRegistry meterRegistry = new CompositeMeterRegistry();
+    Object registries = config.get("registries");
+    if (!(registries instanceof List) || ((List<?>) registries).isEmpty()) {
+      return meterRegistry;
+    }
+    for (Object registryConfig : (List<Object>) registries) {
+      if (registryConfig instanceof Map || !((Map<?, ?>) registryConfig).isEmpty()) {
+        MicrometerProvider.parseMeterRegistryConfig((Map<String, Object>) registryConfig)
+            .ifPresent(meterRegistry::add);
+      }
+    }
+    return meterRegistry;
+  }
+
+  @Override
+  public String type() {
+    return "composite";
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/metrics/MeterRegistryFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/MeterRegistryFactory.java
@@ -1,0 +1,19 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+
+/**
+ * MeterRegistryFactory is an interface that defines methods to build different types of meter
+ * registries from OpenLineage config.
+ */
+public interface MeterRegistryFactory<T extends MeterRegistry> {
+  T registry(Map<String, Object> config);
+
+  String type();
+}

--- a/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
@@ -1,0 +1,114 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.openlineage.client.utils.ReflectionUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * MicrometerProvider is a class that manages global OpenLineage meter registry implementation that
+ * allows integrations to both add metrics backend from common OpenLineage config, or grab an
+ * instance of an initialized MeterRegistry.
+ */
+public class MicrometerProvider {
+
+  private static final List<MeterRegistryFactory> factories;
+  private static CompositeMeterRegistry registry;
+
+  static {
+    ServiceLoader<MeterRegistryFactory> loader = ServiceLoader.load(MeterRegistryFactory.class);
+    factories =
+        Stream.concat(
+                getMetricsBuilders().stream(), StreamSupport.stream(loader.spliterator(), false))
+            .collect(Collectors.toList());
+    registry = new CompositeMeterRegistry();
+  }
+
+  /**
+   * Parses the configuration map to create an optional MeterRegistry.
+   *
+   * @param config The configuration map for the MeterRegistry.
+   * @return Optional MeterRegistry created based on the configuration. Empty optional if the type
+   *     is invalid or empty.
+   */
+  public static Optional<MeterRegistry> parseMeterRegistryConfig(Map<String, Object> config) {
+    if (config == null) {
+      return Optional.empty();
+    }
+    Object type = config.get("type");
+    if (!(type instanceof String) || "".equals(type)) {
+      return Optional.empty();
+    }
+    return getConfigBuilder((String) type).map(x -> x.registry(config));
+  }
+
+  /**
+   * Adds a MeterRegistry to the common OpenLineage meter registry based on the provided
+   * configuration.
+   *
+   * @param config The configuration for the MeterRegistry.
+   * @return Common registry configured with the added MeterRegistry.
+   */
+  public static MeterRegistry addMeterRegistryFromConfig(Map<String, Object> config) {
+    Optional<MeterRegistry> meterRegistry = parseMeterRegistryConfig(config);
+    meterRegistry.ifPresent(x -> registry.add(x));
+    return registry;
+  }
+
+  /**
+   * Adds a MeterRegistry to the common OpenLineage meter registry.
+   *
+   * @param meterRegistry The MeterRegistry to
+   */
+  public static MeterRegistry addMeterRegistry(MeterRegistry meterRegistry) {
+    registry.add(meterRegistry);
+    return registry;
+  }
+
+  /**
+   * Returns the global OpenLineage meter registry.
+   *
+   * @return The global OpenLineage meter registry.
+   */
+  public static MeterRegistry getMeterRegistry() {
+    return registry;
+  }
+
+  /**
+   * Clears the global OpenLineage meter registry and creates a new instance of a
+   * CompositeMeterRegistry.
+   *
+   * @return The newly created CompositeMeterRegistry instance.
+   */
+  public static MeterRegistry clear() {
+    registry.close();
+    registry = new CompositeMeterRegistry();
+    return registry;
+  }
+
+  private static List<MeterRegistryFactory> getMetricsBuilders() {
+    List<MeterRegistryFactory> builders = new ArrayList<>();
+    if (ReflectionUtils.hasClass("io.micrometer.statsd.StatsdMeterRegistry")) {
+      builders.add(new StatsDMeterRegistryFactory());
+    }
+    builders.add(new SimpleMeterRegistryFactory());
+    builders.add(new CompositeMeterRegistryFactory());
+    return builders;
+  }
+
+  private static Optional<MeterRegistryFactory> getConfigBuilder(String type) {
+    return factories.stream().filter(builder -> builder.type().equals(type)).findFirst();
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/metrics/SimpleMeterRegistryFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/SimpleMeterRegistryFactory.java
@@ -1,0 +1,34 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
+
+/**
+ * This class implements the MetricsBuilder interface with SimpleMeterRegistry as its type.
+ * SimpleMeterRegistry is a type of MeterRegistry, designed for testing functionality that does not
+ * require a backend monitoring system.
+ */
+public class SimpleMeterRegistryFactory implements MeterRegistryFactory<SimpleMeterRegistry> {
+
+  /**
+   * Constructs a SimpleMeterRegistry. This method doesn't use the given map parameter, as
+   * SimpleMeterRegistry does not require configuration options.
+   *
+   * @param config The map intended to contain the configurations. This parameter is not used.
+   * @return A new SimpleMeterRegistry instance.
+   */
+  @Override
+  public SimpleMeterRegistry registry(Map<String, Object> config) {
+    return new SimpleMeterRegistry();
+  }
+
+  @Override
+  public String type() {
+    return "simple";
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/metrics/StatsDMeterRegistryFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/StatsDMeterRegistryFactory.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import io.micrometer.statsd.StatsdMeterRegistry;
+import java.util.Map;
+
+/**
+ * StatsDMetricsBuilder is a class that implements the {@link MeterRegistryFactory} interface
+ * specifically for {@link StatsdMeterRegistry}. It provides methods to check if the required {@link
+ * StatsdMeterRegistry} class is available and build a {@link StatsdMeterRegistry} instance based on
+ * a configuration map.
+ *
+ * @see <a
+ *     href="https://docs.micrometer.io/micrometer/reference/implementations/statsD.html">StatsdConfig
+ *     and StatsD micrometer interface docs</a>
+ */
+public class StatsDMeterRegistryFactory implements MeterRegistryFactory<StatsdMeterRegistry> {
+
+  @Override
+  public StatsdMeterRegistry registry(Map<String, Object> config) {
+    return StatsdMeterRegistry.builder(s -> (String) config.get(s)).build();
+  }
+
+  @Override
+  public String type() {
+    return "statsd";
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/ReflectionUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/ReflectionUtils.java
@@ -1,0 +1,59 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils;
+
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.reflect.MethodUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.ClassUtils;
+
+@Slf4j
+public class ReflectionUtils {
+  public static Optional<Object> tryExecuteStaticMethodForClassName(
+      String className, String methodName, Object... args) {
+    Class<?> clazz;
+    try {
+      clazz = ClassUtils.getClass(className);
+    } catch (ClassNotFoundException | Error e) {
+      log.debug("Can't get class {}", className, e);
+      return Optional.empty();
+    }
+    args = ArrayUtils.nullToEmpty(args);
+    Class<?>[] parameterTypes = ClassUtils.toClass(args);
+    try {
+      return Optional.of(MethodUtils.invokeStaticMethod(clazz, methodName, args, parameterTypes));
+    } catch (Error | Exception e) {
+      log.debug("Can't execute static method {}.{}:", className, methodName, e);
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<Object> tryExecuteMethod(
+      Object object, String methodName, Object... args) {
+    try {
+      return Optional.of(MethodUtils.invokeMethod(object, methodName, args));
+    } catch (Exception exception) {
+      return Optional.empty();
+    }
+  }
+
+  public static boolean hasClass(String aClass) {
+    try {
+      ReflectionUtils.class.getClassLoader().loadClass(aClass);
+      return true;
+    } catch (Exception e) {
+      //
+      // we don't care
+    }
+    return false;
+  }
+
+  public static boolean hasClasses(String... classes) {
+    return Arrays.stream(classes).allMatch(ReflectionUtils::hasClass);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/RuntimeUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/RuntimeUtils.java
@@ -2,7 +2,7 @@
 /* Copyright 2018-2024 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
-package io.openlineage.client.circuitBreaker;
+package io.openlineage.client.utils;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -12,20 +12,20 @@ import java.util.List;
  * Class used to access static Runtime properties. Useful for testing as it can be mocked with
  * mockStatic.
  */
-class RuntimeUtils {
-  static long freeMemory() {
+public class RuntimeUtils {
+  public static long freeMemory() {
     return Runtime.getRuntime().freeMemory();
   }
 
-  static long totalMemory() {
+  public static long totalMemory() {
     return Runtime.getRuntime().totalMemory();
   }
 
-  static long maxMemory() {
+  public static long maxMemory() {
     return Runtime.getRuntime().maxMemory();
   }
 
-  static List<GarbageCollectorMXBean> getGarbageCollectorMXBeans() {
+  public static List<GarbageCollectorMXBean> getGarbageCollectorMXBeans() {
     return ManagementFactory.getGarbageCollectorMXBeans();
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -9,26 +9,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreaker;
 import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreakerConfig;
 import io.openlineage.client.circuitBreaker.SimpleMemoryCircuitBreaker;
 import io.openlineage.client.circuitBreaker.SimpleMemoryCircuitBreakerConfig;
+import io.openlineage.client.metrics.MicrometerProvider;
 import io.openlineage.client.transports.HttpTransport;
 import io.openlineage.client.transports.NoopTransport;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 class ConfigTest {
+  @BeforeEach
+  void clear() {
+    MicrometerProvider.clear();
+  }
+
   @Test
   void testLoadConfigFromYaml() throws URISyntaxException {
-    Path configPath =
-        Paths.get(this.getClass().getClassLoader().getResource("config/http.yaml").toURI());
-    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/http.yaml"));
     assertThat(client.transport).isInstanceOf(HttpTransport.class);
   }
 
@@ -37,9 +46,7 @@ class ConfigTest {
     try (MockedStatic mocked = mockStatic(Environment.class)) {
       when(Environment.getEnvironmentVariable("OPENLINEAGE_DISABLED")).thenReturn("true");
 
-      Path configPath =
-          Paths.get(this.getClass().getClassLoader().getResource("config/http.yaml").toURI());
-      OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+      OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/http.yaml"));
       assertThat(client.transport).isInstanceOf(NoopTransport.class);
     }
   }
@@ -49,28 +56,22 @@ class ConfigTest {
     try (MockedStatic mocked = mockStatic(Environment.class)) {
       when(Environment.getEnvironmentVariable("OPENLINEAGE_DISABLED")).thenReturn("anything_else");
 
-      Path configPath =
-          Paths.get(this.getClass().getClassLoader().getResource("config/http.yaml").toURI());
-      OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+      OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/http.yaml"));
       assertThat(client.transport).isInstanceOf(HttpTransport.class);
     }
   }
 
   @Test
   void testFacetsDisabledConfigFromYaml() throws URISyntaxException {
-    Path configPath =
-        Paths.get(this.getClass().getClassLoader().getResource("config/facets.yaml").toURI());
-    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/facets.yaml"));
 
     assertThat(client.disabledFacets).contains("facet1", "facet2");
   }
 
   @Test
   void testJavaRuntimeCircuitBreakerConfigFromYaml() throws URISyntaxException {
-    Path configPath =
-        Paths.get(
-            this.getClass().getClassLoader().getResource("config/circuitBreaker1.yaml").toURI());
-    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+    OpenLineageClient client =
+        Clients.newClient(new TestConfigPathProvider("config/circuitBreaker1.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(JavaRuntimeCircuitBreaker.class)
@@ -78,10 +79,7 @@ class ConfigTest {
 
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(1000);
 
-    configPath =
-        Paths.get(
-            this.getClass().getClassLoader().getResource("config/circuitBreaker2.yaml").toURI());
-    client = Clients.newClient(new TestConfigPathProvider(configPath));
+    client = Clients.newClient(new TestConfigPathProvider("config/circuitBreaker2.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(JavaRuntimeCircuitBreaker.class)
@@ -91,20 +89,15 @@ class ConfigTest {
 
   @Test
   void testSimpleMemoryCircuitBreakerConfigFromYaml() throws URISyntaxException {
-    Path configPath =
-        Paths.get(
-            this.getClass().getClassLoader().getResource("config/circuitBreaker3.yaml").toURI());
-    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider(configPath));
+    OpenLineageClient client =
+        Clients.newClient(new TestConfigPathProvider("config/circuitBreaker3.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(SimpleMemoryCircuitBreaker.class)
         .hasFieldOrPropertyWithValue("config", new SimpleMemoryCircuitBreakerConfig(13));
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(1000);
 
-    configPath =
-        Paths.get(
-            this.getClass().getClassLoader().getResource("config/circuitBreaker4.yaml").toURI());
-    client = Clients.newClient(new TestConfigPathProvider(configPath));
+    client = Clients.newClient(new TestConfigPathProvider("config/circuitBreaker4.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(SimpleMemoryCircuitBreaker.class)
@@ -112,11 +105,36 @@ class ConfigTest {
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(200);
   }
 
+  @Test
+  void testSimpleMetricsConfigFromYaml() {
+    OpenLineageClient client = Clients.newClient(new TestConfigPathProvider("config/metrics.yaml"));
+    CompositeMeterRegistry meterRegistry = (CompositeMeterRegistry) client.meterRegistry;
+    assertThat(meterRegistry.getRegistries())
+        .hasOnlyElementsOfType(SimpleMeterRegistry.class)
+        .hasSize(1);
+  }
+
+  @Test
+  void testCompositeMetricsConfigFromYaml() {
+    OpenLineageClient client =
+        Clients.newClient(new TestConfigPathProvider("config/metrics-complex.yaml"));
+    CompositeMeterRegistry meterRegistry = (CompositeMeterRegistry) client.meterRegistry;
+    assertThat(meterRegistry.getRegistries().iterator().next())
+        .isInstanceOfSatisfying(
+            CompositeMeterRegistry.class,
+            x -> {
+              assertThat(new ArrayList<>(x.getRegistries()))
+                  .hasSize(1)
+                  .anyMatch(y -> y instanceof SimpleMeterRegistry);
+            });
+  }
+
   static class TestConfigPathProvider implements ConfigPathProvider {
     private final Path path;
 
-    public TestConfigPathProvider(Path path) {
-      this.path = path;
+    @SneakyThrows
+    public TestConfigPathProvider(String path) {
+      this.path = Paths.get(this.getClass().getClassLoader().getResource(path).toURI());
     }
 
     @Override

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageClientTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageClientTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage.DatasetEvent;
 import io.openlineage.client.OpenLineage.JobEvent;
 import io.openlineage.client.OpenLineage.RunEvent;
@@ -23,7 +25,8 @@ class OpenLineageClientTest {
 
   CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
   Transport transport = mock(Transport.class);
-  OpenLineageClient client = new OpenLineageClient(transport, circuitBreaker);
+  MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  OpenLineageClient client = new OpenLineageClient(transport, circuitBreaker, meterRegistry);
 
   @Test
   void testCircuitBreakerFroEmitRunEvent() {

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.utils.RuntimeUtils;
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.Arrays;
 import java.util.Collections;

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.utils.RuntimeUtils;
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;

--- a/client/java/src/test/java/io/openlineage/client/metrics/BaseMetricsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/metrics/BaseMetricsTest.java
@@ -1,0 +1,15 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class BaseMetricsTest {
+  @BeforeEach
+  void clear() {
+    MicrometerProvider.clear();
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/metrics/MetricsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/metrics/MetricsTest.java
@@ -1,0 +1,99 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.Transport;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+public class MetricsTest extends BaseMetricsTest {
+
+  @SneakyThrows
+  @Test
+  void testSimpleMeterResolver() {
+    Map<String, Object> config = new ObjectMapper().readValue("{\"type\": \"simple\"}", Map.class);
+    MeterRegistry registry = MicrometerProvider.addMeterRegistryFromConfig(config);
+    assertThat(registry)
+        .isInstanceOfSatisfying(
+            CompositeMeterRegistry.class,
+            x -> {
+              x.getRegistries().stream()
+                  .findFirst()
+                  .ifPresent(y -> assertThat(y).isInstanceOf(SimpleMeterRegistry.class));
+            });
+  }
+
+  @SneakyThrows
+  @Test
+  void testGlobalRegistryBumpsMetrics() {
+    OpenLineage openLineage = new OpenLineage(new URI("http://example.com"));
+    Transport transport = mock(Transport.class);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerProvider.addMeterRegistry(registry);
+    OpenLineageClient client =
+        OpenLineageClient.builder()
+            .transport(transport)
+            .meterRegistry(MicrometerProvider.getMeterRegistry())
+            .build();
+
+    client.emit(
+        openLineage.newRunEvent(
+            ZonedDateTime.now(),
+            OpenLineage.RunEvent.EventType.START,
+            openLineage.newRun(UUID.randomUUID(), openLineage.newRunFacetsBuilder().build()),
+            openLineage.newJob("namespace", "name", openLineage.newJobFacetsBuilder().build()),
+            Collections.emptyList(),
+            Collections.emptyList()));
+    assertThat(registry.get("openlineage.emit.start").counter().count()).isEqualTo(1.0);
+    assertThat(registry.get("openlineage.emit.complete").counter().count()).isEqualTo(1.0);
+  }
+
+  @SneakyThrows
+  @Test
+  void testTimerMeasuresTime() {
+    OpenLineage openLineage = new OpenLineage(new URI("http://example.com"));
+    Transport transport = mock(Transport.class);
+
+    doAnswer(
+            x -> {
+              Thread.sleep(100);
+              return null;
+            })
+        .when(transport)
+        .emit(any(OpenLineage.RunEvent.class));
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerProvider.addMeterRegistry(registry);
+
+    OpenLineageClient client =
+        OpenLineageClient.builder()
+            .transport(transport)
+            .meterRegistry(MicrometerProvider.getMeterRegistry())
+            .build();
+
+    client.emit(openLineage.newRunEventBuilder().build());
+
+    assertThat(registry.get("openlineage.emit.time").timer())
+        .satisfies(timer -> assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isGreaterThan(100));
+  }
+}

--- a/client/java/src/test/resources/config/metrics-complex.yaml
+++ b/client/java/src/test/resources/config/metrics-complex.yaml
@@ -1,0 +1,6 @@
+transport:
+  type: console
+metrics:
+  type: composite
+  registries:
+    - type: simple

--- a/client/java/src/test/resources/config/metrics.yaml
+++ b/client/java/src/test/resources/config/metrics.yaml
@@ -1,0 +1,4 @@
+transport:
+  type: console
+metrics:
+  type: simple

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -174,6 +174,8 @@ shadowJar {
     relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
     relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
     relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
+    relocate "org.hdrhistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
+    relocate "org.latencyutils", "io.openlineage.spark.shaded.org.latencyutils"
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",


### PR DESCRIPTION
This PR adds support for Micrometer-based telemetry. This comprises of: 

- adding `MeterRegistryFactory` mechanism that allows to construct Micrometer's `MeterRegistry` based on passed configuration
- adding `MicrometerProvider` mechanism that allows you to configure metrics from any OpenLineage integration and get configured `MeterRegistry` instance
- adding proper metrics config to OpenLineage config
- adding `StatsDMetricsBuilder`
- implementing instrumentation into Java client. 

The metrics mechanism can forward metrics to any Micrometer compatible implementation - list [here](https://docs.micrometer.io/micrometer/reference/implementations.html) - however compatible wrapper `MeterRegistryFactory` needs to be added. This PR adds only support for StatsD based one, as well as in-memory `SimpleMetricsBuilder` and `CompositeMetricsBuilder` that allows you to configure multiple backends. However, global registry provided by `MicrometerProvider` is a `CompositeMetricsBuilder`, so that using it manually is generally unadvisable.