### PR TITLE
release, quickfix: make spark release job use scala interfaces build in their own release job

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -518,15 +518,25 @@ jobs:
       - run:
           name: Generate cache key
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+      - attach_workspace:
+          at: ~/.m2/repository/io/openlineage/
       - run: |
           # Get, then decode the GPG private key used to sign *.jar
           export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
           export RELEASE_PASSWORD=$(echo $SONATYPE_PASSWORD)
           export RELEASE_USERNAME=$(echo $SONATYPE_USER)
+          
+          ./gradlew --no-daemon --console=plain clean publishToMavenLocal -Pscala.binary.version=2.12
+          ./gradlew --no-daemon --console=plain clean publishToMavenLocal -Pscala.binary.version=2.13
 
           # Publish *.jar
           ./gradlew --no-daemon --console=plain clean publish -Pscala.binary.version=2.12
           ./gradlew --no-daemon --console=plain clean publish -Pscala.binary.version=2.13
+      - persist_to_workspace:
+          root: ~/.m2/repository/io/openlineage/
+          paths:
+            - spark-interfaces-scala_2.12
+            - spark-interfaces-scala_2.13
       - store_artifacts:
           path: ./build/libs
           destination: spark-interfaces-scala-artifacts
@@ -1049,6 +1059,7 @@ workflows:
           requires:
             - release-client-java
             - build-integration-sql-java
+            - release-integration-spark-interfaces-scala
       - release-integration-sql-java:
           filters:
             tags:

--- a/integration/spark-interfaces-scala/gradle.properties
+++ b/integration/spark-interfaces-scala/gradle.properties
@@ -1,3 +1,3 @@
 jdk8.build=true
-version=1.11.1
+version=1.12.0-SNAPSHOT
 scala.binary.version=2.13

--- a/new-version.sh
+++ b/new-version.sh
@@ -169,12 +169,13 @@ if [[ "${NEXT_VERSION}" == *-rc.? ||
   NEXT_VERSION="${NEXT_VERSION}-SNAPSHOT"
 fi
 
-perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/spark/gradle.properties
-perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/sql/iface-java/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./client/java/gradle.properties
-perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./proxy/backend/gradle.properties
+perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/sql/iface-java/gradle.properties
+perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/spark/gradle.properties
+perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/spark-interfaces-scala/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/flink/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/flink/examples/stateful/gradle.properties
+perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./proxy/backend/gradle.properties
 echo "version ${NEXT_VERSION}" > integration/spark/spark2/src/test/resources/io/openlineage/spark/agent/version.properties
 echo "version ${NEXT_VERSION}" > integration/spark/spark3/src/test/resources/io/openlineage/spark/agent/version.properties
 echo "version ${NEXT_VERSION}" > integration/flink/shared/src/test/resources/io/openlineage/flink/client/version.properties


### PR DESCRIPTION
It's a quickfix for release failures.

After that, a refactor of CI is needed to get rid of all dependencies for release jobs: 
- they should reuse artifact generated by build job
- they should not depend on any other job but a build job for a given artifact