### PR TITLE
[PYTHON] fix: load_config now returns empty dict instead of None when empty file

### DIFF
--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -52,8 +52,8 @@ def load_config() -> dict[str, Any]:
     if file:
         try:
             with open(file) as f:
-                config: dict[str, Any] = yaml.safe_load(f)
-                return config
+                config: dict[str, Any] | None = yaml.safe_load(f)
+                return config or defaultdict(dict)
         except Exception:  # noqa: BLE001, S110
             # Just move to read env vars
             pass

--- a/client/python/tests/test_utils.py
+++ b/client/python/tests/test_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import defaultdict
+from unittest.mock import mock_open, patch
+
+from openlineage.client.utils import load_config
+
+
+@patch("openlineage.client.utils._find_yaml", return_value="ol.yml")
+@patch("builtins.open", mock_open(read_data=""))
+@patch("yaml.safe_load", return_value={"database": True})
+def test_load_config_with_values(mock_safe_load, mock_find_yaml):  # noqa: ARG001
+    config = load_config()
+    assert config == {"database": True}
+
+
+@patch("openlineage.client.utils._find_yaml", return_value="empty_config.yaml")
+@patch("builtins.open", mock_open(read_data=""))
+@patch("yaml.safe_load", return_value=None)
+def test_load_config_empty_file(mock_safe_load, mock_find_yaml):  # noqa: ARG001
+    config = load_config()
+    assert config == defaultdict(dict)
+
+
+@patch("openlineage.client.utils._find_yaml", return_value="empty_config.yaml")
+@patch("builtins.open", mock_open(read_data=""))
+@patch("yaml.safe_load", return_value={})
+def test_load_config_empty_dict(mock_safe_load, mock_find_yaml):  # noqa: ARG001
+    config = load_config()
+    assert config == defaultdict(dict)
+
+
+@patch("openlineage.client.utils._find_yaml", return_value=None)
+def test_load_config_file_not_found(mock_find_yaml):  # noqa: ARG001
+    config = load_config()
+    assert config == defaultdict(dict)


### PR DESCRIPTION
### Problem

Thanks to @rahul-madaan that noticed it. When an empty `openlineage.yml` is found, python client crashes during creation as the self.config is non-iterable (None).

### Solution

Make sure the `load_config()` always returns a dict.


#### One-line summary:
`utils.load_config()` now returns empty dict instead of None when empty file to prevent `OpenLineageClient` crash

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project