### PR TITLE
Java: Use UUIDv7 instead of UUIDv4

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,3 @@
 This project includes code from the Marquez Project, part of the LFAI & Data Foundation.
 This project includes code from https://github.com/oittaa/uuid6-python repo (MIT license).
+This project includes code from https://github.com/f4b6a3/uuid-creator repo (MIT license).

--- a/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
@@ -1,0 +1,50 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.utils;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Class used to generate UUID values. */
+public class UUIDUtils {
+  /**
+   * Generate new UUID. Each function call returns a new UUID value.
+   *
+   * <p>UUID version is an implementation detail, and <b>should not</b> be relied on. For now it is
+   * <a href="https://datatracker.ietf.org/doc/rfc9562/">UUIDv7</a>, so for increasing instant
+   * values, returned UUID is always greater than previous one.
+   *
+   * @return {@link UUID} v7
+   * @since 1.15.0
+   */
+  public static UUID generateNewUUID() {
+    return generateNewUUID(Instant.now());
+  }
+
+  /**
+   * Generate new UUID for an instant of time. Each function call returns a new UUID value.
+   *
+   * <p>UUID version is an implementation detail, and <b>should not</b> be relied on. For now it is
+   * <a href="https://datatracker.ietf.org/doc/rfc9562/">UUIDv7</a>, so for increasing instant
+   * values, returned UUID is always greater than previous one.
+   *
+   * <p>Based on <a
+   * href="https://github.com/f4b6a3/uuid-creator/blob/98628c29ac9da704d215245f2099d9b439bc3084/src/main/java/com/github/f4b6a3/uuid/UuidCreator.java#L584-L593"
+   * target="_top">com.github.f4b6a3.uuid.UuidCreator.getTimeOrderedEpoch</a> implementation (MIT
+   * License).
+   *
+   * @param instant a given instant
+   * @return {@link UUID} v7
+   * @since 1.15.0
+   */
+  public static UUID generateNewUUID(Instant instant) {
+    long time = instant.toEpochMilli();
+    SecureRandom random = new SecureRandom();
+    long msb = (time << 16) | (random.nextLong() & 0x0fffL) | 0x7000L;
+    long lsb = (random.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
+    return new UUID(msb, lsb);
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UUIDUtilsTest {
+
+  @Test
+  void testgenerateNewUUIDResultIsAlwaysDifferent() {
+    assertThat(UUIDUtils.generateNewUUID().version()).isEqualTo(7);
+
+    UUID uuid1 = UUIDUtils.generateNewUUID();
+    UUID uuid2 = UUIDUtils.generateNewUUID();
+
+    assertThat(uuid1).isNotEqualTo(uuid2);
+  }
+
+  @Test
+  void testgenerateNewUUIDForInstantResultIsIncreasing() {
+    Instant instant = Instant.now();
+    assertThat(UUIDUtils.generateNewUUID(instant).version()).isEqualTo(7);
+
+    UUID uuid1 = UUIDUtils.generateNewUUID(instant);
+    UUID uuid2 = UUIDUtils.generateNewUUID(instant.plusMillis(1));
+
+    assertThat(uuid1).isNotEqualTo(uuid2);
+    assertThat(uuid1).isLessThan(uuid2);
+  }
+}

--- a/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
@@ -12,13 +12,13 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.circuitBreaker.CircuitBreakerFactory;
 import io.openlineage.client.metrics.MicrometerProvider;
+import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.client.EventEmitter;
 import io.openlineage.flink.client.FlinkConfigParser;
 import io.openlineage.flink.client.FlinkOpenLineageConfig;
 import io.openlineage.flink.client.Versions;
 import java.util.List;
-import java.util.UUID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
@@ -52,7 +52,7 @@ public class FlinkExecutionContextFactory {
         .jobName(jobName)
         .jobNamespace(jobNamespace)
         .transformations(transformations)
-        .runId(UUID.randomUUID())
+        .runId(UUIDUtils.generateNewUUID())
         .circuitBreaker(new CircuitBreakerFactory(config.getCircuitBreaker()).build())
         .openLineageContext(
             OpenLineageContext.builder()

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -6,6 +6,7 @@
 package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.UUIDUtils;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.NonNull;
@@ -23,7 +24,7 @@ import lombok.Value;
 @Value
 @Builder
 public class OpenLineageContext {
-  UUID runUuid = UUID.randomUUID();
+  UUID runUuid = UUIDUtils.generateNewUUID();
 
   /**
    * A non-null, preconfigured {@link OpenLineage} client instance for constructing OpenLineage

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -10,6 +10,7 @@ import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.transports.TransportFactory;
+import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -52,7 +53,7 @@ public class EventEmitter {
             .disableFacets(disabledFacets)
             .build();
     this.applicationJobName = applicationJobName;
-    this.applicationRunId = UUID.randomUUID();
+    this.applicationRunId = UUIDUtils.generateNewUUID();
   }
 
   public void emit(OpenLineage.RunEvent event) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -9,6 +9,7 @@ import static io.openlineage.spark.agent.util.TimeUtils.toZonedTime;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.Versions;
@@ -63,7 +64,7 @@ class RddExecutionContext implements ExecutionContext {
 
   private final EventEmitter eventEmitter;
   private final Optional<SparkContext> sparkContextOption;
-  private final UUID runId = UUID.randomUUID();
+  private final UUID runId = UUIDUtils.generateNewUUID();
   private List<URI> inputs = Collections.emptyList();
   private List<URI> outputs = Collections.emptyList();
   private String jobSuffix;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,7 +51,7 @@ public class OpenLineageContext {
   @Setter @Getter UUID applicationUuid;
 
   // filled up for SparkListener non-application events
-  @Default @NonNull @Getter final UUID runUuid = UUID.randomUUID();
+  @Default @NonNull @Getter final UUID runUuid = UUIDUtils.generateNewUUID();
 
   /** {@link SparkSession} instance when an application is using a Spark SQL configuration */
   final SparkSession sparkSession;


### PR DESCRIPTION
### Problem

See #2541.

### Solution

Introduce `io.openlineage.client.utils.UUIDUtils.generateNewUUID()` static function, returning UUIDv7. Replace all occurrences of `UUID.randomUUID()` with a new function.

#### One-line summary:

Use UUIDv7 instead of UUIDv4 for runEvents. New UUID version produces monotonically increasing values, which leads to more performant queries on OL consumer side. **Note**: UUID version is an implementation detail, and can be changed in future.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project