### PR TITLE
[FLINK] turn on code style check for Flink integration

### DIFF
--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -8,6 +8,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 plugins {
     id 'java-library'
     id 'maven-publish'
+    id 'pmd'
     id 'signing'
     id 'jacoco'
     id "com.adarshr.test-logger"

--- a/integration/flink/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/flink/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -59,11 +59,15 @@ class CommonConfigPlugin : Plugin<Project> {
             rulesMinimumPriority.set(5)
             ruleSetFiles = target.rootProject.files("pmd-openlineage.xml")
             ruleSets = listOf()
-            isIgnoreFailures = true
+            isIgnoreFailures = false
         }
 
         target.tasks.named<Pmd>("pmdMain") {
             this.reports.html.required.set(true)
+        }
+        target.tasks.named<Pmd>("pmdTest") {
+            this.reports.html.required.set(true)
+            this.ruleSetFiles = target.rootProject.files("pmd-openlineage-test.xml")
         }
     }
 

--- a/integration/flink/examples/stateful/build.gradle
+++ b/integration/flink/examples/stateful/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'pmd'
     id "com.adarshr.test-logger"
     id 'com.diffplug.spotless'
     id "com.github.johnrengelman.shadow"

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkJdbcApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkJdbcApplication.java
@@ -29,6 +29,7 @@ public class FlinkJdbcApplication {
     public static final String INPUT_QUERY = "select * from source_event";
     public static final String OUTPUT_QUERY = "insert into sink_event(event_uid, content, created_at) values (?, ?, ?)";
 
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     public static final JdbcStatementBuilder<Row> TEST_ENTRY_JDBC_STATEMENT_BUILDER =
             (ps, row) -> {
                 if (row.getArity() == 3) {

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/MultiTopicSerializationSchema.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/MultiTopicSerializationSchema.java
@@ -16,7 +16,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 public class MultiTopicSerializationSchema extends KafkaTopicsDescriptor implements
     KafkaRecordSerializationSchema<OutputEvent> {
 
-  public MultiTopicSerializationSchema(String[] topics) {
+  public MultiTopicSerializationSchema(String... topics) {
     super(Arrays.asList(topics), null);
   }
 

--- a/integration/flink/flink115/build.gradle
+++ b/integration/flink/flink115/build.gradle
@@ -6,6 +6,7 @@
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'pmd'
     id 'com.adarshr.test-logger'
     id 'com.diffplug.spotless'
     id 'io.franzbecker.gradle-lombok'

--- a/integration/flink/flink115/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
+++ b/integration/flink/flink115/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
@@ -43,7 +43,7 @@ class JdbcSinkVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSinkVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcOutputFormat.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcRowOutputFormat.class)));
@@ -54,7 +54,7 @@ class JdbcSinkVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.OutputDataset> outputDatasets = jdbcSinkVisitor.apply(source);
 
     assertEquals(1, outputDatasets.size());

--- a/integration/flink/flink115/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
+++ b/integration/flink/flink115/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
@@ -48,7 +48,7 @@ class JdbcSourceVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSourceVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcInputFormat.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcRowDataInputFormat.class)));
@@ -58,7 +58,7 @@ class JdbcSourceVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.InputDataset> inputDatasets = jdbcSourceVisitor.apply(source);
 
     assertEquals(1, inputDatasets.size());

--- a/integration/flink/flink117/build.gradle
+++ b/integration/flink/flink117/build.gradle
@@ -6,6 +6,7 @@
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'pmd'
     id 'com.adarshr.test-logger'
     id 'com.diffplug.spotless'
     id 'io.franzbecker.gradle-lombok'

--- a/integration/flink/flink117/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
+++ b/integration/flink/flink117/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
@@ -43,7 +43,7 @@ class JdbcSinkVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSinkVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcOutputFormat.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcRowOutputFormat.class)));
@@ -54,7 +54,7 @@ class JdbcSinkVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.OutputDataset> outputDatasets = jdbcSinkVisitor.apply(source);
 
     assertEquals(1, outputDatasets.size());

