### PR TITLE
[Python] Clean up python client code, add logging.

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, TypeVar, Union
+import warnings
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 import attr
+import yaml
 from openlineage.client.filter import Filter, create_filter
 from openlineage.client.serde import Serde
-from openlineage.client.utils import load_config
 
 if TYPE_CHECKING:
     from requests import Session
@@ -18,7 +19,8 @@ if TYPE_CHECKING:
 from openlineage.client import event_v2
 from openlineage.client.run import DatasetEvent, JobEvent, RunEvent
 from openlineage.client.transport import Transport, TransportFactory, get_default_factory
-from openlineage.client.transport.http import HttpConfig, HttpTransport
+from openlineage.client.transport.http import HttpConfig, HttpTransport, create_token_provider
+from openlineage.client.transport.noop import NoopConfig, NoopTransport
 
 Event_v1 = Union[RunEvent, DatasetEvent, JobEvent]
 Event_v2 = Union[event_v2.RunEvent, event_v2.DatasetEvent, event_v2.JobEvent]
@@ -47,70 +49,39 @@ class OpenLineageClient:
         factory: TransportFactory | None = None,
     ) -> None:
         # Set parent's logging level if environment variable is present
-        if "OPENLINEAGE_CLIENT_LOGGING" in os.environ:
-            logging.getLogger(__name__.rpartition(".")[0]).setLevel(
-                os.environ["OPENLINEAGE_CLIENT_LOGGING"],
-            )
+        custom_logging_level = os.getenv("OPENLINEAGE_CLIENT_LOGGING", None)
+        if custom_logging_level:
+            logging.getLogger(__name__.rpartition(".")[0]).setLevel(custom_logging_level)
 
