### PR TITLE
dagster: add new latest version provider in conftest

### DIFF
--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -17,7 +17,6 @@ from dagster import (
     EventLogRecord,
 )
 from dagster.core.execution.plan.objects import StepFailureData, StepSuccessData
-from dagster.core.host_representation import ExternalRepositoryOrigin
 from dagster.core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster.version import __version__ as DAGSTER_VERSION
 
@@ -44,6 +43,7 @@ class DagsterRunLE1_2_2Provider(DagsterRunProvider):
     def get_instance(self, repository_name: str) -> DagsterRun:
         from dagster.core.host_representation import (  # type: ignore
             ExternalPipelineOrigin,
+            ExternalRepositoryOrigin,
             InProcessRepositoryLocationOrigin,
         )
 
@@ -74,6 +74,7 @@ class DagsterRunLE1_3_2Provider(DagsterRunProvider):
     def get_instance(self, repository_name: str) -> DagsterRun:
         from dagster.core.host_representation import (
             ExternalPipelineOrigin,
+            ExternalRepositoryOrigin,
             InProcessCodeLocationOrigin,
         )
 
@@ -95,6 +96,36 @@ class DagsterRunLE1_3_2Provider(DagsterRunProvider):
         return dagster_run
 
 
+class DagsterRunLE1_6_9Provider(DagsterRunProvider):
+    """Class for provisioning `dagster.DagsterRun` instance for Dagster
+    versioin >= `1.3.3`.
+    """
+
+    def get_instance(self, repository_name: str) -> DagsterRun:
+        from dagster.core.host_representation import (
+            ExternalJobOrigin,
+            ExternalRepositoryOrigin,
+            InProcessCodeLocationOrigin,
+        )
+
+        dagster_run = DagsterRun(
+            job_name="test",
+            execution_plan_snapshot_id="123",
+            external_job_origin=ExternalJobOrigin(
+                external_repository_origin=ExternalRepositoryOrigin(
+                    code_location_origin=InProcessCodeLocationOrigin(
+                        loadable_target_origin=LoadableTargetOrigin(
+                            python_file="/openlineage/dagster/tests/test_pipelines/repo.py",
+                        )
+                    ),
+                    repository_name=repository_name,
+                ),
+                job_name="test",
+            ),
+        )
+        return dagster_run
+
+
 class DagsterRunLatestProvider(DagsterRunProvider):
     """Class for provisioning `dagster.DagsterRun` instance for Dagster
     versioin >= `1.3.3`.
@@ -106,8 +137,9 @@ class DagsterRunLatestProvider(DagsterRunProvider):
     """
 
     def get_instance(self, repository_name: str) -> DagsterRun:
-        from dagster.core.host_representation import (
+        from dagster.core.remote_representation.origin import (
             ExternalJobOrigin,
+            ExternalRepositoryOrigin,
             InProcessCodeLocationOrigin,
         )
 
@@ -174,6 +206,8 @@ def make_pipeline_run_with_external_pipeline_origin(
         dagster_run_provider = DagsterRunLE1_2_2Provider()
     if not dagster_run_provider and parsed_dagster_version <= parse_version("1.3.2"):
         dagster_run_provider = DagsterRunLE1_3_2Provider()
+    if not dagster_run_provider and parsed_dagster_version <= parse_version("1.6.9"):
+        dagster_run_provider = DagsterRunLE1_6_9Provider()
     if not dagster_run_provider:
         dagster_run_provider = DagsterRunLatestProvider()
     return dagster_run_provider.get_instance(repository_name)


### PR DESCRIPTION
### Problem

30 minutes from now new version of Dagster was released. It breaks tests with latest version.


### Solution

Add new provider for latest version as advised in docstrings.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project