### PR TITLE
[PROXY] Rename localServerId to messageKey

### DIFF
--- a/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/ProxyStreamFactory.java
@@ -48,12 +48,7 @@ public final class ProxyStreamFactory {
         lineageStreams.add(new ConsoleLineageStream());
       } else if (config instanceof KafkaConfig) {
         final KafkaConfig kafkaConfig = (KafkaConfig) config;
-        if (!kafkaConfig.hasLocalServerId()) {
-          // Set the local server ID to the lineage source when not specified
-          kafkaConfig.setLocalServerId(source);
-        }
         kafkaConfig.getProperties().put("bootstrap.servers", kafkaConfig.getBootstrapServerUrl());
-        kafkaConfig.getProperties().put("server.id", kafkaConfig.getLocalServerId());
         lineageStreams.add(new KafkaLineageStream((KafkaConfig) config));
       } else if (config instanceof HttpConfig) {
         final HttpConfig httpConfig = (HttpConfig) config;

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
@@ -16,11 +16,23 @@ import lombok.ToString;
 @ToString
 public final class KafkaConfig implements ProxyStreamConfig {
   @Getter @Setter private String topicName;
-  @Getter @Setter private String localServerId;
+  @Getter @Setter private String messageKey;
   @Getter @Setter private String bootstrapServerUrl;
   @Getter @Setter private Properties properties;
 
-  public boolean hasLocalServerId() {
-    return (localServerId != null);
+  /**
+   * @deprecated Replaced by {@link #getMessageKey()} since v1.13.0, and will be removed in v1.16.0
+   */
+  @Deprecated
+  String getLocalServerId() {
+    return messageKey;
+  }
+
+  /**
+   * @deprecated Replaced by {@link #setMessageKey()} since v1.13.0, and will be removed in v1.16.0
+   */
+  @Deprecated
+  void setLocalServerId(String localServerId) {
+    this.messageKey = localServerId;
   }
 }

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaLineageStream.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaLineageStream.java
@@ -17,21 +17,22 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 @Slf4j
 public class KafkaLineageStream extends LineageStream {
   private final String topicName;
-  private final String localServerId;
+  private final String messageKey;
   private final KafkaProducer<String, String> producer;
 
   public KafkaLineageStream(@NonNull final KafkaConfig kafkaConfig) {
     super(Type.KAFKA);
     this.topicName = kafkaConfig.getTopicName();
-    this.localServerId = kafkaConfig.getLocalServerId();
+    this.messageKey = kafkaConfig.getMessageKey();
     this.producer = new KafkaProducer<>(kafkaConfig.getProperties());
   }
 
   @Override
   public void collect(@NonNull String eventAsString) {
     log.debug("Received lineage event: {}", eventAsString);
+    // if messageKey is not set, then the event will be sent to a random partition
     final ProducerRecord<String, String> record =
-        new ProducerRecord<>(topicName, localServerId, eventAsString);
+        new ProducerRecord<>(topicName, messageKey, eventAsString);
     try {
       producer.send(record);
     } catch (Exception e) {


### PR DESCRIPTION
### Problem

Closes: #2559

### Solution

#### One-line summary:

`localServerId` option of `KafkaLineageStream` Proxy config is renamed to `messageKey`, to match Java client implementation.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project