### PR TITLE
[Spark] fix memory leak in unknown-facet-listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   *Fix `ClassNotFoundError` occurring on databricks runtime, extend integration test to verify `DatabricksEnvironmentFacet`.*
 * **Spark: fixed memory leak in JobMetricsHolder.** [`#2565`](https://github.com/OpenLineage/OpenLineage/pull/2565) [@d-m-h](https://github.com/d-m-h)
   *The JobMetricsHolder#cleanUp(int) method now correctly purges unneeded state from both maps.*
+* **Spark: fixed memory leak in `UnknownEntryFacetListener`.** [`#2557`](https://github.com/OpenLineage/OpenLineage/pull/2557) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Prevent storing state when facet is disabled, purge the state after populating run facets.*
 
 ## [1.10.2](https://github.com/OpenLineage/OpenLineage/compare/1.9.1...1.10.2) - 2024-03-15
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.UnknownEntryFacetListener;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -114,6 +115,9 @@ public class SparkGenericIntegrationTest {
                     })
                 .collect(Collectors.toSet()))
         .hasSize(1);
+
+    // test UnknownEntryFacetListener clears its static list of visited nodes
+    assertThat(UnknownEntryFacetListener.getInstance().getVisitedNodesSize()).isEqualTo(0);
   }
 
   @Test

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -330,6 +330,7 @@ class OpenLineageRunEventBuilder {
                     .timer("openlineage.spark.unknownFacet.time")
                     .record(() -> unknownEntryFacetListener.build(qe.optimizedPlan())))
         .ifPresent(facet -> runFacetsBuilder.put("spark_unknown", facet));
+    unknownEntryFacetListener.clear();
 
     RunFacets runFacets = buildRunFacets(nodes, runFacetBuilders, runFacetsBuilder);
     OpenLineage.RunBuilder runBuilder =

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/UnknownEntryFacetListener.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent.lifecycle;
 
 import static java.util.Optional.ofNullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.openlineage.spark.agent.facets.LogicalPlanFacet;
 import io.openlineage.spark.agent.facets.UnknownEntryFacet;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -50,6 +51,15 @@ public class UnknownEntryFacetListener implements Consumer<LogicalPlan> {
   @Override
   public void accept(LogicalPlan logicalPlan) {
     visitedNodes.put(logicalPlan, null);
+  }
+
+  public void clear() {
+    visitedNodes.clear();
+  }
+
+  @VisibleForTesting
+  public Integer getVisitedNodesSize() {
+    return visitedNodes.size();
   }
 
   public Optional<UnknownEntryFacet> build(LogicalPlan root) {


### PR DESCRIPTION
### Problem

Fixed memory leak in `UnknownEntryFacetListener`. 

### Solution

 * prevent storing state when facet is disabled
 * purge the state after populating run facets.*

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project