### PR TITLE
Airflow: Drop old ParentRunFacet key

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -258,7 +258,7 @@ Same information, but compacted to one string, can be passed using `linage_paren
 
 ```python
 def my_task_function(templates_dict, **kwargs):
-    parent_job_namespace, parent_job_name, parent_run_id = templates_dict["parentRun"].split("/")
+    parent_job_namespace, parent_job_name, parent_run_id = templates_dict["parentRunInfo"].split("/")
     ...
 
 
@@ -267,7 +267,7 @@ PythonOperator(
     python_callable=my_task_function,
     templates_dict={
         # joined components as one string `<namespace>/<name>/<run_id>`
-        "parentRun": "{{ macros.OpenLineagePlugin.lineage_parent_id(task_instance) }}",
+        "parentRunInfo": "{{ macros.OpenLineagePlugin.lineage_parent_id(task_instance) }}",
     },
     provide_context=False,
     dag=dag,

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -319,8 +319,6 @@ class OpenLineageAdapter:
             facets.update(
                 {
                     "parent": parent_run_facet,
-                    # Keep sending this for the backward compatibility
-                    "parentRun": parent_run_facet,
                 }
             )
 

--- a/integration/airflow/tests/integration/requests/athena.json
+++ b/integration/airflow/tests/integration/requests/athena.json
@@ -35,12 +35,6 @@
                     "name": "athena_dag",
                     "namespace": "food_delivery"
                 }
-            },
-            "parentRun": {
-                "job": {
-                    "name": "athena_dag",
-                    "namespace": "food_delivery"
-                }
             }
         }
     }

--- a/integration/airflow/tests/integration/requests/failing/bash.json
+++ b/integration/airflow/tests/integration/requests/failing/bash.json
@@ -28,13 +28,6 @@
                     "namespace": "food_delivery"
                 },
                 "run": {}
-            },
-            "parentRun": {
-                "job": {
-                    "name": "bash_dag",
-                    "namespace": "food_delivery"
-                },
-                "run": {}
             }
         }
     }
@@ -49,13 +42,6 @@
     "run": {
         "facets": {
             "parent": {
-                "job": {
-                    "name": "bash_dag",
-                    "namespace": "food_delivery"
-                },
-                "run": {}
-            },
-            "parentRun": {
                 "job": {
                     "name": "bash_dag",
                     "namespace": "food_delivery"
@@ -96,13 +82,6 @@
                     "namespace": "food_delivery"
                 },
                 "run": {}
-            },
-            "parentRun": {
-                "job": {
-                    "name": "bash_dag",
-                    "namespace": "food_delivery"
-                },
-                "run": {}
             }
         }
     }
@@ -117,13 +96,6 @@
         "run": {
         "facets": {
             "parent": {
-                "job": {
-                    "name": "bash_dag",
-                    "namespace": "food_delivery"
-                },
-                "run": {}
-            },
-            "parentRun": {
                 "job": {
                     "name": "bash_dag",
                     "namespace": "food_delivery"

--- a/integration/airflow/tests/test_openlineage_adapter.py
+++ b/integration/airflow/tests/test_openlineage_adapter.py
@@ -184,10 +184,6 @@ def test_emit_start_event_with_additional_information():
                         run={"runId": "parent_run_id"},
                         job={"namespace": "default", "name": "parent_job_name"},
                     ),
-                    "parentRun": ParentRunFacet(
-                        run={"runId": "parent_run_id"},
-                        job={"namespace": "default", "name": "parent_job_name"},
-                    ),
                     "externalQuery1": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                     "externalQuery2": ExternalQueryRunFacet(externalQueryId="999", source="source"),
                 },
@@ -286,10 +282,6 @@ def test_emit_complete_event_with_additional_information():
                         run={"runId": "parent_run_id"},
                         job={"namespace": "default", "name": "parent_job_name"},
                     ),
-                    "parentRun": ParentRunFacet(
-                        run={"runId": "parent_run_id"},
-                        job={"namespace": "default", "name": "parent_job_name"},
-                    ),
                     "externalQuery": ExternalQueryRunFacet(externalQueryId="123", source="source"),
                 },
             ),
@@ -377,10 +369,6 @@ def test_emit_fail_event_with_additional_information():
                 runId=run_id,
                 facets={
                     "parent": ParentRunFacet(
-                        run={"runId": "parent_run_id"},
-                        job={"namespace": "default", "name": "parent_job_name"},
-                    ),
-                    "parentRun": ParentRunFacet(
                         run={"runId": "parent_run_id"},
                         job={"namespace": "default", "name": "parent_job_name"},
                     ),


### PR DESCRIPTION
### Problem

`parentRun` key for ParentRunFacet was replaced with `parent` in #1037 and #2130 (since 0.27.0). I think it's time to drop the old key.

### Solution

#### One-line summary:

Use `parent` key for ParentFacet, drop outdated `parentRun`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project