### PR TITLE
[SQL] Fix parsing JDBCOptions(table=...) containing subquery

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
@@ -83,7 +83,9 @@ public class JdbcSparkUtils {
     Optional<String> table =
         ScalaConversionUtils.asJavaOptional(
             relation.jdbcOptions().parameters().get(JDBCOptions$.MODULE$.JDBC_TABLE_NAME()));
-    if (table.isPresent()) {
+    // in some cases table value can be "(SELECT col1, col2 FROM table_name WHERE some='filter')
+    // ALIAS"
+    if (table.isPresent() && !table.get().startsWith("(")) {
       DbTableMeta origin = new DbTableMeta(null, null, table.get());
       return Optional.of(
           new SqlMeta(
@@ -97,28 +99,31 @@ public class JdbcSparkUtils {
                               Collections.singletonList(new ColumnMeta(origin, field.name()))))
                   .collect(Collectors.toList()),
               Collections.emptyList()));
-    } else {
-      String tableOrQuery = relation.jdbcOptions().tableOrQuery();
-      String query =
-          tableOrQuery.substring(0, tableOrQuery.lastIndexOf(")")).replaceFirst("\\(", "");
-
-      String dialect = extractDialectFromJdbcUrl(relation.jdbcOptions().url());
-      Optional<SqlMeta> sqlMeta = OpenLineageSql.parse(Collections.singletonList(query), dialect);
-
-      if (!sqlMeta.get().errors().isEmpty()) { // error return nothing
-        log.error(
-            String.format(
-                "error while parsing query: %s",
-                sqlMeta.get().errors().stream()
-                    .map(ExtractionError::toString)
-                    .collect(Collectors.joining(","))));
-        return Optional.empty();
-      } else if (sqlMeta.get().inTables().isEmpty()) {
-        log.error("no tables defined in query, this should not happen");
-        return Optional.empty();
-      }
-      return Optional.of(sqlMeta.get());
     }
+
+    String tableOrQuery = relation.jdbcOptions().tableOrQuery();
+    String query = tableOrQuery.substring(0, tableOrQuery.lastIndexOf(")")).replaceFirst("\\(", "");
+
+    String dialect = extractDialectFromJdbcUrl(relation.jdbcOptions().url());
+    Optional<SqlMeta> sqlMeta = OpenLineageSql.parse(Collections.singletonList(query), dialect);
+
+    if (!sqlMeta.isPresent()) { // missing JNI library
+      return sqlMeta;
+    }
+    if (!sqlMeta.get().errors().isEmpty()) { // error return nothing
+      log.error(
+          String.format(
+              "error while parsing query: %s",
+              sqlMeta.get().errors().stream()
+                  .map(ExtractionError::toString)
+                  .collect(Collectors.joining(","))));
+      return Optional.empty();
+    }
+    if (sqlMeta.get().inTables().isEmpty()) {
+      log.error("no tables defined in query, this should not happen");
+      return Optional.empty();
+    }
+    return sqlMeta;
   }
 
   private static String extractDialectFromJdbcUrl(String jdbcUrl) {


### PR DESCRIPTION
### Problem

👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

In the following case:
```python
df = spark.read.jdbc(table="(select * from table where filter='value') T")
```

`openlineage-spark` returns datasets with names like `database.(select * from table where filter='value') T`, not `database.table`. This is because `JDBCOptions.table` is expected to always return a table name, not subquery.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

If `JDBCOptions.table` contains a subquery, fallback to branch with SQL parsing to extract table names from this query.

I've also added a test that `openlineage-spark` can parse query of unknown JDBC dialect.

#### One-line summary:

Fix `openlineage-spark` producing datasets with names like `database.(select * from table)` for JDBC sources.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project