--- a/integration/flink/flink117/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
+++ b/integration/flink/flink117/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
@@ -47,7 +47,7 @@ class JdbcSourceVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSourceVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcInputFormat.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcRowDataInputFormat.class)));
@@ -57,7 +57,7 @@ class JdbcSourceVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.InputDataset> inputDatasets = jdbcSourceVisitor.apply(source);
 
     assertEquals(1, inputDatasets.size());

--- a/integration/flink/flink118/build.gradle
+++ b/integration/flink/flink118/build.gradle
@@ -6,6 +6,7 @@
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'pmd'
     id 'com.adarshr.test-logger'
     id 'com.diffplug.spotless'
     id 'io.franzbecker.gradle-lombok'

--- a/integration/flink/flink118/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
+++ b/integration/flink/flink118/src/test/java/io/openlineage/flink/visitor/JdbcSinkVisitorTest.java
@@ -43,7 +43,7 @@ class JdbcSinkVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSinkVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcOutputFormat.class)));
     assertTrue(jdbcSinkVisitor.isDefinedAt(mock(JdbcRowOutputFormat.class)));
@@ -54,7 +54,7 @@ class JdbcSinkVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.OutputDataset> outputDatasets = jdbcSinkVisitor.apply(source);
 
     assertEquals(1, outputDatasets.size());

--- a/integration/flink/flink118/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
+++ b/integration/flink/flink118/src/test/java/io/openlineage/flink/visitor/JdbcSourceVisitorTest.java
@@ -48,7 +48,7 @@ class JdbcSourceVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(jdbcSourceVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcInputFormat.class)));
     assertTrue(jdbcSourceVisitor.isDefinedAt(mock(JdbcRowDataInputFormat.class)));
@@ -58,7 +58,7 @@ class JdbcSourceVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.InputDataset> inputDatasets = jdbcSourceVisitor.apply(source);
 
     assertEquals(1, inputDatasets.size());

--- a/integration/flink/pmd-openlineage-test.xml
+++ b/integration/flink/pmd-openlineage-test.xml
@@ -17,14 +17,22 @@
         <exclude name="BeanMembersShouldSerialize" />
         <exclude name="CloseResource" /> <!-- we don't deal with closeable resources -->
         <exclude name="MissingSerialVersionUID" />
+        <exclude name="AvoidDuplicateLiterals" />
     </rule>
     <rule ref="category/java/bestpractices.xml">
         <exclude name="GuardLogStatement" />
         <exclude name="JUnitAssertionsShouldIncludeMessage" />
+        <exclude name="AvoidUsingHardCodedIP" />
     </rule>
     <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
         <properties>
             <property name="maximumAsserts" value="10" />
+        </properties>
+    </rule>
+    <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition">
+        <properties>
+            <property name="ignoreMagicNumbers" value="-1,0,1" />
+            <property name="ignoreExpressions" value="true" />
         </properties>
     </rule>
 </ruleset>

--- a/integration/flink/shared/build.gradle
+++ b/integration/flink/shared/build.gradle
@@ -8,6 +8,7 @@ import io.franzbecker.gradle.lombok.task.DelombokTask
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'pmd'
     id 'com.adarshr.test-logger'
     id 'com.diffplug.spotless'
     id 'com.github.johnrengelman.shadow'

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
@@ -47,6 +47,7 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
     private Map<String, String> additionalProperties = new HashMap<>();
   }
 
