### PR TITLE
[FLINK] fix release runtime dependencies

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -156,7 +156,13 @@ signing {
 }
 
 shadowJar {
-    minimize()
+    minimize() {
+        exclude(project(path: ":app"))
+        exclude(project(path: ":shared"))
+        exclude(project(path: ":flink115"))
+        exclude(project(path: ":flink117"))
+        exclude(project(path: ":flink118"))
+    }
     archiveClassifier = ''
     // avoid conflict with any client version of that lib
     relocate 'com.fasterxml.jackson', 'io.openlineage.flink.shaded.com.fasterxml.jackson'


### PR DESCRIPTION
#### One-line summary:

The shadow jar of flink is not minimized, so that some internal jars are listed as runtime dependencies. We need to remove them from the final pom.xml file for the flink module.

It is to resolve the issue raised here  https://github.com/OpenLineage/OpenLineage/issues/2503


----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project