### PR TITLE
[AIRFLOW] Remove redundant operator information from facets

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bash_extractor.py
@@ -5,10 +5,7 @@ import os
 from typing import Dict, List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-from openlineage.airflow.facets import (
-    UnknownOperatorAttributeRunFacet,
-    UnknownOperatorInstance,
-)
+from openlineage.airflow.utils import get_unknown_source_attribute_run_facet
 from openlineage.client.facet import SourceCodeJobFacet
 
 
@@ -43,17 +40,7 @@ class BashExtractor(BaseExtractor):
         return TaskMetadata(
             name=f"{self.operator.dag_id}.{self.operator.task_id}",
             job_facets=job_facet,
-            run_facets={
-                # The BashOperator is recorded as an "unknownSource" even though we have an
-                # extractor, as the <i>data lineage</i> cannot be determined from the operator
-                # directly.
-                "unknownSourceAttribute": UnknownOperatorAttributeRunFacet(
-                    unknownItems=[
-                        UnknownOperatorInstance(
-                            name="BashOperator",
-                            properties={attr: value for attr, value in self.operator.__dict__.items()},
-                        )
-                    ]
-                )
-            },
+            # The BashOperator is recorded as an "unknownSource" even though we have an extractor,
+            # as the <i>data lineage</i> cannot be determined from the operator directly.
+            run_facets=get_unknown_source_attribute_run_facet(task=self.operator, name="BashOperator"),
         )

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -5,11 +5,7 @@ import logging
 from typing import List, Optional, Type
 
 from openlineage.airflow.extractors import BaseExtractor, Extractors, TaskMetadata
-from openlineage.airflow.facets import (
-    UnknownOperatorAttributeRunFacet,
-    UnknownOperatorInstance,
-)
-from openlineage.airflow.utils import get_job_name, get_operator_class
+from openlineage.airflow.utils import get_job_name, get_operator_class, get_unknown_source_attribute_run_facet
 
 
 class ExtractorManager:
@@ -75,16 +71,7 @@ class ExtractorManager:
             # Only include the unkonwnSourceAttribute facet if there is no extractor
             task_metadata = TaskMetadata(
                 name=get_job_name(task),
-                run_facets={
-                    "unknownSourceAttribute": UnknownOperatorAttributeRunFacet(
-                        unknownItems=[
-                            UnknownOperatorInstance(
-                                name=get_operator_class(task).__name__,
-                                properties={attr: value for attr, value in task.__dict__.items()},
-                            )
-                        ]
-                    )
-                },
+                run_facets=get_unknown_source_attribute_run_facet(task=task),
             )
             inlets = task.get_inlet_defs()
             outlets = task.get_outlet_defs()

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -6,10 +6,7 @@ import os
 from typing import Callable, Dict, List, Optional
 
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-from openlineage.airflow.facets import (
-    UnknownOperatorAttributeRunFacet,
-    UnknownOperatorInstance,
-)
+from openlineage.airflow.utils import get_unknown_source_attribute_run_facet
 from openlineage.client.facet import SourceCodeJobFacet
 
 
@@ -44,19 +41,9 @@ class PythonExtractor(BaseExtractor):
         return TaskMetadata(
             name=f"{self.operator.dag_id}.{self.operator.task_id}",
             job_facets=job_facet,
-            run_facets={
-                # The BashOperator is recorded as an "unknownSource" even though we have an
-                # extractor, as the <i>data lineage</i> cannot be determined from the operator
-                # directly.
-                "unknownSourceAttribute": UnknownOperatorAttributeRunFacet(
-                    unknownItems=[
-                        UnknownOperatorInstance(
-                            name="PythonOperator",
-                            properties={attr: value for attr, value in self.operator.__dict__.items()},
-                        )
-                    ]
-                )
-            },
+            # The PythonOperator is recorded as an "unknownSource" even though we have an extractor,
+            # as the <i>data lineage</i> cannot be determined from the operator directly.
+            run_facets=get_unknown_source_attribute_run_facet(task=self.operator, name="PythonOperator"),
         )
 
     def get_source_code(self, callable: Callable) -> Optional[str]:

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -26,15 +26,11 @@ class AirflowVersionRunFacet(BaseFacet):
 
     @classmethod
     def from_dagrun_and_task(cls, dagrun, task):
-        # task.__dict__ may contain values uncastable to str
-        from openlineage.airflow.utils import get_operator_class, to_json_encodable
-
-        task_info = to_json_encodable(task)
-        task_info["dag_run"] = to_json_encodable(dagrun)
+        from openlineage.airflow.utils import get_operator_class
 
         return cls(
             operator=f"{get_operator_class(task).__module__}.{get_operator_class(task).__name__}",
-            taskInfo=task_info,
+            taskInfo={},
             airflowVersion=AIRFLOW_VERSION,
             openlineageAirflowVersion=OPENLINEAGE_AIRFLOW_VERSION,
         )

--- a/integration/airflow/tests/integration/requests/custom_extractor.json
+++ b/integration/airflow/tests/integration/requests/custom_extractor.json
@@ -16,6 +16,9 @@
  		},
  		"run": {
  			"facets": {
+				"airflow_version": {
+					"taskInfo": "{{ 'true' if result == {} else result }}"
+				},
  				"airflow_runArgs": {
  					"externalTrigger": false
  				},

--- a/integration/airflow/tests/integration/requests/default_extractor.json
+++ b/integration/airflow/tests/integration/requests/default_extractor.json
@@ -21,6 +21,9 @@
 	}],
 	"run": {
 		"facets": {
+            "airflow_version": {
+                "taskInfo": "{{ 'true' if result == {} else result }}"
+            },
 			"parent": {
 				"job": {
 					"name": "parentjob",

--- a/integration/airflow/tests/integration/requests/secrets.json
+++ b/integration/airflow/tests/integration/requests/secrets.json
@@ -7,15 +7,16 @@
     "run": {
         "facets": {
             "airflow_version": {
-                "taskInfo": "{{ not_match(result, '1500100900') }}"
+                "taskInfo": "{{ 'true' if result == {} else result }}"
+            },
+            "airflow": {
+                "task": "{{ not_match(result, '1500100900') }}"
             },
             "unknownSourceAttribute": {
                 "unknownItems": [
                     {
                         "name": "SecretsOperator",
-                        "properties": {
-                            "password": "***"
-                        }
+                        "properties": "{{ not_match(result, 'password') }}"
                     }
                 ]
             }
@@ -33,9 +34,7 @@
                 "unknownItems": [
                     {
                         "name": "SecretsOperator",
-                        "properties": {
-                            "password": "***"
-                        }
+                        "properties": "{{ not_match(result, 'password') }}"
                     }
                 ]
             }

--- a/integration/airflow/tests/integration/requests/unknown_operator.json
+++ b/integration/airflow/tests/integration/requests/unknown_operator.json
@@ -12,6 +12,9 @@
  		},
  		"run": {
  			"facets": {
+				"airflow_version": {
+					"taskInfo": "{{ 'true' if result == {} else result }}"
+				},
  				"airflow_runArgs": {
  					"externalTrigger": false
  				},


### PR DESCRIPTION
### Problem

We encountered a case where a customer received an overly large OpenLineage START event, exceeding 2MB. This was traced back to an operator with unusually long arguments and attributes.

### Solution

I propose refining the operator's attribute inclusion logic in facets. Instead of excluding known unimportant or large attributes, we should selectively include only those known to be important or compact. This approach ensures that custom operator attributes with substantial data do not inflate the event size.

#### One-line summary:

Remove redundant operator information from facets

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project