### PR TITLE
[SPARK][FLINK] job ownership facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   *Implement within circuit breaker an optional timeout which switches off OpenLineage integration code when exceeded.*
 * **Spark/Flink: Support yaml config files together with SparkConf & FlinkConf approaches.** [`#2583`](https://github.com/OpenLineage/OpenLineage/pull/2583) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)   
   *Support config entries being provided by both yaml file and integration specific configuration (SparkConf / FlinkConf). Allow each integration to have its specific config entries.*
+* **Spark & Flink: Job Ownership Facet** [`#2533`](https://github.com/OpenLineage/OpenLineage/pull/2533) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+    *Enable configuration entries specifying ownership of the job that will result in `OwnershipJobFacet` attached to job facets.*
+
 
 ### Fixed
 * **Spark: fix PMD for test** [`#2588`](https://github.com/OpenLineage/OpenLineage/pull/2588) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
@@ -40,6 +40,7 @@ public class FlinkExecutionContextFactory {
                 .openLineage(new OpenLineage(EventEmitter.OPEN_LINEAGE_CLIENT_URI))
                 .build())
         .eventEmitter(new EventEmitter(openLineageConfig))
+        .config(openLineageConfig)
         .build();
   }
 }

--- a/integration/flink/app/src/test/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextTest.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextTest.java
@@ -1,0 +1,79 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.client.OpenLineage.OwnershipJobFacetOwners;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+
+public class FlinkExecutionContextTest {
+
+  Configuration config = new Configuration();
+
+  @Test
+  void testBuildEventForEventTypeWithJobOwnershipFacet() {
+    ConfigOption transportTypeOption =
+        ConfigOptions.key("openlineage.transport.type").mapType().noDefaultValue();
+
+    config.setString(transportTypeOption, "console");
+    config.setString("openlineage.job.owners.team", "MyTeam");
+    config.setString("openlineage.job.owners.person", "John Smith");
+
+    FlinkExecutionContext context =
+        FlinkExecutionContextFactory.getContext(
+            config,
+            "jobNamespace",
+            "jobName",
+            mock(JobID.class),
+            "streaming",
+            Collections.emptyList());
+
+    RunEvent runEvent = context.buildEventForEventType(EventType.COMPLETE).build();
+
+    List<OwnershipJobFacetOwners> owners = runEvent.getJob().getFacets().getOwnership().getOwners();
+    assertThat(owners).hasSize(2);
+    assertThat(owners.stream().filter(o -> o.getType().equals("team")).findAny().get().getName())
+        .isEqualTo("MyTeam");
+    assertThat(owners.stream().filter(o -> o.getType().equals("person")).findAny().get().getName())
+        .isEqualTo("John Smith");
+  }
+
+  @Test
+  void testBuildEventForEventTypeWithNoJobOwnersConfig() {
+    ConfigOption transportTypeOption =
+        ConfigOptions.key("openlineage.transport.type").mapType().noDefaultValue();
+
+    config.setString(transportTypeOption, "console");
+
+    FlinkExecutionContext context =
+        FlinkExecutionContextFactory.getContext(
+            config,
+            "jobNamespace",
+            "jobName",
+            mock(JobID.class),
+            "streaming",
+            Collections.emptyList());
+
+    assertThat(
+            context
+                .buildEventForEventType(EventType.COMPLETE)
+                .build()
+                .getJob()
+                .getFacets()
+                .getOwnership())
+        .isNull();
+  }
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
@@ -5,26 +5,46 @@
 
 package io.openlineage.flink.client;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @ToString
 public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageConfig> {
+  @Setter private JobConfig job;
 
   public FlinkOpenLineageConfig(
       TransportConfig transportConfig,
       FacetsConfig facetsConfig,
       CircuitBreakerConfig circuitBreaker,
-      Map metricsConfig) {
+      Map metricsConfig,
+      JobConfig job) {
     super(transportConfig, facetsConfig, circuitBreaker, metricsConfig);
+    this.job = job;
+  }
+
+  @Getter
+  @ToString
+  public static class JobConfig {
+    @Setter @Getter private JobOwnersConfig owners;
+  }
+
+  @Getter
+  @ToString
+  public static class JobOwnersConfig {
+    @JsonAnySetter @Setter @Getter @NonNull
+    private Map<String, String> additionalProperties = new HashMap<>();
   }
 
   public FlinkOpenLineageConfig mergeWithNonNull(FlinkOpenLineageConfig other) {
@@ -32,6 +52,7 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
         mergePropertyWith(transportConfig, other.transportConfig),
         mergePropertyWith(facetsConfig, other.facetsConfig),
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
-        mergePropertyWith(metricsConfig, other.metricsConfig));
+        mergePropertyWith(metricsConfig, other.metricsConfig),
+        mergePropertyWith(job, other.job));
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -20,6 +20,7 @@ import io.openlineage.spark.agent.facets.builder.DebugRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.OwnershipJobFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkVersionFacetBuilder;
@@ -223,6 +224,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 generate(
                     eventHandlerFactories, factory -> factory.createJobFacetBuilders(context)));
 
+    listBuilder.add(new OwnershipJobFacetBuilder(context));
     return listBuilder.build();
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilder.java
@@ -1,0 +1,68 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.client.OpenLineage.OwnershipJobFacet;
+import io.openlineage.client.OpenLineage.OwnershipJobFacetOwners;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark.api.SparkOpenLineageConfig.JobConfig;
+import io.openlineage.spark.api.SparkOpenLineageConfig.JobOwnersConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.apache.spark.scheduler.SparkListenerEvent;
+
+/**
+ * {@link CustomFacetBuilder} that adds the {@link OwnershipJobFacet} to a job. This facet is
+ * generated for every {@link SparkListenerEvent}.
+ */
+public class OwnershipJobFacetBuilder
+    extends CustomFacetBuilder<SparkListenerEvent, OwnershipJobFacet> {
+  private final OpenLineageContext olContext;
+
+  public OwnershipJobFacetBuilder(OpenLineageContext olContext) {
+    this.olContext = olContext;
+  }
+
+  @Override
+  public boolean isDefinedAt(Object x) {
+    return super.isDefinedAt(x);
+  }
+
+  @Override
+  protected void build(
+      SparkListenerEvent event, BiConsumer<String, ? super OwnershipJobFacet> consumer) {
+    List<OwnershipJobFacetOwners> ownersList = new ArrayList<>();
+    Optional.of(olContext.getOpenLineageConfig())
+        .map(SparkOpenLineageConfig::getJob)
+        .map(JobConfig::getOwners)
+        .map(JobOwnersConfig::getAdditionalProperties)
+        .filter(Objects::nonNull)
+        .ifPresent(
+            map -> {
+              map.forEach(
+                  (type, name) ->
+                      ownersList.add(
+                          olContext
+                              .getOpenLineage()
+                              .newOwnershipJobFacetOwnersBuilder()
+                              .name(name)
+                              .type(type)
+                              .build()));
+              consumer.accept(
+                  "ownership",
+                  olContext
+                      .getOpenLineage()
+                      .newOwnershipJobFacetBuilder()
+                      .owners(ownersList)
+                      .build());
+            });
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -5,10 +5,12 @@
 
 package io.openlineage.spark.api;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +36,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
   @Setter @Getter private String overriddenAppName;
   @Setter @NonNull private String debugFacet;
   @Setter private JobNameConfig jobName;
+  @Setter private JobConfig job;
 
   public SparkOpenLineageConfig(
       String namespace,
@@ -43,6 +46,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       String overriddenAppName,
       String debugFacet,
       JobNameConfig jobName,
+      JobConfig job,
       TransportConfig transportConfig,
       FacetsConfig facetsConfig,
       CircuitBreakerConfig circuitBreaker,
@@ -55,6 +59,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     this.overriddenAppName = overriddenAppName;
     this.debugFacet = debugFacet;
     this.jobName = jobName;
+    this.job = job;
   }
 
   public FacetsConfig getFacetsConfig() {
@@ -95,6 +100,19 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     @Setter @Getter @NonNull private Boolean replaceDotWithUnderscore = false;
   }
 
+  @Getter
+  @ToString
+  public static class JobConfig {
+    @Setter @Getter private JobOwnersConfig owners;
+  }
+
+  @Getter
+  @ToString
+  public static class JobOwnersConfig {
+    @JsonAnySetter @Setter @Getter @NonNull
+    private Map<String, String> additionalProperties = new HashMap<>();
+  }
+
   public SparkOpenLineageConfig mergeWithNonNull(SparkOpenLineageConfig other) {
     return new SparkOpenLineageConfig(
         mergeWithDefaultValue(namespace, other.namespace, DEFAULT_NAMESPACE),
@@ -104,6 +122,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(overriddenAppName, other.overriddenAppName),
         mergeWithDefaultValue(debugFacet, other.debugFacet, DEFAULT_DEBUG_FACET),
         mergePropertyWith(jobName, other.jobName),
+        mergePropertyWith(job, other.job),
         mergePropertyWith(transportConfig, other.transportConfig),
         mergePropertyWith(facetsConfig, other.facetsConfig),
         mergePropertyWith(circuitBreaker, other.circuitBreaker),

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.facets.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OwnershipJobFacet;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark.api.SparkOpenLineageConfig.JobConfig;
+import io.openlineage.spark.api.SparkOpenLineageConfig.JobOwnersConfig;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class OwnershipJobFacetBuilderTest {
+
+  OpenLineageContext olContext = mock(OpenLineageContext.class);
+  OwnershipJobFacetBuilder builder = new OwnershipJobFacetBuilder(olContext);
+
+  @Test
+  void testIsDefined() {
+    assertThat(builder.isDefinedAt(mock(SparkListenerEvent.class))).isTrue();
+  }
+
+  @Test
+  void testBuildWhenNoFacetConfig() {
+    SparkOpenLineageConfig config = mock(SparkOpenLineageConfig.class);
+    JobConfig jobConfig = mock(JobConfig.class);
+
+    BiConsumer<String, ? super OwnershipJobFacet> consumer = mock(BiConsumer.class);
+
+    when(olContext.getOpenLineageConfig()).thenReturn(config);
+    when(config.getJob()).thenReturn(jobConfig);
+    when(jobConfig.getOwners()).thenReturn(null);
+
+    builder.build(mock(SparkListenerEvent.class), consumer);
+
+    verify(consumer, Mockito.times(0)).accept(any(), any());
+  }
+
+  @Test
+  void testBuild() {
+    Map<String, String> owners = new HashMap<>();
+    owners.put("team", "MyTeam");
+    owners.put("person", "John Smith");
+
+    SparkOpenLineageConfig config = mock(SparkOpenLineageConfig.class);
+    JobConfig jobConfig = mock(JobConfig.class);
+    JobOwnersConfig jobOwnersConfig = mock(JobOwnersConfig.class);
+
+    BiConsumer<String, ? super OwnershipJobFacet> consumer = mock(BiConsumer.class);
+
+    when(olContext.getOpenLineageConfig()).thenReturn(config);
+    when(config.getJob()).thenReturn(jobConfig);
+    when(jobConfig.getOwners()).thenReturn(jobOwnersConfig);
+    when(jobOwnersConfig.getAdditionalProperties()).thenReturn(owners);
+
+    when(olContext.getOpenLineage())
+        .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+
+    builder.build(mock(SparkListenerEvent.class), consumer);
+    verify(consumer)
+        .accept(
+            eq("ownership"),
+            argThat(
+                (OwnershipJobFacet facet) ->
+                    facet.getOwners().size() == 2
+                        && facet.getOwners().stream()
+                            .filter(o -> o.getName().equals("MyTeam") && o.getType().equals("team"))
+                            .findAny()
+                            .isPresent()
+                        && facet.getOwners().stream()
+                            .filter(
+                                o ->
+                                    o.getName().equals("John Smith")
+                                        && o.getType().equals("person"))
+                            .findAny()
+                            .isPresent()));
+  }
+}


### PR DESCRIPTION
### Problem

Spark and Flink integration should be capable of passing job owner information from config entries that should result in `ownership` facet being attached to OL event. 

### Solution

 * add config entry in java client 
 * consume config entry in both flink & spark job facets generation code
 * refactor on Spark side to include OpenLineageYaml in OpenLineageContext. This should be useful for other features in future as well. 

 * TODO: docs PR will be prepared once this PR gets approved.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project