### PR TITLE
release: make flink release job depend on SQL java build job

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1015,6 +1015,7 @@ workflows:
           context: release
           requires:
             - release-client-java
+            - build-integration-sql-java
       - release-proxy-backend:
           filters:
             tags:


### PR DESCRIPTION
https://github.com/OpenLineage/OpenLineage/pull/2481 added dependency for build and Flink integration test job to use SQL parser integration, but did not do the same for release job.