### PR TITLE
Spark: Add spark.app.id to spark_properties

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilder.java
@@ -22,7 +22,7 @@ import org.apache.spark.sql.SparkSession;
 public class SparkPropertyFacetBuilder
     extends CustomFacetBuilder<SparkListenerEvent, SparkPropertyFacet> {
   private static final Set<String> DEFAULT_ALLOWED_PROPERTIES =
-      new HashSet<>(Arrays.asList("spark.master", "spark.app.name"));
+      new HashSet<>(Arrays.asList("spark.master", "spark.app.name", "spark.app.id"));
   private static final String ALLOWED_PROPERTIES_KEY = "spark.openlineage.capturedProperties";
   private SparkConf conf;
   private Set<String> allowerProperties;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkPropertyFacetBuilderTest.java
@@ -36,15 +36,17 @@ class SparkPropertyFacetBuilderTest {
             new SparkConf()
                 .setAppName("SparkPropertyFacetBuilderTest")
                 .setMaster("local")
+                .set("spark.app.id", "local-1234")
                 .set("test.key.1", "test"));
     Consumer<OpenLineage.RunFacet> runFacetConsumer =
         facet -> {
           assertThat(facet).isInstanceOf(SparkPropertyFacet.class);
 
           assertThat(((SparkPropertyFacet) facet).getProperties())
-              .containsOnlyKeys("spark.master", "spark.app.name")
+              .containsOnlyKeys("spark.master", "spark.app.name", "spark.app.id")
               .containsEntry("spark.master", "local")
-              .containsEntry("spark.app.name", "SparkPropertyFacetBuilderTest");
+              .containsEntry("spark.app.name", "SparkPropertyFacetBuilderTest")
+              .containsEntry("spark.app.id", "local-1234");
         };
 
     checkBuild(sparkContext, runFacetConsumer);


### PR DESCRIPTION
### Problem

Discussion: https://github.com/OpenLineage/OpenLineage/issues/2589#issuecomment-2076816639

### Solution

#### One-line summary:

Add `spark.app.id` to `SparkPropertiesFacet`, allowing to search for specific applicationId in Yarn UI or SparkHistory UI.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_if necessary_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project