### PR TITLE
add custom token provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.12.0...HEAD)
 
+### Added
+* **Spark: add custom token provider support** [`#2613`](https://github.com/OpenLineage/OpenLineage/pull/2613) [@tnazarew](https://github.com/tnazarew)  
+    *Adds support for FQCN as `spark.openlineage.transport.auth.type`*
+
 ## [1.12.0](https://github.com/OpenLineage/OpenLineage/compare/1.11.3...1.12.0) - 2024-04-09
 
 ### Added

--- a/client/java/src/main/java/io/openlineage/client/transports/TokenProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TokenProvider.java
@@ -5,13 +5,11 @@
 
 package io.openlineage.client.transports;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 
-@JsonSubTypes({
-  @JsonSubTypes.Type(value = ApiKeyTokenProvider.class, name = "api_key"),
-})
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeIdResolver(TokenProviderTypeIdResolver.class)
 public interface TokenProvider {
   String getToken();
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/TokenProviderTypeIdResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TokenProviderTypeIdResolver.java
@@ -1,0 +1,49 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import java.util.Objects;
+
+public class TokenProviderTypeIdResolver extends TypeIdResolverBase {
+  private JavaType superType;
+
+  @Override
+  public void init(JavaType baseType) {
+    superType = baseType;
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.NAME;
+  }
+
+  @Override
+  public String idFromValue(Object obj) {
+    return idFromValueAndType(obj, obj.getClass());
+  }
+
+  @Override
+  public String idFromValueAndType(Object obj, Class<?> subType) {
+    return subType.getCanonicalName();
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    if (Objects.equals(id, "api_key")) { // backwards compatibility
+      return context.constructSpecializedType(superType, ApiKeyTokenProvider.class);
+    }
+    try {
+      return context.constructSpecializedType(superType, Class.forName(id));
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(
+          String.format("No class matches %s from spark.openlineage.transport.auth.type", id), e);
+    }
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -228,7 +228,7 @@ class ArgumentParserTest {
             .set(
                 "spark.openlineage.transport.auth.type", FakeTokenProvider.class.getCanonicalName())
             .set("spark.openlineage.transport.auth.token", TEST_TOKEN);
-    OpenLineageYaml openLineageYaml = ArgumentParser.extractOpenlineageConfFromSparkConf(sparkConf);
+    SparkOpenLineageConfig openLineageYaml = ArgumentParser.parse(sparkConf);
     HttpConfig transportConfig = (HttpConfig) openLineageYaml.getTransportConfig();
     assert (transportConfig.getAuth() != null);
     assert (transportConfig.getAuth() instanceof FakeTokenProvider);
@@ -242,8 +242,6 @@ class ArgumentParserTest {
             .set("spark.openlineage.transport.type", "http")
             .set("spark.openlineage.transport.auth.type", "non.existing.TokenProvider")
             .set("spark.openlineage.transport.auth.token", TEST_TOKEN);
-    assertThrows(
-        RuntimeException.class,
-        () -> ArgumentParser.extractOpenlineageConfFromSparkConf(sparkConf));
+    assertThrows(RuntimeException.class, () -> ArgumentParser.parse(sparkConf));
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/FakeTokenProvider.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/FakeTokenProvider.java
@@ -1,0 +1,23 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import io.openlineage.client.transports.TokenProvider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+public class FakeTokenProvider implements TokenProvider {
+  @Getter @Setter private String token;
+
+  @Override
+  public String getToken() {
+    return token;
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/FakeTokenProvider.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/FakeTokenProvider.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent;
 
 import io.openlineage.client.transports.TokenProvider;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,7 +13,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class FakeTokenProvider implements TokenProvider {
-  @Getter @Setter private String token;
+  @Setter private String token;
 
   @Override
   public String getToken() {


### PR DESCRIPTION
### Problem

OL didn't have a support for custom token providers

Closes: #2542

### Solution

`TokenProviderTypeIdResolver` was added to handle both FQCN and (for backward compatibility) `api_key` type in `spark.openlineage.transport.auth.type`

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)


#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [X] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project