### PR TITLE
dbt: Propagate the dbt return code also when no OpenLineage events are emitted

### DIFF
--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -181,12 +181,12 @@ def main():
                 "OpenLineage events not emitted: run_result file (%s) was not modified by dbt",
                 processor.run_result_path,
             )
-            return
+            return return_code
     except FileNotFoundError:
         logger.info(
             "OpenLineage events not emitted: did not find run_result file (%s)", processor.run_result_path
         )
-        return
+        return return_code
 
     try:
         events = processor.parse().events()


### PR DESCRIPTION
### Problem

This is a ~~missed corner case~~ follow-up of https://github.com/OpenLineage/OpenLineage/pull/2560

`dbt-ol` should always propagate dbt's return code, even when the script encounters an early exit because no lineage events were processed.

Closes: #2558 

### Solution

Added `return return_code` to the early exit statements.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

dbt-ol should propagate the exit code of the underlying dbt process even if no lineage events are emitted.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project