### PR TITLE
Add DREMIO to supported dbt profile types

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -36,6 +36,7 @@ class Adapter(Enum):
     POSTGRES = "postgres"
     DATABRICKS = "databricks"
     SQLSERVER = "sqlserver"
+    DREMIO = "dremio"
 
     @staticmethod
     def adapters() -> str:
@@ -544,6 +545,8 @@ class DbtArtifactProcessor:
             return f"databricks://{profile['host']}"
         elif self.adapter_type == Adapter.SQLSERVER:
             return f"mssql://{profile['server']}:{profile['port']}"
+        elif self.adapter_type == Adapter.DREMIO:
+            return f"dremio://{profile['host']}:{profile['port']}"
         elif self.adapter_type == Adapter.SPARK:
             port = ""
 


### PR DESCRIPTION
### Problem

The dbt provider has a hardcoded set of supported dbt connection types. This adds [dremio](https://docs.getdbt.com/docs/core/connect-data-platform/dremio-setup) to the list.

Closes: https://github.com/OpenLineage/OpenLineage/issues/2668

### Solution

Add static DREMIO to the Adapter(Enum)

Add an if clause for DREMIO to DbtArtifactProcessor.extract_namespace

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Add support for dbt-dremio, solving https://github.com/OpenLineage/OpenLineage/issues/2668

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project