### PR TITLE
[Spark] fix PMD for test

### DIFF
--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/OpenLineageRunEventTest.java
@@ -30,7 +30,7 @@ class OpenLineageRunEventTest {
       new TypeReference<Map<String, Object>>() {};
 
   @Test
-  public void testSerializeRunEvent() throws IOException, URISyntaxException {
+  void testSerializeRunEvent() throws IOException, URISyntaxException {
     ObjectMapper mapper = OpenLineageClientUtils.newObjectMapper();
 
     ZonedDateTime dateTime = ZonedDateTime.parse("2021-01-01T00:00:01.000000000+00:00[UTC]");

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
@@ -29,7 +29,8 @@ import org.apache.spark.sql.execution.QueryExecution;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class DebugRunFacetBuilderDelegateTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class DebugRunFacetBuilderDelegateTest {
 
   private static OpenLineageContext openLineageContext =
       mock(OpenLineageContext.class, RETURNS_DEEP_STUBS);
@@ -46,7 +47,7 @@ public class DebugRunFacetBuilderDelegateTest {
   }
 
   @Test
-  public void testSystemDebugFacet() {
+  void testSystemDebugFacet() {
     assertThat(delegate.buildFacet().getSystem())
         .hasFieldOrPropertyWithValue("javaVersion", SystemUtils.JAVA_VERSION)
         .hasFieldOrPropertyWithValue("javaVendor", SystemUtils.JAVA_VENDOR)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
@@ -16,7 +16,7 @@ import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class DebugRunFacetBuilderTest {
+class DebugRunFacetBuilderTest {
 
   private static OpenLineageContext openLineageContext =
       mock(OpenLineageContext.class, RETURNS_DEEP_STUBS);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
@@ -24,7 +24,8 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.junit.jupiter.api.Test;
 
-public class SparkPropertyFacetBuilderTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class SparkPropertyFacetBuilderTest {
 
   @Test
   void testBuildDefault() {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilterTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class AdaptivePlanEventFilterTest {
+class AdaptivePlanEventFilterTest {
 
   OpenLineageContext context = mock(OpenLineageContext.class);
   AdaptivePlanEventFilter filter = new AdaptivePlanEventFilter(context);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/CreateViewFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/CreateViewFilterTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class CreateViewFilterTest {
+class CreateViewFilterTest {
 
   OpenLineageContext context = mock(OpenLineageContext.class);
   CreateViewFilter filter = new CreateViewFilter(context);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -22,7 +22,7 @@ import org.apache.spark.sql.execution.WholeStageCodegenExec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class DatabricksEventFilterTest {
+class DatabricksEventFilterTest {
 
   SparkListenerEvent event = mock(SparkListenerEvent.class);
   OpenLineageContext context = mock(OpenLineageContext.class);
@@ -32,7 +32,7 @@ public class DatabricksEventFilterTest {
   SparkListenerEvent sparkListenerEvent = mock(SparkListenerEvent.class);
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
     when(queryExecution
             .sparkSession()
@@ -47,13 +47,13 @@ public class DatabricksEventFilterTest {
   }
 
   @Test
-  public void testDatabricksEventIsFiltered() {
+  void testDatabricksEventIsFiltered() {
     when(node.nodeName()).thenReturn("collect_Limit");
     assertThat(filter.isDisabled(event)).isTrue();
   }
 
   @Test
-  public void testSerializeFromObjectIsDisabled() {
+  void testSerializeFromObjectIsDisabled() {
     SerializeFromObject serializeFromObject = mock(SerializeFromObject.class);
     when(serializeFromObject.collectLeaves()).thenReturn(ScalaConversionUtils.asScalaSeqEmpty());
     when(queryExecution.optimizedPlan()).thenReturn(serializeFromObject);
@@ -62,19 +62,19 @@ public class DatabricksEventFilterTest {
   }
 
   @Test
-  public void testDatabricksEventIsFilteredWithoutUnderscore() {
+  void testDatabricksEventIsFilteredWithoutUnderscore() {
     when(node.nodeName()).thenReturn("collectlimit");
     assertThat(filter.isDisabled(event)).isTrue();
   }
 
   @Test
-  public void testDatabricksEventIsNotFiltered() {
+  void testDatabricksEventIsNotFiltered() {
     when(node.nodeName()).thenReturn("action_not_to_be_filtered");
     assertThat(filter.isDisabled(event)).isFalse();
   }
 
   @Test
-  public void testOtherEventIsNotFiltered() {
+  void testOtherEventIsNotFiltered() {
     when(queryExecution
             .sparkSession()
             .sparkContext()

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DeltaEventFilterTest.java
@@ -36,8 +36,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.collection.immutable.Seq;
 
-public class DeltaEventFilterTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class DeltaEventFilterTest {
 
+  public static final String SPARK_SQL_EXTENSIONS = "spark.sql.extensions";
   OpenLineageContext context = mock(OpenLineageContext.class);
   DeltaEventFilter filter = new DeltaEventFilter(context);
   SparkSession sparkSession = mock(SparkSession.class);
@@ -57,7 +59,7 @@ public class DeltaEventFilterTest {
   void testNotDeltaIsNotDisabled() {
     try (MockedStatic mocked = mockStatic(SparkSession.class)) {
       when(SparkSession.active()).thenReturn(sparkSession);
-      when(sparkConf.get("spark.sql.extensions")).thenReturn("non-delta-extension");
+      when(sparkConf.get(SPARK_SQL_EXTENSIONS)).thenReturn("non-delta-extension");
 
       assertFalse(filter.isDisabled(sparkListenerEvent));
     }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/SparkNodesFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/SparkNodesFilterTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class SparkNodesFilterTest {
+class SparkNodesFilterTest {
 
   OpenLineageContext context = mock(OpenLineageContext.class);
   SparkNodesFilter filter = new SparkNodesFilter(context);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
@@ -25,7 +25,8 @@ import org.apache.spark.sql.execution.QueryExecution;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JobNameHookTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class JobNameHookTest {
 
   OpenLineageContext context = mock(OpenLineageContext.class);
   QueryExecution queryExecution = mock(QueryExecution.class, RETURNS_DEEP_STUBS);
@@ -64,7 +65,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuildWhenAppendingDatasetNameToJobNameDisabled() {
+  void testPreBuildWhenAppendingDatasetNameToJobNameDisabled() {
     when(sparkConf.get("spark.openlineage.jobName.appendDatasetName", "true")).thenReturn("false");
 
     runEventBuilder = mock(OpenLineage.RunEventBuilder.class);
@@ -73,7 +74,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuild() {
+  void testPreBuild() {
     runEventBuilder.job(
         context
             .getOpenLineage()
@@ -95,7 +96,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuildWhenReplaceDotWithUnderscoreIsTrue() {
+  void testPreBuildWhenReplaceDotWithUnderscoreIsTrue() {
     when(sparkConf.get("spark.openlineage.jobName.replaceDotWithUnderscore", "false"))
         .thenReturn("true");
 
@@ -120,7 +121,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuildWhenNoOutputDataset() {
+  void testPreBuildWhenNoOutputDataset() {
     runEventBuilder.job(
         context.getOpenLineage().newJobBuilder().name("databricks_shell.append_data").build());
 
@@ -130,7 +131,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuildWhenNotADefaultName() {
+  void testPreBuildWhenNotADefaultName() {
     runEventBuilder.job(
         context.getOpenLineage().newJobBuilder().name("non-default-name.append_data").build());
 
@@ -140,7 +141,7 @@ public class JobNameHookTest {
   }
 
   @Test
-  public void testPreBuildWhenJobNamePresentInContext() {
+  void testPreBuildWhenJobNamePresentInContext() {
     when(context.getJobName()).thenReturn("some-job-name");
     runEventBuilder.job(context.getOpenLineage().newJobBuilder().build());
     builderHook.preBuild(runEventBuilder);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
@@ -30,7 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.collection.immutable.Map$;
 
-public class JdbcRelationHandlerTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class JdbcRelationHandlerTest {
   JdbcRelationHandler jdbcRelationHandler;
   DatasetFactory datasetFactory = mock(DatasetFactory.class);
   JDBCRelation relation = mock(JDBCRelation.class);
@@ -84,7 +84,7 @@ public class JdbcRelationHandlerTest {
     when(jdbcOptions.tableOrQuery()).thenReturn(jdbcTable);
     when(relation.schema()).thenReturn(schema);
 
-    List<OpenLineage.Dataset> datasets = jdbcRelationHandler.getDatasets(relation, url);
+    jdbcRelationHandler.getDatasets(relation, url);
 
     verify(datasetFactory, times(1))
         .getDataset("test.tablename", "postgres://localhost:5432", schema);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -61,6 +61,7 @@ import org.mockito.MockedStatic;
 import org.postgresql.Driver;
 import scala.Option;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class LogicalRelationDatasetBuilderTest {
 
   SparkSession session = mock(SparkSession.class);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -36,6 +36,7 @@ import scala.Some;
 import scala.Tuple2;
 
 @Slf4j
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PathUtilsTest {
 
   private static final String HOME_TEST = "/home/test";
@@ -288,6 +289,7 @@ class PathUtilsTest {
   @Nested
   class WithHiveSupport {
     @Test
+    @SuppressWarnings("PMD")
     void testFromCatalogTableShouldReturnADatasetIdentifierWithTheActualScheme() {
       SparkConf sparkConf = new SparkConf();
       sparkConf.set("spark.sql.hive.metastore.uris", "thrift://127.0.0.1:9876");
@@ -309,6 +311,7 @@ class PathUtilsTest {
   @Nested
   class WithoutHiveSupport {
     @Test
+    @SuppressWarnings("PMD")
     void testFromCatalogTableShouldReturnADatasetIdentifierWithTheActualScheme() {
       SparkConf sparkConf = new SparkConf();
       URI tableUri = URI.create("hdfs://namenode/user/hive/warehouse/foo.db/bar");

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -24,6 +24,7 @@ class PlanUtilsTest {
 
   @ParameterizedTest
   @MethodSource()
+  @SuppressWarnings("PMD.UnusedPrivateMethod")
   private static Stream<Arguments> provideJdbcUrls() {
     return Stream.of(
         Arguments.of(

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RddPathUtilsTest.java
@@ -24,7 +24,7 @@ import scala.Tuple2;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
-public class RddPathUtilsTest {
+class RddPathUtilsTest {
 
   @Test
   void testFindRDDPathsForMapPartitionsRDD() {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RemovePathPatternUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RemovePathPatternUtilsTest.java
@@ -25,7 +25,8 @@ import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class RemovePathPatternUtilsTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RemovePathPatternUtilsTest {
 
   OpenLineageContext context = mock(OpenLineageContext.class);
   SparkConf conf;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/SparkConfUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/SparkConfUtilsTest.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import org.apache.spark.SparkConf;
 import org.junit.jupiter.api.Test;
 
-public class SparkConfUtilsTest {
+class SparkConfUtilsTest {
 
   SparkConf conf = new SparkConf().set("existing.property", "test");
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/VendorsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/VendorsTest.java
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.junit.jupiter.api.Test;
 import scala.PartialFunction;
 
+@SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 public class VendorsTest implements Vendor {
 
   static class VisitorFactoryTest implements VisitorFactory {
@@ -28,13 +29,13 @@ public class VendorsTest implements Vendor {
     @Override
     public List<PartialFunction<LogicalPlan, List<OpenLineage.InputDataset>>> getInputVisitors(
         OpenLineageContext context) {
-      return null;
+      return Collections.emptyList();
     }
 
     @Override
     public List<PartialFunction<LogicalPlan, List<OpenLineage.OutputDataset>>> getOutputVisitors(
         OpenLineageContext context) {
-      return null;
+      return Collections.emptyList();
     }
   }
 

--- a/integration/spark/shared/src/testScala213/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer213Test.java
+++ b/integration/spark/shared/src/testScala213/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer213Test.java
@@ -106,6 +106,7 @@ class LogicalPlanSerializer213Test {
             return ScalaConversionUtils.<LogicalPlan>asScalaSeqEmpty();
           }
 
+          @Override
           public LogicalPlan withNewChildrenInternal(IndexedSeq<LogicalPlan> newChildren) {
             return null;
           }
@@ -159,6 +160,7 @@ class LogicalPlanSerializer213Test {
             return ScalaConversionUtils.<LogicalPlan>asScalaSeqEmpty();
           }
 
+          @Override
           public LogicalPlan withNewChildrenInternal(IndexedSeq<LogicalPlan> newChildren) {
             return null;
           }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CustomColumnLineageVisitorTestImpl.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/CustomColumnLineageVisitorTestImpl.java
@@ -5,39 +5,40 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.INPUT_COL_NAME;
-import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.OUTPUT_COL_NAME;
-import static io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest.child;
 import static org.mockito.Mockito.mock;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.CustomColumnLineageVisitor;
-import io.openlineage.spark3.agent.lifecycle.plan.column.CustomCollectorsUtilsTest;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 
 public class CustomColumnLineageVisitorTestImpl implements CustomColumnLineageVisitor {
+  public static final String OUTPUT_COL_NAME = "outputCol";
+  public static final String INPUT_COL_NAME = "inputCol";
+  public static LogicalPlan child = mock(LogicalPlan.class);
+
+  public static ExprId childExprId = mock(ExprId.class);
+  public static ExprId parentExprId = mock(ExprId.class);
 
   @Override
   public void collectInputs(LogicalPlan node, ColumnLevelLineageBuilder builder) {
     if (node.equals(child)) {
-      builder.addInput(
-          CustomCollectorsUtilsTest.childExprId, mock(DatasetIdentifier.class), INPUT_COL_NAME);
+      builder.addInput(childExprId, mock(DatasetIdentifier.class), INPUT_COL_NAME);
     }
   }
 
   @Override
   public void collectOutputs(LogicalPlan node, ColumnLevelLineageBuilder builder) {
     if (node.equals(child)) {
-      builder.addOutput(CustomCollectorsUtilsTest.parentExprId, OUTPUT_COL_NAME);
+      builder.addOutput(parentExprId, OUTPUT_COL_NAME);
     }
   }
 
   @Override
   public void collectExpressionDependencies(LogicalPlan node, ColumnLevelLineageBuilder builder) {
     if (node.equals(child)) {
-      builder.addDependency(
-          CustomCollectorsUtilsTest.parentExprId, CustomCollectorsUtilsTest.childExprId);
+      builder.addDependency(parentExprId, childExprId);
     }
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -44,6 +44,7 @@ import org.mockito.MockedStatic;
 import scala.Option;
 import scala.collection.immutable.HashMap;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class LogicalRelationDatasetBuilderTest {
 
   private static final String SOME_VERSION = "version_1";

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SparkExtensionV1InputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SparkExtensionV1InputDatasetBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
-public class SparkExtensionV1InputDatasetBuilderTest {
+class SparkExtensionV1InputDatasetBuilderTest {
 
   OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
   OpenLineageContext context = mock(OpenLineageContext.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SparkExtensionV1OutputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/SparkExtensionV1OutputDatasetBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
-public class SparkExtensionV1OutputDatasetBuilderTest {
+class SparkExtensionV1OutputDatasetBuilderTest {
 
   OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
   OpenLineageContext context = mock(OpenLineageContext.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CosmosHandlerTest.java
@@ -14,7 +14,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.Test;
 
-public class CosmosHandlerTest {
+class CosmosHandlerTest {
 
   @Test
   void testGetDatasetIdentifier() {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import scala.collection.immutable.Map;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class IcebergHandlerTest {
 
   private OpenLineageContext context = mock(OpenLineageContext.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtilsTest.java
@@ -5,6 +5,9 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
+import static io.openlineage.spark3.agent.lifecycle.plan.CustomColumnLineageVisitorTestImpl.INPUT_COL_NAME;
+import static io.openlineage.spark3.agent.lifecycle.plan.CustomColumnLineageVisitorTestImpl.OUTPUT_COL_NAME;
+import static io.openlineage.spark3.agent.lifecycle.plan.CustomColumnLineageVisitorTestImpl.child;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -19,28 +22,21 @@ import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerEvent;
-import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 @Slf4j
-public class CustomCollectorsUtilsTest {
+class CustomCollectorsUtilsTest {
 
-  public static final String OUTPUT_COL_NAME = "outputCol";
-  public static final String INPUT_COL_NAME = "inputCol";
-  public static ExprId childExprId = mock(ExprId.class);
-  public static ExprId parentExprId = mock(ExprId.class);
   static LogicalPlan plan = mock(LogicalPlan.class);
-  public static LogicalPlan child = mock(LogicalPlan.class);
-
   OpenLineageContext context = mock(OpenLineageContext.class);
   QueryExecution queryExecution = mock(QueryExecution.class);
 
   @Test
   @SneakyThrows
-  public void testCustomCollectorsAreApplied() {
+  void testCustomCollectorsAreApplied() {
     OpenLineage openLineage = new OpenLineage(new URI("some-url"));
     when(plan.children())
         .thenReturn(

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -21,9 +21,7 @@ import io.openlineage.spark.extension.scala.v1.ExpressionDependency;
 import io.openlineage.spark.extension.scala.v1.ExpressionDependencyWithDelegate;
 import io.openlineage.spark.extension.scala.v1.ExpressionDependencyWithIdentifier;
 import io.openlineage.spark.extension.scala.v1.OlExprId;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import org.apache.spark.sql.catalyst.expressions.Alias;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
@@ -200,9 +198,5 @@ class ExpressionDependencyCollectorTest {
     ExpressionDependencyCollector.collectFromNode(context, columnLineagePlanNode);
 
     verify(builder, times(1)).addDependency(ExprId.apply(1L), ExprId.apply(2L));
-  }
-
-  private Seq<NamedExpression> toScalaSeq(Collection<NamedExpression> expressions) {
-    return ScalaConversionUtils.<NamedExpression>fromList(new ArrayList(expressions));
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -51,6 +51,7 @@ import org.mockito.MockedStatic;
 import scala.Option;
 import scala.collection.immutable.Seq;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class InputFieldsCollectorTest {
 
   private static final String FILE = "file";

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.StringType$;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JdbcColumnLineageExpressionCollectorTest {
+class JdbcColumnLineageExpressionCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
   ExprId exprId1 = ExprId.apply(20);
   ExprId exprId2 = ExprId.apply(21);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageInputCollectorTest.java
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JdbcColumnLineageInputCollectorTest {
+class JdbcColumnLineageInputCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
   JDBCRelation relation = mock(JDBCRelation.class);
   JDBCOptions jdbcOptions = mock(JDBCOptions.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/UnionFieldDependencyCollectorTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
@@ -25,7 +24,6 @@ import org.apache.spark.sql.catalyst.plans.logical.Union;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.Metadata$;
 import org.junit.jupiter.api.Test;
-import scala.collection.Seq;
 
 class UnionFieldDependencyCollectorTest {
 
@@ -72,11 +70,5 @@ class UnionFieldDependencyCollectorTest {
 
     // first element of a union is treated as an ancestor node
     verify(builder, times(1)).addDependency(exprId1, exprId2);
-  }
-
-  private Seq<NamedExpression> toScalaSeq(Collection<NamedExpression> expressions) {
-    return scala.collection.JavaConverters.collectionAsScalaIterableConverter(expressions)
-        .asScala()
-        .toSeq();
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2UtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2UtilsTest.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class ExtesionDataSourceV2UtilsTest {
+class ExtesionDataSourceV2UtilsTest {
   static final String DATASET_NAME = "some-dataset-name";
   static final String DATASET_NAMESPACE = "some-dataset-name";
 

--- a/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitorTest.java
+++ b/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoDelta11ColumnLineageVisitorTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
 
-public class MergeIntoDelta11ColumnLineageVisitorTest {
+class MergeIntoDelta11ColumnLineageVisitorTest {
   OpenLineageContext olContext = mock(OpenLineageContext.class);
   ColumnLevelLineageContext clContext = mock(ColumnLevelLineageContext.class);
   MergeIntoCommand command = mock(MergeIntoCommand.class);

--- a/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitorTest.java
+++ b/integration/spark/spark32/src/test/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class MergeIntoIceberg013ColumnLineageVisitorTest {
+class MergeIntoIceberg013ColumnLineageVisitorTest {
 
   OpenLineageContext olContext = mock(OpenLineageContext.class);
   ColumnLevelLineageContext clContext = mock(ColumnLevelLineageContext.class);
@@ -53,6 +53,7 @@ public class MergeIntoIceberg013ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectInputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target =
@@ -71,6 +72,7 @@ public class MergeIntoIceberg013ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectOutputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target =

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceVisitorDatasetBuilderTest.java
@@ -41,7 +41,7 @@ import org.mockito.MockedStatic;
 import scala.collection.immutable.HashMap;
 import scala.collection.immutable.Map;
 
-public class CreateReplaceVisitorDatasetBuilderTest {
+class CreateReplaceVisitorDatasetBuilderTest {
 
   private static final String TABLE = "table";
   OpenLineageContext openLineageContext =

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class ReplaceIcebergDataDatasetBuilderTest {
+class ReplaceIcebergDataDatasetBuilderTest {
 
   OpenLineage openLineage = mock(OpenLineage.class);
   OpenLineageContext openLineageContext =

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilderTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
 
-public class CreateReplaceInputDatasetBuilderTest {
+class CreateReplaceInputDatasetBuilderTest {
   OpenLineageContext openLineageContext =
       OpenLineageContext.builder()
           .sparkSession(mock(SparkSession.class))

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoDelta24ColumnLineageVisitorTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
 
-public class MergeIntoDelta24ColumnLineageVisitorTest {
+class MergeIntoDelta24ColumnLineageVisitorTest {
 
   OpenLineageContext olContext = mock(OpenLineageContext.class);
   ColumnLevelLineageContext clContext = mock(ColumnLevelLineageContext.class);
@@ -66,6 +66,7 @@ public class MergeIntoDelta24ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectInputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target = mock(LogicalPlan.class);
@@ -85,6 +86,7 @@ public class MergeIntoDelta24ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectOutputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target = mock(LogicalPlan.class);

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitorTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/column/MergeIntoIceberg13ColumnLineageVisitorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-public class MergeIntoIceberg13ColumnLineageVisitorTest {
+class MergeIntoIceberg13ColumnLineageVisitorTest {
   OpenLineageContext olContext = mock(OpenLineageContext.class);
   ColumnLevelLineageContext clContext = mock(ColumnLevelLineageContext.class);
   ReplaceIcebergData replaceIcebergData = mock(ReplaceIcebergData.class);
@@ -52,6 +52,7 @@ public class MergeIntoIceberg13ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectInputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target =
@@ -70,6 +71,7 @@ public class MergeIntoIceberg13ColumnLineageVisitorTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCollectOutputsIsCalled() {
     LogicalPlan source = mock(LogicalPlan.class);
     LogicalPlan target =

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceDatasetBuilderTest.java
@@ -43,7 +43,7 @@ import scala.Option;
 import scala.collection.immutable.HashMap;
 import scala.collection.immutable.Map;
 
-public class CreateReplaceDatasetBuilderTest {
+class CreateReplaceDatasetBuilderTest {
 
   private static final String TABLE = "table";
   OpenLineageContext openLineageContext =


### PR DESCRIPTION
### Problem

Fix most obvious PMD warnings that trash logs when building project.

I hope this one is going to be first out of many such PRs to clean the code. I expect there is sth wrong with `pmd` configuration but anyway it is not doable to turn it on now without adding fixes like that. 

### Solution

 * Clear `pmdTestScala212` from warnings