### PR TITLE
spark, snowflake: parse NPE when query option is used and table is empty

### DIFF
--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -17,7 +17,7 @@ ext {
             '3.1.3': '2.11.0',
             '3.2.4': '2.11.0',
             '3.3.4': '2.11.0',
-            '3.4.2': '2.13.0'
+            '3.4.2': '2.15.0'
     ]
 
     sparkProp = project.findProperty('spark.version').toString()

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeRelationVisitor.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/SnowflakeRelationVisitor.java
@@ -64,7 +64,7 @@ public class SnowflakeRelationVisitor<D extends OpenLineage.Dataset>
     String sfSchema = params.sfSchema();
     String sfFullURL = params.sfFullURL();
     Optional<String> dbtable =
-        Optional.<TableName>ofNullable(params.table().getOrElse(null)).map(TableName::toString);
+        ScalaConversionUtils.asJavaOptional(params.table()).map(TableName::toString);
     Optional<String> query = ScalaConversionUtils.asJavaOptional(params.query());
 
     return SnowflakeDataset.getDatasets(

--- a/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/SnowflakeRelationVisitorTest.java
+++ b/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/SnowflakeRelationVisitorTest.java
@@ -109,6 +109,7 @@ public class SnowflakeRelationVisitorTest {
 
   @Test
   void testApplyQuery() {
+    when(relation.params().table()).thenReturn(Option.empty());
     when(relation.params().query()).thenReturn(Option.apply("select * from some_table"));
 
     OpenLineageContext openLineageContext =


### PR DESCRIPTION
This PR fixes NPE when using `query` option when reading from Snowflake:

```
ERROR PlanUtils: Apply failed:
java.lang.NullPointerException
	at scala.Option.getOrElse(Option.scala:189)
	at io.openlineage.spark.agent.vendor.snowflake.lifecycle.SnowflakeRelationVisitor.apply(SnowflakeRelationVisitor.java:67)
	at io.openlineage.spark.agent.vendor.snowflake.lifecycle.SnowflakeRelationVisitor.apply(SnowflakeRelationVisitor.java:31)
	at io.openlineage.spark.agent.util.PlanUtils$1.lambda$apply$2(PlanUtils.java:73)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at io.openlineage.spark.agent.util.PlanUtils$1.apply(PlanUtils.java:90)
	at io.openlineage.spark.agent.util.PlanUtils$1.apply(PlanUtils.java:51)
	at scala.PartialFunction.applyOrElse(PartialFunction.scala:127)
	at scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)
	at scala.runtime.AbstractPartialFunction.applyOrElse(AbstractPartialFunction.scala:30)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:228)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:224)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$collect$1(TreeNode.scala:326)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$collect$1$adapted(TreeNode.scala:326)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreach(TreeNode.scala:285)
	at org.apache.spark.sql.catalyst.trees.TreeNode.collect(TreeNode.scala:326)
	at io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor.lambda$apply$3(CommandPlanVisitor.java:80)
	at java.base/java.util.Optional.map(Optional.java:265)
	at io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor.apply(CommandPlanVisitor.java:80)
	at io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor.apply(CommandPlanVisitor.java:33)
	at io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder$1.apply(AbstractQueryPlanDatasetBuilder.java:97)
	at io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder$1.apply(AbstractQueryPlanDatasetBuilder.java:86)
	at scala.PartialFunction.applyOrElse(PartialFunction.scala:127)
	at scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)
	at scala.runtime.AbstractPartialFunction.applyOrElse(AbstractPartialFunction.scala:30)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:228)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:224)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$collect$1(TreeNode.scala:326)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$collect$1$adapted(TreeNode.scala:326)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreach(TreeNode.scala:285)
	at org.apache.spark.sql.catalyst.trees.TreeNode.collect(TreeNode.scala:326)
	at io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder.lambda$apply$0(AbstractQueryPlanDatasetBuilder.java:72)
	at java.base/java.util.Optional.map(Optional.java:265)
	at io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder.apply(AbstractQueryPlanDatasetBuilder.java:68)
	at io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder.apply(AbstractQueryPlanDatasetBuilder.java:40)
	at io.openlineage.spark.agent.util.PlanUtils.safeApply(PlanUtils.java:264)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.lambda$null$27(OpenLineageRunEventBuilder.java:496)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:274)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:312)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildInputDatasets(OpenLineageRunEventBuilder.java:379)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.populateRun(OpenLineageRunEventBuilder.java:321)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildRun(OpenLineageRunEventBuilder.java:305)
	at io.openlineage.spark.agent.lifecycle.OpenLineageRunEventBuilder.buildRun(OpenLineageRunEventBuilder.java:266)
	at io.openlineage.spark.agent.lifecycle.SparkSQLExecutionContext.start(SparkSQLExecutionContext.java:220)
	at io.openlineage.spark.agent.OpenLineageSparkListener.lambda$null$13(OpenLineageSparkListener.java:192)
	at io.openlineage.client.circuitBreaker.NoOpCircuitBreaker.run(NoOpCircuitBreaker.java:27)
	at io.openlineage.spark.agent.OpenLineageSparkListener.lambda$onJobStart$14(OpenLineageSparkListener.java:190)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at io.openlineage.spark.agent.OpenLineageSparkListener.onJobStart(OpenLineageSparkListener.java:186)
	at org.apache.spark.scheduler.SparkListenerBus.doPostEvent(SparkListenerBus.scala:37)
	at org.apache.spark.scheduler.SparkListenerBus.doPostEvent$(SparkListenerBus.scala:28)
	at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:37)
	at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:37)
	at org.apache.spark.util.ListenerBus.postToAll(ListenerBus.scala:117)
	at org.apache.spark.util.ListenerBus.postToAll$(ListenerBus.scala:101)
	at org.apache.spark.scheduler.AsyncEventQueue.super$postToAll(AsyncEventQueue.scala:105)
	at org.apache.spark.scheduler.AsyncEventQueue.$anonfun$dispatch$1(AsyncEventQueue.scala:105)
	at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
	at org.apache.spark.scheduler.AsyncEventQueue.org$apache$spark$scheduler$AsyncEventQueue$$dispatch(AsyncEventQueue.scala:100)
	at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.$anonfun$run$1(AsyncEventQueue.scala:96)
	at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1471)
	at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.run(AsyncEventQueue.scala:96)
```