+  @Override
   public FlinkOpenLineageConfig mergeWithNonNull(FlinkOpenLineageConfig other) {
     return new FlinkOpenLineageConfig(
         mergePropertyWith(transportConfig, other.transportConfig),

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/CassandraUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/CassandraUtils.java
@@ -64,6 +64,7 @@ public class CassandraUtils {
     };
   }
 
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   private static Optional<String> convertToNamespace(Optional<List<Object>> endpointsOpt) {
     if (endpointsOpt.isPresent() && !endpointsOpt.isEmpty()) {
       Object endpoint = endpointsOpt.get().get(0);

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufFieldResolver.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufFieldResolver.java
@@ -7,11 +7,11 @@ package io.openlineage.flink.utils;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
-import com.google.protobuf.Descriptors.OneofDescriptor;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -76,12 +76,6 @@ public class ProtobufFieldResolver {
         field.getName(), getFieldType(field), "", resolve(field.getMessageType()));
   }
 
-  private List<SchemaDatasetFacetFields> resolveOneOfField(OneofDescriptor oneofDescriptor) {
-    return oneofDescriptor.getFields().stream()
-        .map(f -> resolveField(f))
-        .collect(Collectors.toList());
-  }
-
   private SchemaDatasetFacetFields resolvePrimitiveTypeField(FieldDescriptor field) {
     return openLineage.newSchemaDatasetFacetFields(
         field.getName(), getFieldType(field), "", Collections.emptyList());
@@ -91,7 +85,7 @@ public class ProtobufFieldResolver {
     if (field.getJavaType().equals(JavaType.MESSAGE)) {
       return field.getMessageType().getFullName();
     } else {
-      return field.getType().name().toLowerCase();
+      return field.getType().name().toLowerCase(Locale.ROOT);
     }
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ProtobufUtils.java
@@ -136,7 +136,7 @@ public class ProtobufUtils {
       SerializationSchema serializationSchema) {
     Optional<Class> parameterType =
         Arrays.stream(serializationSchema.getClass().getMethods())
-            .filter(m -> m.getName().equalsIgnoreCase("serialize"))
+            .filter(m -> "serialize".equalsIgnoreCase(m.getName()))
             .filter(m -> m.getParameterTypes()[0] != Object.class)
             .findAny()
             .map(m -> m.getParameterTypes()[0]);
@@ -159,7 +159,7 @@ public class ProtobufUtils {
     } else {
       Optional<Class> parameterType =
           Arrays.stream(deserializationSchema.getClass().getMethods())
-              .filter(m -> m.getName().equalsIgnoreCase("deserialize"))
+              .filter(m -> "deserialize".equalsIgnoreCase(m.getName()))
               .filter(m -> m.getReturnType() != Object.class)
               .findAny()
               .map(m -> m.getReturnType());

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSinkVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSinkVisitor.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.connector.jdbc.JdbcRowOutputFormat;
 import org.apache.flink.connector.jdbc.internal.GenericJdbcSinkFunction;
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
-import org.apache.flink.connector.jdbc.table.JdbcRowDataLookupFunction;
 import org.apache.flink.connector.jdbc.xa.JdbcXaSinkFunction;
 
 @Slf4j
@@ -43,13 +42,13 @@ public class JdbcSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
     log.debug("Apply sink {} in JdbcSinkVisitor", object);
     JdbcSinkWrapper sinkWrapper;
     if (object instanceof JdbcRowOutputFormat) {
-      sinkWrapper = JdbcSinkWrapper.of(object, JdbcRowOutputFormat.class);
+      sinkWrapper = JdbcSinkWrapper.of(object);
     } else if (object instanceof JdbcOutputFormat) {
-      sinkWrapper = JdbcSinkWrapper.of(object, JdbcOutputFormat.class);
+      sinkWrapper = JdbcSinkWrapper.of(object);
     } else if (object instanceof GenericJdbcSinkFunction) {
-      sinkWrapper = JdbcSinkWrapper.of(object, GenericJdbcSinkFunction.class);
+      sinkWrapper = JdbcSinkWrapper.of(object);
     } else if (object instanceof JdbcXaSinkFunction) {
-      sinkWrapper = JdbcSinkWrapper.of(object, JdbcRowDataLookupFunction.class);
+      sinkWrapper = JdbcSinkWrapper.of(object);
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported JDBC sink type %s", object.getClass().getCanonicalName()));

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSourceVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSourceVisitor.java
@@ -40,11 +40,11 @@ public class JdbcSourceVisitor extends Visitor<OpenLineage.InputDataset> {
     log.debug("Apply source {} in JdbcSourceVisitor", object);
     JdbcSourceWrapper sourceWrapper;
     if (object instanceof JdbcInputFormat) {
-      sourceWrapper = JdbcSourceWrapper.of(object, JdbcInputFormat.class);
+      sourceWrapper = JdbcSourceWrapper.of(object);
     } else if (object instanceof JdbcRowDataInputFormat) {
-      sourceWrapper = JdbcSourceWrapper.of(object, JdbcRowDataInputFormat.class);
+      sourceWrapper = JdbcSourceWrapper.of(object);
     } else if (object instanceof JdbcRowDataLookupFunction) {
-      sourceWrapper = JdbcSourceWrapper.of(object, JdbcRowDataLookupFunction.class);
+      sourceWrapper = JdbcSourceWrapper.of(object);
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported JDBC Source type %s", object.getClass().getCanonicalName()));

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSinkWrapper.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSinkWrapper.java
@@ -17,15 +17,13 @@ import org.apache.flink.connector.jdbc.xa.JdbcXaSinkFunction;
 @Slf4j
 public class JdbcSinkWrapper {
   private Object sink;
-  private Class sinkClass;
 
-  public <T> JdbcSinkWrapper(T sink, Class sinkClass) {
+  public <T> JdbcSinkWrapper(T sink) {
     this.sink = sink;
-    this.sinkClass = sinkClass;
   }
 
-  public static <T> JdbcSinkWrapper of(T sink, Class sourceClass) {
-    return new JdbcSinkWrapper(sink, sourceClass);
+  public static <T> JdbcSinkWrapper of(T sink) {
+    return new JdbcSinkWrapper(sink);
   }
 
   public String getConnectionUrl() {

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSourceWrapper.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/wrapper/JdbcSourceWrapper.java
@@ -19,15 +19,13 @@ import org.apache.flink.connector.jdbc.table.JdbcRowDataLookupFunction;
 @Slf4j
 public class JdbcSourceWrapper {
   private Object source;
-  private Class sourceClass;
 
-  public <T> JdbcSourceWrapper(T source, Class sourceClass) {
+  public <T> JdbcSourceWrapper(T source) {
     this.source = source;
-    this.sourceClass = sourceClass;
   }
 
-  public static <T> JdbcSourceWrapper of(T source, Class sourceClass) {
-    return new JdbcSourceWrapper(source, sourceClass);
+  public static <T> JdbcSourceWrapper of(T source) {
+    return new JdbcSourceWrapper(source);
   }
 
   public String getConnectionUrl() {

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
@@ -19,7 +19,7 @@ import org.apache.flink.configuration.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class FlinkConfigParserTest {
+class FlinkConfigParserTest {
 
   Configuration configuration;
   ConfigOption transportTypeOption =

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/pojo/Event.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/pojo/Event.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
  * format.
  */
 @Table(keyspace = "flink", name = "sink_event")
+@SuppressWarnings("PMD.MethodWithSameNameAsEnclosingClass")
 public class Event implements Serializable {
 
   public void Event() {}

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/JobTypeUtilsTest.java
@@ -18,7 +18,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
 import org.junit.jupiter.api.Test;
 
-public class JobTypeUtilsTest {
+class JobTypeUtilsTest {
 
   @Test
   void testExtractWhenExecutionModeIsBatch() {

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-public class ProtobufFieldResolverTest {
+class ProtobufFieldResolverTest {
 
   OpenLineage openLineage = new OpenLineage(mock(URI.class));
   SchemaDatasetFacet facet =

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/CassandraSinkVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/CassandraSinkVisitorTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class CassandraSinkVisitorTest {
+class CassandraSinkVisitorTest {
   private static String insertQuery = "INSERT INTO flink.sink_event (id) VALUES (uuid());";
   OpenLineageContext context = mock(OpenLineageContext.class);
   OpenLineage openLineage = new OpenLineage(EventEmitter.OPEN_LINEAGE_CLIENT_URI);
@@ -48,7 +48,7 @@ public class CassandraSinkVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(cassandraSinkVisitor.isDefinedAt(mock(Object.class)));
     // Use Pojo class
     assertTrue(cassandraSinkVisitor.isDefinedAt(mock(CassandraPojoOutputFormat.class)));
@@ -65,7 +65,7 @@ public class CassandraSinkVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object sink) {
+  void testApply(Object sink) {
     List<OpenLineage.OutputDataset> outputDatasets = cassandraSinkVisitor.apply(sink);
 
     assertEquals(1, outputDatasets.size());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/CassandraSourceVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/CassandraSourceVisitorTest.java
@@ -42,7 +42,7 @@ class CassandraSourceVisitorTest {
 
   @Test
   @SneakyThrows
-  public void testIsDefined() {
+  void testIsDefined() {
     assertFalse(cassandraSourceVisitor.isDefinedAt(mock(Object.class)));
     assertTrue(cassandraSourceVisitor.isDefinedAt(mock(CassandraInputFormat.class)));
     assertTrue(cassandraSourceVisitor.isDefinedAt(mock(CassandraPojoInputFormat.class)));
@@ -51,7 +51,7 @@ class CassandraSourceVisitorTest {
   @SneakyThrows
   @ParameterizedTest
   @MethodSource("provideArguments")
-  public void testApply(Object source) {
+  void testApply(Object source) {
     List<OpenLineage.InputDataset> inputDatasets = cassandraSourceVisitor.apply(source);
 
     assertEquals(1, inputDatasets.size());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/HybridSourceVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/HybridSourceVisitorTest.java
@@ -33,7 +33,6 @@ import org.apache.iceberg.flink.source.IcebergSource;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 class HybridSourceVisitorTest {
   OpenLineageContext context = mock(OpenLineageContext.class);
@@ -64,10 +63,11 @@ class HybridSourceVisitorTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testApply() {
     // Mock Iceberg Source
     Table table = mock(Table.class, RETURNS_DEEP_STUBS);
-    MockedStatic<IcebergSourceWrapper> mockedIcebergStatic = mockStatic(IcebergSourceWrapper.class);
+    mockStatic(IcebergSourceWrapper.class);
     when(IcebergSourceWrapper.of(icebergSource, IcebergSource.class))
         .thenReturn(icebergSourceWrapper);
     when(table.location()).thenReturn("s3://bucket/table/");
@@ -78,7 +78,7 @@ class HybridSourceVisitorTest {
 
     // Mock Kafka Source
     props.put("bootstrap.servers", "server1;server2");
-    MockedStatic<KafkaSourceWrapper> mockedKafkaStatic = mockStatic(KafkaSourceWrapper.class);
+    mockStatic(KafkaSourceWrapper.class);
     when(KafkaSourceWrapper.of(kafkaSource, context)).thenReturn(kafkaSourceWrapper);
 
     when(kafkaSourceWrapper.getTopics()).thenReturn(Arrays.asList("topic1", "topic2"));

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/wrapper/KafkaSourceWrapperTest.java
@@ -64,6 +64,7 @@ class KafkaSourceWrapperTest {
 
   @BeforeEach
   @SneakyThrows
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   public void setup() {
     when(context.getOpenLineage()).thenReturn(new OpenLineage(mock(URI.class)));
     Class kafkaSourceClass = Class.forName("org.apache.flink.connector.kafka.source.KafkaSource");
@@ -177,6 +178,7 @@ class KafkaSourceWrapperTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void testGetTopicsForTopicList() {
     List<String> topics = Arrays.asList("topic1", "topic2");
     Class kafkaSourceClass = Class.forName("org.apache.flink.connector.kafka.source.KafkaSource");
@@ -192,6 +194,7 @@ class KafkaSourceWrapperTest {
 
   @Test
   @SneakyThrows
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   void testGetTopicsForPattern() {
     Pattern pattern = Pattern.compile("topic.*");
     List<String> topics = Arrays.asList("topic1", "topic2");

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/wrapper/MultiTopicSerializationSchema.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/wrapper/MultiTopicSerializationSchema.java
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 public class MultiTopicSerializationSchema extends KafkaTopicsDescriptor
     implements KafkaRecordSerializationSchema<SomeEvent> {
 
-  public MultiTopicSerializationSchema(String[] topics) {
+  public MultiTopicSerializationSchema(String... topics) {
     super(Arrays.asList(topics), null);
   }
 


### PR DESCRIPTION
### Problem

When working on Protobuf support, I realised code style validation is turned OFF for Flink. 
Protobuf PR was already too big to include this. 
This is a follow-up change which fixes all the existing PMD errors and turn ON validation to prevent such case in future. 

### Solution

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project