### PR TITLE
dbt: `dbt-ol` should transparently exit with the same exit code as the child `dbt` process

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -106,7 +106,7 @@ for handler in openlineage_logger.handlers:
 
 
 def main():
-    logger.info(f"Running OpenLineage dbt wrapper version {__version__}")
+    logger.info("Running OpenLineage dbt wrapper version %s", __version__)
     logger.info("This wrapper will send OpenLineage events at the end of dbt execution.")
 
     args = sys.argv[1:]
@@ -167,8 +167,8 @@ def main():
 
     force_send_events = len(sys.argv) > 1 and sys.argv[1] == "send-events"
     if not force_send_events:
-        process = subprocess.Popen(["dbt"] + sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr)
-        return_code = process.wait()
+        with subprocess.Popen(["dbt"] + sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr) as process:
+            return_code = process.wait()
     else:
         logger.warning("Sending events for the last run without running the job")
         return_code = 0
@@ -178,13 +178,13 @@ def main():
     try:
         if os.stat(processor.run_result_path).st_mtime < pre_run_time and not force_send_events:
             logger.info(
-                f"OpenLineage events not emitted: run_result file "
-                f"({processor.run_result_path}) was not modified by dbt"
+                "OpenLineage events not emitted: run_result file (%s) was not modified by dbt",
+                processor.run_result_path,
             )
             return
     except FileNotFoundError:
         logger.info(
-            f"OpenLineage events not emitted:" f"did not find run_result file ({processor.run_result_path})"
+            "OpenLineage events not emitted: did not find run_result file (%s)", processor.run_result_path
         )
         return
 
@@ -209,6 +209,7 @@ def main():
             job_name=dbt_run_metadata.job_name,
             parent_run_metadata=parent_run_metadata,
         )
+
     for event in tqdm(
         events + [last_event],
         desc="Emitting OpenLineage events",
@@ -220,14 +221,15 @@ def main():
             emitted_events += 1
         except Exception as e:
             logger.warning(
-                "OpenLineage client failed to emit event %s runId %s. " "Exception: %s",
+                "OpenLineage client failed to emit event %s runId %s. Exception: %s",
                 event.eventType.value,
                 event.run.runId,
                 e,
                 exc_info=True,
             )
-    logger.info(f"Emitted {emitted_events} openlineage events")
+    logger.info("Emitted %d OpenLineage events", emitted_events)
+    return return_code
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
### Problem

See https://github.com/OpenLineage/OpenLineage/issues/2558

If `dbt-ol` doesn't exit with the same code as the child `dbt` process, then any upstream process(es), including Airflow DAGs, won't be able to detect workflow failures.

Closes: #2558

### Solution

`dbt-ol.main` should return the `return_code` of the child `dbt` process, and we should explicitly `sys.exit` it.

This PR also adds a couple of extra changes to make the code of `dbt-ol` more PEP/Flake compliant. In particular:

- Logging functions [should favor lazy evaluation over f-strings](https://realpython.com/python-f-strings/#lazy-evaluation-in-Logging).

- `subprocess.Popen` should always be run through a context manager (for proper process/resources clean up).

#### One-line summary:

`dbt-ol` should transparently exit with the same exit code as the child `dbt` process.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- ~~[ ] Your changes are accompanied by tests (_if relevant_)~~
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
~~- [ ] You've updated any relevant documentation (_if relevant_)~~
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
~~- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)~~
~~- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)~~

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project