### PR TITLE
[Java] Add GZIP compression to HttpTransport

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.transports;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -20,6 +21,11 @@ import lombok.With;
 @ToString
 @With
 public final class HttpConfig implements TransportConfig {
+  public enum Compression {
+    @JsonProperty("gzip")
+    GZIP
+  };
+
   @Getter @Setter private URI url;
   @Getter @Setter private @Nullable String endpoint;
 
@@ -31,4 +37,5 @@ public final class HttpConfig implements TransportConfig {
   @Getter @Setter private @Nullable TokenProvider auth;
   @Getter @Setter private @Nullable Map<String, String> urlParams;
   @Getter @Setter private @Nullable Map<String, String> headers;
+  @Getter @Setter private @Nullable Compression compression;
 }

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
@@ -117,7 +117,8 @@ class OpenLineageClientUtilsTest {
         "transport:\n"
             + "  type: http\n"
             + "  url: http://localhost:5050\n"
-            + "  endpoint: api/v1/lineage\n";
+            + "  endpoint: api/v1/lineage\n"
+            + "  compression: gzip\n";
     System.out.println(yamlString);
 
     byte[] bytes = yamlString.getBytes(StandardCharsets.UTF_8);
@@ -130,12 +131,13 @@ class OpenLineageClientUtilsTest {
     HttpConfig httpConfig = (HttpConfig) transportConfig;
     assertThat(httpConfig.getUrl()).isEqualTo(URI.create("http://localhost:5050"));
     assertThat(httpConfig.getEndpoint()).isEqualTo("api/v1/lineage");
+    assertThat(httpConfig.getCompression()).isEqualTo(HttpConfig.Compression.GZIP);
   }
 
   @Test
   void loadOpenLineageYaml_shouldFallbackAndDeserialiseJsonEncodedInputStreams() {
     byte[] bytes =
-        "{\"transport\":{\"type\":\"http\",\"url\":\"https://localhost:1234/api/v1/lineage\"}}"
+        "{\"transport\":{\"type\":\"http\",\"url\":\"https://localhost:1234/api/v1/lineage\",\"compression\":\"gzip\"}}"
             .getBytes(StandardCharsets.UTF_8);
 
     OpenLineageYaml yaml =
@@ -145,12 +147,13 @@ class OpenLineageClientUtilsTest {
     assertThat(transportConfig).isInstanceOf(HttpConfig.class);
     HttpConfig httpConfig = (HttpConfig) transportConfig;
     assertThat(httpConfig.getUrl()).isEqualTo(URI.create("https://localhost:1234/api/v1/lineage"));
+    assertThat(httpConfig.getCompression()).isEqualTo(HttpConfig.Compression.GZIP);
   }
 
   @Test
   void loadOpenLineageJson_ShouldDeserialiseJsonEncodedInputStreams() {
     byte[] bytes =
-        "{\"transport\":{\"type\":\"http\",\"url\":\"https://localhost:1234/api/v1/lineage\"}}"
+        "{\"transport\":{\"type\":\"http\",\"url\":\"https://localhost:1234/api/v1/lineage\",\"compression\":\"gzip\"}}"
             .getBytes(StandardCharsets.UTF_8);
 
     OpenLineageYaml yaml =
@@ -160,5 +163,6 @@ class OpenLineageClientUtilsTest {
     assertThat(transportConfig).isInstanceOf(HttpConfig.class);
     HttpConfig httpConfig = (HttpConfig) transportConfig;
     assertThat(httpConfig.getUrl()).isEqualTo(URI.create("https://localhost:1234/api/v1/lineage"));
+    assertThat(httpConfig.getCompression()).isEqualTo(HttpConfig.Compression.GZIP);
   }
 }

--- a/client/java/src/test/resources/config/http.yaml
+++ b/client/java/src/test/resources/config/http.yaml
@@ -5,3 +5,4 @@ transport:
   auth:
     type: api_key
     apiKey: random_token
+  compression: gzip

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
@@ -31,6 +31,8 @@ public class FlinkConfigParserTest {
       ConfigOptions.key("openlineage.transport.auth.type").stringType().noDefaultValue();
   ConfigOption testHeaderOption =
       ConfigOptions.key("openlineage.transport.headers.testHeader").stringType().noDefaultValue();
+  ConfigOption testCompressionOption =
+      ConfigOptions.key("openlineage.transport.compression").stringType().noDefaultValue();
 
   ConfigOption disabledFacetsOption =
       ConfigOptions.key("openlineage.facets.disabled").stringType().noDefaultValue();
@@ -43,6 +45,7 @@ public class FlinkConfigParserTest {
     configuration.set(apiKeyOption, "some-api-key");
     configuration.set(authTypeOption, "api_key");
     configuration.set(testHeaderOption, "some-header");
+    configuration.set(testCompressionOption, "gzip");
 
     OpenLineageYaml openLineageYaml = FlinkConfigParser.parse(configuration);
 
@@ -52,6 +55,7 @@ public class FlinkConfigParserTest {
     assertEquals(new URI("http://some-url"), transportConfig.getUrl());
     assertThat(transportConfig.getAuth().getToken()).contains("some-api-key");
     assertEquals("some-header", transportConfig.getHeaders().get("testHeader"));
+    assertEquals(HttpConfig.Compression.GZIP, transportConfig.getCompression());
   }
 
   @Test

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -96,7 +96,8 @@ class ArgumentParserTest {
             .set("spark.openlineage.transport.urlParams.test1", "test1")
             .set("spark.openlineage.transport.urlParams.test2", "test2")
             .set("spark.openlineage.transport.headers.testHeader1", "test1")
-            .set("spark.openlineage.transport.headers.testHeader2", "test2");
+            .set("spark.openlineage.transport.headers.testHeader2", "test2")
+            .set("spark.openlineage.transport.compression", "gzip");
 
     OpenLineageYaml openLineageYaml = ArgumentParser.extractOpenlineageConfFromSparkConf(sparkConf);
     HttpConfig transportConfig = (HttpConfig) openLineageYaml.getTransportConfig();
@@ -108,6 +109,7 @@ class ArgumentParserTest {
     assertEquals(5000, transportConfig.getTimeout());
     assertEquals("test1", transportConfig.getHeaders().get("testHeader1"));
     assertEquals("test2", transportConfig.getHeaders().get("testHeader2"));
+    assertEquals(HttpConfig.Compression.GZIP, transportConfig.getCompression());
   }
 
   @Test


### PR DESCRIPTION
### Problem

Implements: #2595

### Solution

#### One-line summary:

Add `compression` option to `HttpTransport` config of Java client, with `gzip` implementation.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project