### PR TITLE
[SPARK] job type facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 * **Flink: support Protobuf format for sources and sinks** [`#2482`](https://github.com/OpenLineage/OpenLineage/pull/2482) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Extracts schema from Protobuf classes. Supports nested object types, `array` type, `map` type, `oneOf` and `any`.*
-
+* **Spark: job type facet to distinguish RDD jobs from Spark SQL jobs.** [`#2652`](https://github.com/OpenLineage/OpenLineage/pull/2652) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)    
+  *Fill `jobType` property of `JobTypeJobFacet` to either `SQL_JOB` or `RDD_JOB`.*
 
 ## [1.13.1](https://github.com/OpenLineage/OpenLineage/compare/1.12.0...1.13.1) - 2024-04-25
 ### Added

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 class SparkSQLExecutionContext implements ExecutionContext {
 
   private static final String NO_EXECUTION_INFO = "No execution info {}";
-  private static final String SPARK_JOB_TYPE = "JOB";
+  private static final String SPARK_JOB_TYPE = "SQL_JOB";
   private static final String SPARK_INTEGRATION = "SPARK";
   private static final String SPARK_PROCESSING_TYPE_BATCH = "BATCH";
   private static final String SPARK_PROCESSING_TYPE_STREAMING = "STREAMING";

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -129,6 +129,11 @@ class LibraryTest {
     assertThat(first.getInputs().get(0).getName()).endsWith("test_data");
     assertThat(first.getEventType()).isEqualTo(EventType.START);
 
+    assertThat(first.getJob().getFacets().getJobType())
+        .hasFieldOrPropertyWithValue("jobType", "RDD_JOB")
+        .hasFieldOrPropertyWithValue("processingType", "BATCH")
+        .hasFieldOrPropertyWithValue("integration", "SPARK");
+
     // verify second job event
     RunEvent second = events.get(2);
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -219,7 +219,7 @@ class SparkSQLExecutionContextTest {
     for (RunEvent event : lineageEvent.getAllValues()) {
       OpenLineage.JobTypeJobFacet jobType = event.getJob().getFacets().getJobType();
       assertThat(jobType).isNotNull();
-      assertThat(jobType.getJobType()).isEqualTo("JOB");
+      assertThat(jobType.getJobType()).isEqualTo("SQL_JOB");
       assertThat(jobType.getIntegration()).isEqualTo("SPARK");
       assertThat(jobType.getProcessingType()).isEqualTo("BATCH");
     }
@@ -244,7 +244,7 @@ class SparkSQLExecutionContextTest {
     for (RunEvent event : lineageEvent.getAllValues()) {
       OpenLineage.JobTypeJobFacet jobType = event.getJob().getFacets().getJobType();
       assertThat(jobType).isNotNull();
-      assertThat(jobType.getJobType()).isEqualTo("JOB");
+      assertThat(jobType.getJobType()).isEqualTo("SQL_JOB");
       assertThat(jobType.getIntegration()).isEqualTo("SPARK");
       assertThat(jobType.getProcessingType()).isEqualTo("STREAMING");
     }

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     compileOnly("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-sql-kafka-0-10_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
+    compileOnly("org.apache.spark:spark-streaming_${scalaBinaryVersion}:${sparkVersion}")
+
 
     compileOnly("com.databricks:databricks-dbutils-scala_${scalaBinaryVersion}:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
@@ -98,6 +100,8 @@ dependencies {
     scala212CompileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}")
     scala212CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}")
     scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    scala212CompileOnly("org.apache.spark:spark-streaming_2.12:${sparkVersion}")
+
 
     scala212CompileOnly("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
@@ -110,6 +114,7 @@ dependencies {
     testScala212Implementation("org.apache.spark:spark-hive_2.12:${sparkVersion}")
     testScala212Implementation("org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}")
     testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
+    testScala212Implementation("org.apache.spark:spark-streaming_2.12:${sparkVersion}")
 
     testScala212Implementation("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
@@ -146,6 +151,7 @@ dependencies {
     scala213CompileOnly("org.apache.spark:spark-hive_2.13:${sparkVersion}")
     scala213CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.13:${sparkVersion}")
     scala213CompileOnly("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    scala213CompileOnly("org.apache.spark:spark-streaming_2.13:${sparkVersion}")
 
     scala213CompileOnly("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")
@@ -158,6 +164,7 @@ dependencies {
     testScala213Implementation("org.apache.spark:spark-hive_2.13:${sparkVersion}")
     testScala213Implementation("org.apache.spark:spark-sql-kafka-0-10_2.13:${sparkVersion}")
     testScala213Implementation("org.apache.spark:spark-sql_2.13:${sparkVersion}")
+    testScala213Implementation("org.apache.spark:spark-streaming_2.13:${sparkVersion}")
 
     testScala213Implementation("com.databricks:databricks-dbutils-scala_2.13:${databricksVersion}") {
         exclude(group: "com.fasterxml.jackson.core")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/StreamingContextUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/StreamingContextUtils.java
@@ -1,0 +1,19 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import org.apache.spark.streaming.StreamingContext$;
+
+/** Utility methods to deal with StreamingContext */
+public class StreamingContextUtils {
+
+  public static boolean hasActiveStreamingContext() {
+    if (!ReflectionUtils.hasClass("org.apache.spark.streaming.StreamingContext")) {
+      return false;
+    }
+    return StreamingContext$.MODULE$.getActive().isDefined();
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/StreamingContextUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/StreamingContextUtilsTest.java
@@ -1,0 +1,16 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StreamingContextUtilsTest {
+  @Test
+  void verifyHasActiveStreamingContextWhenInactiveStreamingContext() {
+    assertThat(StreamingContextUtils.hasActiveStreamingContext()).isFalse();
+  }
+}


### PR DESCRIPTION
### Problem

Given OpenLineage event, it is useful to know if the Spark job was RDD job or Spark SQL job. This information can be sent via `jobType` facet. 

Closes: #2477

### Solution

 * For `SparkSQLExecutionContext` make `jobType` property equal to `SQL_JOB`,
 * For `RddExecutionContext` set it to `RDD_JOB`,
 * JobTypeJobFacet requires `processingType` to be set which can be `batch` or `streaming`. Spark structured streaming is a `SQL_JOB` and property can be extracted from `QueryExecution` object. For RDD jobs, we are checking if there is an active `StreamingContext` to detect streaming for DStream API.
 * Modify some integration tests to check the behaviour. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project