### PR TITLE
[Spark] fix PMD for app module

### DIFF
--- a/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
+++ b/integration/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java
@@ -49,6 +49,7 @@ public class MockBigQueryRelationProvider extends BigQueryRelationProvider {
   public static final BigQuery BIG_QUERY = Mockito.mock(BigQuery.class);
   public static final MockInjector INJECTOR = new MockInjector();
 
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   public static Table makeTable(TableId id, StandardTableDefinition tableDefinition)
       throws InstantiationException, IllegalAccessException, InvocationTargetException,
           NoSuchMethodException {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/CircuitBreakerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/CircuitBreakerIntegrationTest.java
@@ -32,7 +32,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.slf4j.event.Level;
 
 @Tag("integration-test")
-public class CircuitBreakerIntegrationTest {
+class CircuitBreakerIntegrationTest {
   private static final int MOCKSERVER_PORT = 1086;
   private static final String LOCAL_IP = "127.0.0.1";
   static SparkSession spark;

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 @EnabledIfSystemProperty(named = "spark.version", matches = "(3.*)")
 @Tag("integration-test")
 @Tag("iceberg")
-public class ColumnLineageIntegrationTest {
+class ColumnLineageIntegrationTest {
   private static final String LOCAL_IP = "127.0.0.1";
   private static final String database = "test";
   private static final String username = "test";
@@ -95,6 +95,7 @@ public class ColumnLineageIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void columnLevelLineageTest() {
     Dataset<Row> df1 = getTable(spark);
     df1.registerTempTable("jdbc_result");
@@ -123,6 +124,7 @@ public class ColumnLineageIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void columnLevelLineageSingleDestinationTest() {
     Dataset<Row> readDf =
         spark

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,8 @@ import org.junit.jupiter.api.Test;
 @Tag("integration-test")
 @Tag("databricks")
 @Slf4j
-public class DatabricksIntegrationTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class DatabricksIntegrationTest {
 
   private static WorkspaceClient workspace;
   private static String clusterId;
@@ -71,7 +73,7 @@ public class DatabricksIntegrationTest {
 
   @Test
   @SneakyThrows
-  public void testCreateTableAsSelect() {
+  void testCreateTableAsSelect() {
     List<RunEvent> runEvents = runScript(workspace, clusterId, "ctas.py");
     RunEvent lastEvent = runEvents.get(runEvents.size() - 1);
 
@@ -122,13 +124,8 @@ public class DatabricksIntegrationTest {
 
   @Test
   @SneakyThrows
-  public void testNarrowTransformation() {
+  void testNarrowTransformation() {
     List<RunEvent> runEvents = runScript(workspace, clusterId, "narrow_transformation.py");
-    List<String> runEventJobNames =
-        runEvents.stream()
-            .map(runEvent -> runEvent.getJob().getName())
-            .collect(Collectors.toList());
-
     assertThat(runEvents).isNotEmpty();
 
     // assert start event exists
@@ -159,13 +156,8 @@ public class DatabricksIntegrationTest {
 
   @Test
   @SneakyThrows
-  public void testWideTransformation() {
+  void testWideTransformation() {
     List<RunEvent> runEvents = runScript(workspace, clusterId, "wide_transformation.py");
-    List<String> runEventJobNames =
-        runEvents.stream()
-            .map(runEvent -> runEvent.getJob().getName())
-            .collect(Collectors.toList());
-
     assertThat(runEvents).isNotEmpty();
 
     // assert start event exists
@@ -189,7 +181,8 @@ public class DatabricksIntegrationTest {
   }
 
   @Test
-  public void testWriteReadFromTableWithLocation() {
+  @Disabled // TODO: this assertions are not working
+  void testWriteReadFromTableWithLocation() {
     List<RunEvent> runEvents = runScript(workspace, clusterId, "dataset_names.py");
 
     // find complete event with output dataset containing name
@@ -211,10 +204,9 @@ public class DatabricksIntegrationTest {
             .get();
 
     // assert input and output are the same
-    // TODO: this assertions are not working
     // https://github.com/OpenLineage/OpenLineage/issues/2543
-    //    assertThat(inputDataset.getNamespace()).isEqualTo(outputDataset.getNamespace());
-    // assertThat(inputDataset.getName()).isEqualTo(outputDataset.getName());
+    assertThat(inputDataset.getNamespace()).isEqualTo(outputDataset.getNamespace());
+    assertThat(inputDataset.getName()).isEqualTo(outputDataset.getName());
     assertThat(runEvents.size()).isLessThan(20);
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java
@@ -5,7 +5,6 @@
 
 package io.openlineage.spark.agent;
 
-import static io.openlineage.spark.agent.MockServerUtils.getEventsEmitted;
 import static io.openlineage.spark.agent.MockServerUtils.verifyEvents;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,7 +46,7 @@ import org.mockserver.integration.ClientAndServer;
 @Tag("google-cloud")
 @Slf4j
 @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
-public class GoogleCloudIntegrationTest {
+class GoogleCloudIntegrationTest {
   private static final String PROJECT_ID =
       Optional.ofNullable(System.getenv("GCLOUD_PROJECT_ID")).orElse("openlineage-ci");
   private static final String BUCKET_NAME =
@@ -200,8 +199,6 @@ public class GoogleCloudIntegrationTest {
       logRunEvents();
     }
 
-    List<RunEvent> events = getEventsEmitted(mockServer);
-
     verifyEvents(mockServer, replacements, "pysparkBigqueryQueryEnd.json");
   }
 
@@ -264,7 +261,6 @@ public class GoogleCloudIntegrationTest {
 
     List<RunEvent> eventsEmitted = MockServerUtils.getEventsEmitted(mockServer);
 
-    String path = baseUri.getPath();
     assertThat(eventsEmitted.get(eventsEmitted.size() - 1).getOutputs().get(0))
         .hasFieldOrPropertyWithValue("name", outputUri.getPath())
         .hasFieldOrPropertyWithValue(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive2Test.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive2Test.java
@@ -35,7 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     "This test is feature incomplete, and needs to be fixed. It doesn't actually test any OpenLineage code.")
 // FIXME: This test does not configure the OpenLineageSparkListener, and thus does not make any
 //  assertions about the events that the listener would emit.
-public class MetastoreHive2Test {
+class MetastoreHive2Test {
   private static final String database = "hive2";
   private static final String table = "test";
   private static final Network network = Network.newNetwork();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive3Test.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive3Test.java
@@ -35,7 +35,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     "This test is feature incomplete, and needs to be fixed. It doesn't actually test any OpenLineage code.")
 // FIXME: This test does not configure the OpenLineageSparkListener, and thus does not make any
 //  assertions about the events that the listener would emit.
-public class MetastoreHive3Test {
+class MetastoreHive3Test {
   private static final String database = "hive3";
   private static final String table = "test";
   private static final Network network = Network.newNetwork();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -294,6 +294,7 @@ class SparkContainerIntegrationTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testFacetsDisable() {
     SparkContainerUtils.runPysparkContainerWithDefaultConf(
         network, openLineageClientMockContainer, "testFacetsDisable", "spark_facets_disable.py");

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
@@ -49,7 +49,8 @@ import org.mockserver.model.RegexBody;
 @Tag("integration-test")
 @Tag("delta")
 @Slf4j
-public class SparkDeltaIntegrationTest {
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class SparkDeltaIntegrationTest {
   @SuppressWarnings("PMD")
   private static final String LOCAL_IP = "127.0.0.1";
 
@@ -329,6 +330,7 @@ public class SparkDeltaIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testCustomEnvVar() {
     spark.sql("DROP TABLE IF EXISTS test");
     spark.sql("CREATE TABLE test (key INT, value STRING) using delta");
@@ -350,6 +352,7 @@ public class SparkDeltaIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testNoDuplicateEventsForDelta() {
     clearTables("t1", "t2", "t3", "t4");
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
@@ -39,7 +39,7 @@ import org.mockserver.integration.ClientAndServer;
  */
 @Tag("integration-test")
 @Slf4j
-public class SparkGenericIntegrationTest {
+class SparkGenericIntegrationTest {
 
   @SuppressWarnings("PMD")
   private static final String LOCAL_IP = "127.0.0.1";
@@ -107,7 +107,7 @@ public class SparkGenericIntegrationTest {
             events.stream()
                 .map(
                     event -> {
-                      if (event.getJob().getName().equals("generic_integration_test")) {
+                      if ("generic_integration_test".equals(event.getJob().getName())) {
                         return event.getRun().getRunId();
                       } else {
                         return event.getRun().getFacets().getParent().getRun().getRunId();
@@ -122,6 +122,7 @@ public class SparkGenericIntegrationTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void sparkGathersMetrics() {
     Dataset<Row> df = createTempDataset();
 
@@ -142,13 +143,13 @@ public class SparkGenericIntegrationTest {
                     (List<Map<String, Object>>) ((Map<String, Object>) metricsFacet).get("metrics");
                 assertThat(
                         metrics.stream()
-                            .filter(metric -> metric.get("name").equals("openlineage.emit.start"))
+                            .filter(metric -> "openlineage.emit.start".equals(metric.get("name")))
                             .findFirst())
                     .isPresent();
                 assertThat(
                         metrics.stream()
                             .filter(
-                                metric -> metric.get("name").equals("openlineage.emit.complete"))
+                                metric -> "openlineage.emit.complete".equals(metric.get("name")))
                             .findFirst())
                     .isPresent();
               }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -43,7 +43,7 @@ import org.mockserver.model.HttpRequest;
 @Tag("integration-test")
 @Tag("iceberg")
 @Slf4j
-public class SparkIcebergIntegrationTest {
+class SparkIcebergIntegrationTest {
   private static final int MOCK_SERVER_PORT = 1084;
 
   @SuppressWarnings("PMD")
@@ -305,6 +305,7 @@ public class SparkIcebergIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testDebugFacet() {
     clearTables("iceberg_temp", "temp");
     createTempDataset().createOrReplaceTempView("temp");

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -60,7 +60,7 @@ import org.testcontainers.utility.DockerImageName;
 @Tag("integration-test")
 @Testcontainers
 @Slf4j
-public class SparkScalaContainerTest {
+class SparkScalaContainerTest {
   private static final Network network = Network.newNetwork();
 
   @Container
@@ -158,6 +158,7 @@ public class SparkScalaContainerTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testScalaUnionRddToParquet() {
     spark = createSparkContainer("io.openlineage.spark.test.RddUnion");
     spark.start();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class UrlParserTest {
 
   private static final String NS_NAME = "ns_name";
@@ -172,6 +173,7 @@ class UrlParserTest {
 
   @ParameterizedTest
   @MethodSource("data")
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testArgument(
       String input,
       String url,

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageDeltaTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageDeltaTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("delta")
-public class ColumnLevelLineageDeltaTest {
+class ColumnLevelLineageDeltaTest {
   @SuppressWarnings("PMD")
   private static final String LOCAL_IP = "127.0.0.1";
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -76,6 +76,7 @@ class LibraryTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testRdd(@TempDir Path tmpDir, SparkSession spark) throws IOException {
     URL url = Resources.getResource("test_data/data.txt");
     JavaSparkContext sc = new JavaSparkContext(spark.sparkContext());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkEventFilterTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkEventFilterTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mockito;
 @ExtendWith(SparkAgentTestExtension.class)
 @Tag("integration-test")
 @Slf4j
-public class SparkEventFilterTest {
+class SparkEventFilterTest {
 
   @Test
   @SneakyThrows

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -13,8 +13,6 @@ import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -163,9 +161,5 @@ public class StaticExecutionContextFactory extends ContextFactory {
         emitter,
         olContext,
         new OpenLineageRunEventBuilder(olContext, new InternalEventHandlerFactory()));
-  }
-
-  private static ZonedDateTime getZonedTime() {
-    return ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
@@ -38,7 +38,7 @@ class CreateTableCommandVisitorTest {
   }
 
   @Test
-  void CreateTableCommandVisitorTest() {
+  void testCreateTableCommandVisitorTest() {
     List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
 
     assertThat(visitor.isDefinedAt(command)).isTrue();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
@@ -40,6 +40,8 @@ import org.mockito.Mockito;
 @ExtendWith(SparkAgentTestExtension.class)
 @Tag("custom_environment_variables_capture")
 class CustomEnvironmentVariablesCaptureTest {
+
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   protected static void setEnv(String key, String value) {
     try {
       Map<String, String> env = System.getenv();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import scala.collection.immutable.HashMap;
 
 @ExtendWith(SparkAgentTestExtension.class)
-public class LogicalRelationBuilderTest {
+class LogicalRelationBuilderTest {
 
   StructType structTypeSchema =
       new StructType(

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -86,6 +86,10 @@ class CommonConfigPlugin : Plugin<Project> {
         target.tasks.named<Pmd>("pmdMain") {
             this.reports.html.required.set(true)
         }
+        target.tasks.named<Pmd>("pmdTest") {
+            this.reports.html.required.set(true)
+            this.ruleSetFiles = target.rootProject.files("pmd-openlineage-test.xml")
+        }
     }
 
     private fun configureLombok(target: Project) = target.plugins.withType<LombokPlugin> {

--- a/integration/spark/pmd-openlineage-test.xml
+++ b/integration/spark/pmd-openlineage-test.xml
@@ -14,10 +14,12 @@
         <exclude name="BeanMembersShouldSerialize" />
         <exclude name="CloseResource" /> <!-- we don't deal with closeable resources -->
         <exclude name="MissingSerialVersionUID" />
+        <exclude name="AvoidDuplicateLiterals" />
     </rule>
     <rule ref="category/java/bestpractices.xml">
         <exclude name="GuardLogStatement" />
         <exclude name="JUnitAssertionsShouldIncludeMessage" />
+        <exclude name="AvoidUsingHardCodedIP" />
     </rule>
     <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
         <properties>


### PR DESCRIPTION
Make Spark code cleaner and pmd check less verbose. 

Enabler to turn on pmdCheck globally later on. 

```
./gradlew clean :app:pmdTest
```

```

> Task :app:pmdMain
/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java:71:      LiteralsFirstInComparisons:     Position literals first in String comparisons
1 PMD rule violations were found. See the report at: file:///spark/app/build/reports/pmd/main.html

> Task :app:pmdTest
/spark/app/src/test/java/com/google/cloud/bigquery/MockBigQueryRelationProvider.java:58: AvoidAccessibilityAlteration:   You should not modify visibility of constructors, methods or fields using setAccessible()
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:28:  : The String literal "test" appears 11 times in this file; the first occurrence is on line 28
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:46:  JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:89:  : The String literal "spark.openlineage.transport.type" appears 4 times in this file; the first occurrence is on line 89
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:96:  : The String literal "test1" appears 12 times in this file; the first occurrence is on line 96
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:97:  : The String literal "test2" appears 12 times in this file; the first occurrence is on line 97
/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java:121: : The String literal "explicit-key" appears 4 times in this file; the first occurrence is on line 121
/spark/app/src/test/java/io/openlineage/spark/agent/CircuitBreakerIntegrationTest.java:35:       JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/CircuitBreakerIntegrationTest.java:37:       AvoidUsingHardCodedIP:  Do not hard code the IP address 
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:38:        JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:39:        AvoidUsingHardCodedIP:  Do not hard code the IP address 
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:40:        : The String literal "test" appears 4 times in this file; the first occurrence is on line 40
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:98:        JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:112:       : The String literal "jdbc" appears 4 times in this file; the first occurrence is on line 112
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:113:       : The String literal "url" appears 4 times in this file; the first occurrence is on line 113
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:115:       : The String literal "user" appears 4 times in this file; the first occurrence is on line 115
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:116:       : The String literal "password" appears 4 times in this file; the first occurrence is on line 116
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:117:       : The String literal "driver" appears 4 times in this file; the first occurrence is on line 117
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:117:       : The String literal "org.postgresql.Driver" appears 4 times in this file; the first occurrence is on line 117
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:126:       JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/ColumnLineageIntegrationTest.java:183:       AvoidLiteralsInIfCondition:     Avoid using Literals in Conditional Statements
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:43:   JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:74:   JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:81:   : The String literal "dbfs" appears 5 times in this file; the first occurrence is on line 81
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:125:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:127:  UnusedLocalVariable:    Avoid unused local variables such as 'runEventJobNames'.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:162:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:164:  UnusedLocalVariable:    Avoid unused local variables such as 'runEventJobNames'.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:192:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:196:  UnusedLocalVariable:    Avoid unused local variables such as 'outputDataset'.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:205:  UnusedLocalVariable:    Avoid unused local variables such as 'inputDataset'.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java:260:  : The String literal "event_id" appears 5 times in this file; the first occurrence is on line 260
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java:188:    DoubleBraceInitialization:      Double-brace initialization should be avoided
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java:240:    : The String literal "dbfs:/databricks/openlineage/" appears 5 times in this file; the first occurrence is on line 240
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java:254:    UnusedLocalVariable:    Avoid unused local variables such as 'createResponse'.
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java:262:    UnusedAssignment:       The initializer for variable 'len' is never used (overwritten on line 263)
/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java:263:    AssignmentInOperand:    Avoid assignments in operands
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:50:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:59:  AvoidUsingHardCodedIP:  Do not hard code the IP address 
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:136: : The String literal "bigquery" appears 6 times in this file; the first occurrence is on line 136
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:136: : The String literal "overwrite" appears 4 times in this file; the first occurrence is on line 136
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:136: : The String literal "table" appears 5 times in this file; the first occurrence is on line 136
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:203: UnusedLocalVariable:    Avoid unused local variables such as 'events'.
/spark/app/src/test/java/io/openlineage/spark/agent/GoogleCloudIntegrationTest.java:267: UnusedLocalVariable:    Avoid unused local variables such as 'path'.
/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive2Test.java:38:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreHive3Test.java:38:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/MetastoreTestUtils.java:27:  AvoidUsingHardCodedIP:  Do not hard code the IP address 
/spark/app/src/test/java/io/openlineage/spark/agent/MockServerUtils.java:37:     : The String literal "/api/v1/lineage" appears 6 times in this file; the first occurrence is on line 37
/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java:297:      JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:50:   : The String literal "delta" appears 7 times in this file; the first occurrence is on line 50
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:52:   JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:112:  : The String literal "temp" appears 4 times in this file; the first occurrence is on line 112
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:173:  : The String literal "/api/v1/lineage" appears 5 times in this file; the first occurrence is on line 173
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:211:  : The String literal "overwrite" appears 6 times in this file; the first occurrence is on line 211
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:280:  : The String literal "bat" appears 4 times in this file; the first occurrence is on line 280
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:282:  : The String literal "horse" appears 4 times in this file; the first occurrence is on line 282
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:332:  JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java:353:  JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java:42: JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java:110:        LiteralsFirstInComparisons:     Position literals first in String comparisons
/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java:125:        JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java:145:        LiteralsFirstInComparisons:     Position literals first in String comparisons
/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java:151:        LiteralsFirstInComparisons:     Position literals first in String comparisons
/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java:46: JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java:135:        : The String literal "temp" appears 17 times in this file; the first occurrence is on line 135
/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java:308:        JUnitTestContainsTooManyAsserts:        Unit tests should not contain more than 10 assert(s).
/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java:63:     JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java:161:    JUnitTestsShouldIncludeAssert:  JUnit tests should include assert() or fail()
/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java:29:       : The String literal "NOT_DEFINED" appears 11 times in this file; the first occurrence is on line 29
/spark/app/src/test/java/io/openlineage/spark/agent/UrlParserTest.java:175:      JUnitTestContainsTooManyAsserts:        Unit tests should not contain more than 10 assert(s).
/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageDeltaTest.java:47:  JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java:63:        : The String literal "file" appears 5 times in this file; the first occurrence is on line 63
/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java:65:        : The String literal "/tmp/column_level_lineage/db.t2" appears 4 times in this file; the first occurrence is on line 65
/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java:148:       : The String literal "CREATE TABLE local.db.t2 USING iceberg AS SELECT * FROM temp" appears 4 times in this file; the first occurrence is on line 148
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java:56:       : The String literal "ns_name" appears 7 times in this file; the first occurrence is on line 56
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java:63:       : The String literal "test_rdd" appears 5 times in this file; the first occurrence is on line 63
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java:79:       JUnitTestContainsTooManyAsserts:        Unit tests should not contain more than 10 assert(s).
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java:102:      : The String literal "namespace" appears 10 times in this file; the first occurrence is on line 102
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java:103:      : The String literal "name" appears 8 times in this file; the first occurrence is on line 103
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkEventFilterTest.java:34:      JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java:96:      : The String literal "eventType" appears 12 times in this file; the first occurrence is on line 96
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java:168:    UnusedPrivateMethod:    Avoid unused private methods such as 'getZonedTime()'.
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java:41:        MethodWithSameNameAsEnclosingClass:     Classes should not have non-constructor methods with the same name as the class
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java:48:        AvoidAccessibilityAlteration:   You should not modify visibility of constructors, methods or fields using setAccessible()
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationBuilderTest.java:30:   JUnit5TestShouldBePackagePrivate:       JUnit 5 tests should be package-private.
/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitorTest.java:112:        : The String literal "name" appears 4 times in this file; the first occurrence is on line 112
86 PMD rule violations were found. See the report at: file:///spark/app/build/reports/pmd/test.html
```