### PR TITLE
Flink: fix SchemaDatasetFacet for Protobuf repeated primitive types

### DIFF
--- a/integration/flink/app/src/test/resources/events/expected_protobuf.json
+++ b/integration/flink/app/src/test/resources/events/expected_protobuf.json
@@ -1,13 +1,13 @@
 {
-  "eventType" : "START",
+  "eventType": "START",
   "eventTime": "${json-unit.any-string}",
-  "job" : {
-    "namespace" : "flink_job_namespace",
+  "job": {
+    "namespace": "flink_job_namespace",
     "name": "flink_protobuf",
     "facets": {
       "jobType": {
-        "processingType" : "STREAMING",
-        "jobType" : "JOB",
+        "processingType": "STREAMING",
+        "jobType": "JOB",
         "integration": "FLINK"
       }
     }
@@ -19,49 +19,52 @@
     {
       "namespace": "kafka://kafka:9092",
       "name": "io.openlineage.flink.kafka.protobuf_input",
-      "facets" : {
-        "schema" : {
-          "fields" : [ {
-            "name" : "id",
-            "type" : "string",
-            "description" : "",
-            "fields" : [ ]
-          }, {
-            "name" : "version",
-            "type" : "int64",
-            "description" : "",
-            "fields" : [ ]
-          }, {
-            "name" : "subEvent",
-            "type" : "io.openlineage.flink.proto.event.SubInputEvent",
-            "description" : "",
-            "fields" : [ {
-              "name" : "id",
-              "type" : "string",
-              "description" : "",
-              "fields" : [ ]
-            }, {
-              "name" : "subSubEvent",
-              "type" : "io.openlineage.flink.proto.event.SubSubInputEvent",
-              "description" : "",
-              "fields" : [ {
-                "name" : "id",
-                "type" : "string",
-                "description" : "",
-                "fields" : [ ]
-              }, {
-                "name" : "version",
-                "type" : "int64",
-                "description" : "",
-                "fields" : [ ]
-              } ]
-            }, {
-              "name" : "arr",
-              "type" : "int64",
-              "description" : "",
-              "fields" : [ ]
-            } ]
-          } ]
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "version",
+              "type": "int64"
+            },
+            {
+              "name": "subEvent",
+              "type": "io.openlineage.flink.proto.event.SubInputEvent",
+              "fields": [
+                {
+                  "name": "id",
+                  "type": "string"
+                },
+                {
+                  "name": "subSubEvent",
+                  "type": "io.openlineage.flink.proto.event.SubSubInputEvent",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": "string"
+                    },
+                    {
+                      "name": "version",
+                      "type": "int64"
+                    }
+                  ]
+                },
+                {
+                  "name": "arr",
+                  "type": "array",
+                  "fields": [
+                    {
+                      "name": "_element",
+                      "type": "int64"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       }
     }
@@ -75,57 +78,47 @@
           "fields": [
             {
               "name": "id",
-              "type": "string",
-              "description": "",
-              "fields": []
+              "type": "string"
             },
             {
               "name": "version",
-              "type": "int64",
-              "description": "",
-              "fields": []
+              "type": "int64"
             },
             {
               "name": "counter",
-              "type": "int64",
-              "description": "",
-              "fields": []
+              "type": "int64"
             },
             {
               "name": "subEvent",
               "type": "io.openlineage.flink.proto.event.SubOutputEvent",
-              "description": "",
               "fields": [
                 {
                   "name": "id",
-                  "type": "string",
-                  "description": "",
-                  "fields": []
+                  "type": "string"
                 },
                 {
                   "name": "subSubEvent",
                   "type": "io.openlineage.flink.proto.event.SubSubOutputEvent",
-                  "description": "",
                   "fields": [
                     {
                       "name": "id",
-                      "type": "string",
-                      "description": "",
-                      "fields": []
+                      "type": "string"
                     },
                     {
                       "name": "version",
-                      "type": "int64",
-                      "description": "",
-                      "fields": []
+                      "type": "int64"
                     }
                   ]
                 },
                 {
                   "name": "arr",
-                  "type": "int64",
-                  "description": "",
-                  "fields": []
+                  "type": "array",
+                  "fields": [
+                    {
+                      "name": "_element",
+                      "type": "int64"
+                    }
+                  ]
                 }
               ]
             }

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/ProtobufFieldResolverTest.java
@@ -26,10 +26,12 @@ class ProtobufFieldResolverTest {
   @Test
   void testConvertNestedDataType() {
     // verify subEvent
+    assertThat(subEvent.getName()).isEqualTo("subEvent");
     assertThat(subEvent.getType())
         .isEqualTo("io.openlineage.flink.proto.event.SubProtobufTestEvent");
+    assertThat(subEvent.getDescription()).isNull();
 
-    assertThat(subEvent.getFields()).hasSize(4);
+    assertThat(subEvent.getFields()).hasSize(5);
     assertThat(getSubField(subEvent.getFields(), "id"))
         .isPresent()
         .map(f -> f.getType())
@@ -54,11 +56,12 @@ class ProtobufFieldResolverTest {
   }
 
   @Test
-  void testConvertVerifyArrayDataType() {
-    SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "arr").get();
+  void testConvertVerifyMessageArrayDataType() {
+    SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "arrMessage").get();
     assertThat(field.getFields()).hasSize(1);
-    assertThat("array").isEqualTo(field.getType());
-    assertThat("arr").isEqualTo(field.getName());
+    assertThat(field.getType()).isEqualTo("array");
+    assertThat(field.getName()).isEqualTo("arrMessage");
+    assertThat(field.getDescription()).isNull();
 
     assertThat(field.getFields().get(0))
         .hasFieldOrPropertyWithValue("name", "_element")
@@ -70,11 +73,27 @@ class ProtobufFieldResolverTest {
   }
 
   @Test
+  void testConvertVerifyPrimitiveArrayDataType() {
+    SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "arrPrimitive").get();
+    assertThat(field.getFields()).hasSize(1);
+    assertThat(field.getType()).isEqualTo("array");
+    assertThat(field.getName()).isEqualTo("arrPrimitive");
+    assertThat(field.getDescription()).isNull();
+
+    assertThat(field.getFields().get(0))
+        .hasFieldOrPropertyWithValue("name", "_element")
+        .hasFieldOrPropertyWithValue("type", "int64");
+
+    assertThat(field.getFields().get(0).getFields()).isNull(); // no nested fields
+  }
+
+  @Test
   void testConvertVerifyMapDataType() {
     SchemaDatasetFacetFields field = getSubField(subEvent.getFields(), "someMap").get();
     assertThat(field.getFields()).hasSize(2);
-    assertThat("map").isEqualTo(field.getType());
-    assertThat("someMap").isEqualTo(field.getName());
+    assertThat(field.getType()).isEqualTo("map");
+    assertThat(field.getName()).isEqualTo("someMap");
+    assertThat(field.getDescription()).isNull();
 
     assertThat(field.getFields().get(0))
         .hasFieldOrPropertyWithValue("name", "key")
@@ -89,8 +108,10 @@ class ProtobufFieldResolverTest {
   void testAny() {
     SchemaDatasetFacetFields anyField = getSubField(facet.getFields(), "testAnyOf").get();
     assertThat(anyField.getFields()).hasSize(2);
-    assertThat("google.protobuf.Any").isEqualTo(anyField.getType());
-    assertThat("testAnyOf").isEqualTo(anyField.getName());
+    assertThat(anyField.getType()).isEqualTo("google.protobuf.Any");
+    assertThat(anyField.getName()).isEqualTo("testAnyOf");
+    assertThat(anyField.getDescription()).isNull();
+
     assertThat(anyField.getFields().get(0))
         .hasFieldOrPropertyWithValue("name", "type_url")
         .hasFieldOrPropertyWithValue("type", "string");

--- a/integration/flink/shared/src/test/proto/ProtobufTestEvent.proto
+++ b/integration/flink/shared/src/test/proto/ProtobufTestEvent.proto
@@ -21,8 +21,9 @@ message ProtobufTestEvent {
 message SubProtobufTestEvent {
   string id = 1;
   SubSubProtobufTestEvent subSubEvent = 2;
-  repeated SubSubProtobufTestEvent arr = 3;
-  map<string, int32> someMap = 4;
+  repeated SubSubProtobufTestEvent arrMessage = 3;
+  repeated int64 arrPrimitive = 4;
+  map<string, int32> someMap = 5;
 }
 
 message SubSubProtobufTestEvent {


### PR DESCRIPTION
### Problem

#2482 introduced converter from Protobuf schema to SchemaDatasetFacet. But it had several issues:
* Repeated fields of primitive types were described as not `array[type]`, [but as `type`](https://github.com/OpenLineage/OpenLineage/pull/2482/files#diff-606b9c133ad2f0e027687cc7dbd1e5b60ad8b2f4a2a09d95bc5cccc8601232f0R59-R62).
* Primitive type fields have `fields` property with empty list value, which does no make any sense.
* All fields have `description: ""` but Protobuf has no concept of fields description if the first place. IMHO in this case it's better not to fill up description at all.

### Solution

#### One-line summary:

Fix SchemaDatasetFacet for Protobuf repeated primitive types.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project