### PR TITLE
[JAVA] Properly set Kafka messages key

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
@@ -13,14 +13,26 @@ import lombok.ToString;
 @ToString
 public final class KafkaConfig implements TransportConfig {
   @Getter @Setter private String topicName;
-  @Getter @Setter private String localServerId;
+  @Getter @Setter private String messageKey;
   @Getter @Setter private Properties properties;
 
   KafkaConfig() {
     properties = new Properties();
   }
 
-  public boolean hasLocalServerId() {
-    return (localServerId != null);
+  /**
+   * @deprecated Replaced by {@link #getMessageKey()} since v1.13.0, and will be removed in v1.16.0
+   */
+  @Deprecated
+  String getLocalServerId() {
+    return messageKey;
+  }
+
+  /**
+   * @deprecated Replaced by {@link #setMessageKey()} since v1.13.0, and will be removed in v1.16.0
+   */
+  @Deprecated
+  void setLocalServerId(String localServerId) {
+    this.messageKey = localServerId;
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransportBuilder.java
@@ -6,7 +6,6 @@
 package io.openlineage.client.transports;
 
 public class KafkaTransportBuilder implements TransportBuilder {
-  private static final String DEFAULT_LINEAGE_SOURCE = "openlineage-java";
 
   @Override
   public TransportConfig getConfig() {
@@ -15,13 +14,7 @@ public class KafkaTransportBuilder implements TransportBuilder {
 
   @Override
   public Transport build(TransportConfig config) {
-    final KafkaConfig kafkaConfig = (KafkaConfig) config;
-    if (!kafkaConfig.hasLocalServerId()) {
-      // Set the local server ID to the lineage source when not specified
-      kafkaConfig.setLocalServerId(DEFAULT_LINEAGE_SOURCE);
-    }
-    kafkaConfig.getProperties().put("server.id", kafkaConfig.getLocalServerId());
-    return new KafkaTransport(kafkaConfig);
+    return new KafkaTransport((KafkaConfig) config);
   }
 
   @Override

--- a/client/java/src/test/java/io/openlineage/client/Events.java
+++ b/client/java/src/test/java/io/openlineage/client/Events.java
@@ -6,23 +6,73 @@
 package io.openlineage.client;
 
 import java.net.URI;
+import java.util.UUID;
 
 public class Events {
-
-  @Deprecated
-  public static OpenLineage.RunEvent event() {
-    return runEvent();
-  }
-
-  public static OpenLineage.RunEvent runEvent() {
+  public static OpenLineage.RunEvent emptyRunEvent() {
     return new OpenLineage(URI.create("http://test.producer")).newRunEventBuilder().build();
   }
 
+  public static OpenLineage.RunEvent runEvent() {
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    OpenLineage.Run run =
+        new OpenLineage.RunBuilder()
+            .runId(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54"))
+            .build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newRunEventBuilder()
+        .job(job)
+        .run(run)
+        .build();
+  }
+
+  public static OpenLineage.RunEvent runEventWithParent() {
+    OpenLineage openLineage = new OpenLineage(URI.create("http://test.producer"));
+
+    OpenLineage.ParentRunFacetJob parentJob =
+        new OpenLineage.ParentRunFacetJobBuilder()
+            .namespace("parent-namespace")
+            .name("parent-job")
+            .build();
+    OpenLineage.ParentRunFacetRun parentRun =
+        new OpenLineage.ParentRunFacetRunBuilder()
+            .runId(UUID.fromString("d9cb8e0b-a410-435e-a619-da5e87ba8508"))
+            .build();
+    OpenLineage.ParentRunFacet parentRunFacet =
+        openLineage.newParentRunFacetBuilder().job(parentJob).run(parentRun).build();
+    OpenLineage.RunFacets runFacets =
+        new OpenLineage.RunFacetsBuilder().parent(parentRunFacet).build();
+
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    OpenLineage.Run run =
+        new OpenLineage.RunBuilder()
+            .runId(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54"))
+            .facets(runFacets)
+            .build();
+
+    return openLineage.newRunEventBuilder().job(job).run(run).build();
+  }
+
   public static OpenLineage.DatasetEvent datasetEvent() {
-    return new OpenLineage(URI.create("http://test.producer")).newDatasetEventBuilder().build();
+    OpenLineage.StaticDataset dataset =
+        new OpenLineage.StaticDatasetBuilder()
+            .namespace("test-namespace")
+            .name("test-dataset")
+            .build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newDatasetEventBuilder()
+        .dataset(dataset)
+        .build();
   }
 
   public static OpenLineage.JobEvent jobEvent() {
-    return new OpenLineage(URI.create("http://test.producer")).newJobEventBuilder().build();
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newJobEventBuilder()
+        .job(job)
+        .build();
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
@@ -5,7 +5,9 @@
 
 package io.openlineage.client.transports;
 
+import static io.openlineage.client.Events.emptyRunEvent;
 import static io.openlineage.client.Events.runEvent;
+import static io.openlineage.client.Events.runEventWithParent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -24,7 +26,7 @@ import org.mockito.ArgumentCaptor;
 
 class KafkaTransportTest {
   @Test
-  void clientEmitsKafkaTransport() throws IOException {
+  void clientEmitsKafkaTransportForRunEvent() throws IOException {
     KafkaProducer<String, String> producer = mock(KafkaProducer.class);
     KafkaConfig config = new KafkaConfig();
 
@@ -47,5 +49,90 @@ class KafkaTransportTest {
     verify(producer, times(1)).send(captor.capture());
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
+    assertThat(captor.getValue().key())
+        .isEqualTo("run:test-namespace/test-job/ea445b5c-22eb-457a-8007-01c7c52b6e54");
+  }
+
+  @Test
+  void clientEmitsKafkaTransportForRunEventWithParent() throws IOException {
+    KafkaProducer<String, String> producer = mock(KafkaProducer.class);
+    KafkaConfig config = new KafkaConfig();
+
+    Properties properties = new Properties();
+    properties.setProperty("bootstrap.servers", "localhost:9092;external:9092");
+
+    config.setTopicName("test-topic");
+    config.setProperties(properties);
+
+    KafkaTransport transport = new KafkaTransport(producer, config);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
+
+    client.emit(runEventWithParent());
+
+    ArgumentCaptor<ProducerRecord<String, String>> captor =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    verify(producer, times(1)).send(captor.capture());
+
+    assertThat(captor.getValue().topic()).isEqualTo("test-topic");
+    assertThat(captor.getValue().key())
+        .isEqualTo("run:parent-namespace/parent-job/d9cb8e0b-a410-435e-a619-da5e87ba8508");
+  }
+
+  @Test
+  void clientEmitsKafkaTransportForRunEventWithExplicitMessageKey() throws IOException {
+    KafkaProducer<String, String> producer = mock(KafkaProducer.class);
+    KafkaConfig config = new KafkaConfig();
+
+    Properties properties = new Properties();
+    properties.setProperty("bootstrap.servers", "localhost:9092;external:9092");
+
+    config.setTopicName("test-topic");
+    config.setMessageKey("explicit-key");
+    config.setProperties(properties);
+
+    KafkaTransport transport = new KafkaTransport(producer, config);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
+
+    client.emit(runEventWithParent());
+
+    ArgumentCaptor<ProducerRecord<String, String>> captor =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    verify(producer, times(1)).send(captor.capture());
+
+    assertThat(captor.getValue().topic()).isEqualTo("test-topic");
+    assertThat(captor.getValue().key()).isEqualTo("explicit-key");
+  }
+
+  @Test
+  void clientEmitsKafkaTransportForEmptyRunEvent() throws IOException {
+    KafkaProducer<String, String> producer = mock(KafkaProducer.class);
+    KafkaConfig config = new KafkaConfig();
+
+    Properties properties = new Properties();
+    properties.setProperty("bootstrap.servers", "localhost:9092;external:9092");
+
+    config.setTopicName("test-topic");
+    config.setProperties(properties);
+
+    KafkaTransport transport = new KafkaTransport(producer, config);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
+
+    client.emit(emptyRunEvent());
+
+    ArgumentCaptor<ProducerRecord<String, String>> captor =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    verify(producer, times(1)).send(captor.capture());
+
+    assertThat(captor.getValue().topic()).isEqualTo("test-topic");
+    assertThat(captor.getValue().key()).isNull();
   }
 }


### PR DESCRIPTION
### Problem

Closes: #2559

### Solution

#### One-line summary:

New `messageKey` option is added to `KafkaTransport` config of Python and Java clients, and also for Proxy. This option replaces `localServerId` option, which is now deprecated. Default value is generated using run id (for `RunEvent`), job name (for `JobEvent`) or dataset name (for `DatasetEvent`).
This value is used by Kafka producer to distribute messages along topic partitions, instead of sending all the events to the same partition. This allows to fully utilize Kafka performance.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project