### PR TITLE
Spark: Add facets to Spark Application events

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -5,16 +5,13 @@
 
 package io.openlineage.spark.agent;
 
-import static io.openlineage.spark.agent.lifecycle.ExecutionContext.CAMEL_TO_SNAKE_CASE;
 import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
-import static io.openlineage.spark.agent.util.TimeUtils.toZonedTime;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.openlineage.client.Environment;
-import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreaker;
 import io.openlineage.client.circuitBreaker.CircuitBreakerFactory;
@@ -25,11 +22,9 @@ import io.openlineage.spark.agent.lifecycle.ContextFactory;
 import io.openlineage.spark.agent.lifecycle.ExecutionContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
-import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -37,7 +32,6 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -70,9 +64,9 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   private static WeakHashMap<RDD<?>, Configuration> outputs = new WeakHashMap<>();
   private static ContextFactory contextFactory;
   private static JobMetricsHolder jobMetrics = JobMetricsHolder.getInstance();
-  private final Function1<SparkSession, SparkContext> sparkContextFromSession =
+  private static final Function1<SparkSession, SparkContext> sparkContextFromSession =
       ScalaConversionUtils.toScalaFn(SparkSession::sparkContext);
-  private final Function0<Option<SparkContext>> activeSparkContext =
+  private static final Function0<Option<SparkContext>> activeSparkContext =
       ScalaConversionUtils.toScalaFn(SparkContext$.MODULE$::getActive);
 
   private static CircuitBreaker circuitBreaker = new NoOpCircuitBreaker();
@@ -81,7 +75,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   private static String sparkVersion = package$.MODULE$.SPARK_VERSION();
 
-  private static final boolean isDisabled = checkIfDisabled();
+  private final boolean isDisabled = checkIfDisabled();
 
   /** called by the tests */
   public static void init(ContextFactory contextFactory) {
@@ -228,6 +222,15 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     jobMetrics.addMetrics(taskEnd.stageId(), taskEnd.taskMetrics());
   }
 
