### PR TITLE
Allow timeout for circuit breakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     *Adds new Airflow macros `lineage_job_namespace()`, `lineage_job_name(task)` that return an Airflow namespace and Airflow job name, respectively.*
 * **Spec: Allow nested struct fields in `SchemaDatasetFacet`** [`#2548`](https://github.com/OpenLineage/OpenLineage/pull/2548) [@dolfinus](https://github.com/dolfinus)  
     *Allows nested fields support to `SchemaDatasetFacet`.*
+* **Spark: enable timeout for circuit breakers.** [`#2609`](https://github.com/OpenLineage/OpenLineage/pull/2609) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Implement within circuit breaker an optional timeout which switches off OpenLineage integration code when exceeded.*
 
 ### Fixed
 * **Spark: fix PMD for test** [`#2588`](https://github.com/OpenLineage/OpenLineage/pull/2588) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreaker.java
@@ -12,6 +12,8 @@ import static io.openlineage.client.utils.RuntimeUtils.totalMemory;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,8 @@ public class JavaRuntimeCircuitBreaker extends ExecutorCircuitBreaker {
 
   public JavaRuntimeCircuitBreaker(@NonNull final JavaRuntimeCircuitBreakerConfig config) {
     super(config.getCircuitCheckIntervalInMillis());
+    this.timeout =
+        Optional.ofNullable(config.getTimeoutInSeconds()).map(s -> Duration.ofSeconds(s));
     this.config = config;
   }
 

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java
@@ -24,6 +24,12 @@ public final class JavaRuntimeCircuitBreakerConfig implements CircuitBreakerConf
   @Getter @Setter private Integer memoryThreshold = 20;
   @Getter @Setter private Integer gcCpuThreshold = 10;
   @Getter @Setter private Integer circuitCheckIntervalInMillis = CIRCUIT_CHECK_INTERVAL_IN_MILLIS;
+  @Getter @Setter private Integer timeoutInSeconds = null;
+
+  public JavaRuntimeCircuitBreakerConfig(
+      int memoryThreshold, int gcCpuThreshold, int circuitCheckIntervalInMillis) {
+    this(memoryThreshold, gcCpuThreshold, circuitCheckIntervalInMillis, null);
+  }
 
   public JavaRuntimeCircuitBreakerConfig(int memoryThreshold, int gcCpuThreshold) {
     this(memoryThreshold, gcCpuThreshold, CIRCUIT_CHECK_INTERVAL_IN_MILLIS);

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreaker.java
@@ -9,6 +9,8 @@ import static io.openlineage.client.utils.RuntimeUtils.freeMemory;
 import static io.openlineage.client.utils.RuntimeUtils.maxMemory;
 import static io.openlineage.client.utils.RuntimeUtils.totalMemory;
 
+import java.time.Duration;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +20,8 @@ public class SimpleMemoryCircuitBreaker extends ExecutorCircuitBreaker {
 
   public SimpleMemoryCircuitBreaker(@NonNull final SimpleMemoryCircuitBreakerConfig config) {
     super(config.getCircuitCheckIntervalInMillis());
+    this.timeout =
+        Optional.ofNullable(config.getTimeoutInSeconds()).map(s -> Duration.ofSeconds(s));
     this.config = config;
   }
 

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerConfig.java
@@ -23,8 +23,13 @@ import lombok.With;
 public final class SimpleMemoryCircuitBreakerConfig implements CircuitBreakerConfig {
   @Getter @Setter private Integer memoryThreshold = 20;
   @Getter @Setter private Integer circuitCheckIntervalInMillis = CIRCUIT_CHECK_INTERVAL_IN_MILLIS;
+  @Getter @Setter private Integer timeoutInSeconds = null;
 
   public SimpleMemoryCircuitBreakerConfig(int memoryThreshold) {
-    this(memoryThreshold, CIRCUIT_CHECK_INTERVAL_IN_MILLIS);
+    this(memoryThreshold, CIRCUIT_CHECK_INTERVAL_IN_MILLIS, null);
+  }
+
+  public SimpleMemoryCircuitBreakerConfig(int memoryThreshold, int circuitCheckIntervalInMillis) {
+    this(memoryThreshold, circuitCheckIntervalInMillis, null);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.circuitBreaker.ExecutorCircuitBreaker;
 import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreaker;
 import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreakerConfig;
 import io.openlineage.client.circuitBreaker.SimpleMemoryCircuitBreaker;
@@ -78,12 +79,13 @@ class ConfigTest {
         .hasFieldOrPropertyWithValue("config", new JavaRuntimeCircuitBreakerConfig(13, 10));
 
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(1000);
+    assertThat(((ExecutorCircuitBreaker) client.circuitBreaker.get()).getTimeout()).isEmpty();
 
     client = Clients.newClient(new TestConfigPathProvider("config/circuitBreaker2.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(JavaRuntimeCircuitBreaker.class)
-        .hasFieldOrPropertyWithValue("config", new JavaRuntimeCircuitBreakerConfig(13, 7, 200));
+        .hasFieldOrPropertyWithValue("config", new JavaRuntimeCircuitBreakerConfig(13, 7, 200, 90));
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(200);
   }
 
@@ -96,12 +98,13 @@ class ConfigTest {
         .isInstanceOf(SimpleMemoryCircuitBreaker.class)
         .hasFieldOrPropertyWithValue("config", new SimpleMemoryCircuitBreakerConfig(13));
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(1000);
+    assertThat(((ExecutorCircuitBreaker) client.circuitBreaker.get()).getTimeout()).isEmpty();
 
     client = Clients.newClient(new TestConfigPathProvider("config/circuitBreaker4.yaml"));
 
     assertThat(client.circuitBreaker.get())
         .isInstanceOf(SimpleMemoryCircuitBreaker.class)
-        .hasFieldOrPropertyWithValue("config", new SimpleMemoryCircuitBreakerConfig(13, 200));
+        .hasFieldOrPropertyWithValue("config", new SimpleMemoryCircuitBreakerConfig(13, 200, 90));
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(200);
   }
 

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/CommonCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/CommonCircuitBreakerTest.java
@@ -54,7 +54,7 @@ class CommonCircuitBreakerTest {
     circuitBreaker.run(longLastingCallable);
     long millisAfter = System.currentTimeMillis();
 
-    assertThat(millisAfter - millisBefore).isGreaterThan(50); // proves callable started
+    assertThat(millisAfter - millisBefore).isGreaterThanOrEqualTo(50); // proves callable started
     assertThat(millisAfter - millisBefore).isLessThan(2000); // proves callable has been interrupted
   }
 

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/ExecutorCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/ExecutorCircuitBreakerTest.java
@@ -1,0 +1,44 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.circuitBreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class ExecutorCircuitBreakerTest {
+
+  SampleExecutorCircuitBreaker circuitBreaker = new SampleExecutorCircuitBreaker();
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void testTimeoutForInfiniteCallable() {
+    Callable<Object> infiniteCallable =
+        () -> {
+          while (true) Thread.sleep(1000);
+        };
+    assertThat(circuitBreaker.<Object>run(infiniteCallable)).isNull();
+  }
+
+  static class SampleExecutorCircuitBreaker extends ExecutorCircuitBreaker {
+
+    CircuitBreakerState openStater = new CircuitBreakerState(false, Optional.empty());
+
+    SampleExecutorCircuitBreaker() {
+      super(100, Duration.ofMillis(500));
+    }
+
+    @Override
+    public CircuitBreakerState currentState() {
+      return openStater;
+    }
+  }
+}

--- a/client/java/src/test/resources/config/circuitBreaker2.yaml
+++ b/client/java/src/test/resources/config/circuitBreaker2.yaml
@@ -5,3 +5,4 @@ circuitBreaker:
   memoryThreshold: 13
   gcCpuThreshold: 7
   circuitCheckIntervalInMillis: 200
+  timeoutInSeconds: 90

--- a/client/java/src/test/resources/config/circuitBreaker4.yaml
+++ b/client/java/src/test/resources/config/circuitBreaker4.yaml
@@ -4,3 +4,4 @@ circuitBreaker:
   type: simpleMemory
   memoryThreshold: 13
   circuitCheckIntervalInMillis: 200
+  timeoutInSeconds: 90


### PR DESCRIPTION
### Problem

Extend circuit breaker mechanism to contain global timeout which stops running OpenLineage integration code when specified amount of time is reached.

### Solution

*TODO* - update docs once PR is merged

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project