### PR TITLE
spark,snowflake: support query option via SQL parser

### DIFF
--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -35,6 +35,7 @@ ext {
 
 dependencies {
     implementation(project(path: ":shared", configuration: activeRuntimeElementsConfiguration))
+    implementation("io.openlineage:openlineage-sql-java:${project.version}")
 
     compileOnly("org.apache.spark:spark-sql_${scala}:${spark}")
 

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeRelationVisitor.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeRelationVisitor.java
@@ -8,11 +8,11 @@ package io.openlineage.spark.agent.vendor.snowflake.lifecycle;
 import static io.openlineage.spark.agent.vendor.snowflake.Constants.SNOWFLAKE_CLASS_NAME;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.vendor.snowflake.lifecycle.plan.SnowflakeSaveIntoDataSourceCommandDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -65,9 +65,9 @@ public class SnowflakeRelationVisitor<D extends OpenLineage.Dataset>
     String sfFullURL = params.sfFullURL();
     Optional<String> dbtable =
         Optional.<TableName>ofNullable(params.table().getOrElse(null)).map(TableName::toString);
+    Optional<String> query = ScalaConversionUtils.asJavaOptional(params.query());
 
-    return Collections.singletonList(
-        SnowflakeDataset.getDataset(
-            factory, sfFullURL, sfDatabase, sfSchema, dbtable, relation.schema()));
+    return SnowflakeDataset.getDatasets(
+        factory, sfFullURL, sfDatabase, sfSchema, dbtable, query, relation.schema());
   }
 }

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/SnowflakeSaveIntoDataSourceCommandDatasetBuilder.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/SnowflakeSaveIntoDataSourceCommandDatasetBuilder.java
@@ -39,19 +39,20 @@ public class SnowflakeSaveIntoDataSourceCommandDatasetBuilder
 
       Map<String, String> options = ScalaConversionUtils.<String, String>fromMap(command.options());
       Optional<String> dbtable = Optional.ofNullable(options.get("dbtable"));
+      Optional<String> query = Optional.ofNullable(options.get("query"));
       String sfSchema = options.get("sfschema");
       String sfUrl = options.get("sfurl");
       String sfDatabase = options.get("sfdatabase");
 
-      return Collections.singletonList(
-          // Similar to Kafka, Snowflake also has some special handling. So we use the method
-          // below for extracting the dataset from Snowflake write operations.
-          SnowflakeDataset.getDataset(
-              outputDataset(), sfUrl, sfDatabase, sfSchema, dbtable, getSchema(command)
-              // command.schema() doesn't seem to contain the schema when tested with Azure
-              // Snowflake,
-              // so we use the helper to extract it from the logical plan.
-              ));
+      return
+      // Similar to Kafka, Snowflake also has some special handling. So we use the method
+      // below for extracting the dataset from Snowflake write operations.
+      SnowflakeDataset.getDatasets(
+          outputDataset(), sfUrl, sfDatabase, sfSchema, dbtable, query, getSchema(command)
+          // command.schema() doesn't seem to contain the schema when tested with Azure
+          // Snowflake,
+          // so we use the helper to extract it from the logical plan.
+          );
     } else {
       return Collections.emptyList();
     }


### PR DESCRIPTION
This is similar (and based on) to https://github.com/OpenLineage/OpenLineage/pull/2556 but concerns Snowflake queries. 

When Snowflake job is bypassing Spark's computation layer, use SQL parser to get the lineage. 