### PR TITLE
[SPARK] make gradle build less verbose

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -65,7 +65,7 @@ public class ArgumentParser {
     // TRY READING CONFIG FROM FILE
     Optional<SparkOpenLineageConfig> configFromFile = extractOpenLineageConfFromFile();
 
-    if (conf.get(SPARK_CONF_TRANSPORT_TYPE, "").equals("http")) {
+    if ("http".equals(conf.get(SPARK_CONF_TRANSPORT_TYPE, ""))) {
       findSparkConfigKey(conf, SPARK_CONF_HTTP_URL)
           .ifPresent(url -> UrlParser.parseUrl(url).forEach(conf::set));
     }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -56,10 +56,10 @@ class ArgumentParserTest {
         ArgumentParser.parse(
             new SparkConf().set(ArgumentParser.SPARK_CONF_TRANSPORT_TYPE, "kinesis"));
 
-    assert (config.getTransportConfig() instanceof ConsoleConfig);
-    assert (configHttp.getTransportConfig() instanceof HttpConfig);
-    assert (configKafka.getTransportConfig() instanceof KafkaConfig);
-    assert (configKinesis.getTransportConfig() instanceof KinesisConfig);
+    assertThat(config.getTransportConfig()).isInstanceOf(ConsoleConfig.class);
+    assertThat(configHttp.getTransportConfig()).isInstanceOf(HttpConfig.class);
+    assertThat(configKafka.getTransportConfig()).isInstanceOf(KafkaConfig.class);
+    assertThat(configKinesis.getTransportConfig()).isInstanceOf(KinesisConfig.class);
   }
 
   @Test

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
@@ -173,19 +173,19 @@ class SparkGenericIntegrationTest {
 
     RunEvent event =
         getEventsEmitted(mockServer).stream()
-            .filter(e -> !e.getJob().getName().equals("generic_integration_test"))
+            .filter(e -> !"generic_integration_test".equals(e.getJob().getName()))
             .findFirst()
             .get();
     List<OwnershipJobFacetOwners> owners = event.getJob().getFacets().getOwnership().getOwners();
     assertThat(owners).hasSize(2);
     assertThat(
         owners.stream()
-            .filter(o -> o.getType().equals("team") && o.getName().equals("MyTeam"))
+            .filter(o -> "team".equals(o.getType()) && "MyTeam".equals(o.getName()))
             .findAny()
             .isPresent());
     assertThat(
         owners.stream()
-            .filter(o -> o.getType().equals("person") && o.getName().equals("John Smith"))
+            .filter(o -> "person".equals(o.getType()) && "John Smith".equals(o.getName()))
             .findAny()
             .isPresent());
   }

--- a/integration/spark/app/src/test/resources/log4j2.properties
+++ b/integration/spark/app/src/test/resources/log4j2.properties
@@ -12,16 +12,62 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c - %m%n
+
 rootLogger.level=info
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT
-loggers=openlineage, openlineage-shaded, spark-sql, shutdown-hook-manager, spark-sql-execution, spark-sql-catalyst, hive
+loggers=openlineage, openlineage-shaded, spark-sql, shutdown-hook-manager, spark-sql-execution, \
+  spark-sql-catalyst, hive, spark-jetty, spark-storage, spark-scheduler, \
+  spark-executor, spark-security-manager, spark-context, spark-resource, \
+  spark-util, spark-env, parquet, hadoop, iceberg, spark-mapred, spark-network
 
 logger.openlineage.name = io.openlineage
 logger.openlineage.level = info
 
 logger.openlineage-shaded.name = io.openlineage.spark.shaded
 logger.openlineage-shaded.level = off
+
+logger.spark-util.name = org.apache.spark.util
+logger.spark-util.level = error
+
+logger.spark-mapred.name = org.apache.spark.mapred
+logger.spark-mapred.level = warn
+
+logger.spark-network.name = org.apache.spark.network
+logger.spark-network.level = warn
+
+logger.spark-env.name = org.apache.spark.SparkEnv
+logger.spark-env.level = warn
+
+logger.iceberg.name = org.apache.iceberg
+logger.iceberg.level = warn
+
+logger.parquet.name = org.apache.parquet
+logger.parquet.level = warn
+
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = error
+
+logger.spark-jetty.name = org.sparkproject.jetty
+logger.spark-jetty.level = warn
+
+logger.spark-storage.name = org.apache.spark.storage
+logger.spark-storage.level = warn
+
+logger.spark-scheduler.name = org.apache.spark.scheduler
+logger.spark-scheduler.level = warn
+
+logger.spark-executor.name = org.apache.spark.executor
+logger.spark-executor.level = warn
+
+logger.spark-security-manager.name = org.apache.spark.SecurityManager
+logger.spark-security-manager.level = warn
+
+logger.spark-context.name = org.apache.spark.SparkContext
+logger.spark-context.level = warn
+
+logger.spark-resource.name = org.apache.spark.resource
+logger.spark-resource.level = warn
 
 logger.spark-sql.name = org.apache.spark.sql
 logger.spark-sql.level = error

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -80,7 +80,7 @@ class CommonConfigPlugin : Plugin<Project> {
             rulesMinimumPriority.set(5)
             ruleSetFiles = target.rootProject.files("pmd-openlineage.xml")
             ruleSets = listOf()
-            isIgnoreFailures = true
+            isIgnoreFailures = false
         }
 
         target.tasks.named<Pmd>("pmdMain") {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -62,6 +62,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     this.job = job;
   }
 
+  @Override
   public FacetsConfig getFacetsConfig() {
     if (facetsConfig == null) {
       facetsConfig = new FacetsConfig();
@@ -113,6 +114,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     private Map<String, String> additionalProperties = new HashMap<>();
   }
 
+  @Override
   public SparkOpenLineageConfig mergeWithNonNull(SparkOpenLineageConfig other) {
     return new SparkOpenLineageConfig(
         mergeWithDefaultValue(namespace, other.namespace, DEFAULT_NAMESPACE),

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
-import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +19,6 @@ class DebugRunFacetBuilderTest {
 
   private static OpenLineageContext openLineageContext =
       mock(OpenLineageContext.class, RETURNS_DEEP_STUBS);
-  private static SparkContext sparkContext = mock(SparkContext.class);
   private static DebugRunFacetBuilder builder = new DebugRunFacetBuilder(openLineageContext);
   private static SparkOpenLineageConfig config = new SparkOpenLineageConfig();
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/OwnershipJobFacetBuilderTest.java
@@ -26,7 +26,7 @@ import org.apache.spark.scheduler.SparkListenerEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class OwnershipJobFacetBuilderTest {
+class OwnershipJobFacetBuilderTest {
 
   OpenLineageContext olContext = mock(OpenLineageContext.class);
   OwnershipJobFacetBuilder builder = new OwnershipJobFacetBuilder(olContext);
@@ -80,14 +80,14 @@ public class OwnershipJobFacetBuilderTest {
                 (OwnershipJobFacet facet) ->
                     facet.getOwners().size() == 2
                         && facet.getOwners().stream()
-                            .filter(o -> o.getName().equals("MyTeam") && o.getType().equals("team"))
+                            .filter(o -> "MyTeam".equals(o.getName()) && "team".equals(o.getType()))
                             .findAny()
                             .isPresent()
                         && facet.getOwners().stream()
                             .filter(
                                 o ->
-                                    o.getName().equals("John Smith")
-                                        && o.getType().equals("person"))
+                                    "John Smith".equals(o.getName())
+                                        && "person".equals(o.getType()))
                             .findAny()
                             .isPresent()));
   }

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier$;
 import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat$;
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.Metadata;
@@ -77,7 +78,7 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
                           "value", StringType$.MODULE$, false, new Metadata(new HashMap<>()))
                     })),
             null,
-            null,
+            mock(LogicalPlan.class),
             Seq$.MODULE$.<String>empty());
 
     assertThat(visitor.isDefinedAt(command)).isTrue();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -69,7 +69,7 @@ public class IcebergHandler implements CatalogHandler {
     String prefix = String.format("spark.sql.catalog.%s", catalogName);
     Map<String, String> conf =
         ScalaConversionUtils.<String, String>fromMap(session.conf().getAll());
-    log.info(conf.toString());
+    log.debug(conf.toString());
     Map<String, String> catalogConf =
         conf.entrySet().stream()
             .filter(x -> x.getKey().startsWith(prefix))
@@ -79,12 +79,12 @@ public class IcebergHandler implements CatalogHandler {
                     x -> x.getKey().substring(prefix.length() + 1), // handle dot after prefix
                     Map.Entry::getValue));
 
