### PR TITLE
[PYTHON] Allow user to set Kafka message key

### DIFF
--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import attr
+from openlineage.client.facet import ParentRunFacet
+from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
 from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Config, Transport
 from openlineage.client.utils import get_only_specified_fields
@@ -13,7 +15,6 @@ from packaging.version import Version
 
 if TYPE_CHECKING:
     from confluent_kafka import KafkaError, Message
-    from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
 log = logging.getLogger(__name__)
 
 _T = TypeVar("_T", bound="KafkaConfig")
@@ -28,12 +29,15 @@ class KafkaConfig(Config):
     # Topic on which we should send messages
     topic: str = attr.ib()
 
+    # Explicit key for Kafka producer
+    messageKey: str | None = attr.ib(default=None)  # noqa: N815
+
     # Set to true if Kafka should flush after each event. The process that emits can be killed in
     # some cases - for example in Airflow integration, so flushing is desirable there.
     flush: bool = attr.ib(default=True)
 
     @classmethod
-    def from_dict(cls: type[_T], params: dict[str, str]) -> _T:
+    def from_dict(cls: type[_T], params: dict[str, Any]) -> _T:
         if "config" not in params:
             msg = "kafka `config` not passed to KafkaConfig"
             raise RuntimeError(msg)
@@ -57,6 +61,7 @@ class KafkaTransport(Transport):
     def __init__(self, config: KafkaConfig) -> None:
         self.topic = config.topic
         self.flush = config.flush
+        self.message_key = config.messageKey
         self.kafka_config = config
         self._is_airflow_sqlalchemy = _check_if_airflow_sqlalchemy_context()
         self.producer = None
@@ -64,11 +69,31 @@ class KafkaTransport(Transport):
             self._setup_producer(self.kafka_config.config)
         log.debug("Constructing openlineage client to send events to topic %s", config.topic)
 
-    def emit(self, event: Union[RunEvent, DatasetEvent, JobEvent]) -> None:  # noqa: UP007
+    def _get_message_key(self, event: RunEvent | DatasetEvent | JobEvent) -> str:
+        if isinstance(event, DatasetEvent):
+            return f"dataset:{event.dataset.namespace}/{event.dataset.name}"
+
+        if isinstance(event, JobEvent):
+            return f"job:{event.job.namespace}/{event.job.name}"
+
+        parent_run_facet: ParentRunFacet = event.run.facets.get("parent") or ParentRunFacet({}, {})
+        parent_job_namespace: str | None = parent_run_facet.job.get("namespace")
+        parent_job_name: str | None = parent_run_facet.job.get("name")
+        parent_run_id: str | None = parent_run_facet.run.get("runId")
+        if parent_job_namespace and parent_job_name and parent_run_id:
+            return f"run:{parent_job_namespace}/{parent_job_name}/{parent_run_id}"
+
+        return f"run:{event.job.namespace}/{event.job.name}/{event.run.runId}"
+
+    def emit(self, event: RunEvent | DatasetEvent | JobEvent) -> None:
         if self._is_airflow_sqlalchemy:
             self._setup_producer(self.kafka_config.config)
+
+        key = self.message_key or self._get_message_key(event)
+
         self.producer.produce(  # type: ignore[attr-defined]
             topic=self.topic,
+            key=key,
             value=Serde.to_json(event).encode("utf-8"),
             on_delivery=on_delivery,
         )

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -2,14 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import datetime
-import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, call
 
 import pytest
 from openlineage.client import OpenLineageClient
