### PR TITLE
[SPEC] Allow nested struct fields in SchemaDatasetFacet

### DIFF
--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -735,7 +735,12 @@ public class JavaPoetGenerator {
 
       @Override
       public TypeName visit(TypeResolver.EnumResolvedType enumType) {
-         return ClassName.get(containerClass, enumType.getParentName() + "." + enumType.getName());
+        return ClassName.get(containerClass, enumType.getParentName() + "." + enumType.getName());
+      }
+
+      @Override
+      public TypeName visit(TypeResolver.RefResolvedType refType) {
+        return ClassName.get(containerClass, refType.getName());
       }
     });
   }

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
@@ -26,6 +26,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.Run;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunFacets;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
 import java.net.URI;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -248,6 +249,81 @@ class OpenLineageTest {
                                 .build())
                         .build())
                 .build());
+
+    SchemaDatasetFacet schemaFacet =
+        ol.newSchemaDatasetFacetBuilder()
+            .fields(
+                Arrays.asList(
+                    ol.newSchemaDatasetFacetFieldsBuilder().name("user_id").type("int64").build(),
+                    ol.newSchemaDatasetFacetFieldsBuilder()
+                        .name("phones")
+                        .type("array")
+                        .description("List of phone numbers")
+                        .fields(
+                            Arrays.asList(
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("_element")
+                                    .type("string")
+                                    .build()))
+                        .build(),
+                    ol.newSchemaDatasetFacetFieldsBuilder()
+                        .name("addresses")
+                        .type("struct")
+                        .description("Has customer completed activation process")
+                        .fields(
+                            Arrays.asList(
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("type")
+                                    .type("string")
+                                    .description("Address type, g.e. home, work, etc.")
+                                    .build(),
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("country")
+                                    .type("string")
+                                    .description("Country name")
+                                    .build(),
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("zip")
+                                    .type("string")
+                                    .description("Zip code")
+                                    .build(),
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("state")
+                                    .type("string")
+                                    .description("State name")
+                                    .build(),
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("street")
+                                    .type("string")
+                                    .description("Street name")
+                                    .build()))
+                        .build(),
+                    ol.newSchemaDatasetFacetFieldsBuilder()
+                        .name("custom_properties")
+                        .type("map")
+                        .fields(
+                            Arrays.asList(
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("key")
+                                    .type("string")
+                                    .build(),
+                                ol.newSchemaDatasetFacetFieldsBuilder()
+                                    .name("value")
+                                    .type("union")
+                                    .fields(
+                                        Arrays.asList(
+                                            ol.newSchemaDatasetFacetFieldsBuilder()
+                                                .name("_0")
+                                                .type("string")
+                                                .build(),
+                                            ol.newSchemaDatasetFacetFieldsBuilder()
+                                                .name("_1")
+                                                .type("int64")
+                                                .build()))
+                                    .build()))
+                        .build()))
+            .build();
+
     List<OutputDataset> outputs =
         Arrays.asList(
             ol.newOutputDatasetBuilder()
@@ -256,6 +332,7 @@ class OpenLineageTest {
                 .facets(
                     ol.newDatasetFacetsBuilder()
                         .version(ol.newDatasetVersionDatasetFacet("output-version"))
+                        .schema(schemaFacet)
                         .build())
                 .outputFacets(
                     ol.newOutputDatasetOutputFacetsBuilder()
@@ -300,18 +377,18 @@ class OpenLineageTest {
 
       DataQualityMetricsInputDatasetFacet dq =
           inputDataset.getInputFacets().getDataQualityMetrics();
-      assertEquals((Long) 10L, dq.getRowCount());
-      assertEquals((Long) 20L, dq.getBytes());
-      assertEquals((Long) 5L, dq.getFileCount());
+      assertEquals(10L, dq.getRowCount());
+      assertEquals(20L, dq.getBytes());
+      assertEquals(5L, dq.getFileCount());
       DataQualityMetricsInputDatasetFacetColumnMetricsAdditional colMetrics =
           dq.getColumnMetrics().getAdditionalProperties().get("mycol");
-      assertEquals((Double) 10D, colMetrics.getCount());
-      assertEquals((Long) 10L, colMetrics.getDistinctCount());
-      assertEquals((Double) 30D, colMetrics.getMax());
-      assertEquals((Double) 5D, colMetrics.getMin());
-      assertEquals((Long) 1L, colMetrics.getNullCount());
-      assertEquals((Double) 3000D, colMetrics.getSum());
-      assertEquals((Double) 52D, colMetrics.getQuantiles().getAdditionalProperties().get("25"));
+      assertEquals(10D, colMetrics.getCount());
+      assertEquals(10L, colMetrics.getDistinctCount());
+      assertEquals(30D, colMetrics.getMax());
+      assertEquals(5D, colMetrics.getMin());
+      assertEquals(1L, colMetrics.getNullCount());
+      assertEquals(3000D, colMetrics.getSum());
+      assertEquals(52D, colMetrics.getQuantiles().getAdditionalProperties().get("25"));
 
       assertEquals(1, runStateUpdate.getOutputs().size());
       OutputDataset outputDataset = runStateUpdate.getOutputs().get(0);
@@ -319,11 +396,14 @@ class OpenLineageTest {
       assertEquals("output", outputDataset.getName());
       assertEquals("output-version", outputDataset.getFacets().getVersion().getDatasetVersion());
 
-      assertEquals(roundTrip(json), roundTrip(mapper.writeValueAsString(read)));
-      assertEquals((Long) 10L, outputDataset.getOutputFacets().getOutputStatistics().getRowCount());
-      assertEquals((Long) 20L, outputDataset.getOutputFacets().getOutputStatistics().getSize());
-      assertEquals((Long) 5L, outputDataset.getOutputFacets().getOutputStatistics().getFileCount());
+      SchemaDatasetFacet outputDatasetSchema = outputDataset.getFacets().getSchema();
+      assertEquals(outputDatasetSchema, schemaFacet);
 
+      assertEquals(10L, outputDataset.getOutputFacets().getOutputStatistics().getRowCount());
+      assertEquals(20L, outputDataset.getOutputFacets().getOutputStatistics().getSize());
+      assertEquals(5L, outputDataset.getOutputFacets().getOutputStatistics().getFileCount());
+
+      assertEquals(roundTrip(json), roundTrip(mapper.writeValueAsString(read)));
       assertEquals(json, mapper.writeValueAsString(read));
     }
 

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -32,8 +32,12 @@ public class AvroSchemaUtils {
         .forEach(
             avroField -> {
               fields.add(
-                  openLineage.newSchemaDatasetFacetFields(
-                      avroField.name(), getTypeName(avroField.schema()), avroField.doc()));
+                  openLineage
+                      .newSchemaDatasetFacetFieldsBuilder()
+                      .name(avroField.name())
+                      .type(getTypeName(avroField.schema()))
+                      .description(avroField.doc())
+                      .build());
             });
 
     return builder.fields(fields).build();

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/IcebergUtils.java
@@ -21,8 +21,11 @@ public class IcebergUtils {
                 field ->
                     context
                         .getOpenLineage()
-                        .newSchemaDatasetFacetFields(
-                            field.name(), field.type().typeId().name(), field.doc()))
+                        .newSchemaDatasetFacetFieldsBuilder()
+                        .name(field.name())
+                        .type(field.type().typeId().name())
+                        .description(field.doc())
+                        .build())
             .collect(Collectors.toList());
     return context.getOpenLineage().newSchemaDatasetFacet(fields);
   }

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
@@ -44,7 +44,12 @@ class LineageProviderVisitorTest {
     OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
         openLineage.newSchemaDatasetFacet(
             Collections.singletonList(
-                openLineage.newSchemaDatasetFacetFields("a", "INTEGER", "desc")));
+                openLineage
+                    .newSchemaDatasetFacetFieldsBuilder()
+                    .name("a")
+                    .type("INTEGER")
+                    .description("desc")
+                    .build()));
     ExampleLineageProvider provider =
         new ExampleLineageProvider("name", "namespace", schemaDatasetFacet);
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java
@@ -46,7 +46,7 @@ import scala.collection.immutable.Map;
 
 class SaveIntoDataSourceCommandVisitorTest {
 
-  SaveIntoDataSourceCommand command = mock(SaveIntoDataSourceCommand.class);;
+  SaveIntoDataSourceCommand command = mock(SaveIntoDataSourceCommand.class);
   OpenLineageContext context = mock(OpenLineageContext.class);
   SaveIntoDataSourceCommandVisitor visitor = new SaveIntoDataSourceCommandVisitor(context);
   DatasetFactory datasetFactory = mock(DatasetFactory.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2UtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2UtilsTest.java
@@ -88,7 +88,7 @@ public class ExtesionDataSourceV2UtilsTest {
         .isEqualTo("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client");
     assertThat(datasetFacetsBuilder.build().getSchema().get_schemaURL().toString())
         .isEqualTo(
-            "https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet");
+            "https://openlineage.io/spec/facets/1-1-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet");
     assertThat(datasetFacetsBuilder.build().getSchema().getFields().get(0))
         .hasFieldOrPropertyWithValue("name", "user_id")
         .hasFieldOrPropertyWithValue("type", "int64");
@@ -104,7 +104,7 @@ public class ExtesionDataSourceV2UtilsTest {
             + "    },\n"
             + "    \"property4\": \"value4\","
             + "    \"_producer\": \"https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client\",\n"
-            + "    \"_schemaURL\": \"https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json\"\n"
+            + "    \"_schemaURL\": \"https://openlineage.io/spec/facets/1-1-0/SchemaDatasetFacet.json\"\n"
             + "  }";
 
     properties.put("openlineage.dataset.facets.customFacet", facetJson);
@@ -127,7 +127,7 @@ public class ExtesionDataSourceV2UtilsTest {
     String facetJson =
         "{\n"
             + "    \"property\": \"value\","
-            + "    \"_schemaURL\": \"https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json\"\n"
+            + "    \"_schemaURL\": \"https://openlineage.io/spec/facets/1-1-0/SchemaDatasetFacet.json\"\n"
             + "  }";
 
     properties.put("openlineage.dataset.facets.customFacet", facetJson);

--- a/spec/facets/SchemaDatasetFacet.json
+++ b/spec/facets/SchemaDatasetFacet.json
@@ -1,7 +1,34 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-1-0/SchemaDatasetFacet.json",
   "$defs": {
+    "SchemaDatasetFacetFields": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the field.",
+          "type": "string",
+          "example": "column1"
+        },
+        "type": {
+          "description": "The type of the field.",
+          "type": "string",
+          "example": "VARCHAR|INT|..."
+        },
+        "description": {
+          "description": "The description of the field.",
+          "type": "string"
+        },
+        "fields": {
+          "description": "Nested struct fields.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SchemaDatasetFacetFields"
+          }
+        }
+      },
+      "required": ["name"]
+    },
     "SchemaDatasetFacet": {
       "allOf": [
         {
@@ -11,27 +38,10 @@
           "type": "object",
           "properties": {
             "fields": {
-              "description": "The fields of the table.",
+              "description": "The fields of the data source.",
               "type": "array",
               "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "The name of the field.",
-                    "type": "string",
-                    "example": "column1"
-                  },
-                  "type": {
-                    "description": "The type of the field.",
-                    "type": "string",
-                    "example": "VARCHAR|INT|..."
-                  },
-                  "description": {
-                    "description": "The description of the field.",
-                    "type": "string"
-                  }
-                },
-                "required": ["name"]
+                "$ref": "#/$defs/SchemaDatasetFacetFields"
               }
             }
           }

--- a/spec/tests/SchemaDatasetFacet/1.json
+++ b/spec/tests/SchemaDatasetFacet/1.json
@@ -16,9 +16,77 @@
       {
         "name": "amount",
         "type": "int64"
+      },
+      {
+        "name": "phones",
+        "type": "array",
+        "description": "List of phone numbers",
+        "fields": [
+          {
+            "name": "_element",
+            "type": "string",
+            "description": "Phone number"
+          }
+        ]
+      },
+      {
+        "name": "addresses",
+        "type": "struct",
+        "description": "Has customer completed activation process",
+        "fields": [
+          {
+            "name": "type",
+            "type": "string",
+            "description": "Address type, g.e. home, work, etc."
+          },
+          {
+            "name": "country",
+            "type": "string",
+            "description": "Country name"
+          },
+          {
+            "name": "zip",
+            "type": "string",
+            "description": "Zip code"
+          },
+          {
+            "name": "state",
+            "type": "string",
+            "description": "State name"
+          },
+          {
+            "name": "street",
+            "type": "string",
+            "description": "Street name"
+          }
+        ]
+      },
+      {
+        "name": "custom_properties",
+        "type": "map",
+        "fields": [
+          {
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "union",
+            "fields": [
+              {
+                "name": "_0",
+                "type": "string"
+              },
+              {
+                "name": "_1",
+                "type": "int64"
+              }
+            ]
+          }
+        ]
       }
     ],
     "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
-    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SchemaDatasetFacet.json"
+    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/SchemaDatasetFacet.json"
   }
 }


### PR DESCRIPTION
### Problem

Closes: #2051

### Solution

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [X] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Allow nested fields support to `SchemaDatasetFacet`

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [X] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project