### PR TITLE
Spark: Add spark_jobDetails facet

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -21,6 +21,7 @@ import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OwnershipJobFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.SparkJobDetailsFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkVersionFacetBuilder;
@@ -205,7 +206,8 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new DebugRunFacetBuilder(context),
                 new SparkVersionFacetBuilder(context),
                 new SparkPropertyFacetBuilder(context),
-                new SparkProcessingEngineRunFacetBuilder(context));
+                new SparkProcessingEngineRunFacetBuilder(context),
+                new SparkJobDetailsFacetBuilder());
     if (DatabricksEnvironmentFacetBuilder.isDatabricksRuntime()) {
       listBuilder.add(new DatabricksEnvironmentFacetBuilder(context));
     } else if (context.getCustomEnvironmentVariables() != null) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -14,6 +14,7 @@ import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.facets.ErrorFacet;
 import io.openlineage.spark.agent.facets.SparkVersionFacet;
+import io.openlineage.spark.agent.facets.builder.SparkJobDetailsFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBuilderDelegate;
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
 import io.openlineage.spark.agent.util.PathUtils;
@@ -253,6 +254,7 @@ class RddExecutionContext implements ExecutionContext {
     addSparkVersionFacet(runFacetsBuilder);
     addProcessingEventFacet(runFacetsBuilder, ol);
     addSparkPropertyFacet(runFacetsBuilder, event);
+    addSparkJobDetailsFacet(runFacetsBuilder, event);
 
     return runFacetsBuilder.build();
   }
@@ -273,6 +275,10 @@ class RddExecutionContext implements ExecutionContext {
 
   private void addSparkPropertyFacet(OpenLineage.RunFacetsBuilder b0, SparkListenerEvent event) {
     b0.put("spark_properties", new SparkPropertyFacetBuilder().buildFacet(event));
+  }
+
+  private void addSparkJobDetailsFacet(OpenLineage.RunFacetsBuilder b0, SparkListenerEvent event) {
+    b0.put("spark_jobDetails", new SparkJobDetailsFacetBuilder().buildFacet(event));
   }
 
   private OpenLineage.ParentRunFacet buildApplicationParentFacet() {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkJobDetailsFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkJobDetailsFacet.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import java.util.Properties;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+
+/** Captures information related to the Apache Spark job. */
+@Getter
+public class SparkJobDetailsFacet extends OpenLineage.DefaultRunFacet {
+  @JsonProperty("jobId")
+  @NonNull
+  private Integer jobId;
+
+  @JsonProperty("jobDescription")
+  private String jobDescription;
+
+  @JsonProperty("jobGroup")
+  private String jobGroup;
+
+  @JsonProperty("jobCallSite")
+  private String jobCallSite;
+
+  public SparkJobDetailsFacet(@NonNull SparkListenerJobStart jobStart) {
+    super(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    this.jobId = jobStart.jobId();
+
+    Properties jobProperties = jobStart.properties();
+    this.jobDescription = jobProperties.getProperty("spark.job.description");
+    this.jobGroup = jobProperties.getProperty("spark.jobGroup.id");
+    this.jobCallSite = jobProperties.getProperty("callSite.short");
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkJobDetailsFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkJobDetailsFacetBuilder.java
@@ -1,0 +1,33 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.spark.agent.facets.SparkJobDetailsFacet;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import java.util.function.BiConsumer;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+
+/**
+ * {@link CustomFacetBuilder} that adds the {@link SparkJobDetailsFacet} to a run. This facet is
+ * generated for every {@link SparkListenerJobStart}.
+ */
+public class SparkJobDetailsFacetBuilder
+    extends CustomFacetBuilder<SparkListenerJobStart, SparkJobDetailsFacet> {
+
+  @Override
+  protected void build(
+      SparkListenerJobStart event, BiConsumer<String, ? super SparkJobDetailsFacet> consumer) {
+    consumer.accept("spark_jobDetails", new SparkJobDetailsFacet(event));
+  }
+
+  public SparkJobDetailsFacet buildFacet(SparkListenerEvent event) {
+    if (event instanceof SparkListenerJobStart) {
+      return new SparkJobDetailsFacet((SparkListenerJobStart) event);
+    }
+    return null;
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkJobDetailsFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkJobDetailsFacetBuilderTest.java
@@ -1,0 +1,77 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage.RunFacet;
+import io.openlineage.spark.agent.facets.SparkJobDetailsFacet;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.junit.jupiter.api.Test;
+
+class SparkJobDetailsFacetBuilderTest {
+  @Test
+  void testIsDefinedForSparkListenerEvents() {
+    SparkJobDetailsFacetBuilder builder = new SparkJobDetailsFacetBuilder();
+
+    assertThat(
+            builder.isDefinedAt(
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
+        .isTrue();
+  }
+
+  @Test
+  void testBuild() {
+    SparkJobDetailsFacetBuilder builder = new SparkJobDetailsFacetBuilder();
+
+    Map<String, RunFacet> runFacetMap = new HashMap<>();
+    int jobId = 1;
+    Properties properties = new Properties();
+    properties.setProperty("spark.jobGroup.id", "group");
+    properties.setProperty("spark.job.description", "description");
+    properties.setProperty("callSite.short", "collect at file:2");
+    builder.build(
+        new SparkListenerJobStart(jobId, 1l, ScalaConversionUtils.asScalaSeqEmpty(), properties),
+        runFacetMap::put);
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_jobDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkJobDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("jobId", jobId)
+                    .hasFieldOrPropertyWithValue("jobDescription", "description")
+                    .hasFieldOrPropertyWithValue("jobGroup", "group")
+                    .hasFieldOrPropertyWithValue("jobCallSite", "collect at file:2"));
+  }
+
+  @Test
+  void testBuildMinimal() {
+    SparkJobDetailsFacetBuilder builder = new SparkJobDetailsFacetBuilder();
+
+    Map<String, RunFacet> runFacetMap = new HashMap<>();
+    int jobId = 1;
+    builder.build(
+        new SparkListenerJobStart(
+            jobId, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties()),
+        runFacetMap::put);
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_jobDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkJobDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("jobId", jobId)
+                    .hasFieldOrPropertyWithValue("jobDescription", null)
+                    .hasFieldOrPropertyWithValue("jobGroup", null)
+                    .hasFieldOrPropertyWithValue("jobCallSite", null));
+  }
+}


### PR DESCRIPTION
### Problem

See [discussion](https://github.com/OpenLineage/OpenLineage/issues/2589#issuecomment-2076816639)

### Solution

#### One-line summary:

Added `SparkJobDetailsFacet`, capturing information about Spark application jobs, e.g. `jobId`, `jobDescription`, `jobGroup`, `jobCallSite`. This allows to track OpenLineage RunEvent with specific Spark job in SparkUI.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project