### PR TITLE
[Java] Sync Kinesis partitionKey format with Kafka implementation

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KinesisTransport.java
@@ -66,7 +66,7 @@ public class KinesisTransport extends Transport {
         this.producer.addUserRecord(
             new UserRecord(
                 streamName,
-                runEvent.getJob().getNamespace() + ":" + runEvent.getJob().getName(),
+                "run:" + runEvent.getJob().getNamespace() + "/" + runEvent.getJob().getName(),
                 ByteBuffer.wrap(eventAsJson.getBytes())));
 
     FutureCallback<UserRecordResult> callback =

--- a/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/KafkaTransportTest.java
@@ -15,7 +15,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.OpenLineageClientUtils;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.Future;
@@ -41,7 +43,8 @@ class KafkaTransportTest {
 
     when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
 
-    client.emit(runEvent());
+    OpenLineage.RunEvent event = runEvent();
+    client.emit(event);
 
     ArgumentCaptor<ProducerRecord<String, String>> captor =
         ArgumentCaptor.forClass(ProducerRecord.class);
@@ -50,6 +53,7 @@ class KafkaTransportTest {
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
     assertThat(captor.getValue().key()).isEqualTo("run:test-namespace/test-job");
+    assertThat(captor.getValue().value()).isEqualTo(OpenLineageClientUtils.toJson(event));
   }
 
   @Test
@@ -68,7 +72,8 @@ class KafkaTransportTest {
 
     when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
 
-    client.emit(runEventWithParent());
+    OpenLineage.RunEvent event = runEventWithParent();
+    client.emit(event);
 
     ArgumentCaptor<ProducerRecord<String, String>> captor =
         ArgumentCaptor.forClass(ProducerRecord.class);
@@ -77,6 +82,7 @@ class KafkaTransportTest {
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
     assertThat(captor.getValue().key()).isEqualTo("run:parent-namespace/parent-job");
+    assertThat(captor.getValue().value()).isEqualTo(OpenLineageClientUtils.toJson(event));
   }
 
   @Test
@@ -96,7 +102,8 @@ class KafkaTransportTest {
 
     when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
 
-    client.emit(runEventWithParent());
+    OpenLineage.RunEvent event = runEvent();
+    client.emit(event);
 
     ArgumentCaptor<ProducerRecord<String, String>> captor =
         ArgumentCaptor.forClass(ProducerRecord.class);
@@ -105,6 +112,7 @@ class KafkaTransportTest {
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
     assertThat(captor.getValue().key()).isEqualTo("explicit-key");
+    assertThat(captor.getValue().value()).isEqualTo(OpenLineageClientUtils.toJson(event));
   }
 
   @Test
@@ -123,7 +131,8 @@ class KafkaTransportTest {
 
     when(producer.send(any(ProducerRecord.class))).thenReturn(mock(Future.class));
 
-    client.emit(emptyRunEvent());
+    OpenLineage.RunEvent event = emptyRunEvent();
+    client.emit(event);
 
     ArgumentCaptor<ProducerRecord<String, String>> captor =
         ArgumentCaptor.forClass(ProducerRecord.class);
@@ -132,5 +141,6 @@ class KafkaTransportTest {
 
     assertThat(captor.getValue().topic()).isEqualTo("test-topic");
     assertThat(captor.getValue().key()).isNull();
+    assertThat(captor.getValue().value()).isEqualTo(OpenLineageClientUtils.toJson(event));
   }
 }


### PR DESCRIPTION
### Problem

See https://github.com/OpenLineage/OpenLineage/issues/2616#issuecomment-2063733508

### Solution

#### One-line summary:

Change format of Kinesis `partitionKey` from `{jobNamespace}:{jobName}` to `run:{jobNamespace}/{jobName}`, to match Kafka transport implementation.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project