### PR TITLE
dagster: limit dagster version to 1.6.9.

### DIFF
--- a/integration/dagster/setup.py
+++ b/integration/dagster/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "attrs>=19.3",
     "cattrs",
     "protobuf<=3.20.0",
-    f"dagster>={DAGSTER_VERSION}",
+    f"dagster>={DAGSTER_VERSION},<=1.6.9",
     f"openlineage-python=={__version__}",
 ]
 


### PR DESCRIPTION
### Problem

Recent releases of dagster have many breaking changes.

### Solution

 As dagster integration is not actively maintained I propose to limit upper version to the latest passing our tests.
#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project