### PR TITLE
[SPARK] Add support for Kafka datasets when Spark is in its streaming configuration

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
@@ -1,0 +1,200 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.from_json;
+import static org.apache.spark.sql.functions.from_unixtime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.streaming.StreamingQuery;
+import org.apache.spark.sql.streaming.StreamingQueryException;
+import org.apache.spark.sql.streaming.Trigger;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import org.testcontainers.utility.DockerImageName;
+
+@Slf4j
+@Tag("integration-test")
+class SparkStreamingTest {
+  @Getter
+  static class InputMessage {
+    private final String id;
+    private final long epoch;
+
+    public InputMessage(String id, long epoch) {
+      this.id = id;
+      this.epoch = epoch;
+    }
+  }
+
+  @Nested
+  class Kafka {
+
+    @Test
+    void testKafkaSourceToKafkaSink() throws TimeoutException, StreamingQueryException {
+      KafkaContainer kafka =
+          new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
+      kafka.start();
+
+      createTopics(kafka.getBootstrapServers(), Arrays.asList("source-topic", "target-topic"));
+      populateTopic(kafka.getBootstrapServers(), "source-topic");
+
+      String userDirProperty = System.getProperty("user.dir");
+      Path userDirPath = Paths.get(userDirProperty);
+      UUID testUuid = UUID.randomUUID();
+      log.info("TestUuid is {}", testUuid);
+
+      Path derbySystemHome =
+          userDirPath.resolve("tmp").resolve("derby").resolve(testUuid.toString());
+      Path sparkSqlWarehouse =
+          userDirPath.resolve("tmp").resolve("spark-sql-warehouse").resolve(testUuid.toString());
+      Path checkpointsDir =
+          userDirPath.resolve("tmp").resolve("checkpoints").resolve(testUuid.toString());
+
+      SparkSession spark =
+          SparkSession.builder()
+              .appName("kafka-source-kafka-sink")
+              .master("local[*]")
+              .config("spark.extraListeners", OpenLineageSparkListener.class.getCanonicalName())
+              .config("spark.driver.host", "localhost")
+              .config("spark.driver.extraJavaOptions", "-Dderby.system.home=" + derbySystemHome)
+              .config("spark.sql.warehouse.dir", sparkSqlWarehouse.toString())
+              .config("spark.ui.enabled", false)
+              .config("spark.openlineage.transport.type", "console")
+              .config("spark.openlineage.facets.disabled", "[spark_unknown;]")
+              .getOrCreate();
+
+      Dataset<Row> sourceStream =
+          spark
+              .readStream()
+              .format("kafka")
+              .option("subscribe", "source-topic")
+              .option("kafka.bootstrap.servers", kafka.getBootstrapServers())
+              .option("startingOffsets", "earliest")
+              .load();
+
+      StructType schema = StructType.fromDDL("id STRING, epoch LONG");
+      StreamingQuery streamingQuery =
+          sourceStream
+              .selectExpr("CAST(value AS STRING) AS value")
+              .select(from_json(col("value"), schema).as("event"))
+              .select(col("event.id").as("id"), col("event.epoch").as("epoch"))
+              .select(col("id"), from_unixtime(col("epoch")).as("timestamp"))
+              .select(functions.struct(col("id"), col("timestamp")).as("converted_event"))
+              .select(functions.to_json(col("converted_event")).as("value"))
+              .writeStream()
+              .format("kafka")
+              .option("topic", "target-topic")
+              .option("kafka.bootstrap.servers", kafka.getBootstrapServers())
+              .option("checkpointLocation", checkpointsDir.toString())
+              .trigger(Trigger.ProcessingTime(Duration.ofSeconds(5).toMillis()))
+              .start();
+
+      streamingQuery.awaitTermination(Duration.ofSeconds(15).toMillis());
+      spark.stop();
+
+      kafka.stop();
+
+      Assertions.fail("Add proper assertions to this test");
+    }
+
+    private void populateTopic(String bootstrapServers, String topic) {
+      Properties props = new Properties();
+      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+      props.put(
+          ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+      props.put(
+          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+      props.put(ProducerConfig.LINGER_MS_CONFIG, "100");
+
+      ObjectMapper om = new ObjectMapper().findAndRegisterModules();
+      try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
+        List<Future<RecordMetadata>> futures =
+            IntStream.range(0, 100)
+                .mapToObj(
+                    ignored ->
+                        new InputMessage(
+                            UUID.randomUUID().toString(), Instant.now().getEpochSecond()))
+                .map(message -> serialize(om, message))
+                .map(json -> new ProducerRecord<String, String>(topic, json))
+                .map(
+                    x ->
+                        producer.send(
+                            x,
+                            (ignored, e) -> {
+                              if (e != null) {
+                                log.error("Failed to publish a message", e);
+                              }
+                            }))
+                .collect(Collectors.toList());
+
+        for (Future<RecordMetadata> future : futures) {
+          future.get();
+        }
+      } catch (ExecutionException | InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @SneakyThrows
+    private String serialize(ObjectMapper mapper, InputMessage message) {
+      return mapper.writeValueAsString(message);
+    }
+
+    private void createTopics(String bootstrapServers, Collection<String> topics) {
+      try (AdminClient adminClient =
+          AdminClient.create(
+              ImmutableMap.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+        List<NewTopic> newTopics =
+            topics.stream()
+                .distinct()
+                .map(topicName -> new NewTopic(topicName, 1, (short) 1))
+                .collect(Collectors.toList());
+
+        CreateTopicsResult result = adminClient.createTopics(newTopics);
+        result.all().get();
+      } catch (ExecutionException | InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/integration/spark/scala-fixtures/src/main/scala/io/openlineage/spark/streaming/Kafka2KafkaJob.scala
+++ b/integration/spark/scala-fixtures/src/main/scala/io/openlineage/spark/streaming/Kafka2KafkaJob.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.spark.streaming
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{col, from_json, from_unixtime, struct, to_json}
+import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.slf4j.LoggerFactory
+
+import java.time.Duration
+import java.util
+
+object Kafka2KafkaJob {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("io.openlineage.spark.streaming.Kafka2Kafka")
+      .getOrCreate()
+    runJob(spark)
+  }
+
+  private def runJob(spark: SparkSession): Unit = {
+    try {
+      val sourceStream = spark.readStream
+        .format("kafka")
+        .option("subscribe", "source-topic")
+        .option("kafka.bootstrap.servers", "kafka.broker.zero:9092")
+        .load()
+
+      val fields = new util.ArrayList[StructField]()
+      fields.add(StructField("registration_id", StringType, nullable = false))
+      fields.add(StructField("registration_epoch", LongType, nullable = false))
+      val eventSchema = StructType(fields)
+
+      val processedEvents = sourceStream.select(col("value").cast(StringType).as("value"))
+        .select(from_json(col("value"), eventSchema).as("registration_event"))
+        .select(col("registration_event.registration_id").as("id"), col("registration_event.registration_epoch").as("epoch"))
+        .select(col("id"), from_unixtime(col("epoch")).as("timestamp"))
+        .select(struct(col("id"), col("timestamp")).as("value"))
+        .select(to_json(col("value")).as("value"))
+
+      val streamingQuery = processedEvents.writeStream
+        .format("kafka")
+        .option("topic", "target-topic")
+        .option("kafka.bootstrap.servers", "kafka.broker.zero:9092")
+        .option("checkpointLocation", "/tmp/checkpoint")
+        .trigger(Trigger.ProcessingTime(Duration.ofSeconds(1).toMillis))
+        .start()
+
+      streamingQuery.awaitTermination(Duration.ofSeconds(30).toMillis)
+    } catch {
+      case e: Exception => log.error("Caught an exception", e)
+    }finally {
+      spark.stop()
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/BaseVisitorFactory.java
@@ -35,6 +35,7 @@ import io.openlineage.spark.agent.lifecycle.plan.OptimizedCreateHiveTableAsSelec
 import io.openlineage.spark.agent.lifecycle.plan.SqlDWDatabricksVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.SqlExecutionRDDVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.TruncateTableCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.WriteToDataSourceV2Visitor;
 import io.openlineage.spark.agent.util.BigQueryUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -121,6 +122,7 @@ abstract class BaseVisitorFactory implements VisitorFactory {
     list.add(new TruncateTableCommandVisitor(context));
     list.add(new AlterTableSetLocationCommandVisitor(context));
     list.add(new AlterTableAddPartitionCommandVisitor(context));
+    list.add(new WriteToDataSourceV2Visitor(context));
     return list;
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaMicroBatchStreamStrategy.java
@@ -1,0 +1,115 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation;
+import org.apache.spark.sql.types.StructType;
+import scala.Option;
+
+@Slf4j
+final class KafkaMicroBatchStreamStrategy extends StreamStrategy {
+  private static final String KAFKA_SOURCE_OFFSET_CLASS_NAME =
+      "org.apache.spark.sql.kafka010.KafkaSourceOffset";
+
+  public KafkaMicroBatchStreamStrategy(
+      DatasetFactory<InputDataset> inputDatasetDatasetFactory,
+      StreamingDataSourceV2Relation relation) {
+    super(inputDatasetDatasetFactory, relation);
+  }
+
+  @Override
+  public List<InputDataset> getInputDatasets() {
+    Optional<String> bootstrapServersOpt = getBootstrapServers();
+    Set<String> topics = getTopics();
+    if (bootstrapServersOpt.isPresent() && !topics.isEmpty()) {
+      return generateInputDatasets(bootstrapServersOpt.get(), topics);
+    } else {
+      log.warn(
+          "Could not generate an input dataset because bootstrapServers need to be present and at least one topic must exist");
+      return Collections.emptyList();
+    }
+  }
+
+  private Optional<String> getBootstrapServers() {
+    Optional<Map<String, Object>> executorKafkaParams =
+        tryReadField(relation.stream(), "executorKafkaParams");
+    return executorKafkaParams.map(m -> (String) m.get("bootstrap.servers"));
+  }
+
+  private Set<String> getTopics() {
+    Option<Offset> offsetOption = relation.startOffset();
+    if (offsetOption.isDefined()) {
+      Offset offset = offsetOption.get();
+      Class<?> offetClass = offset.getClass();
+      String offsetClassName = offetClass.getCanonicalName();
+      if (KAFKA_SOURCE_OFFSET_CLASS_NAME.equals(offsetClassName)) {
+        Optional<scala.collection.immutable.Map<TopicPartition, Long>> topicPartitionsMap =
+            tryReadField(offset, "partitionToOffsets");
+        return topicPartitionsMap
+            .map(ScalaConversionUtils::toJavaMap)
+            .map(Map::keySet)
+            .map(this::convertTopicPartitions)
+            .orElseGet(Collections::emptySet);
+      } else {
+        log.warn("Encountered an unsupported offset class: {}", offsetClassName);
+        return Collections.emptySet();
+      }
+    } else {
+      return Collections.emptySet();
+    }
+  }
+
+  private List<InputDataset> generateInputDatasets(
+      String bootstrapServersConfig, Collection<String> topics) {
+    String[] bootstrapServers = bootstrapServersConfig.split(",");
+    String namespace = "kafka://" + bootstrapServers[0];
+    List<InputDataset> datasets = new ArrayList<>();
+    for (String topic : topics) {
+      InputDataset dataset =
+          datasetFactory.getDataset(topic, namespace, StructType.fromDDL("name STRING"));
+      datasets.add(dataset);
+    }
+    return datasets;
+  }
+
+  private <T> Optional<T> tryReadField(Object target, String fieldName) {
+    try {
+      T value = (T) FieldUtils.readDeclaredField(target, fieldName, true);
+      return Optional.ofNullable(value);
+    } catch (IllegalArgumentException e) {
+      log.error("Could not read the field '{}' because it does not exist", fieldName, e);
+      return Optional.empty();
+    } catch (IllegalAccessException e) {
+      log.error("Could not read the field '{}'", fieldName, e);
+      return Optional.empty();
+    }
+  }
+
+  private Set<String> convertTopicPartitions(Collection collection) {
+    HashSet<String> set = new HashSet<>();
+    for (Object item : collection) {
+      TopicPartitionProxy proxy = new TopicPartitionProxy(item);
+      Optional<String> topicOptional = proxy.topic();
+      topicOptional.ifPresent(set::add);
+    }
+    return set;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/NoOpStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/NoOpStreamStrategy.java
@@ -1,0 +1,29 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.api.DatasetFactory;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation;
+
+@Slf4j
+final class NoOpStreamStrategy extends StreamStrategy {
+
+  public NoOpStreamStrategy(
+      DatasetFactory<InputDataset> inputDatasetDatasetFactory,
+      StreamingDataSourceV2Relation relation) {
+    super(inputDatasetDatasetFactory, relation);
+  }
+
+  @Override
+  List<InputDataset> getInputDatasets() {
+    log.info("The no-op stream strategy has been invoked, and thus an empty list will be returned");
+    return Collections.emptyList();
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamStrategy.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.api.DatasetFactory;
+import java.util.List;
+import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation;
+
+abstract class StreamStrategy {
+  protected final DatasetFactory<InputDataset> datasetFactory;
+  protected final StreamingDataSourceV2Relation relation;
+
+  protected StreamStrategy(
+      DatasetFactory<InputDataset> datasetFactory, StreamingDataSourceV2Relation relation) {
+    this.datasetFactory = datasetFactory;
+    this.relation = relation;
+  }
+
+  abstract List<InputDataset> getInputDatasets();
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
@@ -1,0 +1,63 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.List;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation;
+
+@Slf4j
+public class StreamingDataSourceV2RelationVisitor
+    extends QueryPlanVisitor<StreamingDataSourceV2Relation, InputDataset> {
+
+  public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public List<InputDataset> apply(LogicalPlan x) {
+    log.info(
+        "Applying {} to a logical plan with type {}",
+        this.getClass().getSimpleName(),
+        x.getClass().getCanonicalName());
+    final StreamingDataSourceV2Relation relation = (StreamingDataSourceV2Relation) x;
+    final StreamStrategy streamStrategy = selectStrategy(relation);
+    return streamStrategy.getInputDatasets();
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan x) {
+    boolean result = x instanceof StreamingDataSourceV2Relation;
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "The result of checking whether {} is an instance of {} is {}",
+          x.getClass().getCanonicalName(),
+          StreamingDataSourceV2Relation.class.getCanonicalName(),
+          result);
+    }
+    return result;
+  }
+
+  private StreamStrategy selectStrategy(StreamingDataSourceV2Relation relation) {
+    StreamStrategy streamStrategy;
+    Class<?> streamClass = relation.stream().getClass();
+    String streamClassName = streamClass.getCanonicalName();
+    if ("org.apache.spark.sql.kafka010.KafkaMicroBatchStream".equals(streamClassName)) {
+      streamStrategy = new KafkaMicroBatchStreamStrategy(inputDataset(), relation);
+    } else {
+      log.warn("The {} has been selected because no rules have matched", NoOpStreamStrategy.class);
+      streamStrategy = new NoOpStreamStrategy(inputDataset(), relation);
+    }
+
+    log.info("Selected this strategy: {}", streamStrategy.getClass().getSimpleName());
+    return streamStrategy;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
@@ -17,6 +17,8 @@ import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relati
 @Slf4j
 public class StreamingDataSourceV2RelationVisitor
     extends QueryPlanVisitor<StreamingDataSourceV2Relation, InputDataset> {
+  private static final String KAFKA_MICRO_BATCH_STREAM_CLASS_NAME =
+      "org.apache.spark.sql.kafka010.KafkaMicroBatchStream";
 
   public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
     super(context);
@@ -50,10 +52,13 @@ public class StreamingDataSourceV2RelationVisitor
     StreamStrategy streamStrategy;
     Class<?> streamClass = relation.stream().getClass();
     String streamClassName = streamClass.getCanonicalName();
-    if ("org.apache.spark.sql.kafka010.KafkaMicroBatchStream".equals(streamClassName)) {
+    if (KAFKA_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
       streamStrategy = new KafkaMicroBatchStreamStrategy(inputDataset(), relation);
     } else {
-      log.warn("The {} has been selected because no rules have matched", NoOpStreamStrategy.class);
+      log.warn(
+          "The {} has been selected because no rules have matched for the stream class of {}",
+          NoOpStreamStrategy.class,
+          streamClassName);
       streamStrategy = new NoOpStreamStrategy(inputDataset(), relation);
     }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
@@ -68,7 +68,7 @@ final class TopicPartitionProxy {
    */
   @Nullable
   private <T> T tryInvokeMethod(String methodName) {
-    T result;
+    T result = null;
     try {
       result = (T) MethodUtils.invokeMethod(topicPartition, methodName);
     } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
@@ -77,7 +77,6 @@ final class TopicPartitionProxy {
           methodName,
           topicPartition.getClass().getCanonicalName(),
           e);
-      result = null;
     }
     return result;
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
@@ -1,0 +1,84 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+/**
+ * A proxy class for TopicPartition in Kafka. This class is used to interact with the TopicPartition
+ * object without directly depending on the Kafka library.
+ */
+@Slf4j
+final class TopicPartitionProxy {
+  private static final String EXPECTED_CLASS_NAME = "org.apache.kafka.common.TopicPartition";
+  private final Object topicPartition;
+
+  /**
+   * Constructs a new TopicPartitionProxy.
+   *
+   * @param topicPartition the TopicPartition object from Kafka library
+   * @throws IllegalArgumentException if the provided object is null or not an instance of
+   *     TopicPartition
+   */
+  public TopicPartitionProxy(Object topicPartition) {
+    if (topicPartition == null) {
+      throw new IllegalArgumentException("constructor argument cannot be null");
+    }
+
+    if (!EXPECTED_CLASS_NAME.equals(topicPartition.getClass().getCanonicalName())) {
+      throw new IllegalArgumentException(
+          "constructor argument must be of type" + EXPECTED_CLASS_NAME);
+    }
+
+    this.topicPartition = topicPartition;
+  }
+
+  /**
+   * Retrieves the topic name from the TopicPartition object.
+   *
+   * @return an Optional containing the topic name, or an empty Optional if the method invocation
+   *     fails
+   */
+  public Optional<String> topic() {
+    return Optional.ofNullable(tryInvokeMethod("topic"));
+  }
+
+  /**
+   * Retrieves the partition number from the TopicPartition object.
+   *
+   * @return an Optional containing the partition number, or an empty Optional if the method
+   *     invocation fails
+   */
+  public Optional<Integer> partition() {
+    return Optional.ofNullable(tryInvokeMethod("partition"));
+  }
+
+  /**
+   * Tries to invoke a method on the TopicPartition object.
+   *
+   * @param methodName the name of the method to invoke
+   * @return the result of the method invocation, or null if the invocation fails
+   */
+  @Nullable
+  private <T> T tryInvokeMethod(String methodName) {
+    T result;
+    try {
+      result = (T) MethodUtils.invokeMethod(topicPartition, methodName);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      log.error(
+          "Method '{}' could not be invoked on object with type '{}'",
+          methodName,
+          topicPartition.getClass().getCanonicalName(),
+          e);
+      result = null;
+    }
+    return result;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TopicPartitionProxy.java
@@ -34,7 +34,7 @@ final class TopicPartitionProxy {
 
     if (!EXPECTED_CLASS_NAME.equals(topicPartition.getClass().getCanonicalName())) {
       throw new IllegalArgumentException(
-          "constructor argument must be of type" + EXPECTED_CLASS_NAME);
+          "constructor argument must be of type: " + EXPECTED_CLASS_NAME);
     }
 
     this.topicPartition = topicPartition;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
@@ -1,0 +1,129 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.QueryPlanVisitor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2;
+import org.apache.spark.sql.execution.streaming.sources.MicroBatchWrite;
+import org.jetbrains.annotations.NotNull;
+import scala.Option;
+
+@Slf4j
+public final class WriteToDataSourceV2Visitor
+    extends QueryPlanVisitor<WriteToDataSourceV2, OutputDataset> {
+  private static final String KAFKA_STREAMING_WRITE_CLASS_NAME =
+      "org.apache.spark.sql.kafka010.KafkaStreamingWrite";
+
+  public WriteToDataSourceV2Visitor(@NonNull OpenLineageContext context) {
+    super(context);
+  }
+
+  @Override
+  public boolean isDefinedAt(LogicalPlan plan) {
+    boolean result = plan instanceof WriteToDataSourceV2;
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "The supplied logical plan {} an instance of {}",
+          result ? "IS" : "IS NOT",
+          WriteToDataSourceV2.class.getCanonicalName());
+    }
+    return result;
+  }
+
+  @Override
+  public List<OutputDataset> apply(LogicalPlan plan) {
+    WriteToDataSourceV2 write = (WriteToDataSourceV2) plan;
+    BatchWrite batchWrite = write.batchWrite();
+    if (batchWrite instanceof MicroBatchWrite) {
+      MicroBatchWrite microBatchWrite = (MicroBatchWrite) batchWrite;
+      StreamingWrite streamingWrite = microBatchWrite.writeSupport();
+      Class<? extends StreamingWrite> streamingWriteClass = streamingWrite.getClass();
+      String streamingWriteClassName = streamingWriteClass.getCanonicalName();
+      if (KAFKA_STREAMING_WRITE_CLASS_NAME.equals(streamingWriteClassName)) {
+        return handleKafkaStreamingWrite(streamingWrite, write);
+      }
+    }
+
+    return Collections.emptyList();
+  }
+
+  private @NotNull List<OutputDataset> handleKafkaStreamingWrite(
+      StreamingWrite streamingWrite, WriteToDataSourceV2 write) {
+    KafkaStreamWriteProxy proxy = new KafkaStreamWriteProxy(streamingWrite);
+    Optional<String> topicOpt = proxy.getTopic();
+    Optional<String> bootstrapServersOpt = proxy.getBootstrapServers();
+    if (topicOpt.isPresent() && bootstrapServersOpt.isPresent()) {
+      String topic = topicOpt.get();
+      String bootstrapServers = bootstrapServersOpt.get();
+      OutputDataset dataset =
+          outputDataset().getDataset(topic, "kafka://" + bootstrapServers, write.schema());
+      return Collections.singletonList(dataset);
+    } else {
+      String topicPresent =
+          topicOpt.isPresent() ? "Topic **IS** present" : "Topic **IS NOT** present";
+      String bootstrapServersPresent =
+          bootstrapServersOpt.isPresent()
+              ? "Bootstrap servers **IS** present"
+              : "Bootstrap servers **IS NOT** present";
+      log.warn(
+          "Both topic and bootstrapServers need to be present in order to construct an output dataset. {}. {}",
+          bootstrapServersPresent,
+          topicPresent);
+      return Collections.emptyList();
+    }
+  }
+
+  @Slf4j
+  private static final class KafkaStreamWriteProxy {
+    private final StreamingWrite streamingWrite;
+
+    public KafkaStreamWriteProxy(StreamingWrite streamingWrite) {
+      String incomingClassName = streamingWrite.getClass().getCanonicalName();
+      if (!KAFKA_STREAMING_WRITE_CLASS_NAME.equals(incomingClassName)) {
+        throw new IllegalArgumentException(
+            "Expected the supplied argument to be of type '"
+                + KAFKA_STREAMING_WRITE_CLASS_NAME
+                + "' but received '"
+                + incomingClassName
+                + "' instead");
+      }
+
+      this.streamingWrite = streamingWrite;
+    }
+
+    public Optional<String> getTopic() {
+      return this.<Option<String>>tryReadField(streamingWrite, "topic")
+          .flatMap(opt -> Optional.ofNullable(opt.isDefined() ? opt.get() : null));
+    }
+
+    public Optional<String> getBootstrapServers() {
+      Optional<Map<String, Object>> producerParams = tryReadField(streamingWrite, "producerParams");
+      return producerParams.flatMap(
+          props -> Optional.ofNullable((String) props.get("bootstrap.servers")));
+    }
+
+    private <T> Optional<T> tryReadField(Object target, String fieldName) {
+      try {
+        T result = (T) FieldUtils.readDeclaredField(target, fieldName, true);
+        return result == null ? Optional.empty() : Optional.of(result);
+      } catch (IllegalAccessException e) {
+        return Optional.empty();
+      }
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
@@ -68,7 +68,7 @@ public final class WriteToDataSourceV2Visitor
       log.warn("Unsupported batch write class: {}", batchWrite.getClass().getCanonicalName());
     }
 
-      return result;
+    return result;
   }
 
   private @NotNull List<OutputDataset> handleKafkaStreamingWrite(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -108,7 +109,7 @@ public final class WriteToDataSourceV2Visitor
 
     public Optional<String> getTopic() {
       return this.<Option<String>>tryReadField(streamingWrite, "topic")
-          .flatMap(opt -> Optional.ofNullable(opt.isDefined() ? opt.get() : null));
+          .flatMap(ScalaConversionUtils::asJavaOptional);
     }
 
     public Optional<String> getBootstrapServers() {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
@@ -147,14 +147,7 @@ public class ScalaConversionUtils {
    * @return
    */
   public static <T> Optional<T> asJavaOptional(Option<T> opt) {
-    return Optional.ofNullable(
-        opt.getOrElse(
-            new AbstractFunction0<T>() {
-              @Override
-              public T apply() {
-                return null;
-              }
-            }));
+    return opt == null || opt.isEmpty() ? Optional.empty() : Optional.ofNullable(opt.get());
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ScalaConversionUtils.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.util;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import scala.Function0;
 import scala.Function1;
 import scala.Option;
 import scala.Tuple2;
+import scala.collection.Iterator;
 import scala.collection.JavaConverters;
 import scala.collection.Set;
 import scala.collection.immutable.Seq;
@@ -91,6 +93,16 @@ public class ScalaConversionUtils {
     // the same.
     return (scala.collection.immutable.Map<K, V>)
         scala.collection.immutable.Map$.MODULE$.apply(scalaSeq);
+  }
+
+  public static <K, V> Map<K, V> toJavaMap(scala.collection.immutable.Map<K, V> map) {
+    Iterator<Tuple2<K, V>> iterator = map.iterator();
+    HashMap<K, V> result = new HashMap<>(map.size());
+    while (iterator.hasNext()) {
+      Tuple2<K, V> item = iterator.next();
+      result.put(item._1(), item._2());
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
# Problem

Currently, when you read from and write to Apache Kafka using Spark streaming, the OpenLineage events that are generated lack inputs and outputs.

# Solution

This PR aims to add support for Kafka sources and sinks when Spark is running in its streaming configuration