### PR TITLE
[JAVA] fix javadoc for java client

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -27,7 +27,7 @@ pmd {
     rulesMinimumPriority = 5
     ruleSetFiles = rootProject.files("pmd-openlineage.xml")
     ruleSets = []
-    ignoreFailures = true
+    ignoreFailures = false
 }
 
 pmdMain {
@@ -125,6 +125,28 @@ openApiGenerate {
 task sourceJar(type: Jar) {
     archiveClassifier='sources'
     from sourceSets.main.allJava
+}
+
+javadoc {
+    dependsOn delombok
+    failOnError = true
+
+    def capturedOutput = []
+    def listener = { capturedOutput << it } as StandardOutputListener
+    doFirst {
+        logging.addStandardErrorListener(listener)
+        logging.addStandardOutputListener(listener)
+    }
+    doLast {
+        logging.removeStandardOutputListener(listener)
+        logging.removeStandardErrorListener(listener)
+        capturedOutput.each { e ->
+            if(e.toString() =~ " warning: " && !(e.toString() =~ "Config.java")) {
+                // doesn't count *Config.java classes with use failing `@with` annotation
+                throw new GradleException("You have some javadoc warnings, please fix them!");
+            }
+        }
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/client/java/generator/src/main/java/io/openlineage/client/Generator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/Generator.java
@@ -49,7 +49,7 @@ public class Generator {
    * @throws JsonParseException if the spec is not valid
    * @throws JsonMappingException if the spec is not valid
    * @throws IOException if the spec can't be read or class can not be generated
-   * @throws URISyntaxException
+   * @throws URISyntaxException when invalid URI provided
    */
   public static void main(String[] args) throws JsonParseException, JsonMappingException, IOException, URISyntaxException {
     List<String> baseURLs = Arrays.asList(args);

--- a/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
+++ b/client/java/generator/src/main/java/io/openlineage/client/JavaPoetGenerator.java
@@ -401,7 +401,7 @@ public class JavaPoetGenerator {
   private MethodSpec factoryModelMethodUnderContainer(ObjectResolvedType type) {
     Builder factory = MethodSpec.methodBuilder("new" + type.getName())
         .addModifiers(PUBLIC)
-        .addJavadoc("Factory method for $N", type.getName())
+        .addJavadoc("Factory method for $N\n\n", type.getName())
         .returns(getTypeName(type));
 
     List<CodeBlock> factoryParams = new ArrayList<>();

--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -16,7 +16,9 @@ import java.util.Optional;
 public final class Clients {
   private Clients() {}
 
-  /** Returns a new {@code OpenLineageClient} object. */
+  /**
+   * @return a new {@code OpenLineageClient} object.
+   */
   public static OpenLineageClient newClient() {
     return newClient(new DefaultConfigPathProvider());
   }

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -153,8 +153,8 @@ public final class OpenLineageClient {
   }
 
   /**
-   * Returns an new {@link OpenLineageClient.Builder} object for building {@link
-   * OpenLineageClient}s.
+   * @return an new {@link OpenLineageClient.Builder} object for building {@link
+   *     OpenLineageClient}s.
    */
   public static Builder builder() {
     return new Builder();
@@ -204,8 +204,8 @@ public final class OpenLineageClient {
     }
 
     /**
-     * Returns an {@link OpenLineageClient} object with the properties of this {@link
-     * OpenLineageClient.Builder}.
+     * @return an {@link OpenLineageClient} object with the properties of this {@link
+     *     OpenLineageClient.Builder}.
      */
     public OpenLineageClient build() {
       return new OpenLineageClient(transport, circuitBreaker, meterRegistry, disabledFacets);

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientException.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientException.java
@@ -13,12 +13,20 @@ import lombok.NoArgsConstructor;
 public class OpenLineageClientException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
-  /** Constructs a {@code OpenLineageClientException} with the message {@code message}. */
+  /**
+   * Constructs a {@code OpenLineageClientException} with the message {@code message}.
+   *
+   * @param message message
+   */
   public OpenLineageClientException(@Nullable final String message) {
     super(message);
   }
 
-  /** Constructs a {@code OpenLineageClientException} with the cause {@code cause}. */
+  /**
+   * Constructs a {@code OpenLineageClientException} with the cause {@code cause}.
+   *
+   * @param cause cause
+   */
   public OpenLineageClientException(@Nullable final Throwable cause) {
     super(cause);
   }
@@ -26,6 +34,9 @@ public class OpenLineageClientException extends RuntimeException {
   /**
    * Constructs a {@code OpenLineageClientException} with the message {@code message} and the cause
    * {@code cause}.
+   *
+   * @param message message
+   * @param cause cause
    */
   public OpenLineageClientException(
       @Nullable final String message, @Nullable final Throwable cause) {

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -65,6 +65,7 @@ public final class OpenLineageClientUtils {
    * Creates a new {@link ObjectMapper} instance configured with modules for JDK8 and JavaTime,
    * including settings to ignore unknown properties and to not write dates as timestamps.
    *
+   * @param jsonFactory JsonFactory
    * @return A configured {@link ObjectMapper} instance.
    */
   public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreaker.java
@@ -14,11 +14,9 @@ public interface CircuitBreaker {
   CircuitBreakerState currentState();
 
   /**
-   * Runs callable and breaks it when circuit breaker is closed
-   *
-   * @param callable
-   * @return
-   * @param <T>
+   * @param callable The callable to be run
+   * @return result of callable
+   * @param <T> callable generic type
    */
   <T> T run(Callable<T> callable);
 

--- a/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
+++ b/client/java/src/main/java/io/openlineage/client/metrics/MicrometerProvider.java
@@ -72,6 +72,7 @@ public class MicrometerProvider {
    * Adds a MeterRegistry to the common OpenLineage meter registry.
    *
    * @param meterRegistry The MeterRegistry to
+   * @return MeterRegistry
    */
   public static MeterRegistry addMeterRegistry(MeterRegistry meterRegistry) {
     registry.add(meterRegistry);

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -14,12 +14,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.With;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-@With
 public final class HttpConfig implements TransportConfig {
   public enum Compression {
     @JsonProperty("gzip")

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -169,7 +169,9 @@ public final class HttpTransport extends Transport implements Closeable {
     http.close();
   }
 
-  /** Returns an new {@link HttpTransport.Builder} object for building {@link HttpTransport}s. */
+  /**
+   * @return an new {@link HttpTransport.Builder} object for building {@link HttpTransport}s.
+   */
   public static Builder builder() {
     return new Builder();
   }
@@ -245,8 +247,8 @@ public final class HttpTransport extends Transport implements Closeable {
     }
 
     /**
-     * Returns an {@link HttpTransport} object with the properties of this {@link
-     * HttpTransport.Builder}.
+     * @return an {@link HttpTransport} object with the properties of this {@link
+     *     HttpTransport.Builder}.
      */
     public HttpTransport build() {
       if (httpClient != null) {

--- a/client/java/src/main/java/io/openlineage/client/utils/JdbcUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/JdbcUtils.java
@@ -24,6 +24,7 @@ public class JdbcUtils {
    * JdbcUrl can contain username and password this method clean-up credentials from jdbcUrl and
    * strip the jdbc prefix from the url
    *
+   * @param jdbcUrl url to database
    * @return String
    */
   public static String sanitizeJdbcUrl(String jdbcUrl) {


### PR DESCRIPTION
Building `openlineage-java` throws over 80 `javaDoc` warnings, which looks horrible.
This is actually one of the first screens a developer sees when building a project. 

Within this PR:
 * fix the issue resulting in incorrect javadoc generated with JavaPoetGenerator
 * fix other javadoc warning
 * make `javadoc` step fail in case of warnings encountered
 * turn on failing pmdCheck in case of failiures encountered

```
> Task :javadoc
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/CircuitBreaker.java:19: warning: no description for @param
   * @param callable
     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/CircuitBreaker.java:20: warning: no description for @return
   * @return
     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/CircuitBreaker.java:21: warning: no description for @param
   * @param <T>
     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java:76: warning: no @param for memoryThreshold
  public JavaRuntimeCircuitBreakerConfig withMemoryThreshold(final Integer memoryThreshold) {
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java:83: warning: no @param for gcCpuThreshold
  public JavaRuntimeCircuitBreakerConfig withGcCpuThreshold(final Integer gcCpuThreshold) {
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java:90: warning: no @param for circuitCheckIntervalInMillis
  public JavaRuntimeCircuitBreakerConfig withCircuitCheckIntervalInMillis(final Integer circuitCheckIntervalInMillis) {
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/JavaRuntimeCircuitBreakerConfig.java:97: warning: no @param for timeoutInSeconds
  public JavaRuntimeCircuitBreakerConfig withTimeoutInSeconds(final Integer timeoutInSeconds) {
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerConfig.java:69: warning: no @param for memoryThreshold
  public SimpleMemoryCircuitBreakerConfig withMemoryThreshold(final Integer memoryThreshold) {
                                          ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerConfig.java:76: warning: no @param for circuitCheckIntervalInMillis
  public SimpleMemoryCircuitBreakerConfig withCircuitCheckIntervalInMillis(final Integer circuitCheckIntervalInMillis) {
                                          ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/SimpleMemoryCircuitBreakerConfig.java:83: warning: no @param for timeoutInSeconds
  public SimpleMemoryCircuitBreakerConfig withTimeoutInSeconds(final Integer timeoutInSeconds) {
                                          ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/StaticCircuitBreakerConfig.java:58: warning: no @param for valuesReturned
  public StaticCircuitBreakerConfig withValuesReturned(final String valuesReturned) {
                                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/circuitBreaker/StaticCircuitBreakerConfig.java:65: warning: no @param for circuitCheckIntervalInMillis
  public StaticCircuitBreakerConfig withCircuitCheckIntervalInMillis(final Integer circuitCheckIntervalInMillis) {
                                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/Clients.java:20: warning: no @return
  public static OpenLineageClient newClient() {
                                  ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:64: warning: no @param for eventTime
  public RunEvent newRunEvent(ZonedDateTime eventTime, RunEvent.EventType eventType, Run run,
                  ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:84: warning: no @param for name
  public SchemaDatasetFacetFields newSchemaDatasetFacetFields(String name, String type,
                                  ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:102: warning: no @param for run
  public ParentRunFacet newParentRunFacet(ParentRunFacetRun run, ParentRunFacetJob job) {
                        ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:120: warning: no @param for rowCount
  public OutputStatisticsOutputDatasetFacet newOutputStatisticsOutputDatasetFacet(Long rowCount,
                                            ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:140: warning: no @param for errorMessage
  public ExtractionErrorRunFacetErrors newExtractionErrorRunFacetErrors(String errorMessage,
                                       ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:159: warning: no @param for processingType
  public JobTypeJobFacet newJobTypeJobFacet(String processingType, String integration,
                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:177: warning: no @param for runId
  public Run newRun(UUID runId, RunFacets facets) {
             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:192: warning: no @return
  public DataQualityMetricsInputDatasetFacetColumnMetricsAdditionalQuantiles newDataQualityMetricsInputDatasetFacetColumnMetricsAdditionalQuantiles(
                                                                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:211: warning: no @param for externalQueryId
  public ExternalQueryRunFacet newExternalQueryRunFacet(String externalQueryId, String source) {
                               ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:227: warning: no @param for outputStatistics
  public OutputDatasetOutputFacets newOutputDatasetOutputFacets(
                                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:245: warning: no @param for nominalStartTime
  public NominalTimeRunFacet newNominalTimeRunFacet(ZonedDateTime nominalStartTime,
                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:270: warning: no @param for name
  public OwnershipJobFacetOwners newOwnershipJobFacetOwners(String name, String type) {
                                 ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:296: warning: no @param for eventTime
  public JobEvent newJobEvent(ZonedDateTime eventTime, Job job, List<InputDataset> inputs,
                  ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:315: warning: no @param for totalTasks
  public ExtractionErrorRunFacet newExtractionErrorRunFacet(Long totalTasks, Long failedTasks,
                                 ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:334: warning: no @param for inputFields
  public ColumnLineageDatasetFacetFieldsAdditional newColumnLineageDatasetFacetFieldsAdditional(
                                                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:354: warning: no @param for name
  public OwnershipDatasetFacetOwners newOwnershipDatasetFacetOwners(String name, String type) {
                                     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:376: warning: no @param for nullCount
  public DataQualityMetricsInputDatasetFacetColumnMetricsAdditional newDataQualityMetricsInputDatasetFacetColumnMetricsAdditional(
                                                                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:394: warning: no @return
  public DataQualityMetricsInputDatasetFacetColumnMetrics newDataQualityMetricsInputDatasetFacetColumnMetrics(
                                                          ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:415: warning: no @param for rowCount
  public DataQualityMetricsInputDatasetFacet newDataQualityMetricsInputDatasetFacet(Long rowCount,
                                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:433: warning: no @param for description
  public DocumentationJobFacet newDocumentationJobFacet(String description) {
                               ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:454: warning: no @param for jobType
  public JobFacets newJobFacets(JobTypeJobFacet jobType, SourceCodeJobFacet sourceCode,
                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:473: warning: no @param for dataQualityAssertions
  public InputDatasetInputFacets newInputDatasetInputFacets(
                                 ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:505: warning: no @param for owners
  public OwnershipDatasetFacet newOwnershipDatasetFacet(List<OwnershipDatasetFacetOwners> owners) {
                               ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:521: warning: no @param for query
  public SQLJobFacet newSQLJobFacet(String query) {
                     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:545: warning: no @param for documentation
  public DatasetFacets newDatasetFacets(DocumentationDatasetFacet documentation,
                       ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:565: warning: no @param for owners
  public OwnershipJobFacet newOwnershipJobFacet(List<OwnershipJobFacetOwners> owners) {
                           ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:582: warning: no @param for namespace
  public ParentRunFacetJob newParentRunFacetJob(String namespace, String name) {
                           ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:601: warning: no @param for namespace
  public OutputDataset newOutputDataset(String namespace, String name, DatasetFacets facets,
                       ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:620: warning: no @param for message
  public ErrorMessageRunFacet newErrorMessageRunFacet(String message, String programmingLanguage,
                              ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:656: warning: no @param for errorMessage
  public RunFacets newRunFacets(ErrorMessageRunFacet errorMessage,
                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:675: warning: no @param for fields
  public SchemaDatasetFacet newSchemaDatasetFacet(List<SchemaDatasetFacetFields> fields) {
                            ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:692: warning: no @param for language
  public SourceCodeJobFacet newSourceCodeJobFacet(String language, String sourceCode) {
                            ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:708: warning: no @param for description
  public DocumentationDatasetFacet newDocumentationDatasetFacet(String description) {
                                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:730: warning: no @param for type
  public SourceCodeLocationJobFacet newSourceCodeLocationJobFacet(String type, URI url,
                                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:747: warning: no @param for fields
  public ColumnLineageDatasetFacet newColumnLineageDatasetFacet(
                                   ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:764: warning: no @param for assertions
  public DataQualityAssertionsDatasetFacet newDataQualityAssertionsDatasetFacet(
                                           ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:782: warning: no @param for eventTime
  public DatasetEvent newDatasetEvent(ZonedDateTime eventTime, StaticDataset dataset) {
                      ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:800: warning: no @param for version
  public ProcessingEngineRunFacet newProcessingEngineRunFacet(String version, String name,
                                  ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:818: warning: no @param for name
  public LifecycleStateChangeDatasetFacetPreviousIdentifier newLifecycleStateChangeDatasetFacetPreviousIdentifier(
                                                            ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:838: warning: no @param for namespace
  public Job newJob(String namespace, String name, JobFacets facets) {
             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:854: warning: no @param for datasetVersion
  public DatasetVersionDatasetFacet newDatasetVersionDatasetFacet(String datasetVersion) {
                                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:872: warning: no @param for namespace
  public SymlinksDatasetFacetIdentifiers newSymlinksDatasetFacetIdentifiers(String namespace,
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:891: warning: no @param for assertion
  public DataQualityAssertionsDatasetFacetAssertions newDataQualityAssertionsDatasetFacetAssertions(
                                                     ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:911: warning: no @param for namespace
  public ColumnLineageDatasetFacetFieldsAdditionalInputFields newColumnLineageDatasetFacetFieldsAdditionalInputFields(
                                                              ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:929: warning: no @param for runId
  public ParentRunFacetRun newParentRunFacetRun(UUID runId) {
                           ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:954: warning: no @param for namespace
  public StaticDataset newStaticDataset(String namespace, String name, DatasetFacets facets) {
                       ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:969: warning: no @return
  public ColumnLineageDatasetFacetFields newColumnLineageDatasetFacetFields() {
                                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:985: warning: no @param for identifiers
  public SymlinksDatasetFacet newSymlinksDatasetFacet(
                              ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:1003: warning: no @param for storageLayer
  public StorageDatasetFacet newStorageDatasetFacet(String storageLayer, String fileFormat) {
                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:1022: warning: no @param for namespace
  public InputDataset newInputDataset(String namespace, String name, DatasetFacets facets,
                      ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:1040: warning: no @param for name
  public DatasourceDatasetFacet newDatasourceDatasetFacet(String name, URI uri) {
                                ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineage.java:1057: warning: no @param for lifecycleStateChange
  public LifecycleStateChangeDatasetFacet newLifecycleStateChangeDatasetFacet(
                                          ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClient.java:158: warning: no @return
  public static Builder builder() {
                        ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClient.java:222: warning: no @return
    public OpenLineageClient build() {
                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClientException.java:18: warning: no @param for message
  public OpenLineageClientException(@Nullable final String message) {
         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClientException.java:25: warning: no @param for cause
  public OpenLineageClientException(@Nullable final Throwable cause) {
         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClientException.java:33: warning: no @param for message
  public OpenLineageClientException(@Nullable final String message, @Nullable final Throwable cause) {
         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClientException.java:33: warning: no @param for cause
  public OpenLineageClientException(@Nullable final String message, @Nullable final Throwable cause) {
         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/OpenLineageClientUtils.java:70: warning: no @param for jsonFactory
  public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {
                             ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/metrics/MicrometerProvider.java:76: warning: no @return
  public static MeterRegistry addMeterRegistry(MeterRegistry meterRegistry) {
                              ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/FacetsConfig.java:31: warning: no @param for disabledFacets
  public FacetsConfig withDisabledFacets(final String[] disabledFacets) {
                      ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/FacetsConfig.java:38: warning: no @param for customEnvironmentVariables
  public FacetsConfig withCustomEnvironmentVariables(final String[] customEnvironmentVariables) {
                      ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/FileConfig.java:25: warning: no @param for location
  public FileConfig withLocation(final String location) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:57: warning: no @param for url
  public HttpConfig withUrl(final URI url) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:64: warning: no @param for endpoint
  public HttpConfig withEndpoint(@Nullable final String endpoint) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:71: warning: no @param for timeout
  public HttpConfig withTimeout(@Nullable final Double timeout) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:78: warning: no @param for timeoutInMillis
  public HttpConfig withTimeoutInMillis(@Nullable final Integer timeoutInMillis) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:85: warning: no @param for auth
  public HttpConfig withAuth(@Nullable final TokenProvider auth) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:92: warning: no @param for urlParams
  public HttpConfig withUrlParams(@Nullable final Map<String, String> urlParams) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:99: warning: no @param for headers
  public HttpConfig withHeaders(@Nullable final Map<String, String> headers) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpConfig.java:106: warning: no @param for compression
  public HttpConfig withCompression(@Nullable final Compression compression) {
                    ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpTransport.java:173: warning: no @return
  public static Builder builder() {
                        ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/transports/HttpTransport.java:271: warning: no @return
    public HttpTransport build() {
                         ^
Openlineage/client/java/build/generated/sources/delombok/java/main/io/openlineage/client/utils/JdbcUtils.java:25: warning: no @param for jdbcUrl
  public static String sanitizeJdbcUrl(String jdbcUrl) {
                       ^
87 warnings

```