### PR TITLE
common: use uv instead of pip in openlineage-common tests.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -341,7 +341,7 @@ jobs:
       - *checkout_project_root
       - attach_workspace:
           at: .
-      - run: pip install tox==3.27.1
+      - run: pip install uv tox==4.12.1
       - run: tox
       - run: bash <(curl -s https://codecov.io/bash)
       - store_test_results:

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -31,8 +31,9 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-install_command = python -m pip install {opts} --find-links target/wheels/ --find-links ../sql/iface-py/target/wheels {packages}
-deps = ../../client/python
+allowlist_externals = uv
+install_command = uv pip install {opts} --find-links target/wheels {packages} 
+deps = openlineage-python@../../client/python
 	-e .[dev]
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3


### PR DESCRIPTION
### Problem

`unit-test-integration-common` step in current CI takes over 8 min to complete.

### Solution

Use `uv` as alternative package manager to `pip`. In Airflow new tool written in Rust (with love from @mobuchowski 😅 ) has already been introduced to speed up parts of CI.

With this PR the step goes under 1 minute. 🚀 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project