### PR TITLE
Fix : DREMIO to supported dbt profile types

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -546,7 +546,10 @@ class DbtArtifactProcessor:
         elif self.adapter_type == Adapter.SQLSERVER:
             return f"mssql://{profile['server']}:{profile['port']}"
         elif self.adapter_type == Adapter.DREMIO:
-            return f"dremio://{profile['host']}:{profile['port']}"
+            if "software_host" in profile:
+                return f"dremio://{profile['software_host']}:{profile['port']}"
+            elif "host" in profile:
+                return f"dremio://{profile['host']}:{profile['port']}"
         elif self.adapter_type == Adapter.SPARK:
             port = ""
 


### PR DESCRIPTION
### Problem

The dbt provider has a hardcoded set of supported dbt connection types FIX. This adds [dremio](https://docs.getdbt.com/docs/core/connect-data-platform/dremio-setup) to the list.

Closes: https://github.com/OpenLineage/OpenLineage/issues/2668
Reference Review : [#2671](https://github.com/OpenLineage/OpenLineage/pull/2671/files/7e36199933ecbd4c98792935f5efdce2eec16270#diff-1fd4c9fcd29eedeb247a2e9e2a1b3a10413f6023614a36ad3e935e1d26bd8555)

### Solution

Add an if-elif clause for DREMIO to DbtArtifactProcessor.extract_namespace for profile (host or software_host)

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Add support for dbt-dremio, solving https://github.com/OpenLineage/OpenLineage/issues/2668 and reference review [#2671](https://github.com/OpenLineage/OpenLineage/pull/2671/files/7e36199933ecbd4c98792935f5efdce2eec16270#diff-1fd4c9fcd29eedeb247a2e9e2a1b3a10413f6023614a36ad3e935e1d26bd8555)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project