-    log.info(catalogConf.toString());
+    log.debug(catalogConf.toString());
     String catalogType = getCatalogType(catalogConf);
     if (catalogType == null) {
       throw new UnsupportedCatalogException(catalogName);
     }
-    log.info(catalogConf.get(TYPE));
+    log.debug(catalogConf.get(TYPE));
 
     String warehouse = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
     DatasetIdentifier di = PathUtils.fromPath(new Path(warehouse, identifier.toString()));


### PR DESCRIPTION
### Problem

Building Spark integration  should be less verbose. It's really difficult to find a failing test and figure out what was wrong from the amount of text printed to the screen. 

Within this PR: 
 * Change logging level for multiple internal Spark classes to `warn` or `error`
 * fix issue of NullPointerException in tests when applying `toString` on LogicalPlan with null field (tests are still passing, but an ugly NPE stack trace is printed several times)
 * Turn on pad check to fail in case of errors. 
 * `IcbergHandler` should not use `INFO` to do debugging. 
 * fix few pmd errors introduced yesterday (this will not happen again after this PR)


Benefit:
 * Some latest  build from `main` branch -> https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/10295/workflows/20ddcbb9-adf5-4e09-b260-aefe83a7f940/jobs/209354 (more than 10K of output lines !)
 * https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/10299/workflows/cf376c29-e495-4135-8161-1ec33298da34/jobs/209446 -> Build from the PR branch printed less than 4K lines of output
