### PR TITLE
fix: missing libs in final jar

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("org.mockito:mockito-inline:${mockitoVersion}")
     testImplementation("org.mockito:mockito-junit-jupiter:${mockitoVersion}")
-    testImplementation("com.databricks:databricks-sdk-java:0.4.0") {
+    testImplementation("com.databricks:databricks-sdk-java:0.7.0") {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.module'
     }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -189,10 +189,11 @@ public class DatabricksUtils {
             .build();
 
     log.info("Creating cluster");
+    Map<String, String> emptyHeaders = new HashMap<>();
     CreateClusterResponse response =
         workspace
             .apiClient()
-            .POST("/api/2.0/clusters/create", createCluster, CreateClusterResponse.class);
+            .POST("/api/2.0/clusters/create", createCluster, CreateClusterResponse.class, emptyHeaders);
 
     return response.getClusterId();
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -193,7 +193,11 @@ public class DatabricksUtils {
     CreateClusterResponse response =
         workspace
             .apiClient()
-            .POST("/api/2.0/clusters/create", createCluster, CreateClusterResponse.class, emptyHeaders);
+            .POST(
+                "/api/2.0/clusters/create",
+                createCluster,
+                CreateClusterResponse.class,
+                emptyHeaders);
 
     return response.getClusterId();
   }
@@ -258,7 +262,9 @@ public class DatabricksUtils {
 
   @SneakyThrows
   private static List<RunEvent> fetchEventsEmitted(WorkspaceClient workspace) {
-    return workspace.dbfs().readAllLines(Paths.get(DBFS_EVENTS_FILE), StandardCharsets.UTF_8)
+    return workspace
+        .dbfs()
+        .readAllLines(Paths.get(DBFS_EVENTS_FILE), StandardCharsets.UTF_8)
         .stream()
         .map(event -> OpenLineageClientUtils.runEventFromJson(event))
         .collect(Collectors.toList());

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -174,6 +174,8 @@ shadowJar {
     relocate "org.apache.commons.beanutils", "io.openlineage.spark.shaded.org.apache.commons.beanutils"
     relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
     relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
+    relocate "org.yaml.snakeyaml", "io.openlineage.spark.shaded.org.yaml.snakeyaml"
+    relocate "com.databricks.sdk", "io.openlineage.spark.shaded.com.databricks.sdk"
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compileOnly("org.apache.spark:spark-sql-kafka-0-10_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
 
-    compileOnly("com.databricks:databricks-dbutils-scala_${scalaBinaryVersion}:${databricksVersion}") {
+    implementation("com.databricks:databricks-dbutils-scala_${scalaBinaryVersion}:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
     }
     compileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_${scalaBinaryVersion}:${bigqueryVersion}") {
@@ -94,7 +94,7 @@ dependencies {
     scala212CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}")
     scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
-    scala212CompileOnly("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}") {
+    scala212Implementation("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
     }
     scala212CompileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
@@ -140,7 +140,7 @@ dependencies {
     scala213CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.13:${sparkVersion}")
     scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
 
-    scala213CompileOnly("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}") {
+    scala213Implementation("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
     }
     scala213CompileOnly("com.google.cloud.spark:spark-bigquery-with-dependencies_2.13:${bigqueryVersion}") {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -110,7 +110,7 @@ public class DatabricksEnvironmentFacetBuilder
   private static Optional<DbfsUtils> getDbfsUtils()
       throws ClassNotFoundException, InstantiationException, IllegalAccessException,
           IllegalArgumentException, InvocationTargetException {
-    Class dbutilsClass = Class.forName("com.databricks.dbutils_v1.impl.DbfsUtilsImpl");
+    Class dbutilsClass = Class.forName("com.databricks.sdk.scala.dbutils.SdkDBUtilsImpl");
     Constructor[] dbutilsConstructors = dbutilsClass.getDeclaredConstructors();
     if (dbutilsConstructors.length == 0) {
       log.warn(


### PR DESCRIPTION
### Problem

Since OpenLineage 1.9.1, we started getting this error in Databricks environments

```
ERROR Utils: throw uncaught fatal error in thread spark-listener-group-shared
java.lang.NoClassDefFoundError: com/databricks/sdk/scala/dbutils/DbfsUtils
	at io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder.getDbfsUtils(DatabricksEnvironmentFacetBuilder.java:124)
	at io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder.getDatabricksEnvironmentalAttributes(DatabricksEnvironmentFacetBuilder.java:92)
	at io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder.build(DatabricksEnvironmentFacetBuilder.java:58)
	at io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder.build(DatabricksEnvironmentFacetBuilder.java:32)
	at io.openlineage.spark.api.CustomFacetBuilder.accept(CustomFacetBuilder.java:40)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.lambda$null$27(OpenLineageRunEventBuilder.java:508)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.lambda$buildRunFacets$28(OpenLineageRunEventBuilder.java:508)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildRunFacets(OpenLineageRunEventBuilder.java:508)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.populateRun(OpenLineageRunEventBuilder.java:328)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildRun(OpenLineageRunEventBuilder.java:304)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildRun(OpenLineageRunEventBuilder.java:265)
	at io.openlineage.spark.agent.lifecycle.SparkSQLExecutionContext.start(SparkSQLExecutionContext.java:221)
	at io.openlineage.spark.agent.OpenLineageSparkListener.lambda$null$13(OpenLineageSparkListener.java:178)
	at io.openlineage.client.circuitBreaker.NoOpCircuitBreaker.run(NoOpCircuitBreaker.java:27)
	at io.openlineage.spark.agent.OpenLineageSparkListener.lambda$onJobStart$14(OpenLineageSparkListener.java:176)
	at java.util.Optional.ifPresent(Optional.java:159)
	at io.openlineage.spark.agent.OpenLineageSparkListener.onJobStart(OpenLineageSparkListener.java:172)
	at org.apache.spark.scheduler.SparkListenerBus.doPostEvent(SparkListenerBus.scala:37)
	at org.apache.spark.scheduler.SparkListenerBus.doPostEvent$(SparkListenerBus.scala:28)
	at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:42)
	at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:42)
	at org.apache.spark.util.ListenerBus.postToAll(ListenerBus.scala:118)
	at org.apache.spark.util.ListenerBus.postToAll$(ListenerBus.scala:102)
	at org.apache.spark.scheduler.AsyncEventQueue.super$postToAll(AsyncEventQueue.scala:114)
	at org.apache.spark.scheduler.AsyncEventQueue.$anonfun$dispatch$1(AsyncEventQueue.scala:114)
	at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
	at org.apache.spark.scheduler.AsyncEventQueue.org$apache$spark$scheduler$AsyncEventQueue$$dispatch(AsyncEventQueue.scala:109)
	at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.$anonfun$run$1(AsyncEventQueue.scala:105)
	at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1493)
	at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.run(AsyncEventQueue.scala:105)
Caused by: java.lang.ClassNotFoundException: com.databricks.sdk.scala.dbutils.DbfsUtils
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	... 33 more
```

Closes: https://github.com/OpenLineage/OpenLineage/issues/2499

### Solution

The package `com.databricks:dbutils-api_2.11:0.0.4` and `com.databricks:databricks-sdk-java:0.14.0` exist bu default in the databricks clusters while the package `com.databricks:databricks-dbutils-scala_2.12:0.1.4` need to be added to the jar.

#### One-line summary:

Add the `com.databricks:databricks-dbutils-scala_2.12:0.1.4` in the `gradle.build`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project