-        if factory is None:
-            factory = get_default_factory()
+        if url:
+            warnings.warn(
+                message="Initializing OpenLineageClient with url, options and session is deprecated.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Make config ellipsis - as a guard value to not try to
         # reload yaml each time config is referred to.
         self._config: dict[str, dict[str, str]] | None = None
-        if url:
-            # Backwards compatibility: if URL or options is set, use old path to initialize
-            # HTTP transport.
-            if not options:
-                options = OpenLineageClientOptions()
-            self._initialize_url(url, options, session)
-        elif transport:
-            self.transport = transport
-        else:
-            transport_config = self.config.get("transport", None)
-            self.transport = factory.create(transport_config)
+
+        self.transport = self._resolve_transport(
+            url=url, options=options, session=session, transport=transport, factory=factory
+        )
+        log.info("OpenLineageClient will use `%s` transport", self.transport.kind)
 
         self._filters: list[Filter] = []
-        if "filters" in self.config:
-            for conf in self.config["filters"]:
-                _filter = create_filter(conf)
-                if _filter:
-                    self._filters.append(_filter)
-
-    def _initialize_url(
-        self,
-        url: str,
-        options: OpenLineageClientOptions,
-        session: Session | None,
-    ) -> None:
-        self.transport = HttpTransport(
-            HttpConfig.from_options(
-                url=url,
-                options=options,
-                session=session,
-            ),
-        )
-
-    def emit(self, event: Event) -> None:
-        from typing import get_args
-
-        if type(event) not in get_args(Event):
-            msg = "`emit` only accepts RunEvent, DatasetEvent, JobEvent classes"
-            raise ValueError(msg)
-        if self._filters and self.filter_event(event) is None:
-            return
-        if not self.transport:
-            log.error("Tried to emit OpenLineage event, but transport is not configured.")
-            return
-
-        if log.isEnabledFor(logging.DEBUG):
-            val = Serde.to_json(event).encode("utf-8")
-            log.debug("OpenLineageClient will emit event %s", val)
-        self.transport.emit(event)
+        for conf in self.config.get("filters", []):
+            _filter = create_filter(conf)
+            if _filter:
+                self._filters.append(_filter)
 
     @classmethod
     def from_environment(cls: type[_T]) -> _T:
-        # Deprecated way of creating client, use constructor or from_dict
+        warnings.warn(
+            message="`OpenLineageClient.from_environment()` is deprecated. Use `OpenLineageClient()`.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return cls()
 
     @classmethod
@@ -127,8 +98,150 @@ class OpenLineageClient:
                 return None
         return event
 
+    def emit(self, event: Event) -> None:
+        from typing import get_args
+
+        if type(event) not in get_args(Event):
+            msg = "`emit` only accepts RunEvent, DatasetEvent, JobEvent classes"
+            raise ValueError(msg)
+        if not self.transport:
+            log.error("Tried to emit OpenLineage event, but transport is not configured.")
+            return
+        if self.transport.kind == NoopTransport.kind:
+            log.debug("OpenLineage is disabled. No events will be emitted.")
+            return
+        if self._filters and self.filter_event(event) is None:
+            log.debug("OpenLineage event has been filtered out and will not be emitted.")
+            return
+
+        if log.isEnabledFor(logging.DEBUG):
+            val = Serde.to_json(event).encode("utf-8")
+            log.debug("OpenLineageClient will emit event %s", val)
+        self.transport.emit(event)
+        log.debug("OpenLineage event successfully emitted.")
+
     @property
     def config(self) -> dict[str, Any]:
+        """Content of OpenLineage YAML config file."""
         if self._config is None:
-            self._config = load_config()
+            config_path = self._find_yaml_config_path()
+            if config_path:
+                self._config = self._get_config_file_content(config_path)
+            else:
+                self._config = {}
         return self._config
+
+    def _resolve_transport(self, **kwargs: Any) -> Transport:
+        """
+        Resolves the transport mechanism based on the provided arguments or environment settings.
+
+        This method determines the appropriate transport by executing a sequence of checks:
+        1. Verifies if OpenLineage is disabled through environment variable.
+        2. Looks for a transport object provided in the arguments.
+        3. Attempts to configure the transport from a YAML config file.
+        4. Tries to initialize HTTP transport with an url argument (deprecated).
+        5. Tries to set up HTTP transport using environment variables.
+        6. If no configuration is found, defaults to a console transport and logs a warning message.
+
+        Returns:
+            The transport object that will be used to send lineage events.
+        """
+        # 1. Check if OpenLineage is disabled
+        if os.getenv("OPENLINEAGE_DISABLED", "").lower().strip() == "true":
+            log.info("OpenLineage is disabled. No events will be emitted.")
+            return NoopTransport(NoopConfig())
+
+        # 2. Check if transport is provided explicitly
+        if kwargs.get("transport"):
+            return cast(Transport, kwargs["transport"])
+
+        # 3. Check if transport configuration is provided in YAML config file
+        if self.config.get("transport"):
+            factory = kwargs.get("factory") or get_default_factory()
+            return factory.create(self.config["transport"])
+
+        # 4. Check legacy HTTP transport initialization with url and options
+        if kwargs.get("url"):
+            return self._http_transport_from_url(
+                url=kwargs["url"], options=kwargs.get("options"), session=kwargs.get("session")
+            )
+
+        # 5. Check HTTP transport initialization with env variables
+        if os.environ.get("OPENLINEAGE_URL"):
+            return self._http_transport_from_env_variables()
+
+        # 6. If all else fails, print events to console
+        from openlineage.client.transport.console import ConsoleConfig, ConsoleTransport
+
+        log.warning("Couldn't find any OpenLineage transport configuration; will print events to console.")
+        return ConsoleTransport(ConsoleConfig())
+
+    @staticmethod
+    def _get_config_file_content(config_path: str) -> dict[str, Any]:
+        try:
+            with open(config_path) as f:
+                config: dict[str, Any] | None = yaml.safe_load(f)
+                if not config:
+                    log.error("Empty OpenLineage config file: `%s`", config_path)
+                    return {}
+                log.debug("Using content of OpenLineage config file: `%s`", config_path)
+                return config
+        except Exception:
+            log.exception("Couldn't read content of the OpenLineage config file `%s`: ", config_path)
+        return {}
+
+    @staticmethod
+    def _find_yaml_config_path() -> str | None:
+        paths_to_check = (
+            # Check OPENLINEAGE_CONFIG env variable
+            (os.getenv("OPENLINEAGE_CONFIG", None), True),
+            # Check current working directory for `openlineage.yml` file
+            (os.path.join(os.getcwd(), "openlineage.yml"), False),
+            # Check $HOME/.openlineage dir for `openlineage.yml` file
+            (os.path.join(os.path.expanduser("~/.openlineage"), "openlineage.yml"), False),
+        )
+
+        for path, verbose in paths_to_check:
+            try:
+                if path and os.path.isfile(path) and os.access(path, os.R_OK):
+                    return path
+                if path and verbose:
+                    log.debug("OpenLineage config file is missing or not readable: `%s`.", path)
+            except Exception:  # noqa: BLE001
+                # We can get different errors depending on system
+                if verbose:
+                    log.exception("Couldn't check if OpenLineage config file is readable: `%s`", path)
+        return None
+
+    @staticmethod
+    def _http_transport_from_env_variables() -> HttpTransport:
+        config = HttpConfig(
+            url=os.environ["OPENLINEAGE_URL"],
+            auth=create_token_provider(
+                {
+                    "type": "api_key",
+                    "apiKey": os.environ.get("OPENLINEAGE_API_KEY", ""),
+                },
+            ),
+        )
+        endpoint = os.environ.get("OPENLINEAGE_ENDPOINT", None)
+        if endpoint is not None:
+            config.endpoint = endpoint
+
+        return HttpTransport(config)
+
+    @staticmethod
+    def _http_transport_from_url(
+        url: str,
+        options: OpenLineageClientOptions | None,
+        session: Session | None,
+    ) -> HttpTransport:
+        if not options:
+            options = OpenLineageClientOptions()
+        return HttpTransport(
+            HttpConfig.from_options(
+                url=url,
+                options=options,
+                session=session,
+            ),
+        )

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -7,7 +7,7 @@ from openlineage.client.transport.factory import DefaultTransportFactory
 from openlineage.client.transport.file import FileTransport
 from openlineage.client.transport.http import HttpConfig, HttpTransport
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
-from openlineage.client.transport.msk_iam import MSKIAMTransport
+from openlineage.client.transport.msk_iam import MSKIAMConfig, MSKIAMTransport
 from openlineage.client.transport.noop import NoopTransport
 from openlineage.client.transport.transport import Config, Transport, TransportFactory
 

--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -22,8 +22,9 @@ class ConsoleTransport(Transport):
 
     def __init__(self, config: ConsoleConfig) -> None:  # noqa: ARG002
         self.log = logging.getLogger(__name__)
-        self.log.debug("Constructing openlineage client to send events to console or logs")
+        self.log.debug("Constructing OpenLineage transport that will send events to console or logs")
 
     def emit(self, event: Event) -> None:
-        # If logging is set to DEBUG, this will also log event in client.py
+        # Note: When the logging level is set to DEBUG, the content of events is logged twice:
+        # here on the INFO level and in client.py on the DEBUG level for when different transport is used.
         self.log.info(Serde.to_json(event))

--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -13,6 +14,8 @@ from openlineage.client.transport.transport import Config, Transport
 if TYPE_CHECKING:
     from openlineage.client.client import Event
 from openlineage.client.serde import Serde
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -35,6 +38,11 @@ class FileTransport(Transport):
 
     def __init__(self, config: FileConfig) -> None:
         self.config = config
+        log.debug(
+            "Constructing OpenLineage transport that will send events "
+            "to file(s) using the following config: %s",
+            self.config,
+        )
 
     def emit(self, event: Event) -> None:
         if self.config.append:
@@ -43,6 +51,7 @@ class FileTransport(Transport):
             time_str = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
             log_file_path = f"{self.config.log_file_path}-{time_str}"
 
+        log.debug("Openlineage event will be emitted to file: `%s`", log_file_path)
         try:
             with open(log_file_path, "a" if self.config.append else "w") as log_file_handle:
                 log_file_handle.write(Serde.to_json(event) + "\n")

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -123,7 +123,12 @@ class HttpTransport(Transport):
         url = config.url.strip()
         self.config = config
 
-        log.debug("Constructing openlineage client to send events to %s - config %s", url, config)
+        log.debug(
+            "Constructing OpenLineage transport that will send events "
+            "to HTTP endpoint `%s` using the following config: %s",
+            urljoin(url, config.endpoint),
+            config,
+        )
         try:
             from urllib3.util import parse_url
 

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -70,7 +70,12 @@ class KafkaTransport(Transport):
         self.producer = None
         if not self._is_airflow_sqlalchemy:
             self._setup_producer(self.kafka_config.config)
-        log.debug("Constructing openlineage client to send events to topic %s", config.topic)
+        log.debug(
+            "Constructing OpenLineage transport that will send events "
+            "to kafka topic `%s` using the following config: %s",
+            self.topic,
+            self.kafka_config,
+        )
 
     def _get_message_key(self, event: Event) -> str:
         if isinstance(event, (DatasetEvent, event_v2.DatasetEvent)):

--- a/client/python/openlineage/client/transport/msk_iam.py
+++ b/client/python/openlineage/client/transport/msk_iam.py
@@ -78,7 +78,7 @@ class MSKIAMTransport(KafkaTransport):
 
     def _setup_producer(self, config: dict) -> None:  # type: ignore[type-arg]
         try:
-            log.debug("Setup the MSK transport with this configuration: %s", self.msk_config)
+            log.debug("Use MSK producer with the following config: %s", self.msk_config)
 
             # https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
             if self.msk_config.region is None:

--- a/client/python/openlineage/client/transport/noop.py
+++ b/client/python/openlineage/client/transport/noop.py
@@ -22,7 +22,7 @@ class NoopTransport(Transport):
     config_class = NoopConfig
 
     def __init__(self, config: NoopConfig) -> None:  # noqa: ARG002
-        log.info("OpenLineage client is disabled. NoopTransport.")
+        log.debug("Constructing OpenLineage transport that will NOT send any events.")
 
     def emit(self, event: Event) -> None:  # noqa: ARG002
         return None

--- a/client/python/openlineage/client/utils.py
+++ b/client/python/openlineage/client/utils.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import importlib
 import logging
-import os
-from collections import defaultdict
 from typing import Any, ClassVar, Type, cast
 
 import attr
-import yaml
 
 log = logging.getLogger(__name__)
 
@@ -45,47 +42,3 @@ class RedactMixin:
     @property
     def skip_redact(self) -> list[str]:
         return self._skip_redact
-
-
-def load_config() -> dict[str, Any]:
-    file = _find_yaml()
-    if file:
-        try:
-            with open(file) as f:
-                config: dict[str, Any] | None = yaml.safe_load(f)
-                return config or defaultdict(dict)
-        except Exception:  # noqa: BLE001, S110
-            # Just move to read env vars
-            pass
-    return defaultdict(dict)
-
-
-def _find_yaml() -> str | None:
-    # Check OPENLINEAGE_CONFIG env variable
-    path = os.getenv("OPENLINEAGE_CONFIG", None)
-    try:
-        if path and os.path.isfile(path) and os.access(path, os.R_OK):
-            return path
-    except Exception:  # noqa: BLE001
-        if path:
-            log.exception("Couldn't read file %s: ", path)
-        else:
-            pass  # We can get different errors depending on system
-
-    # Check current working directory:
-    try:
-        cwd = os.getcwd()
-        if "openlineage.yml" in os.listdir(cwd):
-            return os.path.join(cwd, "openlineage.yml")
-    except Exception:  # noqa: BLE001, S110
-        pass  # We can get different errors depending on system
-
-    # Check $HOME/.openlineage dir
-    try:
-        path = os.path.expanduser("~/.openlineage")
-        if "openlineage.yml" in os.listdir(path):
-            return os.path.join(path, "openlineage.yml")
-    except Exception:  # noqa: BLE001, S110
-        # We can get different errors depending on system
-        pass
-    return None

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from openlineage.client.client import OpenLineageClient
+from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
 from openlineage.client.run import (
     SCHEMA_URL,
     Dataset,
@@ -21,9 +21,13 @@ from openlineage.client.run import (
     RunEvent,
     RunState,
 )
+from openlineage.client.transport.http import HttpTransport
+from openlineage.client.transport.noop import NoopTransport
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
 
 def test_client_fails_with_wrong_event_type() -> None:
@@ -231,3 +235,157 @@ def test_setting_ol_client_log_level() -> None:
         OpenLineageClient()
         assert parent_logger.getEffectiveLevel() == logging.CRITICAL
         assert logger.getEffectiveLevel() == logging.CRITICAL
+
+
+@patch.dict("os.environ", {})
+@patch("warnings.warn")
+def test_client_with_url_and_options(mock_warn) -> None:
+    timeout = 10
+    options = OpenLineageClientOptions(timeout=timeout, verify=True, api_key="xxx")
+    client = OpenLineageClient(url="http://example.com", options=options)
+    mock_warn.assert_any_call(
+        message="Initializing OpenLineageClient with url, options and session is deprecated.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    assert client.transport.kind == HttpTransport.kind
+    assert client.transport.url == "http://example.com"
+    assert client.transport.timeout == timeout
+    assert client.transport.verify is True
+    assert client.transport.config.auth.api_key == "xxx"
+
+
+@patch.dict(
+    "os.environ",
+    {"OPENLINEAGE_URL": "http://example.com", "OPENLINEAGE_ENDPOINT": "v7", "OPENLINEAGE_API_KEY": "xxx"},
+)
+def test_init_with_openlineage_url_env_var_warning() -> None:
+    client = OpenLineageClient()
+    assert client.transport.kind == HttpTransport.kind
+    assert client.transport.url == "http://example.com"
+    assert client.transport.endpoint == "v7"
+    assert client.transport.config.auth.api_key == "xxx"
+
+
+@patch("warnings.warn")
+def test_from_environment_deprecation_warning(mock_warn) -> None:
+    OpenLineageClient.from_environment()
+    mock_warn.assert_called_once_with(
+        message="`OpenLineageClient.from_environment()` is deprecated. Use `OpenLineageClient()`.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+@patch.dict("os.environ", {"OPENLINEAGE_DISABLED": "true"})
+def test_client_disabled() -> None:
+    client = OpenLineageClient()
+    assert isinstance(client.transport, NoopTransport)
+
+
+def test_client_with_yaml_config(mocker: MockerFixture, root: Path) -> None:
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": str(root / "config" / "http.yml")})
+    client = OpenLineageClient()
+    assert client.transport.kind == HttpTransport.kind
+    assert client.transport.url == "http://localhost:5050"
+    assert client.transport.endpoint == "api/v1/lineage"
+    assert client.transport.config.auth.api_key == "random_token"
+
+
+def test_get_config_file_content(root: Path) -> None:
+    result = OpenLineageClient._get_config_file_content(str(root / "config" / "http.yml"))  # noqa: SLF001
+    assert result == {
+        "transport": {
+            "auth": {"apiKey": "random_token", "type": "api_key"},
+            "compression": "gzip",
+            "endpoint": "api/v1/lineage",
+            "type": "http",
+            "url": "http://localhost:5050",
+        }
+    }
+
+
+@patch("yaml.safe_load", return_value=None)
+def test_get_config_file_content_empty(mock_yaml) -> None:  # noqa: ARG001
+    result = OpenLineageClient._get_config_file_content("empty.yml")  # noqa: SLF001
+    assert result == {}
+
+
+@patch("os.path.isfile", return_value=False)
+def test_find_yaml_config_path_no_config_passed_and_no_files_found(mock_is_file) -> None:
+    result = OpenLineageClient._find_yaml_config_path()  # noqa: SLF001
+    mock_is_file.assert_any_call(os.path.join(os.getcwd(), "openlineage.yml"))
+    mock_is_file.assert_any_call(os.path.join(os.path.expanduser("~/.openlineage"), "openlineage.yml"))
+    assert result is None
+
+
+@patch("os.path.isfile", return_value=True)
+@patch("os.access", return_value=True)
+def test_find_yaml_config_path_cwd_found(mock_access, mock_is_file) -> None:  # noqa: ARG001
+    result = OpenLineageClient._find_yaml_config_path()  # noqa: SLF001
+    path = os.path.join(os.getcwd(), "openlineage.yml")
+    mock_is_file.assert_any_call(path)
+    assert result == path
+
+
+@patch("os.path.isfile", side_effect=[False, True])
+@patch("os.access", return_value=True)
+def test_find_yaml_config_path_user_home_found(mock_access, mock_is_file) -> None:  # noqa: ARG001
+    result = OpenLineageClient._find_yaml_config_path()  # noqa: SLF001
+    path = os.path.join(os.path.expanduser("~/.openlineage"), "openlineage.yml")
+    mock_is_file.assert_any_call(path)
+    assert result == path
+
+
+@patch("os.path.isfile", return_value=False)
+def test_find_yaml_config_path_checks_all_paths(mock_is_file, mocker: MockerFixture, root: Path) -> None:
+    path = str(root / "config" / "openlineage.yml")
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": path})
+    result = OpenLineageClient._find_yaml_config_path()  # noqa: SLF001
+    mock_is_file.assert_any_call(path)
+    mock_is_file.assert_any_call(os.path.join(os.getcwd(), "openlineage.yml"))
+    mock_is_file.assert_any_call(os.path.join(os.path.expanduser("~/.openlineage"), "openlineage.yml"))
+    assert result is None
+
+
+@patch("yaml.safe_load", return_value=None)
+def test_config_file_content_empty_file(mock_yaml) -> None:  # noqa: ARG001
+    assert OpenLineageClient().config == {}
+
+
+def test_config(mocker: MockerFixture, root: Path) -> None:
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": str(root / "config" / "http.yml")})
+    assert OpenLineageClient().config == {
+        "transport": {
+            "auth": {"apiKey": "random_token", "type": "api_key"},
+            "compression": "gzip",
+            "endpoint": "api/v1/lineage",
+            "type": "http",
+            "url": "http://localhost:5050",
+        }
+    }
+
+
+@patch.dict(
+    "os.environ",
+    {"OPENLINEAGE_URL": "http://example.com", "OPENLINEAGE_ENDPOINT": "v7", "OPENLINEAGE_API_KEY": "xxx"},
+)
+def test_http_transport_from_env_variables() -> None:
+    transport = OpenLineageClient._http_transport_from_env_variables()  # noqa: SLF001
+    assert transport.kind == HttpTransport.kind
+    assert transport.url == "http://example.com"
+    assert transport.endpoint == "v7"
+    assert transport.config.auth.api_key == "xxx"
+
+
+def test_http_transport_from_url_no_options() -> None:
+    timeout = 10
+    options = OpenLineageClientOptions(timeout=timeout, verify=True, api_key="xxx")
+    transport = OpenLineageClient._http_transport_from_url(  # noqa: SLF001
+        url="http://example.com", options=options, session=None
+    )
+    assert transport.kind == HttpTransport.kind
+    assert transport.url == "http://example.com"
+    assert transport.timeout == timeout
+    assert transport.verify is True
+    assert transport.config.auth.api_key == "xxx"

--- a/client/python/tests/test_factory.py
+++ b/client/python/tests/test_factory.py
@@ -34,23 +34,15 @@ def test_client_uses_default_http_factory() -> None:
     assert client.transport.endpoint == "endpoint"
 
 
-def test_factory_registers_new_transports(mocker: MockerFixture) -> None:
-    yaml = mocker.patch("openlineage.client.utils.yaml")
-    yaml.safe_load.return_value = {"transport": {"type": "accumulating"}}
-    mocker.patch("os.listdir", return_value=["openlineage.yml"])
-    mocker.patch("os.path.join")
-
+def test_factory_registers_new_transports(mocker: MockerFixture, root: Path) -> None:
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": str(root / "config" / "openlineage.yml")})
     factory = DefaultTransportFactory()
     factory.register_transport("accumulating", clazz=AccumulatingTransport)
     assert isinstance(OpenLineageClient(factory=factory).transport, AccumulatingTransport)
 
 
-def test_factory_registers_transports_from_string(mocker: MockerFixture) -> None:
-    yaml = mocker.patch("openlineage.client.utils.yaml")
-    yaml.safe_load.return_value = {"transport": {"type": "accumulating"}}
-    mocker.patch("os.listdir", return_value=["openlineage.yml"])
-    mocker.patch("os.path.join")
-
+def test_factory_registers_transports_from_string(mocker: MockerFixture, root: Path) -> None:
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": str(root / "config" / "openlineage.yml")})
     factory = DefaultTransportFactory()
     factory.register_transport(
         "accumulating",
@@ -116,11 +108,8 @@ def test_automatically_registers_http_kafka() -> None:
     assert KafkaTransport in factory.transports.values()
 
 
-def test_transport_decorator_registers(mocker: MockerFixture) -> None:
-    yaml = mocker.patch("openlineage.client.utils.yaml")
-    yaml.safe_load.return_value = {"transport": {"type": "fake"}}
-    mocker.patch("os.listdir", return_value=["openlineage.yml"])
-    mocker.patch("os.path.join")
+def test_transport_decorator_registers(mocker: MockerFixture, root: Path) -> None:
+    mocker.patch.dict(os.environ, {"OPENLINEAGE_CONFIG": str(root / "config" / "config.yml")})
 
     factory = DefaultTransportFactory()
     factory.register_transport("fake", FakeTransport)

--- a/client/python/tests/test_utils.py
+++ b/client/python/tests/test_utils.py
@@ -2,37 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections import defaultdict
-from unittest.mock import mock_open, patch
-
-from openlineage.client.utils import load_config
+import pytest
+from openlineage.client.utils import import_from_string, try_import_from_string
 
 
-@patch("openlineage.client.utils._find_yaml", return_value="ol.yml")
-@patch("builtins.open", mock_open(read_data=""))
-@patch("yaml.safe_load", return_value={"database": True})
-def test_load_config_with_values(mock_safe_load, mock_find_yaml):  # noqa: ARG001
-    config = load_config()
-    assert config == {"database": True}
+def test_import_from_string():
+    from openlineage.client.filter import ExactMatchFilter
+
+    result = import_from_string("openlineage.client.filter.ExactMatchFilter")
+    assert result == ExactMatchFilter
 
 
-@patch("openlineage.client.utils._find_yaml", return_value="empty_config.yaml")
-@patch("builtins.open", mock_open(read_data=""))
-@patch("yaml.safe_load", return_value=None)
-def test_load_config_empty_file(mock_safe_load, mock_find_yaml):  # noqa: ARG001
-    config = load_config()
-    assert config == defaultdict(dict)
+def test_import_from_string_unknown_path():
+    with pytest.raises(ImportError):
+        import_from_string("openlineage.client.non-existing-module")
 
 
-@patch("openlineage.client.utils._find_yaml", return_value="empty_config.yaml")
-@patch("builtins.open", mock_open(read_data=""))
-@patch("yaml.safe_load", return_value={})
-def test_load_config_empty_dict(mock_safe_load, mock_find_yaml):  # noqa: ARG001
-    config = load_config()
-    assert config == defaultdict(dict)
+def test_try_import_from_string():
+    from openlineage.client.filter import ExactMatchFilter
+
+    result = try_import_from_string("openlineage.client.filter.ExactMatchFilter")
+    assert result == ExactMatchFilter
 
 
-@patch("openlineage.client.utils._find_yaml", return_value=None)
-def test_load_config_file_not_found(mock_find_yaml):  # noqa: ARG001
-    config = load_config()
-    assert config == defaultdict(dict)
+def test_try_import_from_string_unknown():
+    result = try_import_from_string("openlineage.client.non-existing-module")
+    assert result is None


### PR DESCRIPTION
### Problem

After debugging some user issues i feel like we could add some more logs, so that we can deduce more information about what's happening inside OpenLineage.

Also, at the moment the whole process of resolving what transport we will have is distributed in three places (factory, client and utils), i moved everything to one location so it's easier to grasp.

### One-line summary:

Clean up python client code, refactor logging in all python modules.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project