### PR TITLE
[Client] Remove runId from Kafka messageKey

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -45,16 +45,11 @@ public final class KafkaTransport extends Transport {
         final OpenLineage.ParentRunFacetJob parentJob = parentRunFacet.getJob();
         final OpenLineage.ParentRunFacetRun parentRun = parentRunFacet.getRun();
         if (parentRun != null && parentJob != null) {
-          return "run:"
-              + parentJob.getNamespace()
-              + "/"
-              + parentJob.getName()
-              + "/"
-              + parentRun.getRunId().toString();
+          return "run:" + parentJob.getNamespace() + "/" + parentJob.getName();
         }
       }
     }
-    return "run:" + job.getNamespace() + "/" + job.getName() + "/" + run.getRunId().toString();
+    return "run:" + job.getNamespace() + "/" + job.getName();
   }
 
   @Override

--- a/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
@@ -49,8 +49,7 @@ class KafkaTransportTest {
     verify(producer, times(1)).send(captor.capture());
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
-    assertThat(captor.getValue().key())
-        .isEqualTo("run:test-namespace/test-job/ea445b5c-22eb-457a-8007-01c7c52b6e54");
+    assertThat(captor.getValue().key()).isEqualTo("run:test-namespace/test-job");
   }
 
   @Test
@@ -77,8 +76,7 @@ class KafkaTransportTest {
     verify(producer, times(1)).send(captor.capture());
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
-    assertThat(captor.getValue().key())
-        .isEqualTo("run:parent-namespace/parent-job/d9cb8e0b-a410-435e-a619-da5e87ba8508");
+    assertThat(captor.getValue().key()).isEqualTo("run:parent-namespace/parent-job");
   }
 
   @Test

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -130,7 +130,7 @@ def test_client_with_kafka_transport_emits_run_event(run_event: RunEvent, mocker
     client.emit(run_event)
     transport.producer.produce.assert_called_once_with(
         topic="random-topic",
-        key="run:test-namespace/test-job/ea445b5c-22eb-457a-8007-01c7c52b6e54",
+        key="run:test-namespace/test-job",
         value=Serde.to_json(run_event).encode("utf-8"),
         on_delivery=ANY,
     )
@@ -154,7 +154,7 @@ def test_client_with_kafka_transport_emits_run_event_with_parent(
     client.emit(run_event_with_parent)
     transport.producer.produce.assert_called_once_with(
         topic="random-topic",
-        key="run:parent-namespace/parent-job/d9cb8e0b-a410-435e-a619-da5e87ba8508",
+        key="run:parent-namespace/parent-job",
         value=Serde.to_json(run_event_with_parent).encode("utf-8"),
         on_delivery=ANY,
     )


### PR DESCRIPTION
### Problem

Related: #2559

### Solution

Remove `runId` from Kafka messageKey.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project