### PR TITLE
[SPEC] Add fileCount to dataset stats facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   *Adding the ability to support OpenLineage within Spark extensions' code. Refer to [README](https://github.com/OpenLineage/OpenLineage/tree/spark/built-in-lineage/integration/spark-interfaces-scala#readme) for more details.*
 * **Flink: support Flink 1.19.0** [`#2545`](https://github.com/OpenLineage/OpenLineage/pull/2545) [@HuangZhenQiu](https://github.com/HuangZhenQiu)
   *Adding the integration test coverage for flink 1.19.0.
+* **Spec: add "fileCount" to dataset stat facets** [`#2562`](https://github.com/OpenLineage/OpenLineage/pull/2562) [@dolfinus](https://github.com/dolfinus)
+  *Adds "fileCount" field to DataQualityMetricsInputDatasetFacet and OutputStatisticsOutputDatasetFacet specification*
 
 ### Fixed
 * **Flink: disable module metadata generation** [`#2507`](https://github.com/OpenLineage/OpenLineage/pull/2531) [@HuangZhenQiu](https://github.com/HuangZhenQiu)

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageTest.java
@@ -227,6 +227,7 @@ class OpenLineageTest {
                             ol.newDataQualityMetricsInputDatasetFacetBuilder()
                                 .rowCount(10L)
                                 .bytes(20L)
+                                .fileCount(5L)
                                 .columnMetrics(
                                     ol.newDataQualityMetricsInputDatasetFacetColumnMetricsBuilder()
                                         .put(
@@ -258,7 +259,12 @@ class OpenLineageTest {
                         .build())
                 .outputFacets(
                     ol.newOutputDatasetOutputFacetsBuilder()
-                        .outputStatistics(ol.newOutputStatisticsOutputDatasetFacet(10L, 20L))
+                        .outputStatistics(
+                            ol.newOutputStatisticsOutputDatasetFacetBuilder()
+                                .rowCount(10L)
+                                .size(20L)
+                                .fileCount(5L)
+                                .build())
                         .build())
                 .build());
 
@@ -296,6 +302,7 @@ class OpenLineageTest {
           inputDataset.getInputFacets().getDataQualityMetrics();
       assertEquals((Long) 10L, dq.getRowCount());
       assertEquals((Long) 20L, dq.getBytes());
+      assertEquals((Long) 5L, dq.getFileCount());
       DataQualityMetricsInputDatasetFacetColumnMetricsAdditional colMetrics =
           dq.getColumnMetrics().getAdditionalProperties().get("mycol");
       assertEquals((Double) 10D, colMetrics.getCount());
@@ -315,6 +322,7 @@ class OpenLineageTest {
       assertEquals(roundTrip(json), roundTrip(mapper.writeValueAsString(read)));
       assertEquals((Long) 10L, outputDataset.getOutputFacets().getOutputStatistics().getRowCount());
       assertEquals((Long) 20L, outputDataset.getOutputFacets().getOutputStatistics().getSize());
+      assertEquals((Long) 5L, outputDataset.getOutputFacets().getOutputStatistics().getFileCount());
 
       assertEquals(json, mapper.writeValueAsString(read));
     }

--- a/client/python/openlineage/client/facet.py
+++ b/client/python/openlineage/client/facet.py
@@ -145,10 +145,11 @@ class DataSourceDatasetFacet(BaseFacet):
 
 @attr.s
 class OutputStatisticsOutputDatasetFacet(BaseFacet):
-    rowCount: int = attr.ib()  # noqa: N815
+    rowCount: Optional[int] = attr.ib(default=None)  # noqa: N815
     size: Optional[int] = attr.ib(default=None)
+    fileCount: Optional[int] = attr.ib(default=None)  # noqa: N815
 
-    _additional_skip_redact: ClassVar[List[str]] = ["rowCount", "size"]
+    _additional_skip_redact: ClassVar[List[str]] = ["rowCount", "size", "fileCount"]
 
     @staticmethod
     def _get_schema() -> str:
@@ -170,6 +171,7 @@ class ColumnMetric:
 class DataQualityMetricsInputDatasetFacet(BaseFacet):
     rowCount: Optional[int] = attr.ib(default=None)  # noqa: N815
     bytes: Optional[int] = attr.ib(default=None)  # noqa: A003
+    fileCount: Optional[int] = attr.ib(default=None)  # noqa: N815
     columnMetrics: Dict[str, ColumnMetric] = attr.ib(factory=dict)  # noqa: N815
 
     @staticmethod

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
@@ -39,13 +39,16 @@ public class OutputStatisticsOutputDatasetFacetBuilder
           "outputStatistics",
           context
               .getOpenLineage()
-              .newOutputStatisticsOutputDatasetFacet(
+              .newOutputStatisticsOutputDatasetFacetBuilder()
+              .rowCount(
                   Optional.of(metrics.get(JobMetricsHolder.Metric.WRITE_RECORDS))
                       .map(Number::longValue)
-                      .orElse(null),
+                      .orElse(null))
+              .size(
                   Optional.of(metrics.get(JobMetricsHolder.Metric.WRITE_BYTES))
                       .map(Number::longValue)
-                      .orElse(null)));
+                      .orElse(null))
+              .build());
     }
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -81,6 +81,7 @@ class OpenLineageRunEventTest {
                         ol.newDataQualityMetricsInputDatasetFacetBuilder()
                             .rowCount(10L)
                             .bytes(20L)
+                            .fileCount(5L)
                             .columnMetrics(
                                 ol.newDataQualityMetricsInputDatasetFacetColumnMetricsBuilder()
                                     .put(
@@ -107,7 +108,12 @@ class OpenLineageRunEventTest {
                 "output",
                 null,
                 ol.newOutputDatasetOutputFacetsBuilder()
-                    .outputStatistics(ol.newOutputStatisticsOutputDatasetFacet(10L, 20L))
+                    .outputStatistics(
+                        ol.newOutputStatisticsOutputDatasetFacetBuilder()
+                            .rowCount(10L)
+                            .size(20L)
+                            .fileCount(5L)
+                            .build())
                     .build()));
     OpenLineage.RunEvent runStateUpdate =
         ol.newRunEventBuilder()

--- a/integration/spark/shared/src/test/resources/test_data/serde/openlineage-event.json
+++ b/integration/spark/shared/src/test/resources/test_data/serde/openlineage-event.json
@@ -46,6 +46,7 @@
         "dataQualityMetrics": {
           "rowCount": 10,
           "bytes": 20,
+          "fileCount": 5,
           "columnMetrics": {
             "mycol": {
               "nullCount": 1,
@@ -70,7 +71,8 @@
       "outputFacets": {
         "outputStatistics": {
           "rowCount": 10,
-          "size": 20
+          "size": 20,
+          "fileCount": 5
         }
       }
     }

--- a/proxy/fluentd/events/event_full.json
+++ b/proxy/fluentd/events/event_full.json
@@ -87,7 +87,8 @@
           "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
           "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/DataQualityMetricsInputDatasetFacet",
           "rowCount": 1000,
-          "bytes": 1048576
+          "bytes": 1048576,
+          "fileCount": 5
         },
         "dataQualityAssertions": {
           "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
@@ -155,7 +156,8 @@
           "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
           "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
           "rowCount": 2000,
-          "size": 2097152
+          "size": 2097152,
+          "fileCount": 5
         }
       },
       "facets": {

--- a/proxy/fluentd/events/event_invalid_input_dataset_facet.json
+++ b/proxy/fluentd/events/event_invalid_input_dataset_facet.json
@@ -17,12 +17,13 @@
           "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
           "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/DataQualityMetricsInputDatasetFacet",
           "noRowCount": 1000,
-          "bytes": 1048576
+          "bytes": 1048576,
+          "fileCount": 5
         }
       }
     }
   ],
-  "outputs": [ ],
+  "outputs": [],
   "producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
   "schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/RunEvent"
 }

--- a/proxy/fluentd/events/event_invalid_output_dataset_facet.json
+++ b/proxy/fluentd/events/event_invalid_output_dataset_facet.json
@@ -8,7 +8,7 @@
     "namespace": "my-scheduler-namespace",
     "name": "myjob"
   },