+  public static ExecutionContext getSparkApplicationExecutionContext() {
+    Optional<SparkContext> sparkContext =
+        asJavaOptional(
+            SparkSession.getDefaultSession()
+                .map(sparkContextFromSession)
+                .orElse(activeSparkContext));
+    return contextFactory.createSparkApplicationExecutionContext(sparkContext.orElse(null));
+  }
+
   public static Optional<ExecutionContext> getSparkSQLExecutionContext(long executionId) {
     return Optional.ofNullable(
         sparkSqlExecutionRegistry.computeIfAbsent(
@@ -251,20 +254,6 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     return outputs.get(rdd);
   }
 
-  @SuppressWarnings(
-      "PMD") // javadoc -> Closing a ByteArrayOutputStream has no effect. The methods in this class
-  // can be called after the stream has been closed without generating an IOException.
-  private static OpenLineage.RunFacets errorRunFacet(Exception e, OpenLineage ol) {
-    OpenLineage.RunFacet errorFacet = ol.newRunFacet();
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    e.printStackTrace(new PrintWriter(buffer, true));
-    errorFacet.getAdditionalProperties().put("exception", buffer.toString());
-
-    OpenLineage.RunFacetsBuilder runFacetsBuilder = ol.newRunFacetsBuilder();
-    runFacetsBuilder.put("lineage.error", errorFacet);
-    return runFacetsBuilder.build();
-  }
-
   private static void clear() {
     sparkSqlExecutionRegistry.clear();
     rddExecutionRegistry.clear();
@@ -273,13 +262,17 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   @Override
   public void onApplicationEnd(SparkListenerApplicationEnd applicationEnd) {
+    if (isDisabled) {
+      return;
+    }
     meterRegistry.counter("openlineage.spark.event.app.end").increment();
     meterRegistry
         .counter("openlineage.spark.event.app.end.memoryusage")
         .increment(RuntimeUtils.getMemoryFractionUsage());
+
     circuitBreaker.run(
         () -> {
-          emitApplicationEndEvent(applicationEnd.time());
+          getSparkApplicationExecutionContext().end(applicationEnd);
           return null;
         });
     close();
@@ -293,20 +286,24 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   @Override
   public void onApplicationStart(SparkListenerApplicationStart applicationStart) {
+    if (isDisabled) {
+      return;
+    }
     initializeContextFactoryIfNotInitialized(applicationStart.appName());
     meterRegistry.counter("openlineage.spark.event.app.start").increment();
     meterRegistry
         .counter("openlineage.spark.event.app.start.memoryusage")
         .increment(RuntimeUtils.getMemoryFractionUsage());
+
     circuitBreaker.run(
         () -> {
-          emitApplicationStartEvent(applicationStart.time());
+          getSparkApplicationExecutionContext().start(applicationStart);
           return null;
         });
   }
 
   private void initializeContextFactoryIfNotInitialized() {
-    if (contextFactory != null || isDisabled) {
+    if (contextFactory != null) {
       return;
     }
     asJavaOptional(activeSparkContext.apply())
@@ -314,7 +311,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   }
 
   private void initializeContextFactoryIfNotInitialized(String appName) {
-    if (contextFactory != null || isDisabled) {
+    if (contextFactory != null) {
       return;
     }
     SparkEnv sparkEnv = SparkEnv$.MODULE$.get();
@@ -328,7 +325,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   }
 
   private void initializeContextFactoryIfNotInitialized(SparkConf sparkConf, String appName) {
-    if (contextFactory != null || isDisabled) {
+    if (contextFactory != null) {
       return;
     }
     try {
@@ -369,54 +366,6 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
                             Tag.of("openlineage.spark.integration.version", Versions.getVersion()),
                             Tag.of("openlineage.spark.version", sparkVersion),
                             Tag.of("openlineage.spark.disabled.facets", disabledFacets))));
-  }
-
-  private void emitApplicationEvent(Long time, OpenLineage.RunEvent.EventType eventType) {
-    OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
-    EventEmitter emitter = contextFactory.openLineageEventEmitter;
-    OpenLineage.RunBuilder runBuilder =
-        openLineage.newRunBuilder().runId(emitter.getApplicationRunId());
-    if (emitter.getParentRunId().isPresent()
-        && emitter.getParentJobName().isPresent()
-        && emitter.getParentJobNamespace().isPresent()) {
-      runBuilder.facets(
-          openLineage
-              .newRunFacetsBuilder()
-              .parent(
-                  openLineage.newParentRunFacet(
-                      openLineage.newParentRunFacetRun(emitter.getParentRunId().get()),
-                      openLineage.newParentRunFacetJob(
-                          emitter.getParentJobNamespace().get(), emitter.getParentJobName().get())))
-              .build());
-    }
-    OpenLineage.RunEvent applicationEvent =
-        openLineage
-            .newRunEventBuilder()
-            .eventType(eventType)
-            .eventTime(toZonedTime(time))
-            .job(
-                openLineage
-                    .newJobBuilder()
-                    .namespace(emitter.getJobNamespace())
-                    .name(
-                        emitter
-                            .getApplicationJobName()
-                            .replaceAll(CAMEL_TO_SNAKE_CASE, "_$1")
-                            .toLowerCase(Locale.ROOT))
-                    .build())
-            .run(runBuilder.build())
-            .inputs(Collections.emptyList())
-            .outputs(Collections.emptyList())
-            .build();
-    emitter.emit(applicationEvent);
-  }
-
-  private void emitApplicationStartEvent(Long time) {
-    emitApplicationEvent(time, OpenLineage.RunEvent.EventType.START);
-  }
-
-  private void emitApplicationEndEvent(Long time) {
-    emitApplicationEvent(time, OpenLineage.RunEvent.EventType.COMPLETE);
   }
 
   private static boolean checkIfDisabled() {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -84,6 +84,12 @@ class RddExecutionContext implements ExecutionContext {
   public void end(SparkListenerStageCompleted stageCompleted) {}
 
   @Override
+  public void start(SparkListenerApplicationStart applicationStart) {}
+
+  @Override
+  public void end(SparkListenerApplicationEnd applicationEnd) {}
+
+  @Override
   @SuppressWarnings("PMD") //  f.setAccessible(true);
   public void setActiveJob(ActiveJob activeJob) {
     log.debug("setActiveJob within RddExecutionContext {}", activeJob);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -1,0 +1,148 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static io.openlineage.client.OpenLineage.RunEvent.EventType.COMPLETE;
+import static io.openlineage.client.OpenLineage.RunEvent.EventType.START;
+import static io.openlineage.spark.agent.util.TimeUtils.toZonedTime;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.filters.EventFilterUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Locale;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+
+@Slf4j
+class SparkApplicationExecutionContext implements ExecutionContext {
+  private final OpenLineageContext olContext;
+  private final EventEmitter eventEmitter;
+  private final OpenLineageRunEventBuilder runEventBuilder;
+  private final OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+
+  public SparkApplicationExecutionContext(
+      EventEmitter eventEmitter,
+      OpenLineageContext olContext,
+      OpenLineageRunEventBuilder runEventBuilder) {
+    this.eventEmitter = eventEmitter;
+    this.olContext = olContext;
+    this.runEventBuilder = runEventBuilder;
+  }
+
+  @Override
+  public void setActiveJob(ActiveJob activeJob) {}
+
+  @Override
+  public void start(SparkListenerJobStart jobStart) {}
+
+  @Override
+  public void start(SparkListenerSQLExecutionStart sqlStart) {}
+
+  @Override
+  public void start(SparkListenerStageSubmitted stageSubmitted) {}
+
+  @Override
+  public void end(SparkListenerJobEnd jobEnd) {}
+
+  @Override
+  public void end(SparkListenerSQLExecutionEnd sqlEnd) {}
+
+  @Override
+  public void end(SparkListenerStageCompleted stageCompleted) {}
+
+  @Override
+  public void start(SparkListenerApplicationStart applicationStart) {
+    String applicationId =
+        olContext.getSparkContext().map(context -> context.applicationId()).orElse(null);
+    log.debug("SparkListenerApplicationStart - applicationId: {}", applicationId);
+    if (EventFilterUtils.isDisabled(olContext, applicationStart)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerApplicationStart");
+      return;
+    }
+
+    RunEvent event =
+        runEventBuilder.buildRun(
+            buildApplicationParentFacet(),
+            openLineage
+                .newRunEventBuilder()
+                .eventTime(toZonedTime(applicationStart.time()))
+                .eventType(START),
+            buildJob(),
+            openLineage.newJobFacetsBuilder(),
+            applicationStart);
+
+    log.debug("Posting event for applicationId {} start: {}", applicationId, event);
+    eventEmitter.emit(event);
+  }
+
+  @Override
+  public void end(SparkListenerApplicationEnd applicationEnd) {
+    String applicationId =
+        olContext.getSparkContext().map(context -> context.applicationId()).orElse(null);
+    log.debug("SparkListenerApplicationEnd - applicationId: {}", applicationId);
+    if (EventFilterUtils.isDisabled(olContext, applicationEnd)) {
+      log.info(
+          "OpenLineage received Spark event that is configured to be skipped: SparkListenerApplicationEnd");
+      return;
+    }
+
+    RunEvent event =
+        runEventBuilder.buildRun(
+            buildApplicationParentFacet(),
+            openLineage
+                .newRunEventBuilder()
+                .eventTime(toZonedTime(applicationEnd.time()))
+                .eventType(COMPLETE),
+            buildJob(),
+            openLineage.newJobFacetsBuilder(),
+            applicationEnd);
+
+    log.debug("Posting event for applicationId {} end: {}", applicationId, event);
+    eventEmitter.emit(event);
+  }
+
+  private OpenLineage.ParentRunFacet buildApplicationParentFacet() {
+    if (eventEmitter.getParentRunId().isPresent()
+        && eventEmitter.getParentJobName().isPresent()
+        && eventEmitter.getParentJobNamespace().isPresent()) {
+      OpenLineage ol = olContext.getOpenLineage();
+      return ol.newParentRunFacet(
+          ol.newParentRunFacetRun(eventEmitter.getParentRunId().get()),
+          ol.newParentRunFacetJob(
+              eventEmitter.getParentJobNamespace().get(), eventEmitter.getParentJobName().get()));
+    }
+    return null;
+  }
+
+  protected OpenLineage.JobBuilder buildJob() {
+    String name =
+        eventEmitter
+            .getOverriddenAppName()
+            .orElse(olContext.getSparkContext().map(SparkContext::appName).orElse("unknown"));
+    return openLineage
+        .newJobBuilder()
+        .namespace(eventEmitter.getJobNamespace())
+        .name(normalizeName(name));
+  }
+
+  // normalizes string, changes CamelCase to snake_case and replaces all non-alphanumerics with '_'
+  private static String normalizeName(String name) {
+    return name.replaceAll(CAMEL_TO_SNAKE_CASE, "_$1").toLowerCase(Locale.ROOT);
+  }
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.JobFailed;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.SparkListenerStageCompleted;
@@ -274,6 +276,12 @@ class SparkSQLExecutionContext implements ExecutionContext {
     log.debug("Posting event for end {}: {}", executionId, event);
     eventEmitter.emit(event);
   }
+
+  @Override
+  public void start(SparkListenerApplicationStart applicationStart) {}
+
+  @Override
+  public void end(SparkListenerApplicationEnd applicationEnd) {}
 
   private OpenLineage.ParentRunFacet buildApplicationParentFacet() {
     return PlanUtils.parentRunFacet(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -27,15 +27,15 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URISyntaxException;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.UUID;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
-import org.apache.spark.scheduler.StageInfo;
+import org.apache.spark.scheduler.SparkListenerTaskEnd;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -154,10 +154,15 @@ class OpenLineageSparkListenerTest {
       OpenLineageSparkListener.init(contextFactory);
       OpenLineageSparkListener listener = new OpenLineageSparkListener();
 
-      listener.onJobStart(
-          new SparkListenerJobStart(
-              0, 2L, ScalaConversionUtils.<StageInfo>asScalaSeqEmpty(), new Properties()));
+      listener.onApplicationStart(mock(SparkListenerApplicationStart.class));
+      listener.onApplicationEnd(mock(SparkListenerApplicationEnd.class));
+      listener.onJobStart(mock(SparkListenerJobStart.class));
+      listener.onJobEnd(mock(SparkListenerJobEnd.class));
+      listener.onTaskEnd(mock(SparkListenerTaskEnd.class));
+      listener.onOtherEvent(mock(SparkListenerSQLExecutionStart.class));
+      listener.onOtherEvent(mock(SparkListenerSQLExecutionEnd.class));
 
+      verify(contextFactory, never()).createSparkApplicationExecutionContext(sparkContext);
       verify(contextFactory, never()).createSparkSQLExecutionContext(anyLong());
     }
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
@@ -1,0 +1,142 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
+import io.openlineage.spark.agent.EventEmitter;
+import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.filters.EventFilterUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+@ExtendWith(SparkAgentTestExtension.class)
+class SparkApplicationExecutionContextTest {
+
+  private final OpenLineageContext olContext = mock(OpenLineageContext.class);
+  private final OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+  private final EventEmitter eventEmitter = mock(EventEmitter.class);
+  private final SparkApplicationExecutionContext context =
+      new SparkApplicationExecutionContext(
+          eventEmitter,
+          olContext,
+          new OpenLineageRunEventBuilder(olContext, mock(OpenLineageEventHandlerFactory.class)));
+
+  @AfterEach
+  void reset() {
+    Mockito.reset(olContext, eventEmitter);
+  }
+
+  @BeforeEach
+  void setup(SparkSession spark) {
+    when(olContext.getOpenLineage()).thenReturn(openLineage);
+    when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
+    when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
+    when(olContext.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
+
+    when(eventEmitter.getOverriddenAppName()).thenReturn(Optional.of("app-name"));
+    when(eventEmitter.getApplicationRunId())
+        .thenReturn(UUID.fromString("993426b3-1ca7-44af-8473-8e58c757ebd1"));
+
+    when(eventEmitter.getJobNamespace()).thenReturn("ns_name");
+    when(eventEmitter.getParentJobName()).thenReturn(Optional.of("parent_name"));
+    when(eventEmitter.getParentJobNamespace()).thenReturn(Optional.of("parent_namespace"));
+    when(eventEmitter.getParentRunId())
+        .thenReturn(Optional.of(UUID.fromString("4e948e60-1639-4796-950e-cdc6d45915f4")));
+  }
+
+  @Test
+  void testSingleStartIsSent(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+    }
+
+    context.start(mock(SparkListenerApplicationStart.class));
+    verify(eventEmitter, times(1)).emit(lineageEvent.capture());
+
+    RunEvent runEvent = lineageEvent.getAllValues().get(0);
+    assertThat(runEvent).hasFieldOrPropertyWithValue("eventType", EventType.START);
+  }
+
+  @Test
+  void testSingleEndIsSent(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+
+      context.end(mock(SparkListenerApplicationEnd.class));
+    }
+    verify(eventEmitter, times(1)).emit(lineageEvent.capture());
+
+    assertThat(lineageEvent.getAllValues().get(0))
+        .hasFieldOrPropertyWithValue("eventType", EventType.COMPLETE);
+  }
+
+  @Test
+  void testRunAndJobAreSet(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+
+      context.start(mock(SparkListenerApplicationStart.class));
+      context.end(mock(SparkListenerApplicationEnd.class));
+    }
+
+    for (RunEvent runEvent : lineageEvent.getAllValues()) {
+      OpenLineage.Run run = runEvent.getRun();
+      OpenLineage.Job job = runEvent.getJob();
+      assertThat(job.getName()).isEqualTo("app_name");
+      assertThat(job.getNamespace()).isEqualTo("ns_name");
+      assertThat(run.getRunId()).isEqualTo(UUID.fromString("993426b3-1ca7-44af-8473-8e58c757ebd1"));
+    }
+  }
+
+  @Test
+  void testParentRunFacetIsSet(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+
+      context.start(mock(SparkListenerApplicationStart.class));
+      context.end(mock(SparkListenerApplicationEnd.class));
+    }
+
+    for (RunEvent runEvent : lineageEvent.getAllValues()) {
+      OpenLineage.ParentRunFacet parentRunFacet = runEvent.getRun().getFacets().getParent();
+      OpenLineage.ParentRunFacetJob parentJob = parentRunFacet.getJob();
+      OpenLineage.ParentRunFacetRun parentRun = parentRunFacet.getRun();
+      assertThat(parentJob.getName()).isEqualTo("parent_name");
+      assertThat(parentJob.getNamespace()).isEqualTo("parent_namespace");
+      assertThat(parentRun.getRunId())
+          .isEqualTo(UUID.fromString("4e948e60-1639-4796-950e-cdc6d45915f4"));
+    }
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -63,22 +63,23 @@ class SparkSQLExecutionContextTest {
   }
 
   @BeforeEach
-  void setup() {
+  void setup(SparkSession spark) {
     when(olContext.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
+    when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
     when(olContext.getOpenLineage()).thenReturn(openLineage);
     when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
     when(olContext.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
-    when(eventEmitter.getOverriddenAppName()).thenReturn(Optional.of("app-name"));
+    when(olContext.getRunUuid())
+        .thenReturn(UUID.fromString("8d99e33e-2a1c-4254-9600-18f23435fc3b"));
+
+    when(eventEmitter.getOverriddenAppName()).thenReturn(Optional.of("test-rdd"));
     when(queryExecution.executedPlan().nodeName()).thenReturn("some-node-name");
 
     when(eventEmitter.getJobNamespace()).thenReturn("ns_name");
-    when(eventEmitter.getParentJobName()).thenReturn(Optional.of("parent_name"));
-    when(eventEmitter.getParentJobNamespace()).thenReturn(Optional.of("parent_namespace"));
-    when(eventEmitter.getParentRunId())
-        .thenReturn(Optional.of(UUID.fromString("8d99e33e-2a1c-4254-9600-18f23435fc3b")));
     when(eventEmitter.getApplicationRunId())
         .thenReturn(UUID.fromString("8d99e33e-bbbb-cccc-dddd-18f2343aaaaa"));
-    when(eventEmitter.getApplicationJobName()).thenReturn("test_rdd");
+    when(eventEmitter.getApplicationJobName()).thenReturn("app-name");
   }
 
   @Test
@@ -86,8 +87,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
     }
 
     context.start(mock(SparkListenerSQLExecutionStart.class));
@@ -105,8 +104,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.start(mock(SparkListenerSQLExecutionStart.class));
@@ -124,8 +121,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.start(mock(SparkListenerSQLExecutionStart.class));
@@ -145,8 +140,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.start(mock(SparkListenerSQLExecutionStart.class));
@@ -166,8 +159,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.end(mock(SparkListenerJobEnd.class));
@@ -187,8 +178,6 @@ class SparkSQLExecutionContextTest {
     when(jobEnd.jobResult()).thenReturn(mock(JobFailed.class));
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.end(jobEnd);
@@ -206,8 +195,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
 
       context.start(mock(SparkListenerJobStart.class));
       context.start(mock(SparkListenerSQLExecutionStart.class));
@@ -230,8 +217,6 @@ class SparkSQLExecutionContextTest {
     ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
     try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
       when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
-      when(olContext.getSparkContext()).thenReturn(spark.sparkContext());
-      when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
       when(queryExecution.optimizedPlan().isStreaming()).thenReturn(true);
 
       context.start(mock(SparkListenerJobStart.class));
@@ -247,6 +232,51 @@ class SparkSQLExecutionContextTest {
       assertThat(jobType.getJobType()).isEqualTo("SQL_JOB");
       assertThat(jobType.getIntegration()).isEqualTo("SPARK");
       assertThat(jobType.getProcessingType()).isEqualTo("STREAMING");
+    }
+  }
+
+  @Test
+  void testRunAndJobAreSet(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+
+      context.start(mock(SparkListenerJobStart.class));
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+      context.end(mock(SparkListenerJobEnd.class));
+    }
+
+    for (RunEvent runEvent : lineageEvent.getAllValues()) {
+      OpenLineage.Run run = runEvent.getRun();
+      OpenLineage.Job job = runEvent.getJob();
+      assertThat(job.getName()).isEqualTo("test_rdd.some_node_name");
+      assertThat(job.getNamespace()).isEqualTo("ns_name");
+      assertThat(run.getRunId()).isEqualTo(UUID.fromString("8d99e33e-2a1c-4254-9600-18f23435fc3b"));
+    }
+  }
+
+  @Test
+  void testParentRunFacetIsSet(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+      when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
+
+      context.start(mock(SparkListenerJobStart.class));
+      context.start(mock(SparkListenerSQLExecutionStart.class));
+      context.end(mock(SparkListenerSQLExecutionEnd.class));
+      context.end(mock(SparkListenerJobEnd.class));
+    }
+
+    for (RunEvent runEvent : lineageEvent.getAllValues()) {
+      OpenLineage.ParentRunFacet parentRunFacet = runEvent.getRun().getFacets().getParent();
+      OpenLineage.ParentRunFacetJob parentJob = parentRunFacet.getJob();
+      OpenLineage.ParentRunFacetRun parentRun = parentRunFacet.getRun();
+      assertThat(parentJob.getName()).isEqualTo("app_name");
+      assertThat(parentJob.getNamespace()).isEqualTo("ns_name");
+      assertThat(parentRun.getRunId())
+          .isEqualTo(UUID.fromString("8d99e33e-bbbb-cccc-dddd-18f2343aaaaa"));
     }
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
@@ -85,6 +85,9 @@ class CustomEnvironmentVariablesCaptureTest {
             .filter(
                 e ->
                     e.getEventType().equals(EventType.START)
+                        && e.getJob().getFacets() != null
+                        // Exclude SparkApplication start event because env variable was set after
+                        && e.getJob().getFacets().getJobType() != null
                         && e.getRun().getFacets() != null
                         && e.getRun()
                                 .getFacets()

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
@@ -79,7 +79,8 @@ public class DebugRunFacetBuilderDelegate {
   }
 
   private List<String> getSparkJars() {
-    return Optional.ofNullable(olContext.getSparkContext())
+    return olContext
+        .getSparkContext()
         .map(sc -> sc.listJars())
         .map(jars -> ScalaConversionUtils.fromSeq(jars))
         .orElse(null);
@@ -167,18 +168,20 @@ public class DebugRunFacetBuilderDelegate {
   }
 
   private String getDeployMode() {
-    return Optional.ofNullable(olContext.getSparkContext()).map(sc -> sc.deployMode()).orElse(null);
+    return olContext.getSparkContext().map(sc -> sc.deployMode()).orElse(null);
   }
 
   private String getSparkConfOrNull(String confKey) {
-    return Optional.ofNullable(olContext.getSparkContext())
+    return olContext
+        .getSparkContext()
         .map(sc -> sc.conf())
         .map(c -> c.get(confKey, null))
         .orElse(null);
   }
 
   private Map<String, String> getOpenLineageConfig() {
-    return Optional.ofNullable(olContext.getSparkContext())
+    return olContext
+        .getSparkContext()
         .map(sc -> sc.conf())
         .map(conf -> conf.getAllWithPrefix("spark.openlineage."))
         .map(arr -> Arrays.stream(arr))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilder.java
@@ -31,7 +31,7 @@ public class SparkProcessingEngineRunFacetBuilder
   public SparkProcessingEngineRunFacetBuilder(OpenLineageContext openLineageContext) {
     this.delegate =
         new SparkProcessingEngineRunFacetBuilderDelegate(
-            openLineageContext.getOpenLineage(), openLineageContext.getSparkContext());
+            openLineageContext.getOpenLineage(), openLineageContext.getSparkVersion());
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineRunFacetBuilderDelegate.java
@@ -23,11 +23,16 @@ import org.apache.spark.SparkContext;
  */
 public final class SparkProcessingEngineRunFacetBuilderDelegate {
   private final OpenLineage ol;
-  private final SparkContext sparkContext;
+  private final String version;
 
   public SparkProcessingEngineRunFacetBuilderDelegate(OpenLineage ol, SparkContext sparkContext) {
     this.ol = ol;
-    this.sparkContext = sparkContext;
+    this.version = sparkContext.version();
+  }
+
+  public SparkProcessingEngineRunFacetBuilderDelegate(OpenLineage ol, String version) {
+    this.ol = ol;
+    this.version = version;
   }
 
   public ProcessingEngineRunFacet buildFacet() {
@@ -36,7 +41,7 @@ public final class SparkProcessingEngineRunFacetBuilderDelegate {
     //  snake_case
     return ol.newProcessingEngineRunFacetBuilder()
         .name("spark")
-        .version(sparkContext.version())
+        .version(version)
         .openlineageAdapterVersion(this.getClass().getPackage().getImplementationVersion())
         .build();
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -54,7 +54,6 @@ public class EventFilterUtils {
   static boolean isDeltaPlan() {
     return SparkSessionUtils.activeSession()
         .map(SparkSession::sparkContext)
-        .filter(context -> context != null)
         .map(SparkContext::conf)
         .map(conf -> conf.get("spark.sql.extensions", ""))
         .filter(extension -> "io.delta.sql.DeltaSparkSessionExtension".equals(extension))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -6,6 +6,8 @@
 package io.openlineage.spark.agent.lifecycle;
 
 import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.SparkListenerStageCompleted;
@@ -25,11 +27,15 @@ public interface ExecutionContext {
 
   void setActiveJob(ActiveJob activeJob);
 
+  void start(SparkListenerApplicationStart applicationStart);
+
   void start(SparkListenerJobStart jobStart);
 
   void start(SparkListenerSQLExecutionStart sqlStart);
 
   void start(SparkListenerStageSubmitted stageSubmitted);
+
+  void end(SparkListenerApplicationEnd applicationEnd);
 
   void end(SparkListenerJobEnd jobEnd);
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RemovePathPatternUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RemovePathPatternUtils.java
@@ -77,7 +77,8 @@ public class RemovePathPatternUtils {
   }
 
   private static Optional<Pattern> getPattern(OpenLineageContext context) {
-    return Optional.ofNullable(context.getSparkContext())
+    return context
+        .getSparkContext()
         .map(sparkContext -> sparkContext.conf())
         .filter(conf -> conf.contains(SPARK_OPENLINEAGE_DATASET_REMOVE_PATH_PATTERN))
         .map(conf -> conf.get(SPARK_OPENLINEAGE_DATASET_REMOVE_PATH_PATTERN))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SparkSessionUtils.java
@@ -16,7 +16,7 @@ public class SparkSessionUtils {
     try {
       return Optional.of(SparkSession.active());
     } catch (IllegalStateException e) {
-      log.warn("Cannot obtain active spark session", e);
+      log.debug("Cannot obtain active spark session", e);
       return Optional.empty();
     }
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -16,12 +16,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.spark.SparkContext;
 import org.apache.spark.package$;
@@ -46,10 +44,12 @@ import scala.PartialFunction;
  *
  * @apiNote This interface is evolving and may change in future releases
  */
-@RequiredArgsConstructor
-@AllArgsConstructor
 @Builder
 public class OpenLineageContext {
+  // filled up only for SparkListenerApplication{Start,End} events
+  @Setter @Getter UUID applicationUuid;
+
+  // filled up for SparkListener non-application events
   @Default @NonNull @Getter final UUID runUuid = UUID.randomUUID();
 
   /** {@link SparkSession} instance when an application is using a Spark SQL configuration */
@@ -59,8 +59,15 @@ public class OpenLineageContext {
     return Optional.ofNullable(sparkSession);
   }
 
-  /** The non-null {@link SparkContext} running for the application we're reporting run data for */
-  @NonNull @Getter final SparkContext sparkContext;
+  /** The {@link SparkContext} running for the application we're reporting run data for */
+  final SparkContext sparkContext;
+
+  public Optional<SparkContext> getSparkContext() {
+    if (sparkContext != null) {
+      return Optional.of(sparkContext);
+    }
+    return getSparkSession().map(session -> session.sparkContext());
+  }
 
   /** The list of custom environment variables to be captured */
   @Default @NonNull @Getter final List<String> customEnvironmentVariables = Collections.emptyList();
@@ -112,7 +119,9 @@ public class OpenLineageContext {
   }
 
   /** Spark version of currently running job */
-  @Default @NonNull @Getter String sparkVersion = package$.MODULE$.SPARK_VERSION();
+  public String getSparkVersion() {
+    return getSparkContext().map(sc -> sc.version()).orElse(package$.MODULE$.SPARK_VERSION());
+  }
 
   /**
    * Job name is build when the first event of the run is build is created on the top of ready event

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegateTest.java
@@ -65,7 +65,7 @@ class DebugRunFacetBuilderDelegateTest {
 
   @Test
   void testSystemDebugFacetExecutionContext() {
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(sparkContext.deployMode()).thenReturn("local");
     assertThat(delegate.buildFacet().getSystem())
         .hasFieldOrPropertyWithValue("sparkDeployMode", "local");
@@ -89,7 +89,7 @@ class DebugRunFacetBuilderDelegateTest {
     SparkOpenLineageConfig config = new SparkOpenLineageConfig();
     config.setTransportConfig(httpConfig);
 
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(openLineageContext.getOpenLineageConfig()).thenReturn(config);
     when(sparkContext.conf()).thenReturn(conf);
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
@@ -112,7 +112,7 @@ class DebugRunFacetBuilderDelegateTest {
 
   @Test
   void testBuildClasspathDebugFacet() {
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(sparkContext.listJars())
         .thenReturn(ScalaConversionUtils.fromList(Collections.singletonList("oneJar")));
     when(openLineageContext.getSparkVersion()).thenReturn("3.3.0");

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkProcessingEngineFacetBuilderTest.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.facets.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
@@ -18,6 +19,8 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.JobSucceeded$;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.SparkListenerStageCompleted;
@@ -34,7 +37,6 @@ class SparkProcessingEngineFacetBuilderTest {
   @BeforeAll
   public static void setupSparkContext() {
     sparkContext = Mockito.mock(SparkContext.class);
-    Mockito.when(sparkContext.appName()).thenReturn("SparkProcessingEngineFacetBuilderTest");
     Mockito.when(sparkContext.version()).thenReturn("3.3.0");
   }
 
@@ -48,6 +50,13 @@ class SparkProcessingEngineFacetBuilderTest {
                 .meterRegistry(new SimpleMeterRegistry())
                 .openLineageConfig(new SparkOpenLineageConfig())
                 .build());
+
+    // Spark 2.x and 3.x have different number of arguments in SparkListenerApplicationStart
+    // constructor.
+    // using mock to avoid complex conditions and calling constructor using Java reflection.
+    assertThat(builder.isDefinedAt(mock(SparkListenerApplicationStart.class))).isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerApplicationEnd(1L))).isTrue();
+
     assertThat(builder.isDefinedAt(new SparkListenerSQLExecutionEnd(1, 1L))).isTrue();
     assertThat(
             builder.isDefinedAt(

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
@@ -22,11 +22,53 @@ import java.util.Properties;
 import java.util.function.Consumer;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.JobSucceeded$;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class SparkPropertyFacetBuilderTest {
+
+  @Test
+  void testIsDefinedForSparkListenerEvents() {
+    SparkContext sparkContext = mock(SparkContext.class);
+    SparkProcessingEngineRunFacetBuilder builder =
+        new SparkProcessingEngineRunFacetBuilder(
+            OpenLineageContext.builder()
+                .sparkContext(sparkContext)
+                .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+                .meterRegistry(new SimpleMeterRegistry())
+                .openLineageConfig(new SparkOpenLineageConfig())
+                .build());
+
+    // Spark 2.x and 3.x have different number of arguments in SparkListenerApplicationStart
+    // constructor.
+    // using mock to avoid complex conditions and calling constructor using Java reflection.
+    assertThat(builder.isDefinedAt(mock(SparkListenerApplicationStart.class))).isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerApplicationEnd(1L))).isTrue();
+
+    assertThat(builder.isDefinedAt(new SparkListenerSQLExecutionEnd(1, 1L))).isTrue();
+    assertThat(
+            builder.isDefinedAt(
+                new SparkListenerSQLExecutionStart(1L, "abc", "abc", "abc", null, 1L)))
+        .isTrue();
+    assertThat(
+            builder.isDefinedAt(
+                new SparkListenerJobStart(
+                    1, 1L, ScalaConversionUtils.asScalaSeqEmpty(), new Properties())))
+        .isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerJobEnd(1, 1L, JobSucceeded$.MODULE$))).isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerStageSubmitted(null, new Properties())))
+        .isTrue();
+    assertThat(builder.isDefinedAt(new SparkListenerStageCompleted(null))).isTrue();
+  }
 
   @Test
   void testBuildDefault() {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/hooks/JobNameHookTest.java
@@ -43,7 +43,7 @@ class JobNameHookTest {
     config = new SparkOpenLineageConfig();
     when(context.getQueryExecution()).thenReturn(Optional.of(queryExecution));
     when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
-    when(context.getSparkContext()).thenReturn(sparkContext);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(context.getOpenLineageConfig()).thenReturn(config);
     when(sparkContext.conf()).thenReturn(sparkConf);
 

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -151,7 +151,7 @@ class LogicalRelationDatasetBuilderTest {
     Path p2 = new Path("/tmp/path2");
 
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
@@ -190,7 +190,7 @@ class LogicalRelationDatasetBuilderTest {
     when(fileSystem.isFile(p)).thenReturn(true);
 
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RemovePathPatternUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/RemovePathPatternUtilsTest.java
@@ -20,6 +20,7 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ class RemovePathPatternUtilsTest {
   public void setup() {
     conf = mock(SparkConf.class);
     SparkContext sparkContext = mock(SparkContext.class);
-    when(context.getSparkContext()).thenReturn(sparkContext);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(sparkContext.conf()).thenReturn(conf);
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -63,7 +63,7 @@ class LogicalRelationDatasetBuilderTest {
   void setup() {
     when(openLineageContext.getOpenLineage())
         .thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
-    when(openLineageContext.getSparkContext()).thenReturn(sparkContext);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
     when(openLineageContext.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     when(facet.getDatasetVersion()).thenReturn(SOME_VERSION);


### PR DESCRIPTION
### Problem

Discussion: https://github.com/OpenLineage/OpenLineage/issues/2589#issuecomment-2076816639

### Solution

* Add support of `SparkListenerApplicationStart` and `SparkListenerApplicationEnd` events to `ExecutionContext` interface. Now these handled in the same way as other event types.
* Move Spark application facets generation to `SparkApplicationContext` class. It uses `InternalEventHandlerFactory` feature to call facet builders, so both internal facet builders (like `ProcessingEngineRunFacet`, `SparkPropertyFacet`, `CustomEnvironmentFacet`) and custom ones are populated for Spark application runEvents too.

  Before:
  ```json
  {
    "eventTime": "2024-05-07T17:12:36.305Z",
    "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.13.1/integration/spark",
    "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
    "eventType": "START",
    "run": {
      "runId": "9931c1fd-7584-4236-ae3f-04fc34a2c2a0"
    },
    "job": {
      "namespace": "spark_integration",
      "name": "onetl"
    },
    "inputs": [],
    "outputs": []
  }
  ```

  After:
  ```json
     {
    "eventTime": "2024-05-07T17:10:51.548Z",
    "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.14.0-SNAPSHOT/integration/spark",
    "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
    "eventType": "START",
    "run": {
      "runId": "8eee1fd3-67c9-4962-a25c-746a6ddbaf0e",
      "facets": {
        "spark_properties": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.14.0-SNAPSHOT/integration/spark",
          "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
          "properties": {
            "spark.master": "local[*]",
            "spark.app.name": "onetl"
          }
        },
        "processing_engine": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.14.0-SNAPSHOT/integration/spark",
          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
          "version": "3.4.3",
          "name": "spark",
          "openlineageAdapterVersion": "1.14.0-SNAPSHOT"
        },
        "environment-properties": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.14.0-SNAPSHOT/integration/spark",
          "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet",
          "environment-properties": {}
        }
      }
    },
    "job": {
      "namespace": "spark_integration",
      "name": "onetl",
      "facets": {}
    },
    "inputs": [],
    "outputs": []
  }
  ```

* `sparkContext` can be empty for some listener event types (e.g. `SparkListenerApplicationEnd`), so I've updated `OpenLineageContext.getSparkContext` to return `Optional<SparkContext>`. Context nullability was already expected in some methods.

#### One-line summary:

Emit Run facets for Spark application start & stop events.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project