-from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.facet import ParentRunFacet
+from openlineage.client.run import (
+    Dataset,
+    DatasetEvent,
+    Job,
+    JobEvent,
+    Run,
+    RunEvent,
+    RunState,
+)
 from openlineage.client.serde import Serde
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 
@@ -18,12 +25,50 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture()
-def event() -> RunEvent:
+def run_event() -> RunEvent:
     return RunEvent(
         eventType=RunState.START,
-        eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
-        job=Job(namespace="kafka", name="test"),
+        eventTime="2024-04-10T15:08:01.333999",
+        run=Run(runId="ea445b5c-22eb-457a-8007-01c7c52b6e54"),
+        job=Job(namespace="test-namespace", name="test-job"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+@pytest.fixture()
+def run_event_with_parent() -> RunEvent:
+    parent_run_facet = ParentRunFacet.create(
+        runId="d9cb8e0b-a410-435e-a619-da5e87ba8508",
+        namespace="parent-namespace",
+        name="parent-job",
+    )
+
+    return RunEvent(
+        eventType=RunState.START,
+        eventTime="2024-04-10T15:08:01.333999",
+        run=Run(runId="ea445b5c-22eb-457a-8007-01c7c52b6e54", facets={"parent": parent_run_facet}),
+        job=Job(namespace="test-namespace", name="test-job"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+@pytest.fixture()
+def dataset_event() -> DatasetEvent:
+    return DatasetEvent(
+        eventTime="2024-04-10T15:08:01.333999",
+        dataset=Dataset(namespace="test-namespace", name="test-dataset"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+@pytest.fixture()
+def job_event() -> JobEvent:
+    return JobEvent(
+        eventTime="2024-04-10T15:08:01.333999",
+        job=Job(namespace="test-namespace", name="test-job"),
         producer="prod",
         schemaURL="schema",
     )
@@ -35,12 +80,14 @@ def test_kafka_loads_full_config() -> None:
             "type": "kafka",
             "config": {"bootstrap.servers": "localhost:9092"},
             "topic": "random-topic",
+            "messageKey": "key",
             "flush": False,
         },
     )
 
     assert config.config["bootstrap.servers"] == "localhost:9092"
     assert config.topic == "random-topic"
+    assert config.messageKey == "key"
     assert config.flush is False
 
 
@@ -55,6 +102,7 @@ def test_kafka_loads_partial_config_with_defaults() -> None:
 
     assert config.config["bootstrap.servers"] == "localhost:9092"
     assert config.topic == "random-topic"
+    assert config.messageKey is None
     assert config.flush is True
 
 
@@ -68,7 +116,7 @@ def test_kafka_load_config_fails_on_no_config() -> None:
         )
 
 
-def test_client_with_kafka_transport_emits(event: RunEvent, mocker: MockerFixture) -> None:
+def test_client_with_kafka_transport_emits_run_event(run_event: RunEvent, mocker: MockerFixture) -> None:
     mocker.patch("confluent_kafka.Producer")
     config = KafkaConfig(
         config={"bootstrap.servers": "localhost:9092"},
@@ -78,26 +126,161 @@ def test_client_with_kafka_transport_emits(event: RunEvent, mocker: MockerFixtur
     transport = KafkaTransport(config)
 
     client = OpenLineageClient(transport=transport)
-    event = RunEvent(
-        eventType=RunState.START,
-        eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
-        job=Job(namespace="kafka", name="test"),
-        producer="prod",
-        schemaURL="schema",
-    )
 
-    client.emit(event)
+    client.emit(run_event)
     transport.producer.produce.assert_called_once_with(
         topic="random-topic",
-        value=Serde.to_json(event).encode("utf-8"),
+        key="run:test-namespace/test-job/ea445b5c-22eb-457a-8007-01c7c52b6e54",
+        value=Serde.to_json(run_event).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_run_event_with_parent(
+    run_event_with_parent: RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(run_event_with_parent)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="run:parent-namespace/parent-job/d9cb8e0b-a410-435e-a619-da5e87ba8508",
+        value=Serde.to_json(run_event_with_parent).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_run_event_with_explicit_message_key(
+    run_event: RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(run_event)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="explicit-key",
+        value=Serde.to_json(run_event).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_job_event(job_event: DatasetEvent, mocker: MockerFixture) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(job_event)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="job:test-namespace/test-job",
+        value=Serde.to_json(job_event).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_job_event_with_explicit_message_key(
+    job_event: DatasetEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(job_event)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="explicit-key",
+        value=Serde.to_json(job_event).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_dataset_event(
+    dataset_event: DatasetEvent, mocker: MockerFixture
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(dataset_event)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="dataset:test-namespace/test-dataset",
+        value=Serde.to_json(dataset_event).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_client_with_kafka_transport_emits_dataset_event_explicit_message_key(
+    dataset_event: DatasetEvent, mocker: MockerFixture
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+        flush=True,
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(dataset_event)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="explicit-key",
+        value=Serde.to_json(dataset_event).encode("utf-8"),
         on_delivery=ANY,
     )
     transport.producer.flush.assert_called_once()
 
 
 def test_airflow_sqlalchemy_constructs_producer_each_call(
-    event: RunEvent,
+    run_event: RunEvent,
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
@@ -114,12 +297,12 @@ def test_airflow_sqlalchemy_constructs_producer_each_call(
 
     client = OpenLineageClient(transport=transport)
 
-    client.emit(event)
-    client.emit(event)
+    client.emit(run_event)
+    client.emit(run_event)
     mock.assert_has_calls([call(config.config), call(config.config)], any_order=True)
 
 
-def test_airflow_direct_onstructs_producer_once(event: RunEvent, mocker: MockerFixture) -> None:
+def test_airflow_direct_constructs_producer_once(run_event: RunEvent, mocker: MockerFixture) -> None:
     mocker.patch(
         "openlineage.client.transport.kafka._check_if_airflow_sqlalchemy_context",
         return_value=False,
@@ -134,6 +317,6 @@ def test_airflow_direct_onstructs_producer_once(event: RunEvent, mocker: MockerF
 
     client = OpenLineageClient(transport=transport)
 
-    client.emit(event)
-    client.emit(event)
+    client.emit(run_event)
+    client.emit(run_event)
     mock.assert_called_once_with(config.config)


### PR DESCRIPTION
### Problem

Closes: #2559

### Solution

#### One-line summary:

New `messageKey` option is added to `KafkaTransport` config of Python client. Default value is generated using run id (for `RunEvent`), job name (for `JobEvent`) or dataset name (for `DatasetEvent`).
This value is used by Kafka producer to distribute messages along topic partitions, instead of sending all the events to a random partition. This allows to read events from Kafka in the same order as sent by client.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project