-  "inputs": [ ],
+  "inputs": [],
   "outputs": [
     {
       "namespace": "my-datasource-namespace",
@@ -17,8 +17,9 @@
         "outputStatistics": {
           "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
           "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
-          "notARowCount": 2000,
-          "size": 2097152
+          "rowCount": "wrong",
+          "size": 2097152,
+          "fileCount": 5
         }
       }
     }

--- a/proxy/fluentd/test/plugin/test_parser_openlineage.rb
+++ b/proxy/fluentd/test/plugin/test_parser_openlineage.rb
@@ -130,7 +130,7 @@ class OpenlineageParserTest < Test::Unit::TestCase
     err = assert_raise Fluent::ParserError do
       @parser.instance.parse(ol_event)
     end
-    assert_match(/Openlineage validation failed: (.+) "rowCount" is a required property/, err.message)
+    assert_match(/Openlineage validation failed: (.+) path \"\/outputs\/0\/outputFacets\/outputStatistics\/rowCount/, err.message)
   end
 
   private

--- a/spec/facets/DataQualityMetricsInputDatasetFacet.json
+++ b/spec/facets/DataQualityMetricsInputDatasetFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/DataQualityMetricsInputDatasetFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-0-1/DataQualityMetricsInputDatasetFacet.json",
   "$defs": {
     "DataQualityMetricsInputDatasetFacet": {
       "allOf": [
@@ -17,6 +17,10 @@
             },
             "bytes": {
               "description": "The size in bytes",
+              "type": "integer"
+            },
+            "fileCount": {
+              "description": "The number of files evaluated",
               "type": "integer"
             },
             "columnMetrics": {

--- a/spec/facets/OutputStatisticsOutputDatasetFacet.json
+++ b/spec/facets/OutputStatisticsOutputDatasetFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-0/OutputStatisticsOutputDatasetFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-0-1/OutputStatisticsOutputDatasetFacet.json",
   "$defs": {
     "OutputStatisticsOutputDatasetFacet": {
       "allOf": [
@@ -17,9 +17,12 @@
             "size": {
               "description": "The size in bytes written to the dataset",
               "type": "integer"
+            },
+            "fileCount": {
+              "description": "The number of files written to the dataset",
+              "type": "integer"
             }
-          },
-          "required": ["rowCount"]
+          }
         }
       ]
     }

--- a/spec/tests/DataQualityMetricsInputDatasetFacet/1.json
+++ b/spec/tests/DataQualityMetricsInputDatasetFacet/1.json
@@ -16,7 +16,7 @@
       }
     },
     "rowCount": 10,
-
+    "fileCount": 5,
     "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
     "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DataQualityMetricsInputDatasetFacet.json"
   }

--- a/spec/tests/OutputStatisticsOutputDatasetFacet/1.json
+++ b/spec/tests/OutputStatisticsOutputDatasetFacet/1.json
@@ -3,6 +3,7 @@
     "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
     "_schemaURL": "https://openlineage.io/spec/1-0-1/OpenLineage.json#/definitions/OutputStatisticsOutputDatasetFacet",
     "rowCount": 2000,
-    "size": 2097152
+    "size": 2097152,
+    "fileCount": 5
   }
 }


### PR DESCRIPTION
### Problem

👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

Closes: #2550

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [X] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Adds "fileCount" field to DataQualityMetricsInputDatasetFacet and OutputStatisticsOutputDatasetFacet specification

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [X] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project