### PR TITLE
python: allow relative paths in URI formats for Python facets.

### DIFF
--- a/.pre_commit/generate-facets/templates/validators.jinja2
+++ b/.pre_commit/generate-facets/templates/validators.jinja2
@@ -15,11 +15,7 @@
     @{{ name }}.validator
     def {{ name | lower }}_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
-
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "{{ name }} is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)
     {%- elif 'uuid' in type %}
 {#- check uuid format #}
     @{{ name }}.validator

--- a/client/python/openlineage/client/generated/base.py
+++ b/client/python/openlineage/client/generated/base.py
@@ -57,19 +57,13 @@ class BaseEvent(RedactMixin):
     def producer_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "producer is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)
 
     @schemaURL.validator
     def schemaurl_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "schemaURL is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)
 
 
 @define
@@ -100,19 +94,13 @@ class BaseFacet(RedactMixin):
     def _producer_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "_producer is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)
 
     @_schemaURL.validator
     def _schemaurl_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "_schemaURL is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)
 
 
 @define

--- a/client/python/openlineage/client/generated/datasource_dataset.py
+++ b/client/python/openlineage/client/generated/datasource_dataset.py
@@ -23,7 +23,4 @@ class DatasourceDatasetFacet(DatasetFacet):
     def uri_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "uri is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)

--- a/client/python/openlineage/client/generated/source_code_location_job.py
+++ b/client/python/openlineage/client/generated/source_code_location_job.py
@@ -42,7 +42,4 @@ class SourceCodeLocationJobFacet(JobFacet):
     def url_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
         from urllib.parse import urlparse
 
-        result = urlparse(value)
-        if value and not all([result.scheme, result.netloc]):
-            msg = "url is not a valid URI"
-            raise ValueError(msg)
+        urlparse(value)


### PR DESCRIPTION
### Problem

With #2520 there was introduced URI validator that checked if scheme and netloc are present in the parsed result. This, however, is not required by RFC 3986 (that's a standard valid with JSON Schema https://json-schema.org/understanding-json-schema/reference/string#resource-identifiers).

### Solution

Check only `urllib.parse.urlparse` result (similarly to `uuid.UUID`).

#### One-line summary:
Python client: allow relative paths in URI formats for Python facets.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project