### PR TITLE
Airflow: Add lineage_job_namespace and lineage_job_name macros

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -225,26 +225,53 @@ To see an example of a working configuration, see [DAG](https://github.com/OpenL
 In addition to conventional logging approaches, the `openlineage-airflow` package provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_AIRFLOW_LOGGING` environment variable, you can establish the logging level for the `openlineage.airflow` and its child modules.
 
 ## Triggering Child Jobs
+
 Commonly, Airflow DAGs will trigger processes on remote systems, such as an Apache Spark or Apache
 Beam job. Those systems may have their own OpenLineage integrations and report their own
 job runs and dataset inputs/outputs. To propagate the job hierarchy, tasks must send their own run
 ids so that the downstream process can report the [ParentRunFacet](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json#/definitions/ParentRunFacet)
 with the proper run id.
 
-The `lineage_run_id` and `lineage_parent_id` macros exists to inject the run id or whole parent run information
-of a given task into the arguments sent to a remote processing job's Airflow operator. The macro requires the 
-DAG `run_id` and the task to access the generated `run_id` for that task. For example, a Spark job can be triggered
-using the `DataProcPySparkOperator` with the correct parent `run_id` using the following configuration:
+These macros:
+  * `lineage_job_namespace()`
+  * `lineage_job_name(task_instance)`
+  * `lineage_run_id(task_instance)`
+
+allow injecting pieces of run information of a given Airflow task into the arguments sent to a remote processing job.
+For example, `SparkSubmitOperator` can be set up like this:
 
 ```python
-t1 = DataProcPySparkOperator(
-    task_id=job_name,
-    #required pyspark configuration,
-    job_name=job_name,
-    dataproc_pyspark_properties={
-        'spark.driver.extraJavaOptions':
-            f"-javaagent:{jar}={os.environ.get('OPENLINEAGE_URL')}/api/v1/namespaces/{os.getenv('OPENLINEAGE_NAMESPACE', 'default')}/jobs/{job_name}/runs/{{{{macros.OpenLineagePlugin.lineage_run_id(task_instance)}}}}?api_key={os.environ.get('OPENLINEAGE_API_KEY')}"
-        dag=dag)
+SparkSubmitOperator(
+    task_id="my_task",
+    application="/script.py",
+    conf={
+      # separated components
+      "spark.openlineage.parentJobNamespace": "{{ macros.OpenLineagePlugin.lineage_job_namespace() }}",
+      "spark.openlineage.parentJobName": "{{ macros.OpenLineagePlugin.lineage_job_name(task_instance) }}",
+      "spark.openlineage.parentRunId": "{{ macros.OpenLineagePlugin.lineage_run_id(task_instance) }}",
+    },
+    dag=dag,
+)
+```
+
+Same information, but compacted to one string, can be passed using `linage_parent_id(task_instance)` macro:
+
+```python
+def my_task_function(templates_dict, **kwargs):
+    parent_job_namespace, parent_job_name, parent_run_id = templates_dict["parentRun"].split("/")
+    ...
+
+
+PythonOperator(
+    task_id="render_template",
+    python_callable=my_task_function,
+    templates_dict={
+        # joined components as one string `<namespace>/<name>/<run_id>`
+        "parentRun": "{{ macros.OpenLineageProviderPlugin.lineage_parent_id(task_instance) }}",
+    },
+    provide_context=False,
+    dag=dag,
+)
 ```
 
 ## Secrets redaction

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import typing
 
 from openlineage.airflow.adapter import _DAG_NAMESPACE, OpenLineageAdapter
@@ -10,47 +12,82 @@ if typing.TYPE_CHECKING:
     from airflow.models import TaskInstance
 
 
-def lineage_run_id(task_instance: "TaskInstance"):
+def lineage_job_namespace():
     """
-    Macro function which returns the generated run id for a given task. This
+    Macro function which returns Airflow OpenLineage namespace.
+    Invoke as a jinja template, e.g.
+
+    PythonOperator(
+        task_id='render_template',
+        python_callable=my_task_function,
+        op_args=['{{ lineage_job_namespace() }}'], # invoke macro
+        provide_context=False,
+        dag=dag
+    )
+    """
+    return _DAG_NAMESPACE
+
+
+def lineage_job_name(task_instance: TaskInstance):
+    """
+    Macro function which returns Airflow task name in OpenLineage format (`<dag_id>.<task_id>`).
+    Invoke as a jinja template, e.g.
+
+    PythonOperator(
+        task_id='render_template',
+        python_callable=my_task_function,
+        op_args=['{{ lineage_job_name(task_instance) }}'], # invoke macro
+        provide_context=False,
+        dag=dag
+    )
+    """
+    return get_job_name(task_instance)
+
+
+def lineage_run_id(task_instance: TaskInstance):
+    """
+    Macro function which returns the generated runId (UUID) for a given Airflow task. This
     can be used to forward the run id from a task to a child run so the job
     hierarchy is preserved. Invoke as a jinja template, e.g.
 
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_run_id(task_instance) }}'], # lineage_run_id macro invoked
+        op_args=['{{ lineage_run_id(task_instance) }}'], # invoke macro
         provide_context=False,
         dag=dag
     )
     """
     return OpenLineageAdapter.build_task_instance_run_id(
         task_instance.dag_id,
-        task_instance.task.task_id,
+        task_instance.task_id,
         task_instance.execution_date,
         task_instance.try_number,
     )
 
 
-def lineage_parent_id(task_instance: "TaskInstance"):
+def lineage_parent_id(task_instance: TaskInstance):
     """
-    Macro function which returns the generated job and run id for a given task. This
+    Macro function which returns the job name and runId for a given Airflow task. This
     can be used to forward the ids from a task to a child run so the job
     hierarchy is preserved. Child run can create ParentRunFacet from those ids.
+
+    Result format: `<namespace>/<job_name>/<run_id>`.
+
     Invoke as a jinja template, e.g.
 
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_parent_id(task_instance) }}'], # macro invoked
+        op_args=['{{ lineage_parent_id(task_instance) }}'], # invoke macro
         provide_context=False,
         dag=dag
     )
     """
     return "/".join(
         [
-            _DAG_NAMESPACE,
-            get_job_name(task_instance),
+            lineage_job_namespace(),
+            lineage_job_name(task_instance),
             lineage_run_id(task_instance),
         ]
     )

--- a/integration/airflow/openlineage/airflow/plugin.py
+++ b/integration/airflow/openlineage/airflow/plugin.py
@@ -4,7 +4,12 @@
 import os
 
 # Provide empty plugin for older version
-from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+from openlineage.airflow.macros import (
+    lineage_job_name,
+    lineage_job_namespace,
+    lineage_parent_id,
+    lineage_run_id,
+)
 from packaging.version import Version
 
 from airflow.plugins_manager import AirflowPlugin
@@ -32,7 +37,7 @@ if (
 
     class OpenLineagePlugin(AirflowPlugin):
         name = "OpenLineagePlugin"
-        macros = [lineage_run_id, lineage_parent_id]
+        macros = [lineage_run_id, lineage_parent_id, lineage_job_namespace, lineage_job_name]
 
 else:
     from openlineage.airflow import listener
@@ -41,4 +46,4 @@ else:
     class OpenLineagePlugin(AirflowPlugin):  # type: ignore
         name = "OpenLineagePlugin"
         listeners = [listener]
-        macros = [lineage_run_id, lineage_parent_id]
+        macros = [lineage_run_id, lineage_parent_id, lineage_job_namespace, lineage_job_name]

--- a/integration/airflow/tests/test_macros.py
+++ b/integration/airflow/tests/test_macros.py
@@ -4,13 +4,32 @@ import uuid
 from unittest import mock
 
 from openlineage.airflow.adapter import _DAG_NAMESPACE
-from openlineage.airflow.macros import lineage_parent_id, lineage_run_id
+from openlineage.airflow.macros import (
+    lineage_job_name,
+    lineage_job_namespace,
+    lineage_parent_id,
+    lineage_run_id,
+)
+
+
+def test_lineage_job_namespace():
+    assert lineage_job_namespace() == _DAG_NAMESPACE
+
+
+def test_lineage_job_name():
+    task_instance = mock.MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        execution_date="execution_date",
+        try_number=1,
+    )
+    assert lineage_job_name(task_instance) == "dag_id.task_id"
 
 
 def test_lineage_run_id():
     task_instance = mock.MagicMock(
         dag_id="dag_id",
-        task=mock.MagicMock(task_id="task_id"),
+        task_id="task_id",
         execution_date="execution_date",
         try_number=1,
     )
@@ -29,14 +48,13 @@ def test_lineage_run_id():
 def test_lineage_parent_id():
     task_instance = mock.MagicMock(
         dag_id="dag_id",
-        task=mock.MagicMock(task_id="task_id"),
         task_id="task_id",
         execution_date="execution_date",
         try_number=1,
     )
 
     actual = lineage_parent_id(task_instance)
-    job_name = f"{task_instance.dag_id}.{task_instance.task.task_id}"
+    job_name = "dag_id.task_id"
     run_id = str(
         uuid.uuid3(
             uuid.NAMESPACE_URL,


### PR DESCRIPTION
### Problem

https://github.com/OpenLineage/OpenLineage/issues/2488#issuecomment-2027946160

Current `lineage_parent_id(task_instance)` macro is hard to use with Spark, it returns value in format `<job_namespace>/<job_name>/<run_id>`, but Spark requires passing separated options:
* `spark.openlineage.parentJobNamespace`
* `spark.openlineage.parentJobName`
* `spark.openlineage.parentRunId`

### Solution

#### One-line summary:

Added new Airflow macros `lineage_job_namespace()`, `lineage_job_name(task)` which return Airflow namespace and Airflow job name respectively.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project