### PR TITLE
spark: use hashset in column level lineage instead of iterating through linkedlist

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -40,7 +40,7 @@ import org.apache.spark.sql.catalyst.expressions.ExprId;
 public class ColumnLevelLineageBuilder {
 
   private Map<ExprId, Set<ExprId>> exprDependencies = new HashMap<>();
-  @Getter private Map<ExprId, List<Pair<DatasetIdentifier, String>>> inputs = new HashMap<>();
+  @Getter private Map<ExprId, Set<Pair<DatasetIdentifier, String>>> inputs = new HashMap<>();
   private Map<OpenLineage.SchemaDatasetFacetFields, ExprId> outputs = new HashMap<>();
   private Map<ColumnMeta, ExprId> externalExpressionMappings = new HashMap<>();
   private final OpenLineage.SchemaDatasetFacet schema;
@@ -61,13 +61,8 @@ public class ColumnLevelLineageBuilder {
    * @param attributeName
    */
   public void addInput(ExprId exprId, DatasetIdentifier datasetIdentifier, String attributeName) {
-    inputs.computeIfAbsent(exprId, k -> new LinkedList<>());
-
-    Pair<DatasetIdentifier, String> input = Pair.of(datasetIdentifier, attributeName);
-
-    if (!inputs.get(exprId).contains(input)) {
-      inputs.get(exprId).add(input);
-    }
+    inputs.computeIfAbsent(exprId, k -> new HashSet<>());
+    inputs.get(exprId).add(Pair.of(datasetIdentifier, attributeName));
   }
 
   /**


### PR DESCRIPTION
Original implementation used `LinkedList` which iteration performance is terrible. There's no real need to use list in that place - `HashSet` will be more performant collection.