### PR TITLE
spark: add GCP environment facet

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.agent.facets.builder.CustomEnvironmentFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.DatabricksEnvironmentFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.DebugRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.GCPEnvironmentFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OwnershipJobFacetBuilder;
@@ -25,6 +26,7 @@ import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBu
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkVersionFacetBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
+import io.openlineage.spark.agent.util.GCPUtils;
 import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
@@ -208,6 +210,8 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new SparkProcessingEngineRunFacetBuilder(context));
     if (DatabricksEnvironmentFacetBuilder.isDatabricksRuntime()) {
       listBuilder.add(new DatabricksEnvironmentFacetBuilder(context));
+    } else if (GCPUtils.isGCPRuntime()) {
+      listBuilder.add(new GCPEnvironmentFacetBuilder(context));
     } else if (context.getCustomEnvironmentVariables() != null) {
       listBuilder.add(new CustomEnvironmentFacetBuilder(context));
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/EnvironmentFacet.java
@@ -5,7 +5,7 @@
 
 package io.openlineage.spark.agent.facets;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
 import java.util.Map;
@@ -15,9 +15,7 @@ import java.util.Map;
  * cluster used, reporting certain environment variables, or resolving mount points.
  */
 public class EnvironmentFacet extends OpenLineage.DefaultRunFacet {
-  @JsonProperty("environment-properties")
-  @SuppressWarnings("PMD")
-  private Map<String, Object> properties;
+  @JsonIgnore private Map<String, Object> properties;
 
   public Map<String, Object> getProperties() {
     return properties;
@@ -26,5 +24,6 @@ public class EnvironmentFacet extends OpenLineage.DefaultRunFacet {
   public EnvironmentFacet(Map<String, Object> environmentDetails) {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
     this.properties = environmentDetails;
+    this.getAdditionalProperties().putAll(environmentDetails);
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/GCPEnvironmentFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/GCPEnvironmentFacetBuilder.java
@@ -1,0 +1,54 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.spark.agent.facets.EnvironmentFacet;
+import io.openlineage.spark.agent.util.GCPUtils;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+
+/**
+ * {@link CustomFacetBuilder} that generates an {@link EnvironmentFacet} when using OpenLineage on
+ * Google Cloud Platform (GCP).
+ */
+public class GCPEnvironmentFacetBuilder
+    extends CustomFacetBuilder<SparkListenerEvent, EnvironmentFacet> {
+
+  private final SparkContext sparkContext;
+  private final Optional<OpenLineageContext> openLineageContext;
+
+  public GCPEnvironmentFacetBuilder(OpenLineageContext openLineageContext) {
+    this.sparkContext = openLineageContext.getSparkContext();
+    this.openLineageContext = Optional.of(openLineageContext);
+  }
+
+  public GCPEnvironmentFacetBuilder(SparkContext sparkContext) {
+    this.sparkContext = sparkContext;
+    this.openLineageContext = Optional.empty();
+  }
+
+  @Override
+  protected void build(
+      SparkListenerEvent event, BiConsumer<String, ? super EnvironmentFacet> consumer) {
+    consumer.accept(
+        "environment-properties", new EnvironmentFacet(getGCPEnvironmentalAttributes()));
+  }
+
+  private Map<String, Object> getGCPEnvironmentalAttributes() {
+    Map<String, Object> dbProperties = new HashMap<>();
+    GCPUtils.setDataprocSpecificFacets(dbProperties, sparkContext);
+    openLineageContext
+        .flatMap(GCPUtils::getSparkQueryExecutionNodeName)
+        .ifPresent(p -> dbProperties.put("spark.query.node.name", p));
+    return dbProperties;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GCPUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/GCPUtils.java
@@ -1,0 +1,251 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.io.CharStreams;
+import io.openlineage.client.Environment;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.http.Consts;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.WholeStageCodegenExec;
+
+/** Util to extract values from GCP environment */
+public class GCPUtils {
+
+  private static final String PROJECT_ID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/project/project-id";
+  private static final String BATCH_ID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-batch-id";
+  private static final String BATCH_UUID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-batch-uuid";
+  private static final String SESSION_ID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-session-id";
+  private static final String SESSION_UUID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-session-uuid";
+  private static final String CLUSTER_UUID_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-cluster-uuid";
+  private static final String DATAPROC_REGION_URI =
+      "http://metadata.google.internal/computeMetadata/v1/instance/attributes/dataproc-region";
+  private static final String DATAPROC_CLASSPATH = "/usr/local/share/google/dataproc/lib";
+  private static final CloseableHttpClient HTTP_CLIENT;
+  private static final String SPARK_YARN_TAGS = "spark.yarn.tags";
+  private static final String SPARK_DRIVER_HOST = "spark.driver.host";
+  private static final String SPARK_APP_ID = "spark.app.id";
+  private static final String SPARK_APP_NAME = "spark.app.name";
+  private static final String SPARK_MASTER = "spark.master";
+  private static final String JOB_ID_PREFIX = "dataproc_job_";
+  private static final String JOB_UUID_PREFIX = "dataproc_uuid_";
+  private static final String METADATA_FLAVOUR = "Metadata-Flavor";
+  private static final String GOOGLE = "Google";
+  private static final String SPARK_DIST_CLASSPATH = "SPARK_DIST_CLASSPATH";
+
+  enum ResourceType {
+    CLUSTER,
+    BATCH,
+    INTERACTIVE,
+    UNKNOWN
+  }
+
+  static {
+    RequestConfig config =
+        RequestConfig.custom()
+            .setConnectTimeout(100)
+            .setConnectionRequestTimeout(100)
+            .setSocketTimeout(100)
+            .build();
+    HTTP_CLIENT = HttpClients.custom().setDefaultRequestConfig(config).build();
+  }
+
+  public static boolean isGCPRuntime() {
+    String sparkDistClasspath = Environment.getEnvironmentVariable(SPARK_DIST_CLASSPATH);
+    return (sparkDistClasspath != null && sparkDistClasspath.contains(DATAPROC_CLASSPATH));
+  }
+
+  public static void setDataprocSpecificFacets(
+      Map<String, Object> dataprocProperties, SparkContext sparkContext) {
+    ResourceType resource = identifyResource(sparkContext);
+
+    switch (resource) {
+      case CLUSTER:
+        getDriverHost(sparkContext).ifPresent(p -> dataprocProperties.put("spark.driver.host", p));
+        getClusterName(sparkContext)
+            .ifPresent(p -> dataprocProperties.put("spark.cluster.name", p));
+        getRegionName().ifPresent(p -> dataprocProperties.put("spark.cluster.region", p));
+        getClusterUUID().ifPresent(p -> dataprocProperties.put("spark.cluster.uuid", p));
+        getGCPJobID(sparkContext).ifPresent(p -> dataprocProperties.put("spark.job.id", p));
+        getGCPJobUUID(sparkContext).ifPresent(p -> dataprocProperties.put("spark.job.uuid", p));
+        break;
+      case BATCH:
+        getRegionName().ifPresent(p -> dataprocProperties.put("spark.batch.region", p));
+        getGCPBatchID().ifPresent(p -> dataprocProperties.put("spark.batch.id", p));
+        getGCPBatchUUID().ifPresent(p -> dataprocProperties.put("spark.batch.uuid", p));
+        break;
+      case INTERACTIVE:
+        getRegionName().ifPresent(p -> dataprocProperties.put("spark.session.region", p));
+        getGCPSessionID().ifPresent(p -> dataprocProperties.put("spark.session.id", p));
+        getGCPSessionUUID().ifPresent(p -> dataprocProperties.put("spark.session.uuid", p));
+        break;
+    }
+    getGCPProjectId().ifPresent(p -> dataprocProperties.put("spark.project.id", p));
+    getApplicationId(sparkContext).ifPresent(p -> dataprocProperties.put("spark.app.id", p));
+    getApplicationName(sparkContext).ifPresent(p -> dataprocProperties.put("spark.app.name", p));
+    dataprocProperties.put("origin", createOriginFacet(dataprocProperties, resource));
+  }
+
+  public static Optional<String> getSparkQueryExecutionNodeName(OpenLineageContext context) {
+    if (!context.getQueryExecution().isPresent()) return Optional.empty();
+
+    SparkPlan node = context.getQueryExecution().get().executedPlan();
+    if (node instanceof WholeStageCodegenExec) node = ((WholeStageCodegenExec) node).child();
+    return Optional.of(normalizeName(node.nodeName()));
+  }
+
+  private static ResourceType identifyResource(SparkContext context) {
+    if (context.getConf().get(SPARK_MASTER, null).equals("yarn")) return ResourceType.CLUSTER;
+    if (getGCPBatchID().isPresent()) return ResourceType.BATCH;
+    if (getGCPSessionID().isPresent()) return ResourceType.INTERACTIVE;
+    return ResourceType.UNKNOWN;
+  }
+
+  private static Optional<String> getDriverHost(SparkContext context) {
+    return Optional.ofNullable(context.getConf().get(SPARK_DRIVER_HOST));
+  }
+  /* sample hostname:
+   * sample-cluster-m.us-central1-a.c.hadoop-cloud-dev.google.com.internal */
+  private static Optional<String> getClusterName(SparkContext context) {
+    return getDriverHost(context)
+        .map(host -> host.split("\\.")[0])
+        .map(s -> s.substring(0, s.lastIndexOf("-")));
+  }
+
+  private static Optional<String> getRegionName() {
+    return fetchGCPMetadata(DATAPROC_REGION_URI);
+  }
+
+  private static Optional<String> getGCPJobID(SparkContext context) {
+    return getPropertyFromYarnTag(context, JOB_ID_PREFIX);
+  }
+
+  private static Optional<String> getGCPJobUUID(SparkContext context) {
+    return getPropertyFromYarnTag(context, JOB_UUID_PREFIX);
+  }
+
+  private static Optional<String> getGCPBatchID() {
+    return fetchGCPMetadata(BATCH_ID_URI);
+  }
+
+  private static Optional<String> getGCPBatchUUID() {
+    return fetchGCPMetadata(BATCH_UUID_URI);
+  }
+
+  private static Optional<String> getGCPSessionID() {
+    return fetchGCPMetadata(SESSION_ID_URI);
+  }
+
+  private static Optional<String> getGCPSessionUUID() {
+    return fetchGCPMetadata(SESSION_UUID_URI);
+  }
+
+  private static Optional<String> getGCPProjectId() {
+    return fetchGCPMetadata(PROJECT_ID_URI).map(b -> b.substring(b.lastIndexOf('/') + 1));
+  }
+
+  private static Optional<String> getApplicationId(SparkContext context) {
+    return Optional.ofNullable(context.getConf().get(SPARK_APP_ID));
+  }
+
+  private static Optional<String> getApplicationName(SparkContext context) {
+    return Optional.ofNullable(context.getConf().get(SPARK_APP_NAME));
+  }
+
+  private static Optional<String> getClusterUUID() {
+    return fetchGCPMetadata(CLUSTER_UUID_URI);
+  }
+
+  private static Map<String, Object> createOriginFacet(
+      Map<String, Object> dataprocProperties, ResourceType resourceType) {
+    Map<String, Object> originProperties = new HashMap<>();
+    String nameFormat = "";
+    String resourceID = "";
+    String regionName = getRegionName().orElse("");
+    String projectID = dataprocProperties.get("spark.project.id").toString();
+
+    switch (resourceType) {
+      case CLUSTER:
+        nameFormat = "projects/%s/regions/%s/clusters/%s";
+        resourceID = dataprocProperties.get("spark.cluster.name").toString();
+        break;
+      case BATCH:
+        nameFormat = "projects/%s/locations/%s/batches/%s";
+        resourceID = dataprocProperties.get("spark.batch.id").toString();
+        break;
+      case INTERACTIVE:
+        nameFormat = "projects/%s/locations/%s/sessions/%s";
+        resourceID = dataprocProperties.get("spark.session.id").toString();
+        break;
+    }
+    String dataprocResource = String.format(nameFormat, projectID, regionName, resourceID);
+    originProperties.put("name", dataprocResource);
+    originProperties.put("sourceType", "DATAPROC");
+    return originProperties;
+  }
+
+  private static String normalizeName(String name) {
+    String CAMEL_TO_SNAKE_CASE =
+        "[\\s\\-_]?((?<=.)[A-Z](?=[a-z\\s\\-_])|(?<=[^A-Z])[A-Z]|((?<=[\\s\\-_])[a-z\\d]))";
+    return name.replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT);
+  }
+
+  private static Optional<String> getPropertyFromYarnTag(SparkContext context, String tagPrefix) {
+    String yarnTag = context.getConf().get(SPARK_YARN_TAGS, null);
+    if (yarnTag == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(yarnTag.split(","))
+        .filter(tag -> tag.contains(tagPrefix))
+        .findFirst()
+        .map(tag -> tag.substring(tagPrefix.length()));
+  }
+
+  private static Optional<String> fetchGCPMetadata(String httpURI) {
+    HttpGet httpGet = new HttpGet(httpURI);
+    httpGet.addHeader(METADATA_FLAVOUR, GOOGLE);
+    try (CloseableHttpResponse response = HTTP_CLIENT.execute(httpGet)) {
+      handleError(response);
+      return Optional.of(
+          CharStreams.toString(new InputStreamReader(response.getEntity().getContent(), UTF_8)));
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static void handleError(HttpResponse response) throws IOException {
+    final int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode < 400 || statusCode >= 600) return;
+    String message =
+        String.format(
+            "code: %d, response: %s",
+            statusCode, EntityUtils.toString(response.getEntity(), Consts.UTF_8));
+    throw new IOException(message);
+  }
+}


### PR DESCRIPTION
### Problem

Adds GCPEnvironmentFacetBuilder to collect GCP-specific environment properties. These properties should be added only when it is running on GCP.

Closes: #2641

### Solution

The `SPARK_DIST_CLASSPATH` property can be used to determine whether it is a GCP environment, depending on which we can decide to add GCPEnvironmentFacetBuilder to the builders list. Other properties are obtained from Google's compute metadata API.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [x] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Adds GCPEnvironmentFacetBuilder to collect additional properties when running on Google Cloud Platform

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project