### PR TITLE
[JAVA] fix javadoc on main

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -40,6 +40,7 @@ public abstract class Transport {
    *     <p>Will be removed in version 1.16.0.
    *     <p>Please use {@link #emit(OpenLineage.DatasetEvent)} or {@link
    *     #emit(OpenLineage.JobEvent)} instead
+   * @param eventAsJson string json event
    */
   @Deprecated
   public void emit(String eventAsJson) {


### PR DESCRIPTION
When turning on `javadoc` validation, another PR got merged roughly at the same time with no javadoc validation turned on which leads to failing CI. 