### PR TITLE
CI: Don't cache ./venv in pre-commit step.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -955,7 +955,7 @@ jobs:
       - *checkout_project_root
       - restore_cache:
           keys:
-          - v1.1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+          - v1.2-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Install Dependencies
@@ -968,8 +968,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.cache/pre-commit
-            - ./venv
-          key: v1.1-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
+          key: v1.2-precommit-deps-{{ checksum ".pre-commit-config.yaml" }}
 
       - run:
           name: Run pre-commit


### PR DESCRIPTION
### Problem

`./venv` appears to be wrong to be cached. It contains symlinks to versioned paths of Python, e.g. recently cached `/home/circleci/openlineage/venv/bin/python3.8` pointed to `/home/circleci/.pyenv/versions/3.8.18/bin/python3.8` while the updated `cimg/python:3.8` image moved it to `/home/circleci/.pyenv/versions/3.8.19/bin/python3.8`.

### Solution

Bump cache version. Remove `./venv` from caching.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project