### PR TITLE
[Python] Add GZIP compression to HttpTransport

### DIFF
--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import gzip
 import inspect
 import logging
 import warnings
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
@@ -28,6 +30,13 @@ class TokenProvider:
 
     def get_bearer(self) -> str | None:
         return None
+
+
+class HttpCompression(Enum):
+    GZIP = "gzip"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class ApiKeyTokenProvider(TokenProvider):
@@ -71,6 +80,7 @@ class HttpConfig(Config):
     # check TLS certificates
     verify: bool = attr.ib(default=True)
     auth: TokenProvider = attr.ib(factory=lambda: TokenProvider({}))
+    compression: HttpCompression | None = attr.ib(default=None)
     # not set by TransportFactory
     session: Session | None = attr.ib(default=None)
     # not set by TransportFactory
@@ -83,6 +93,9 @@ class HttpConfig(Config):
             raise RuntimeError(msg)
         specified_dict = get_only_specified_fields(cls, params)
         specified_dict["auth"] = create_token_provider(specified_dict.get("auth", {}))
+        compression = specified_dict.get("compression")
+        if compression:
+            specified_dict["compression"] = HttpCompression(compression)
         return cls(**specified_dict)
 
     @classmethod
@@ -132,6 +145,7 @@ class HttpTransport(Transport):
             self.session.headers.update(auth_headers)
         self.timeout = config.timeout
         self.verify = config.verify
+        self.compression = config.compression
 
         if config.adapter:
             self.set_adapter(config.adapter)
@@ -141,23 +155,23 @@ class HttpTransport(Transport):
             self.session.mount(self.url, adapter)
 
     def emit(self, event: Event) -> Response:
-        event_str = Serde.to_json(event)
+        body, headers = self._prepare_request(Serde.to_json(event))
+
         if self.session:
             resp = self.session.post(
-                urljoin(self.url, self.endpoint),
-                event_str,
+                url=urljoin(self.url, self.endpoint),
+                data=body,
+                headers=headers,
                 timeout=self.timeout,
                 verify=self.verify,
             )
         else:
-            headers = {
-                "Content-Type": "application/json",
-            }
+            headers["Content-Type"] = "application/json"
             headers.update(self._auth_headers(self.config.auth))
             with Session() as session:
                 resp = session.post(
-                    urljoin(self.url, self.endpoint),
-                    event_str,
+                    url=urljoin(self.url, self.endpoint),
+                    data=body,
                     headers=headers,
                     timeout=self.timeout,
                     verify=self.verify,
@@ -171,3 +185,9 @@ class HttpTransport(Transport):
         if bearer:
             return {"Authorization": bearer}
         return {}
+
+    def _prepare_request(self, event_str: str) -> tuple[bytes | str, dict[str, str]]:
+        if self.compression == HttpCompression.GZIP:
+            return gzip.compress(event_str.encode("utf-8")), {"Content-Encoding": "gzip"}
+
+        return event_str, {}

--- a/client/python/tests/config/http.yml
+++ b/client/python/tests/config/http.yml
@@ -5,3 +5,4 @@ transport:
   auth:
     type: api_key
     apiKey: random_token
+  compression: gzip

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -81,12 +81,16 @@ def test_client_sends_proper_json_with_minimal_run_event() -> None:
         ),
     )
 
-    session.post.assert_called_with(
-        "http://example.com/api/v1/lineage",
+    body = (
         '{"eventTime": "2021-11-03T10:53:52.427343", "eventType": "START", "inputs": [], "job": '
         '{"facets": {}, "name": "job", "namespace": "openlineage"}, "outputs": [], '
         '"producer": "producer", "run": {"facets": {}, "runId": '
-        f'"69f4acab-b87d-4fc0-b27b-8ea950370ff3"}}, "schemaURL": "{SCHEMA_URL}"}}',
+        f'"69f4acab-b87d-4fc0-b27b-8ea950370ff3"}}, "schemaURL": "{SCHEMA_URL}"}}'
+    )
+    session.post.assert_called_with(
+        url="http://example.com/api/v1/lineage",
+        data=body,
+        headers={},
         timeout=5.0,
         verify=True,
     )
@@ -105,12 +109,16 @@ def test_client_sends_proper_json_with_minimal_dataset_event() -> None:
         ),
     )
 
-    session.post.assert_called_with(
-        "http://example.com/api/v1/lineage",
+    body = (
         '{"dataset": {"facets": {}, "name": "my-ds", '
         '"namespace": "my-namespace"}, "eventTime": '
         '"2021-11-03T10:53:52.427343", "producer": "producer", '
-        '"schemaURL": "datasetSchemaUrl"}',
+        '"schemaURL": "datasetSchemaUrl"}'
+    )
+    session.post.assert_called_with(
+        url="http://example.com/api/v1/lineage",
+        data=body,
+        headers={},
         timeout=5.0,
         verify=True,
     )
@@ -129,12 +137,17 @@ def test_client_sends_proper_json_with_minimal_job_event() -> None:
         ),
     )
 
