### PR TITLE
[FLINK] support flink 1.19.0

### DIFF
--- a/.circleci/workflows/openlineage-flink.yml
+++ b/.circleci/workflows/openlineage-flink.yml
@@ -4,14 +4,14 @@ workflows:
       - build-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1', '1.19.0' ]
           requires:
             - build-integration-sql-java
             - build-client-java
       - integration-test-integration-flink:
           matrix:
             parameters:
-              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1' ]
+              flink-version: [ '1.15.4', '1.16.2', '1.17.1', '1.18.1', '1.19.0' ]
           requires:
             - build-integration-flink
       - workflow_complete:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 * **Spark: support for built-in lineage extraction** [`#2272`](https://github.com/OpenLineage/OpenLineage/pull/2272) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Adding the ability to support OpenLineage within Spark extensions' code. Refer to [README](https://github.com/OpenLineage/OpenLineage/tree/spark/built-in-lineage/integration/spark-interfaces-scala#readme) for more details.*
+* **Flink: support Flink 1.19.0** [`#2545`](https://github.com/OpenLineage/OpenLineage/pull/2545) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
+  *Adding the integration test coverage for flink 1.19.0.
 
 ### Fixed
 * **Flink: disable module metadata generation** [`#2507`](https://github.com/OpenLineage/OpenLineage/pull/2531) [@HuangZhenQiu](https://github.com/HuangZhenQiu)

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -27,7 +27,8 @@ ext {
             "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "jdbc": "1.15.4", "alternativeShort": "1.15"],
             "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "jdbc": "1.16.3", "alternativeShort": "1.16"],
             "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "jdbc": "3.1.1-1.17", "alternativeShort": "1.17"],
-            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"]
+            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"],
+            "1.19": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"]
     ]
 
     versions = versionsMap[flinkVersionShort]

--- a/integration/flink/gradle.properties
+++ b/integration/flink/gradle.properties
@@ -1,9 +1,9 @@
 jdk8.build=true
 version=1.11.0-SNAPSHOT
-flink.version=1.18.1
+flink.version=1.19.0
 org.gradle.jvmargs=-Xmx1G
 
-flink.shared.version=1.18.1
+flink.shared.version=1.19.0
 flink.flink115.version=1.15.4
 flink.flink116.version=1.16.3
 flink.flink117.version=1.17.2

--- a/integration/flink/shared/build.gradle
+++ b/integration/flink/shared/build.gradle
@@ -75,7 +75,8 @@ ext {
             "1.15": ["cassandra": "1.15.4", "kafka": flinkVersion, "jdbc": "1.15.4", "alternativeShort": "1.15"],
             "1.16": ["cassandra": "3.0.0-1.16", "kafka": flinkVersion, "jdbc": "1.16.3", "alternativeShort": "1.16"],
             "1.17": ["cassandra": "3.1.0-1.17", "kafka": flinkVersion, "jdbc": "3.1.1-1.17", "alternativeShort": "1.17"],
-            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"]
+            "1.18": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"],
+            "1.19": ["cassandra": "3.1.0-1.17", "kafka": "3.0.2-1.18", "jdbc": "3.1.2-1.18", "alternativeShort": "1.17"]
     ]
 
     versions = versionsMap[flinkVersionShort]


### PR DESCRIPTION
#### One-line summary:
As Flink 1.19.0 is released recently, support flink 1.19.0 as default flink version with integration test coverage.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project