### PR TITLE
[SQL] Show error message then OpenLineageSql cannot find native library

### DIFF
--- a/integration/sql/README.md
+++ b/integration/sql/README.md
@@ -66,10 +66,10 @@ python -c "import openlineage_sql"
 
 ### Java
 
-To build the Java interface run the following script from the project root:
+To build the Java interface run the following script from `./iface-java` directory:
 
 ```bash
-./iface-java/script/build.sh
+./script/build.sh
 ```
 
 This produces an `openlineage-sql.jar` in the `iface-java/target` directory.

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
@@ -90,5 +90,9 @@ public final class OpenLineageSql {
           Optional.of(
               String.format("Error extracting native library '%s': %s", libName, e.getMessage()));
     }
+
+    if (loadError.isPresent()) {
+      System.err.println(loadError.get());
+    }
   }
 }


### PR DESCRIPTION
### Problem

👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

If `OpenLineageSql` class cannot load native library, if returns `None` for all operations. But the error message is suppressed, and user cannot determine the reason.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Show error messages when `OpenLineageSql` cannot load native library.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project