### PR TITLE
[FLINK] disable module metadata generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.10.2...HEAD)
 
+
+### Fixed
+* **Flink: disable module metadata generation** [`#2507`](https://github.com/OpenLineage/OpenLineage/pull/2531) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
+  *Fixes the issue flink module generated contains the internal libs that are not published*
+
 ## [1.10.2](https://github.com/OpenLineage/OpenLineage/compare/1.9.1...1.10.2) - 2024-03-15
 
 ### Added

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -94,6 +94,10 @@ tasks.named("build").configure {
     dependsOn(validateReleaseVersionProperty)
 }
 
+tasks.withType(GenerateModuleMetadata.class).configureEach {
+    enabled = false
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {


### PR DESCRIPTION
#### One-line summary:
Disable the module metadata publish for flink to resolve the issue:
https://github.com/OpenLineage/OpenLineage/issues/2527


----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project