### PR TITLE
Fix pmd for java client

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -55,9 +55,10 @@ public final class OpenLineageClient {
     this.disabledFacets = Arrays.copyOf(disabledFacets, disabledFacets.length);
     this.circuitBreaker = Optional.ofNullable(circuitBreaker);
     if (meterRegistry == null) {
-      meterRegistry = MicrometerProvider.getMeterRegistry();
+      this.meterRegistry = MicrometerProvider.getMeterRegistry();
+    } else {
+      this.meterRegistry = meterRegistry;
     }
-    this.meterRegistry = meterRegistry;
 
     initializeMetrics();
     OpenLineageClientUtils.configureObjectMapper(disabledFacets);

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -204,6 +204,7 @@ public final class OpenLineageClientUtils {
    * @return An instance of {@link OpenLineageYaml} containing the parsed configuration.
    * @throws OpenLineageClientException According to the rules defined above.
    */
+  @SuppressWarnings("PMD.AvoidCatchingNPE")
   public static OpenLineageYaml loadOpenLineageYaml(ConfigPathProvider configPathProvider)
       throws OpenLineageClientException {
     try {
@@ -220,9 +221,9 @@ public final class OpenLineageClientUtils {
           "No OpenLineage configuration file found at provided paths, looked in: "
               + concatenatedPaths);
     } catch (NullPointerException e) {
-      throw new OpenLineageClientException("ConfigPathProvider was null");
+      throw new OpenLineageClientException("ConfigPathProvider was null", e);
     } catch (FileNotFoundException e) {
-      throw new OpenLineageClientException("No OpenLineage configuration file found");
+      throw new OpenLineageClientException("No OpenLineage configuration file found", e);
     } catch (IOException e) {
       throw new OpenLineageClientException(e);
     }

--- a/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
@@ -16,6 +16,7 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * MicrometerProvider is a class that manages global OpenLineage meter registry implementation that
@@ -48,7 +49,7 @@ public class MicrometerProvider {
       return Optional.empty();
     }
     Object type = config.get("type");
-    if (!(type instanceof String) || "".equals(type)) {
+    if (!(type instanceof String) || type == null || StringUtils.isEmpty((String) type)) {
       return Optional.empty();
     }
     return getConfigBuilder((String) type).map(x -> x.registry(config));

--- a/client/java/src/main/java/io/openlineage/client/utils/JdbcUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/JdbcUtils.java
@@ -56,12 +56,11 @@ public class JdbcUtils {
    */
   public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(
       String jdbcUrl, List<String> parts) {
-    jdbcUrl = sanitizeJdbcUrl(jdbcUrl);
-    String namespace = jdbcUrl;
+    String namespace = sanitizeJdbcUrl(jdbcUrl);
     String urlDatabase = null;
 
     try {
-      URI uri = new URI(jdbcUrl);
+      URI uri = new URI(namespace);
       String path = uri.getPath();
       if (path != null) {
         namespace = String.format("%s://%s", uri.getScheme(), uri.getAuthority());

--- a/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java
@@ -119,7 +119,6 @@ class OpenLineageClientUtilsTest {
             + "  url: http://localhost:5050\n"
             + "  endpoint: api/v1/lineage\n"
             + "  compression: gzip\n";
-    System.out.println(yamlString);
 
     byte[] bytes = yamlString.getBytes(StandardCharsets.UTF_8);
 

--- a/client/java/src/test/java/io/openlineage/client/metrics/MetricsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/metrics/MetricsTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
-public class MetricsTest extends BaseMetricsTest {
+class MetricsTest extends BaseMetricsTest {
 
   @SneakyThrows
   @Test

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -308,10 +308,11 @@ class HttpTransportTest {
     GZIPInputStream uncompressedStream =
         new GZIPInputStream(new ByteArrayInputStream(compressedData.toByteArray()));
     ByteArrayOutputStream uncompressedData = new ByteArrayOutputStream();
-    int nRead;
     byte[] buffer = new byte[1024];
-    while ((nRead = uncompressedStream.read(buffer, 0, buffer.length)) != -1) {
+    int nRead = uncompressedStream.read(buffer, 0, buffer.length);
+    while (nRead != -1) {
       uncompressedData.write(buffer, 0, nRead);
+      nRead = uncompressedStream.read(buffer, 0, buffer.length);
     }
     uncompressedData.flush();
 
@@ -358,6 +359,7 @@ class HttpTransportTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testTimeout() {
     HttpConfig config = new HttpConfig();
     config.setUrl(URI.create("https://localhost:1500/api/v1/lineage"));
@@ -375,6 +377,7 @@ class HttpTransportTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testTimeoutInMillis() {
     HttpConfig config = new HttpConfig();
     config.setUrl(URI.create("https://localhost:1500/api/v1/lineage"));

--- a/client/java/src/test/java/io/openlineage/client/utils/JdbcUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/JdbcUtilsTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class JdbcUtilsTest {
+class JdbcUtilsTest {
 
   @Test
   void testSanitizeJdbc() {


### PR DESCRIPTION
Fix pmd for java client

```
> Task :pmdMain
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java:58:  AvoidReassigningParameters:     Avoid reassigning parameters such as 'meterRegistry'
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java:222:    AvoidCatchingNPE:       Avoid catching NullPointerException; consider removing the cause of the NPE.
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java:223:    PreserveStackTrace:     New exception is thrown in catch block, original stack trace may be lost
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java:225:    PreserveStackTrace:     New exception is thrown in catch block, original stack trace may be lost
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java:51: AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/client/java/src/main/java/io/openlineage/client/utils/JdbcUtils.java:59:    AvoidReassigningParameters:     Avoid reassigning parameters such as 'jdbcUrl'
6 PMD rule violations were found. See the report at: file:///Users/pawelleszczynski/Openlineage/client/java/build/reports/pmd/main.html

> Task :pmdTest
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/OpenLineageClientUtilsTest.java:122:        SystemPrintln:  System.out.println is used
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/metrics/MetricsTest.java:29:        JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java:313:      AssignmentInOperand:    Avoid assignments in operands
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java:361:      JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java:378:      JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/Users/pawelleszczynski/Openlineage/client/java/src/test/java/io/openlineage/client/utils/JdbcUtilsTest.java:12:        JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
6 PMD rule violations were found. See the report at: file:///Users/pawelleszczynski/Openlineage/client/java/build/reports/pmd/test.html


```