### PR TITLE
common: force higher version of typing_extensions

### DIFF
--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -35,6 +35,7 @@ allowlist_externals = uv
 install_command = uv pip install {opts} --find-links target/wheels {packages}
 deps = openlineage-python@../../client/python
 	-e .[dev]
+	typing_extensions>=4.11.0
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
 commands = python -m mypy --ignore-missing-imports --no-namespace-packages openlineage


### PR DESCRIPTION
Fixes the build by forcing typing_extensions to use version that doesn't break with dbt <1.3