### PR TITLE
fix: CI error for clone() in common-sql

### DIFF
--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -172,8 +172,8 @@ impl<'a> Context<'a> {
     pub fn push_frame(&mut self) {
         let mut frame = ContextFrame::new();
         if let Some(recent) = self.frames.last() {
-            frame.table = recent.table.clone();
-            frame.column = recent.column.clone();
+            frame.table.clone_from(&recent.table);
+            frame.column.clone_from(&recent.column);
         }
         self.frames.push(frame);
     }


### PR DESCRIPTION
### Problem
Two CI steps:
> ci/circleci: build-integration-sql-x86
ci/circleci: build-integration-sql-arm 

failed in [this](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/10383/workflows/f36f7ce1-42f1-42eb-8a99-bec5e974ba26) build with the same error, [something](https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones) introduced in Rust 1.78 released today.

### Solution

I applied changes recommended by the error message, but I have no idea about Rust 😄 

#### One-line summary:

Fix CI failing on common-sql build

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project