### PR TITLE
[COMMON] feat: Add support for SCRIPT type jobs in BigQuery

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -48,7 +48,7 @@ class BigQueryExtractor(BaseExtractor):
 
         stats = BigQueryDatasetsProvider(client=client).get_facets(bigquery_job_id)
         inputs = stats.inputs
-        output = stats.output
+        outputs = stats.outputs
 
         for ds in inputs:
             ds.input_facets = self._get_input_facets()
@@ -59,7 +59,7 @@ class BigQueryExtractor(BaseExtractor):
         return TaskMetadata(
             name=get_job_name(task=self.operator),
             inputs=[ds.to_openlineage_dataset() for ds in inputs],
-            outputs=[output.to_openlineage_dataset()] if output else [],
+            outputs=[o.to_openlineage_dataset() for o in outputs],
             run_facets=run_facets,
             job_facets=job_facets,
         )

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -120,6 +120,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
         )
 
         assert len(task_meta.run_facets) == 2
+        job_details["configuration"]["query"].pop("query")
         assert (
             BigQueryJobRunFacet(cached=False, billedBytes=111149056, properties=json.dumps(job_details))
             == task_meta.run_facets["bigQuery_job"]
@@ -194,7 +195,9 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         assert len(task_meta.run_facets) == 2
         print(task_meta.run_facets.keys())
-        assert task_meta.run_facets["bigQuery_job"] == BigQueryJobRunFacet(cached=True)
+        job_run_facet = task_meta.run_facets["bigQuery_job"]
+        assert job_run_facet.cached is True
+        assert job_run_facet.billedBytes == 0
 
         assert (
             ExternalQueryRunFacet(externalQueryId=bq_job_id, source="bigquery")

--- a/integration/airflow/tests/integration/requests/bigquery.json
+++ b/integration/airflow/tests/integration/requests/bigquery.json
@@ -131,7 +131,7 @@
 	"job": {
 		"facets": {
 			"sql": {
-				"query": "\n    INSERT INTO `openlineage-ci.***_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM ***_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times\n    GROUP BY order_placed_on;"
+				"query": "\n    DECLARE mock_var BOOL;\n    SET mock_var = false;\n    INSERT INTO `openlineage-ci.***_integration.{{ env_var('BIGQUERY_PREFIX') }}_popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)\n    SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,\n        order_placed_on,\n        COUNT(*) AS orders_placed\n    FROM ***_integration.{{ env_var('BIGQUERY_PREFIX') }}_top_delivery_times\n    GROUP BY order_placed_on;"
 			}
 		},
 		"name": "bigquery_orders_popular_day_of_week.bigquery_insert",

--- a/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/bigquery_orders_popular_day_of_week.py
@@ -106,7 +106,10 @@ t5 = BigQueryExecuteQueryOperator(
 t6 = BigQueryExecuteQueryOperator(
     task_id="bigquery_insert",
     gcp_conn_id="bq_conn",
+    # Adding mock declare / set allows us to test SCRIPT type job lineage
     sql=f"""
+    DECLARE mock_var BOOL;
+    SET mock_var = false;
     INSERT INTO `{PROJECT_ID}.{DATASET_ID}.{PREFIX}popular_orders_day_of_week` (order_day_of_week, order_placed_on, orders_placed)
     SELECT EXTRACT(DAYOFWEEK FROM order_placed_on) AS order_day_of_week,
         order_placed_on,

--- a/integration/common/tests/bigquery/script_job_details.json
+++ b/integration/common/tests/bigquery/script_job_details.json
@@ -1,0 +1,36 @@
+{
+   "kind": "bigquery#job",
+   "etag": "123",
+   "id": "project-id:EU.bquxjob_2894c210_18e85d7a86e",
+   "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/project-id/jobs/bquxjob_2894c210_18e85d7a86e?location=EU",
+   "configuration": {
+      "query": {
+         "query": "DECLARE\n  start_ts TIMESTAMP;\nSET\n  start_ts = TIMESTAMP(\"2020-01-04 12:00:00 UTC\"); \nCREATE OR REPLACE TABLE ...",
+         "priority": "INTERACTIVE",
+         "allowLargeResults": false
+      },
+      "jobType": "QUERY"
+   },
+   "jobReference": {
+      "projectId": "project-id",
+      "jobId": "bquxjob_2894c210_18e85d7a86e",
+      "location": "EU"
+   },
+   "statistics": {
+      "creationTime": 1711642487190.0,
+      "startTime": 1711642487224.0,
+      "endTime": 1711642490618.0,
+      "totalBytesProcessed": "119672332",
+      "query": {
+         "totalBytesProcessed": "119672332",
+         "totalBytesBilled": "120586240",
+         "totalSlotMs": "31441",
+         "statementType": "SCRIPT"
+      },
+      "totalSlotMs": "31441",
+      "numChildJobs": "1"
+   },
+   "status": {
+      "state": "DONE"
+   }
+}

--- a/integration/common/tests/bigquery/test_bigquery.py
+++ b/integration/common/tests/bigquery/test_bigquery.py
@@ -4,11 +4,13 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
 from openlineage.client.facet import ExternalQueryRunFacet
 from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.provider.bigquery import (
     BigQueryDatasetsProvider,
     BigQueryJobRunFacet,
+    BigQueryStatisticsDatasetFacet,
 )
 
 
@@ -39,6 +41,7 @@ def test_bq_job_information():
 
     statistics = BigQueryDatasetsProvider(client=client).get_facets("job_id")
 
+    job_details["configuration"]["query"].pop("query")
     assert statistics.run_facets == {
         "bigQuery_job": BigQueryJobRunFacet(
             cached=False, billedBytes=111149056, properties=json.dumps(job_details)
@@ -62,3 +65,158 @@ def test_bq_job_information():
         source=Source(scheme="bigquery", connection_url="bigquery"),
         name="bq-airflow-openlineage.new_dataset.output_table",
     )
+    assert statistics.outputs == [
+        Dataset(
+            source=Source(scheme="bigquery", connection_url="bigquery"),
+            name="bq-airflow-openlineage.new_dataset.output_table",
+        )
+    ]
+
+
+def test_bq_script_job_information():
+    script_job_details = read_file_json("tests/bigquery/script_job_details.json")
+    query_job_details = read_file_json("tests/bigquery/job_details.json")
+    client = MagicMock()
+    client.get_job.side_effect = [
+        MagicMock(_properties=script_job_details),
+        MagicMock(_properties=query_job_details),
+    ]
+    client.list_jobs.return_value = ["child_job_id"]
+
+    client.get_table.return_value = TableMock()
+
+    statistics = BigQueryDatasetsProvider(client=client).get_facets("script_job_id")
+
+    script_job_details["configuration"]["query"].pop("query")
+    assert statistics.run_facets == {
+        "bigQuery_job": BigQueryJobRunFacet(
+            cached=False, billedBytes=120586240, properties=json.dumps(script_job_details)
+        ),
+        "externalQuery": ExternalQueryRunFacet(externalQueryId="script_job_id", source="bigquery"),
+    }
+    assert statistics.inputs == [
+        Dataset(
+            source=Source(scheme="bigquery", connection_url="bigquery"),
+            name="bigquery-public-data.usa_names.usa_1910_2013",
+            fields=[
+                Field("state", "STRING", [], "2-digit state code"),
+                Field("gender", "STRING", [], "Sex (M=male or F=female)"),
+                Field("year", "INTEGER", [], "4-digit year of birth"),
+                Field("name", "STRING", [], "Given name of a person at birth"),
+                Field("number", "INTEGER", [], "Number of occurrences of the name"),
+            ],
+        )
+    ]
+    assert statistics.output == Dataset(
+        source=Source(scheme="bigquery", connection_url="bigquery"),
+        name="bq-airflow-openlineage.new_dataset.output_table",
+    )
+    assert statistics.outputs == [
+        Dataset(
+            source=Source(scheme="bigquery", connection_url="bigquery"),
+            name="bq-airflow-openlineage.new_dataset.output_table",
+        )
+    ]
+
+
+def test_deduplicate_outputs():
+    outputs = [
+        None,
+        Dataset(
+            Source(name="s1"),
+            name="d1",
+            custom_facets={"stats": BigQueryStatisticsDatasetFacet(1, 2), "test1": "test1"},
+            output_facets={"outputStatistics": BigQueryStatisticsDatasetFacet(3, 4)},
+        ),
+        Dataset(
+            Source(name="s4"),
+            name="d1",
+            custom_facets={"stats": BigQueryStatisticsDatasetFacet(10, 20)},
+            output_facets={"outputStatistics": BigQueryStatisticsDatasetFacet(30, 40), "test10": "test10"},
+        ),
+        Dataset(
+            Source(name="s2"),
+            name="d2",
+            custom_facets={"stats": BigQueryStatisticsDatasetFacet(8, 9)},
+            output_facets={"outputStatistics": BigQueryStatisticsDatasetFacet(6, 7), "test20": "test20"},
+        ),
+        Dataset(
+            Source(name="s3"),
+            name="d2",
+            custom_facets={"stats": BigQueryStatisticsDatasetFacet(80, 90), "test2": "test2"},
+            output_facets={"outputStatistics": BigQueryStatisticsDatasetFacet(60, 70)},
+        ),
+    ]
+    result = BigQueryDatasetsProvider._deduplicate_outputs(outputs)
+    assert len(result) == 2
+    first_result = result[0]
+    assert first_result.name == "d1"
+    assert not first_result.custom_facets
+    assert first_result.output_facets == {"test10": "test10"}
+    second_result = result[1]
+    assert second_result.name == "d2"
+    assert second_result.custom_facets == {"test2": "test2"}
+    assert not second_result.output_facets
+
+
+@pytest.mark.parametrize("cache", (None, "false", False, 0))
+def test_get_job_run_facet_no_cache_and_with_bytes(cache):
+    properties = {
+        "statistics": {"query": {"cacheHit": cache, "totalBytesBilled": 10}},
+        "configuration": {"query": {"query": "SELECT ..."}},
+    }
+    result = BigQueryDatasetsProvider._get_job_run_facet(properties)
+    assert result.cached is False
+    assert result.billedBytes == 10
+    properties["configuration"]["query"].pop("query")
+    assert result.properties == json.dumps(properties)
+
+
+@pytest.mark.parametrize("cache", ("true", True))
+def test_get_job_run_facet_with_cache_and_no_bytes(cache):
+    properties = {
+        "statistics": {
+            "query": {
+                "cacheHit": cache,
+            }
+        },
+        "configuration": {"query": {"query": "SELECT ..."}},
+    }
+    result = BigQueryDatasetsProvider._get_job_run_facet(properties)
+    assert result.cached is True
+    assert result.billedBytes is None
+    properties["configuration"]["query"].pop("query")
+    assert result.properties == json.dumps(properties)
+
+
+def test_get_statistics_dataset_facet_no_query_plan():
+    properties = {
+        "statistics": {"query": {"totalBytesBilled": 10}},
+        "configuration": {"query": {"query": "SELECT ..."}},
+    }
+    result = BigQueryDatasetsProvider._get_statistics_dataset_facet(properties)
+    assert result is None
+
+
+def test_get_statistics_dataset_facet_no_stats():
+    properties = {
+        "statistics": {"query": {"totalBytesBilled": 10, "queryPlan": [{"test": "test"}]}},
+        "configuration": {"query": {"query": "SELECT ..."}},
+    }
+    result = BigQueryDatasetsProvider._get_statistics_dataset_facet(properties)
+    assert result is None
+
+
+def test_get_statistics_dataset_facet_with_stats():
+    properties = {
+        "statistics": {
+            "query": {
+                "totalBytesBilled": 10,
+                "queryPlan": [{"recordsWritten": 123, "shuffleOutputBytes": "321"}],
+            }
+        },
+        "configuration": {"query": {"query": "SELECT ..."}},
+    }
+    result = BigQueryDatasetsProvider._get_statistics_dataset_facet(properties)
+    assert result.rowCount == 123
+    assert result.size == 321


### PR DESCRIPTION
### Problem

When using SCRIPT type jobs in BigQuery, no lineage is extracted, because SCRIPT job has no lineage information - it only spawns child jobs that have that information.

### Solution

Extract lineage information from child jobs when dealing with SCRIPT type job. 

I removed query string from `BigQueryJobRunFacet` - it can increase event size a lot and it's already included in SqlJobFacet so it's not necessary here. 

I also added deduplication of input and output datasets to avoid duplicates in case the script job writes to / read from a table multiple times.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project