-    session.post.assert_called_with(
-        "http://example.com/api/v1/lineage",
+    body = (
         '{"eventTime": "2021-11-03T10:53:52.427343", '
         '"inputs": [], "job": {"facets": {}, "name": "job", "namespace": '
         '"openlineage"}, "outputs": [], "producer": "producer", '
-        '"schemaURL": "jobSchemaURL"}',
+        '"schemaURL": "jobSchemaURL"}'
+    )
+
+    session.post.assert_called_with(
+        url="http://example.com/api/v1/lineage",
+        data=body,
+        headers={},
         timeout=5.0,
         verify=True,
     )

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -101,7 +101,7 @@ def test_symlink_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
@@ -145,7 +145,7 @@ def test_storage_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
@@ -197,7 +197,7 @@ def test_ownership_job_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["job"]["facets"] = {}
@@ -242,7 +242,7 @@ def test_dataset_version_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
@@ -295,7 +295,7 @@ def test_lifecycle_state_change_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     dataset_facets = {}
     dataset_facets["lifecycleStateChange"] = lifecycle_state_change_dataset_facet
@@ -351,7 +351,7 @@ def test_ownership_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
@@ -420,7 +420,7 @@ def test_column_lineage_dataset_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"][0]["facets"] = {}
@@ -457,7 +457,7 @@ def test_job_type_job_facet(event: dict[str, Any]) -> None:
         ),
     )
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = copy.deepcopy(event)
     expected_event["outputs"] = []

--- a/client/python/tests/test_facet_v2.py
+++ b/client/python/tests/test_facet_v2.py
@@ -68,7 +68,7 @@ def test_custom_facet() -> None:
 
     client.emit(event)
 
-    event_sent = json.loads(session.post.call_args[0][1])
+    event_sent = json.loads(session.post.call_args.kwargs["data"])
 
     expected_event = {
         "eventType": "START",
@@ -190,7 +190,7 @@ def test_full_core_event_serializes_properly() -> None:
 
         client.emit(event)
 
-        event_sent = json.loads(session.post.call_args[0][1])
+        event_sent = json.loads(session.post.call_args.kwargs["data"])
 
         dirpath = os.path.dirname(os.path.realpath(__file__))
         with open(os.path.join(dirpath, "example_full_event.json")) as f:

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import datetime
+import gzip
 import uuid
 from typing import TYPE_CHECKING
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
-from openlineage.client.transport.http import HttpConfig, HttpTransport
+from openlineage.client.transport.http import HttpCompression, HttpConfig, HttpTransport
 from requests import Session
 
 if TYPE_CHECKING:
@@ -27,6 +28,7 @@ def test_http_loads_full_config() -> None:
                 "type": "api_key",
                 "api_key": "1500100900",
             },
+            "compression": "gzip",
         },
     )
 
@@ -36,6 +38,7 @@ def test_http_loads_full_config() -> None:
     assert config.auth.api_key == "1500100900"
     assert config.session is None
     assert config.adapter is None
+    assert config.compression is HttpCompression.GZIP
 
 
 def test_http_loads_minimal_config() -> None:
@@ -50,6 +53,7 @@ def test_http_loads_minimal_config() -> None:
     assert not hasattr(config.auth, "api_key")
     assert config.session is None
     assert config.adapter is None
+    assert config.compression is None
 
 
 def test_client_with_http_transport_emits(mocker: MockerFixture) -> None:
@@ -75,8 +79,9 @@ def test_client_with_http_transport_emits(mocker: MockerFixture) -> None:
 
     client.emit(event)
     transport.session.post.assert_called_once_with(
-        "http://backend:5000/api/v1/lineage",
-        Serde.to_json(event),
+        url="http://backend:5000/api/v1/lineage",
+        data=Serde.to_json(event),
+        headers={},
         timeout=5.0,
         verify=True,
     )
@@ -105,10 +110,48 @@ def test_client_with_http_transport_emits_custom_endpoint(mocker: MockerFixture)
 
     client.emit(event)
     transport.session.post.assert_called_once_with(
-        "http://backend:5000/custom/lineage",
-        Serde.to_json(event),
+        url="http://backend:5000/custom/lineage",
+        data=Serde.to_json(event),
+        headers={},
         timeout=5.0,
         verify=True,
+    )
+
+
+def test_client_with_http_transport_emits_with_gzip_compression(mocker: MockerFixture) -> None:
+    session = mocker.patch("requests.Session")
+    config = HttpConfig.from_dict(
+        {
+            "type": "http",
+            "url": "http://backend:5000",
+            "session": session,
+            "compression": "gzip",
+        },
+    )
+    transport = HttpTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2024-04-12T18:04:58.134314",
+        run=Run(runId="75782cf3-8be4-49dc-83e5-d2cf6239c168"),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+    client.emit(event)
+    session.post.assert_called_once()
+
+    headers = session.post.call_args.kwargs["headers"]
+    assert headers["Content-Encoding"] == "gzip"
+
+    data = session.post.call_args.kwargs["data"]
+    assert gzip.decompress(data) == (
+        b'{"eventTime": "2024-04-12T18:04:58.134314", "eventType": "START", '
+        b'"inputs": [], "job": {"facets": {}, "name": "test", "namespace": "http"}, "outputs": [], '
+        b'"producer": "prod", "run": {"facets": {}, "runId": "75782cf3-8be4-49dc-83e5-d2cf6239c168"}, '
+        b'"schemaURL": "schema"}'
     )
 
 


### PR DESCRIPTION
### Problem

Implements: #2595

### Solution

#### One-line summary:

Add `compression` option to `HttpTransport` config of Python client, with `gzip` implementation.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project