### PR TITLE
make sure string isn't empty to prevent going out of bounds

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
@@ -57,7 +57,7 @@ public class DatasetIdentifierUtils {
   }
 
   private static String removeLastSlash(String name) {
-    if (name.charAt(name.length() - 1) == File.separatorChar) {
+    if (!name.isEmpty() && name.charAt(name.length() - 1) == File.separatorChar) {
       return name.substring(0, name.length() - 1);
     }
     return name;


### PR DESCRIPTION
### Problem

String lookup was not accounting for empty strings and causing java.lang.StringIndexOutOfBoundsException.

### Solution

Make sure string isn't empty first.

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project