### PR TITLE
[Spark] fix PMD for shared and spark3

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java
@@ -99,6 +99,7 @@ public class DatabricksEnvironmentFacetBuilder
   // If running on an older version, the constructor has no parameters.
   // If running on DBR 11 or above, you need to specify whether you allow mount operations (true or
   // false)
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   private static List<DatabricksMountpoint> getDatabricksMountpoints() {
     Class dbutilsClass;
     try {
@@ -125,7 +126,7 @@ public class DatabricksEnvironmentFacetBuilder
         return Collections.emptyList();
       }
     } else if (constructorParams.length == 1
-        && constructorParams[0].getName().equals("allowMountOperations")) {
+        && "allowMountOperations".equals(constructorParams[0].getName())) {
       log.debug("DbUtils constructor had one parameter named allowMountOperations");
       try {
         dbfsUtils = firstConstructor.newInstance(true);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilder.java
@@ -31,7 +31,7 @@ public class DebugRunFacetBuilder extends CustomFacetBuilder<Object, DebugRunFac
     return Optional.of(openLineageContext.getSparkContext())
         .map(sc -> sc.conf())
         .map(conf -> conf.get("spark.openlineage.debugFacet", "disabled"))
-        .map(value -> value.equalsIgnoreCase("enabled"))
+        .map(value -> "enabled".equalsIgnoreCase(value))
         .orElse(false);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -184,7 +185,7 @@ public class DebugRunFacetBuilderDelegate {
         .map(
             stream ->
                 stream
-                    .filter(tuple -> !tuple._1().toLowerCase().contains("key"))
+                    .filter(tuple -> !tuple._1().toLowerCase(Locale.getDefault()).contains("key"))
                     .collect(
                         Collectors.<Tuple2<String, String>, String, String>toMap(
                             t -> t._1(), t -> t._2())))
@@ -197,15 +198,6 @@ public class DebugRunFacetBuilderDelegate {
         .map(sparkSession -> sparkSession.catalog())
         .map(catalog -> catalog.getClass().getCanonicalName())
         .orElse(null);
-  }
-
-  private boolean isOnClassPath(String aClass) {
-    try {
-      this.getClass().getClassLoader().loadClass(aClass);
-      return true;
-    } catch (Exception e) {
-      return false;
-    }
   }
 
   private ClasspathDebugClassDetails toClasspathDebugClassDetails(String aClass) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
@@ -27,6 +27,7 @@ public class AdaptivePlanEventFilter implements EventFilter {
    *
    * @return
    */
+  @Override
   public boolean isDisabled(SparkListenerEvent event) {
     if (!isDeltaPlan()) {
       return false;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java
@@ -19,13 +19,13 @@ public class CreateViewFilter implements EventFilter {
     this.context = context;
   }
 
+  @Override
   public boolean isDisabled(SparkListenerEvent event) {
     return getLogicalPlan(context)
         .filter(plan -> plan instanceof CreateViewCommand)
         .filter(
-            plan ->
-                context.getSparkVersion().compareTo("3.3")
-                    >= 0) // CreateViewCommand is not filtered for lower spark versions as it breaks
+            // CreateViewCommand is not filtered for lower spark versions as it breaks
+            plan -> "3.3".compareTo(context.getSparkVersion()) < 0)
         // io.openlineage.spark.agent.lifecycle.SparkReadWriteIntegTest.testCacheReadFromFileWriteToParquet test
         .isPresent();
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -36,6 +36,7 @@ public class DatabricksEventFilter implements EventFilter {
     this.context = context;
   }
 
+  @Override
   public boolean isDisabled(SparkListenerEvent event) {
     return isSerializeFromObject() || isWriteIntoDeltaCommand() || isDisabledDatabricksPlan(event);
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java
@@ -38,6 +38,7 @@ public class DeltaEventFilter implements EventFilter {
     this.context = context;
   }
 
+  @Override
   public boolean isDisabled(SparkListenerEvent event) {
     if (!isDeltaPlan()) {
       return false;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -57,7 +57,7 @@ public class EventFilterUtils {
         .filter(context -> context != null)
         .map(SparkContext::conf)
         .map(conf -> conf.get("spark.sql.extensions", ""))
-        .filter(extension -> extension.equals("io.delta.sql.DeltaSparkSessionExtension"))
+        .filter(extension -> "io.delta.sql.DeltaSparkSessionExtension".equals(extension))
         .isPresent();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
@@ -34,6 +34,7 @@ public class SparkNodesFilter implements EventFilter {
     this.context = context;
   }
 
+  @Override
   public boolean isDisabled(SparkListenerEvent event) {
     return getLogicalPlan(context)
         .map(plan -> plan.getClass().getCanonicalName())

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java
@@ -106,6 +106,7 @@ public class JobNameHook implements RunEventBuilderHook {
     return jobName;
   }
 
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   private static String trimPath(String path) {
     if (path.lastIndexOf("/") > 0) {
       // is path

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java
@@ -83,6 +83,7 @@ public class BigQueryNodeInputVisitor
         .orElse(Collections.emptyList());
   }
 
+  @SuppressWarnings("PMD.AvoidCatchingNPE")
   private List<OpenLineage.InputDataset> tryGetFromQuery(DirectBigQueryRelation relation) {
     try {
       SparkBigQueryConfig config =

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java
@@ -98,7 +98,7 @@ public class KustoRelationVisitor<D extends OpenLineage.Dataset>
   }
 
   private static Optional<String> getName(BaseRelation relation) {
-    String tableName = "";
+    String tableName;
     try {
       Object query = FieldUtils.readField(relation, "query", true);
       tableName = (String) query;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -210,6 +210,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
     }
   }
 
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   private boolean isSingleFileRelation(Collection<Path> paths, Configuration hadoopConfig) {
     if (paths.size() != 1) {
       return false;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
@@ -51,12 +51,11 @@ public class JdbcSparkUtils {
    */
   public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(
       String jdbcUrl, List<String> parts) {
-    jdbcUrl = sanitizeJdbcUrl(jdbcUrl);
-    String namespace = jdbcUrl;
+    String namespace = sanitizeJdbcUrl(jdbcUrl);
     String urlDatabase = null;
 
     try {
-      URI uri = new URI(jdbcUrl);
+      URI uri = new URI(namespace);
       String path = uri.getPath();
       if (path != null) {
         namespace = String.format("%s://%s", uri.getScheme(), uri.getAuthority());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -86,12 +86,13 @@ public class RddPathUtils {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public Stream<Path> extract(FileScanRDD rdd) {
       return ScalaConversionUtils.fromSeq(rdd.filePartitions()).stream()
           .flatMap(fp -> Arrays.stream(fp.files()))
           .map(
               f -> {
-                if (package$.MODULE$.SPARK_VERSION().compareTo("3.4") > 0) {
+                if ("3.4".compareTo(package$.MODULE$.SPARK_VERSION()) <= 0) {
                   // filePath returns SparkPath for Spark 3.4
                   return ReflectionUtils.tryExecuteMethod(f, "filePath")
                       .map(o -> ReflectionUtils.tryExecuteMethod(o, "toPath"))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
@@ -47,6 +47,7 @@ public class SqlUtils {
         .orElse(Collections.emptyList());
   }
 
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   private static String getName(String defaultDatabase, String defaultSchema, String parsedName) {
     // database and schema from parser have priority over default ones
     String[] parts = parsedName.split("\\.");

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/Vendors.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/Vendors.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface Vendors {
+
+  @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
   List<String> VENDORS =
       Arrays.asList(
           // Add vendor classes here

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -89,25 +89,23 @@ public class IcebergHandler implements CatalogHandler {
     String warehouse = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
     DatasetIdentifier di = PathUtils.fromPath(new Path(warehouse, identifier.toString()));
 
-    if (catalogType.equals("hive")) {
+    if ("hive".equals(catalogType)) {
       di.withSymlink(
           getHiveIdentifier(
               session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if (catalogType.equals("hadoop")) {
+    } else if ("hadoop".equals(catalogType)) {
       di.withSymlink(
           identifier.toString(),
           StringUtils.substringBeforeLast(
               di.getName(), File.separator), // parent location from a name becomes a namespace
           DatasetIdentifier.SymlinkType.TABLE);
-    } else if (catalogType.equals("rest")) {
+    } else if ("rest".equals(catalogType)) {
       di.withSymlink(
-          getRestIdentifier(
-              session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if (catalogType.equals("nessie")) {
+          getRestIdentifier(catalogConf.get(CatalogProperties.URI), identifier.toString()));
+    } else if ("nessie".equals(catalogType)) {
       di.withSymlink(
-          getNessieIdentifier(
-              session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if (catalogType.equals("glue")) {
+          getNessieIdentifier(catalogConf.get(CatalogProperties.URI), identifier.toString()));
+    } else if ("glue".equals(catalogType)) {
       di.withSymlink(
           identifier.toString(),
           StringUtils.substringBeforeLast(di.getName(), File.separator),
@@ -118,8 +116,7 @@ public class IcebergHandler implements CatalogHandler {
   }
 
   @SneakyThrows
-  private DatasetIdentifier.Symlink getNessieIdentifier(
-      SparkSession session, @Nullable String confUri, String table) {
+  private DatasetIdentifier.Symlink getNessieIdentifier(@Nullable String confUri, String table) {
 
     String uri = new URI(confUri).toString();
     return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
@@ -148,9 +145,7 @@ public class IcebergHandler implements CatalogHandler {
   }
 
   @SneakyThrows
-  private DatasetIdentifier.Symlink getRestIdentifier(
-      SparkSession session, @Nullable String confUri, String table) {
-
+  private DatasetIdentifier.Symlink getRestIdentifier(@Nullable String confUri, String table) {
     String uri = new URI(confUri).toString();
     return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java
@@ -30,9 +30,6 @@ public abstract class MergeIntoDeltaColumnLineageVisitor implements ColumnLevelL
     if (node instanceof MergeIntoCommand) {
       InputFieldsCollector.collect(context, ((MergeIntoCommand) node).target());
 
-      List<Expression> mergeActions =
-          getMergeActions((MergeIntoCommand) node).collect(Collectors.toList());
-
       // remove builder target inputs that are not contained within merge actions
       List<ExprId> mergeActionsExprIds =
           getMergeActions((MergeIntoCommand) node)
@@ -92,19 +89,5 @@ public abstract class MergeIntoDeltaColumnLineageVisitor implements ColumnLevelL
                               .get(),
                           ((AttributeReference) action.child()).exprId()));
     }
-  }
-
-  private Stream<DeltaMergeAction> getMergeActionsAttributes(
-      ColumnLevelLineageContext context, LogicalPlan node) {
-    return getMergeActions((MergeIntoCommand) node)
-        .filter(action -> action instanceof DeltaMergeAction)
-        .map(action -> (DeltaMergeAction) action)
-        .filter(action -> action.child() instanceof AttributeReference)
-        .filter(
-            action ->
-                context
-                    .getBuilder()
-                    .getOutputExprIdByFieldName(action.targetColNameParts().mkString())
-                    .isPresent());
   }
 }


### PR DESCRIPTION
```
./gradlew clean shared:pmdMain spark3:pmdMain
```
should return no code smells. Current behaviour:


```
> Task :shared:pmdMain
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DatabricksEnvironmentFacetBuilder.java:128:        LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilder.java:34:      LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java:187:     UseLocaleWithCaseConversions:   When doing a String.toLowerCase()/toUpperCase() call, use a Locale
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java:202:     UnusedPrivateMethod:    Avoid unused private methods such as 'isOnClassPath(String)'.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java:30:  MissingOverride:        The method 'isDisabled(SparkListenerEvent)' is missing an @Override annotation.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java:22: MissingOverride:        The method 'isDisabled(SparkListenerEvent)' is missing an @Override annotation.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/CreateViewFilter.java:27: LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java:39:    MissingOverride:        The method 'isDisabled(SparkListenerEvent)' is missing an @Override annotation.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DeltaEventFilter.java:41: MissingOverride:        The method 'isDisabled(SparkListenerEvent)' is missing an @Override annotation.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java:60: LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java:37: MissingOverride:        The method 'isDisabled(SparkListenerEvent)' is missing an @Override annotation.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/hooks/JobNameHook.java:113:       AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/BigQueryNodeInputVisitor.java:93:  AvoidCatchingNPE:       Avoid catching NullPointerException; consider removing the cause of the NPE.
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitor.java:101:     UnusedAssignment:       The initializer for variable 'tableName' is never used (overwritten on line 104)
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java:214:    AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java:54:      AvoidReassigningParameters:     Avoid reassigning parameters such as 'jdbcUrl'

> Task :spark3:compileJava
Note: /Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/CustomCollectorsUtils.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :shared:pmdMain
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java:94:        LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java:53:    AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java:55:    AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/integration/spark/shared/src/main/java/io/openlineage/spark/api/Vendors.java:18:    AvoidFieldNameMatchingTypeName: It is somewhat confusing to have a field name matching the declaring class name
20 PMD rule violations were found. See the report at: file:///Users/pawelleszczynski/Openlineage/integration/spark/shared/build/reports/pmd/main.html

> Task :spark3:pmdMain
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:92:   LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:96:   LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:102:  LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:106:  LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:110:  LiteralsFirstInComparisons:     Position literals first in String comparisons
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:122:  UnusedFormalParameter:  Avoid unused method parameters such as 'session'.
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java:152:  UnusedFormalParameter:  Avoid unused method parameters such as 'session'.
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java:33:        UnusedLocalVariable:    Avoid unused local variables such as 'mergeActions'.
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/MergeIntoDeltaColumnLineageVisitor.java:97:        UnusedPrivateMethod:    Avoid unused private methods such as 'getMergeActionsAttributes(ColumnLevelLineageContext,LogicalPlan)'.
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java:51:        AvoidDuplicateLiterals: The String literal "matchedOutputs" appears 4 times in this file; the first occurrence is on line 51
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/visitors/IcebergMergeIntoDependencyVisitor.java:75:        AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2Utils.java:39: DoubleBraceInitialization:      Double-brace initialization should be avoided
/Users/pawelleszczynski/Openlineage/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtesionDataSourceV2Utils.java:63: AvoidDuplicateLiterals: Th
```