### PR TITLE
[Spark] always catch IllegalStateException when accessing SparkSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Fixed
 * **Flink: disable module metadata generation** [`#2507`](https://github.com/OpenLineage/OpenLineage/pull/2531) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
   *Fixes the issue flink module generated contains the internal libs that are not published*
+* **Spark: fix access to active Spark session ** [`#2535`](https://github.com/OpenLineage/OpenLineage/pull/2535) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Always catch `IllegalStateException` when accessing `SparkSession`.*
 
 ## [1.10.2](https://github.com/OpenLineage/OpenLineage/compare/1.9.1...1.10.2) - 2024-03-15
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.filters;
 
+import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.Optional;
@@ -51,7 +52,7 @@ public class EventFilterUtils {
    * @return
    */
   static boolean isDeltaPlan() {
-    return Optional.of(SparkSession.active())
+    return SparkSessionUtils.activeSession()
         .map(SparkSession::sparkContext)
         .filter(context -> context != null)
         .map(SparkContext::conf)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -90,7 +90,6 @@ public class PathUtils {
     }
   }
 
-  @SneakyThrows
   private static URI prepareUriFromDefaultTablePath(CatalogTable catalogTable) {
     URI uri =
         SparkSession.active().sessionState().catalog().defaultTablePath(catalogTable.identifier());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
@@ -1,0 +1,23 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.SparkSession;
+
+@Slf4j
+public class SparkSessionUtils {
+
+  public static Optional<SparkSession> activeSession() {
+    try {
+      return Optional.of(SparkSession.active());
+    } catch (IllegalStateException e) {
+      log.warn("Cannot obtain active spark session", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkVersionUtils.java
@@ -9,6 +9,9 @@ import org.apache.spark.sql.SparkSession;
 
 public class SparkVersionUtils {
   public static boolean isSpark3() {
-    return SparkSession.active().version().startsWith("3");
+    return SparkSessionUtils.activeSession()
+        .map(SparkSession::version)
+        .filter(v -> v.startsWith("3"))
+        .isPresent();
   }
 }


### PR DESCRIPTION
### Problem

`IllegalStateException` is not caught. 

### Solution

Catch the exception when calling `SparkSession.active()`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project