### PR TITLE
[CLIENT] Fix missing pkg_resources module on Python 3.12

### DIFF
--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -9,7 +9,7 @@ import attr
 from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Config, Transport
 from openlineage.client.utils import get_only_specified_fields
-from pkg_resources import parse_version
+from packaging.version import Version
 
 if TYPE_CHECKING:
     from confluent_kafka import KafkaError, Message
@@ -103,8 +103,8 @@ def _check_if_airflow_sqlalchemy_context() -> bool:
     try:
         from airflow.version import version  # type: ignore[import]
 
-        parsed_version = parse_version(version)
-        if parse_version("2.3.0") <= parsed_version < parse_version("2.6.0"):
+        parsed_version = Version(version)
+        if Version("2.3.0") <= parsed_version < Version("2.6.0"):
             return True
     except ImportError:
         pass  # we want to leave it to false if airflow import fails

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "python-dateutil>=2.8.2",
   "pyyaml>=5.4",
   "requests>=2.20.0",
+  "packaging>=21.0",
 ]
 optional-dependencies.kafka = [
   "confluent-kafka>=2.1.1",

--- a/integration/airflow/openlineage/airflow/__init__.py
+++ b/integration/airflow/openlineage/airflow/__init__.py
@@ -6,13 +6,13 @@
 import logging
 
 from openlineage.airflow.version import __version__
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.version import version as AIRFLOW_VERSION
 
 __author__ = """OpenLineage"""
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.1.0"):  # type: ignore
+if Version(AIRFLOW_VERSION) < Version("2.1.0"):  # type: ignore
     logging.warning(
         f"""
         OpenLineage support for Airflow version {AIRFLOW_VERSION} is REMOVED.
@@ -20,7 +20,7 @@ if parse_version(AIRFLOW_VERSION) < parse_version("2.1.0"):  # type: ignore
         in order to continue using OpenLineage.
         """
     )
-elif parse_version(AIRFLOW_VERSION) >= parse_version("2.8.0b1"):  # type: ignore
+elif Version(AIRFLOW_VERSION) >= Version("2.8.0b1"):  # type: ignore
     logging.warning(
         f"""
         OpenLineage support for Airflow version {AIRFLOW_VERSION} is REMOVED.

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -5,7 +5,7 @@ import os
 
 # Provide empty plugin for older version
 from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.version import version as AIRFLOW_VERSION
@@ -14,8 +14,8 @@ from airflow.version import version as AIRFLOW_VERSION
 def _is_disabled():
     try:
         # If the Airflow provider is installed, skip running the openlineage-airflow plugin.
-        from airflow.providers.openlineage.plugins.openlineage import (
-            OpenLineageProviderPlugin,  # noqa: F401
+        from airflow.providers.openlineage.plugins.openlineage import (  # noqa: F401
+            OpenLineageProviderPlugin,
         )
 
         return True
@@ -25,8 +25,8 @@ def _is_disabled():
 
 
 if (
-    parse_version(AIRFLOW_VERSION) < parse_version("2.3.0.dev0")  # type: ignore
-    or parse_version(AIRFLOW_VERSION) >= parse_version("2.8.0.b1")  # type: ignore
+    Version(AIRFLOW_VERSION) < Version("2.3.0.dev0")  # type: ignore
+    or Version(AIRFLOW_VERSION) >= Version("2.8.0.b1")  # type: ignore
     or _is_disabled()
 ):
 

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -20,8 +20,8 @@ from openlineage.airflow.facets import (
     UnknownOperatorInstance,
 )
 from openlineage.client.utils import RedactMixin
+from packaging.version import Version
 from pendulum import from_timestamp
-from pkg_resources import parse_version
 
 from airflow.models import DAG as AIRFLOW_DAG
 
@@ -537,7 +537,7 @@ def is_airflow_version_enough(x):
         from airflow.version import version as AIRFLOW_VERSION
     except ImportError:
         AIRFLOW_VERSION = "0.0.0"
-    return parse_version(AIRFLOW_VERSION) >= parse_version(x)
+    return Version(AIRFLOW_VERSION) >= Version(x)
 
 
 def getboolean(env, default: bool = False) -> bool:

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from typing import Optional
 
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.lineage.backend import LineageBackend
 from airflow.version import version as AIRFLOW_VERSION
@@ -97,7 +97,7 @@ class OpenLineageBackend(LineageBackend):
     @classmethod
     def send_lineage(cls, *args, **kwargs):
         # Do not use LineageBackend approach when we can use plugins
-        if parse_version(AIRFLOW_VERSION) >= parse_version("2.3.0.dev0"):
+        if Version(AIRFLOW_VERSION) >= Version("2.3.0.dev0"):
             return None
         # Make this method a noop if OPENLINEAGE_DISABLED is set to true
         if os.getenv("OPENLINEAGE_DISABLED", "").lower() == "true":

--- a/integration/airflow/tests/conftest.py
+++ b/integration/airflow/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 from unittest.mock import patch
 
 import pytest
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.version import version as AIRFLOW_VERSION
 
@@ -15,14 +15,14 @@ log = logging.getLogger(__name__)
 collect_ignore = []
 
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
+if Version(AIRFLOW_VERSION) < Version("2.3.0"):
     collect_ignore.append("test_listener.py")
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.2.4"):
+if Version(AIRFLOW_VERSION) < Version("2.2.4"):
     collect_ignore.append("extractors/test_redshift_sql_extractor.py")
     collect_ignore.append("extractors/test_s3_extractor.py")
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.3.0"):
+if Version(AIRFLOW_VERSION) < Version("2.3.0"):
     collect_ignore.append("extractors/test_redshift_data_extractor.py")
     collect_ignore.append("extractors/test_sagemaker_extractors.py")
 

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -22,7 +22,7 @@ from openlineage.common.provider.bigquery import (
     BigQueryStatisticsDatasetFacet,
 )
 from openlineage.common.utils import get_from_nullable_chain
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.models import DAG, TaskInstance
 from airflow.utils import timezone
@@ -285,7 +285,7 @@ class TestBigQueryExtractor(unittest.TestCase):
     @staticmethod
     def _get_ti(task):
         kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+        if Version(AIRFLOW_VERSION) > Version("2.2.0"):
             kwargs["run_id"] = "test_run_id"  # change in 2.2.0
         task_instance = TaskInstance(
             task=task,

--- a/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
+++ b/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 import pytz
 from openlineage.airflow.utils import try_import_from_string
-from pkg_resources import parse_version
+from packaging.version import Version
 from pytest_mock import MockerFixture
 
 from airflow.models import DAG, TaskInstance
@@ -79,7 +79,7 @@ class MockResponse:
 
 class TestDbtCloudExtractorE2E:
     @pytest.mark.skipif(
-        parse_version(AIRFLOW_VERSION) < parse_version("2.4.0"),
+        Version(AIRFLOW_VERSION) < Version("2.4.0"),
         reason="Airflow < 2.4.0",
     )
     def test_extractor(self, mocker: MockerFixture):

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -19,7 +19,7 @@ from openlineage.client.facet import (
 )
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
@@ -86,7 +86,7 @@ class TestRedshiftDataExtractor(unittest.TestCase):
     @staticmethod
     def _get_ti(task, run_id):
         kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+        if Version(AIRFLOW_VERSION) > Version("2.2.0"):
             kwargs["run_id"] = run_id
         else:
             kwargs["execution_date"] = datetime.utcnow().replace(tzinfo=pytz.utc)
@@ -175,7 +175,7 @@ class TestRedshiftDataExtractor(unittest.TestCase):
         )
 
     @pytest.mark.skipif(
-        parse_version(AIRFLOW_VERSION) >= parse_version("2.5.0"),
+        Version(AIRFLOW_VERSION) >= Version("2.5.0"),
         reason="Airflow >= 2.5.0",
     )
     @mock.patch(

--- a/integration/airflow/tests/extractors/test_sagemaker_extractors.py
+++ b/integration/airflow/tests/extractors/test_sagemaker_extractors.py
@@ -13,7 +13,7 @@ from openlineage.airflow.extractors.sagemaker_extractors import (
     SageMakerTrainingExtractor,
     SageMakerTransformExtractor,
 )
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.models import DAG, TaskInstance
 from airflow.providers.amazon.aws.operators.sagemaker import (
@@ -69,7 +69,7 @@ class TestSageMakerProcessingExtractor(TestCase):
     @staticmethod
     def _get_ti(task):
         kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+        if Version(AIRFLOW_VERSION) > Version("2.2.0"):
             kwargs["run_id"] = "test_run_id"  # change in 2.2.0
         task_instance = TaskInstance(
             task=task,
@@ -123,7 +123,7 @@ class TestSageMakerTransformExtractor(TestCase):
     @staticmethod
     def _get_ti(task):
         kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+        if Version(AIRFLOW_VERSION) > Version("2.2.0"):
             kwargs["run_id"] = "test_run_id"  # change in 2.2.0
         task_instance = TaskInstance(
             task=task,
@@ -173,7 +173,7 @@ class TestSageMakerTrainingExtractor(TestCase):
     @staticmethod
     def _get_ti(task):
         kwargs = {}
-        if parse_version(AIRFLOW_VERSION) > parse_version("2.2.0"):
+        if Version(AIRFLOW_VERSION) > Version("2.2.0"):
             kwargs["run_id"] = "test_run_id"  # change in 2.2.0
         task_instance = TaskInstance(
             task=task,

--- a/integration/airflow/tests/extractors/test_sftp_extractor.py
+++ b/integration/airflow/tests/extractors/test_sftp_extractor.py
@@ -9,7 +9,7 @@ import pytest
 from openlineage.airflow.extractors.sftp_extractor import SFTPExtractor
 from openlineage.airflow.utils import try_import_from_string
 from openlineage.common.dataset import Dataset, Source
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.models import DAG, Connection
 from airflow.providers.sftp.hooks.sftp import SFTPHook
@@ -18,7 +18,7 @@ from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers_manager import ProvidersManager
 from airflow.utils import timezone
 
-SFTP_PROVIDER_VERSION = parse_version(ProvidersManager().providers["apache-airflow-providers-sftp"].version)
+SFTP_PROVIDER_VERSION = Version(ProvidersManager().providers["apache-airflow-providers-sftp"].version)
 
 SFTPOperator = try_import_from_string("airflow.providers.sftp.operators.sftp.SFTPOperator")
 
@@ -86,7 +86,7 @@ def test_extract_ssh_conn_id(get_connection, get_conn, operation, expected):
 
 
 @pytest.mark.skipif(
-    parse_version("4.0.0") > SFTP_PROVIDER_VERSION,
+    Version("4.0.0") > SFTP_PROVIDER_VERSION,
     reason="SFTPOperator doesn't support sftp_hook as a constructor parameter in this version.",
 )
 @pytest.mark.parametrize(

--- a/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
+++ b/integration/airflow/tests/integration/failures/airflow/dags/hanging_extractor_dag.py
@@ -5,7 +5,7 @@ import os
 from typing import Any
 
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow import DAG
 from airflow.models import BaseOperator
@@ -18,7 +18,7 @@ set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/
 # Exercise the extractor only for Airflow 2.3.0+
 # This is to test the thread handling in the Airflow listener.
 # The thread should be shutdown after 2 seconds, even if the extractor is hanging
-if parse_version(AIRFLOW_VERSION) > parse_version("2.3.0"):
+if Version(AIRFLOW_VERSION) > Version("2.3.0"):
     os.environ["OPENLINEAGE_EXTRACTOR_CustomOperator"] = "hanging_extractor.HangingExtractor"
 
 default_args = {

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -16,7 +16,7 @@ import requests
 from openlineage.client.run import RunState
 from openlineage.common.test import match, setup_jinja
 from openlineage.common.utils import get_from_nullable_chain
-from pkg_resources import parse_version
+from packaging.version import Version
 from retrying import retry
 
 env = setup_jinja()
@@ -42,7 +42,7 @@ SNOWFLAKE_AIRFLOW_TEST_VERSION = os.environ.get("SNOWFLAKE_AIRFLOW_TEST_VERSION"
 
 
 def IS_AIRFLOW_VERSION_ENOUGH(x):
-    return parse_version(os.environ.get("AIRFLOW_VERSION", "0.0.0")) >= parse_version(x)
+    return Version(os.environ.get("AIRFLOW_VERSION", "0.0.0")) >= Version(x)
 
 
 params = [

--- a/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/failed_sql_extraction.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
@@ -33,7 +33,7 @@ dag = DAG(
 sql = "DROP POLICY IF EXISTS name ON table_name"
 
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.5.0"):
+if Version(AIRFLOW_VERSION) < Version("2.5.0"):
     t1 = PostgresOperator(task_id="fail", postgres_conn_id="food_delivery_db", sql=sql, dag=dag)
 else:
     from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator

--- a/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/postgres_orders_popular_day_of_week.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client import set_producer
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
@@ -39,7 +39,7 @@ dag = DAG(
     description="Determines the popular day of week orders are placed.",
 )
 
-if parse_version(AIRFLOW_VERSION) < parse_version("2.5.0"):
+if Version(AIRFLOW_VERSION) < Version("2.5.0"):
     t1 = PostgresOperator(
         task_id="postgres_if_not_exists",
         postgres_conn_id="food_delivery_db",

--- a/integration/airflow/tests/test_utils.py
+++ b/integration/airflow/tests/test_utils.py
@@ -23,7 +23,7 @@ from openlineage.airflow.utils import (
     url_to_https,
 )
 from openlineage.client.utils import RedactMixin
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from airflow.models import DAG as AIRFLOW_DAG
 from airflow.models import DagModel
@@ -76,7 +76,7 @@ def test_pendulum_to_iso_8601():
     assert DagUtils.to_iso_8601(tz.convert(dt)) == "2021-08-05T19:05:01.000000Z"
 
 
-@pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.4.0"), reason="Airflow < 2.4.0")
+@pytest.mark.skipif(Version(AIRFLOW_VERSION) < Version("2.4.0"), reason="Airflow < 2.4.0")
 def test_get_dagrun_start_end():
     dag = AIRFLOW_DAG("test", start_date=days_ago(1), schedule_interval="@once")
     AIRFLOW_DAG.bulk_write_to_db([dag])
@@ -91,18 +91,18 @@ def test_get_dagrun_start_end():
     assert get_dagrun_start_end(dagrun, dag) == (days_ago(1), days_ago(1))
 
 
-def test_parse_version():
-    assert parse_version("2.3.0") >= parse_version("2.3.0.dev0")
-    assert parse_version("2.3.0.dev0") >= parse_version("2.3.0.dev0")
-    assert parse_version("2.3.0.beta1") >= parse_version("2.3.0.dev0")
-    assert parse_version("2.3.1") >= parse_version("2.3.0.dev0")
-    assert parse_version("2.4.0") >= parse_version("2.3.0.dev0")
-    assert parse_version("3.0.0") >= parse_version("2.3.0.dev0")
-    assert parse_version("2.2.0") < parse_version("2.3.0.dev0")
-    assert parse_version("2.1.3") < parse_version("2.3.0.dev0")
-    assert parse_version("2.2.4") < parse_version("2.3.0.dev0")
-    assert parse_version("1.10.15") < parse_version("2.3.0.dev0")
-    assert parse_version("2.2.4.dev0") < parse_version("2.3.0.dev0")
+def test_Version():
+    assert Version("2.3.0") >= Version("2.3.0.dev0")
+    assert Version("2.3.0.dev0") >= Version("2.3.0.dev0")
+    assert Version("2.3.0.beta1") >= Version("2.3.0.dev0")
+    assert Version("2.3.1") >= Version("2.3.0.dev0")
+    assert Version("2.4.0") >= Version("2.3.0.dev0")
+    assert Version("3.0.0") >= Version("2.3.0.dev0")
+    assert Version("2.2.0") < Version("2.3.0.dev0")
+    assert Version("2.1.3") < Version("2.3.0.dev0")
+    assert Version("2.2.4") < Version("2.3.0.dev0")
+    assert Version("1.10.15") < Version("2.3.0.dev0")
+    assert Version("2.2.4.dev0") < Version("2.3.0.dev0")
 
 
 def test_to_json_encodable():

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from dagster import (
     DagsterEvent,
@@ -200,13 +200,13 @@ def _make_dagster_event(event_type: DagsterEventType, pipeline_name: str, step_k
 def make_pipeline_run_with_external_pipeline_origin(
     repository_name: str,
 ):
-    parsed_dagster_version = parse_version(DAGSTER_VERSION)
+    parsed_dagster_version = Version(DAGSTER_VERSION)
     dagster_run_provider: DagsterRunProvider = None
-    if not dagster_run_provider and parsed_dagster_version <= parse_version("1.2.2"):
+    if not dagster_run_provider and parsed_dagster_version <= Version("1.2.2"):
         dagster_run_provider = DagsterRunLE1_2_2Provider()
-    if not dagster_run_provider and parsed_dagster_version <= parse_version("1.3.2"):
+    if not dagster_run_provider and parsed_dagster_version <= Version("1.3.2"):
         dagster_run_provider = DagsterRunLE1_3_2Provider()
-    if not dagster_run_provider and parsed_dagster_version <= parse_version("1.6.9"):
+    if not dagster_run_provider and parsed_dagster_version <= Version("1.6.9"):
         dagster_run_provider = DagsterRunLE1_6_9Provider()
     if not dagster_run_provider:
         dagster_run_provider = DagsterRunLatestProvider()


### PR DESCRIPTION
### Problem

After installing `openlineage-python` on Python 3.12 virtual environment, I try to import it:
```python
from openlineage.client import OpenLineageClient
```

I got an exception:
```
ImportError occurred when trying to import numpy module.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maxim/Repo/airflow-cd/venv/lib/python3.12/site-packages/openlineage/client/__init__.py", line 5, in <module>
    from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
  File "/home/maxim/Repo/airflow-cd/venv/lib/python3.12/site-packages/openlineage/client/client.py", line 19, in <module>
    from openlineage.client.transport import Transport, TransportFactory, get_default_factory
  File "/home/maxim/Repo/airflow-cd/venv/lib/python3.12/site-packages/openlineage/client/transport/__init__.py", line 9, in <module>
    from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
  File "/home/maxim/Repo/airflow-cd/venv/lib/python3.12/site-packages/openlineage/client/transport/kafka.py", line 12, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
```

This is because `pkg_resources` is not a part of stdlib, but actually provided by `setuptools`. And setuptools is not automatically installed to virtual environments since Python 3.12.

For example, Python 3.11:
```bash
$ python -V
Python 3.11.8
$ python -m venv venv
$ source venv/bin/activate
$ pip freeze --all
pip==24.0
setuptools==65.5.0
```

Python 3.12:
```bash
$ python -V
Python 3.12.2
$ python -m venv venv
$ source venv/bin/activate
$ pip freeze --all
pip==24.0
```

### Solution

#### One-line summary:

Remove `pkg_resources` dependency and replace it with [packaging](https://packaging.pypa.io/en/latest/version.html) lib.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project