### PR TITLE
[Airflow] Fix macros docstrings

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -267,7 +267,7 @@ PythonOperator(
     python_callable=my_task_function,
     templates_dict={
         # joined components as one string `<namespace>/<name>/<run_id>`
-        "parentRun": "{{ macros.OpenLineageProviderPlugin.lineage_parent_id(task_instance) }}",
+        "parentRun": "{{ macros.OpenLineagePlugin.lineage_parent_id(task_instance) }}",
     },
     provide_context=False,
     dag=dag,

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -20,7 +20,7 @@ def lineage_job_namespace():
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_job_namespace() }}'], # invoke macro
+        op_args=['{{ macros.OpenLineagePlugin.lineage_job_namespace() }}'],
         provide_context=False,
         dag=dag
     )
@@ -36,7 +36,7 @@ def lineage_job_name(task_instance: TaskInstance):
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_job_name(task_instance) }}'], # invoke macro
+        op_args=['{{ macros.OpenLineagePlugin.lineage_job_name(task_instance) }}'],
         provide_context=False,
         dag=dag
     )
@@ -53,7 +53,7 @@ def lineage_run_id(task_instance: TaskInstance):
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_run_id(task_instance) }}'], # invoke macro
+        op_args=['{{ macros.OpenLineagePlugin.lineage_run_id(task_instance) }}'],
         provide_context=False,
         dag=dag
     )
@@ -79,7 +79,7 @@ def lineage_parent_id(task_instance: TaskInstance):
     PythonOperator(
         task_id='render_template',
         python_callable=my_task_function,
-        op_args=['{{ lineage_parent_id(task_instance) }}'], # invoke macro
+        op_args=['{{ macros.OpenLineagePlugin.lineage_parent_id(task_instance) }}'],
         provide_context=False,
         dag=dag
     )


### PR DESCRIPTION
### Problem

Docstrings of Airflow macros contain examples which will fail on real Airflow instance.

Also example of `lineage_parent_id` used `OpenLineageProviderPlugin` from Airflow provider, instead of `OpenLineagePlugin` OpenLineage plugin.

### Solution

Fix examples of Airflow macros usage.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project