### PR TITLE
Flink refine jdbc table name

### DIFF
--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSourceWrapper.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSourceWrapper.java
@@ -56,7 +56,9 @@ public class JdbcSourceWrapper {
 
     return queryOpt
         .flatMap(query -> OpenLineageSql.parse(List.of(query)))
-        .map(sqlMeta -> sqlMeta.inTables().isEmpty() ? "" : sqlMeta.inTables().get(0).name());
+        .map(
+            sqlMeta ->
+                sqlMeta.inTables().isEmpty() ? "" : sqlMeta.inTables().get(0).qualifiedName());
   }
 
   private Optional<JdbcConnectionOptions> getConnectionOptions() {


### PR DESCRIPTION
#### One-line summary:
Enable the jdbc table name with schema prefix. 

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project