### PR TITLE
java, release: fix java 8 required unnecessary cast

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -6,6 +6,7 @@
 package io.openlineage.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.openlineage.client.circuitBreaker.CircuitBreakerFactory;
 import io.openlineage.client.metrics.MicrometerProvider;
 import io.openlineage.client.transports.NoopTransport;
@@ -53,7 +54,7 @@ public final class Clients {
 
     Optional.ofNullable(openLineageConfig.getMetricsConfig())
         .map(MicrometerProvider::addMeterRegistryFromConfig)
-        .ifPresent(builder::meterRegistry);
+        .ifPresent(f -> builder.meterRegistry((MeterRegistry) f)); // Java 8 requires cast here :(
     return builder.transport(transport).build();
   }
 


### PR DESCRIPTION
Java 8 requires unnecessary cast in this place, so I added it: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/10321/workflows/57f4adf6-eff7-4a65-b1fb-83e89176173c/jobs/209983