### PR TITLE
GreatExpectations: Rename ParentRunFacet key

### DIFF
--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -155,11 +155,11 @@ class OpenLineageValidationAction(ValidationAction):
         if self.parent_run_id is not None:
             run_facets.update(
                 {
-                    "parentRun": ParentRunFacet.create(
+                    "parent": ParentRunFacet.create(
                         self.parent_run_id,
                         self.parent_job_namespace,
                         self.parent_job_name,
-                    )
+                    ),
                 }
             )
 


### PR DESCRIPTION
### Problem

OpenLineage spec defines the `ParentRunFacet` with the property name `parent` but Great Expectations integration creates a lineage event with `parentRun`. Same issue was in Airflow integration before #1036, but was fixed in #1037 and #2130.

### Solution

#### One-line summary:

Rename `ParentRunFacet` key from `parentRun` to `parent` in Great Expectations integration. For backward compatibility keep the old name.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project