### PR TITLE
Python: Use UUIDv7 instead of UUIDv4

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,1 +1,2 @@
 This project includes code from the Marquez Project, part of the LFAI & Data Foundation.
+This project includes code from https://github.com/oittaa/uuid6-python repo (MIT license).

--- a/client/python/docs/source/openlineage.client.rst
+++ b/client/python/docs/source/openlineage.client.rst
@@ -65,6 +65,14 @@ openlineage.client.utils module
    :undoc-members:
    :show-inheritance:
 
+openlineage.client.uuid module
+-------------------------------
+
+.. automodule:: openlineage.client.uuid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 openlineage.client.generated.base module
 ----------------------------------------
 

--- a/client/python/openlineage/client/uuid.py
+++ b/client/python/openlineage/client/uuid.py
@@ -1,0 +1,89 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import secrets
+import time
+from datetime import timezone
+from hashlib import sha1
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+def generate_new_uuid(instant: datetime | None = None) -> UUID:
+    """Generate new UUID for an instant of time. Each function call returns a new UUID value.
+
+    UUID version is an implementation detail, and **should not** be relied on.
+    For now it is [UUIDv7](https://datatracker.ietf.org/doc/rfc9562/), so for increasing instant values,
+    returned UUID is always greater than previous one.
+
+    Using uuid6 lib implementation (MIT License), with few changes:
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L128-L147
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L46-L51
+
+    Added in v1.15.0
+
+    :param instant: instant of time used to generate UUID. If not provided, current time is used.
+    :return: UUID
+    """
+
+    timestamp_ms = int(instant.timestamp() * 1000) if instant else time.time_ns() // 10**6
+    node = secrets.randbits(76)
+    return _build_uuidv7(timestamp_ms, node)
+
+
+def generate_static_uuid(
+    instant: datetime,
+    data: bytes,
+) -> UUID:
+    """Generate UUID for instant of time and input data.
+    Calling function with same arguments always produces the same result.
+
+    UUID version is an implementation detail, and **should not* be relied on.
+    For now it is [UUIDv7](https://datatracker.ietf.org/doc/rfc9562/), so for increasing instant values,
+    returned UUID is always greater than previous one. The only difference from RFC 9562 is that
+    least significant bytes are not random, but instead a SHA-1 hash of input data.
+
+    Using uuid6 lib implementation (MIT License), with few changes:
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L128-L147
+    * https://github.com/oittaa/uuid6-python/blob/4f879849178b8a7a564f7cb76c3f7a6e5228d9ed/src/uuid6/__init__.py#L46-L51
+
+    Added in v1.15.0
+
+    :param instant: instant of time used to generate UUID. If not provided, current time is used.
+    :param data: input data to generate random part from.
+    :return: UUID
+    """
+
+    instant_utc = instant.astimezone(timezone.utc)
+    timestamp_ms = int(instant_utc.timestamp() * 1000)
+
+    # generate the rest of bytes using some hash.
+    # can be used to generate consistent UUIDs for some input, e.g. external runId.
+    # if data is some static value, e.g. job name, mix it with timestamp to make it more random
+    digest = sha1(instant_utc.isoformat().encode("utf-8") + data).digest()  # noqa: S324
+    # sha1 returns 160bit hash, we need only first 76 bits
+    node = int(digest.hex(), 16) >> 84
+
+    return _build_uuidv7(timestamp_ms, node)
+
+
+def _build_uuidv7(timestamp: int, node: int) -> UUID:
+    # merge timestamp and node into 128-bit UUID
+    # timestamp is first 48 bits, node is last 80 bits
+    uuid_int = (timestamp & 0xFFFFFFFFFFFF) << 80
+    uuid_int |= node & 0xFFFFFFFFFFFFFFFFFFFF
+
+    # Set the version number (4 bit).
+    version = 7
+    uuid_int &= ~(0xF000 << 64)
+    uuid_int |= version << 76
+
+    # Set the variant (2 bit) to RFC 4122.
+    uuid_int &= ~(0xC000 << 48)
+    uuid_int |= 0x8000 << 48
+
+    return UUID(int=uuid_int)

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +22,7 @@ from openlineage.client.run import (
 )
 from openlineage.client.transport.http import HttpTransport
 from openlineage.client.transport.noop import NoopTransport
+from openlineage.client.uuid import generate_new_uuid
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -207,7 +207,7 @@ def test_client_filters_exact_job_name_events(
         factory.create.return_value = transport
         client = OpenLineageClient(factory=factory)
 
-        run = Run(runId=str(uuid.uuid4()))
+        run = Run(runId=str(generate_new_uuid()))
         event = RunEvent(
             eventType=RunState.START,
             eventTime="2021-11-03T10:53:52.427343",

--- a/client/python/tests/test_file.py
+++ b/client/python/tests/test_file.py
@@ -5,7 +5,6 @@ import json
 import os
 import tempfile
 import time
-import uuid
 from os import listdir
 from os.path import exists, isfile, join
 from typing import Any, Dict, List
@@ -15,6 +14,7 @@ import pytest
 from openlineage.client import OpenLineageClient
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.transport.file import FileConfig, FileTransport
+from openlineage.client.uuid import generate_new_uuid
 
 
 def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> List[Dict[str, Any]]:
@@ -37,7 +37,7 @@ def emit_test_events(client: OpenLineageClient, debuff_time: int = 0) -> List[Di
         event = RunEvent(
             eventType=test_event["eventType"],
             eventTime=datetime.datetime.now().isoformat(),
-            run=Run(runId=str(uuid.uuid4())),
+            run=Run(runId=str(generate_new_uuid())),
             job=Job(namespace=test_event["namespace"], name=test_event["name"]),
             producer=test_event["producer"],
         )
@@ -107,7 +107,7 @@ def test_file_transport_raises_error_with_non_writeable_file(mock_dt, append) ->
     event = RunEvent(
         eventType=RunState.START,
         eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
+        run=Run(runId=str(generate_new_uuid())),
         job=Job(namespace="file", name="test"),
         producer="prod",
     )

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import datetime
 import gzip
-import uuid
 from typing import TYPE_CHECKING
 
 from openlineage.client import OpenLineageClient
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
 from openlineage.client.transport.http import HttpCompression, HttpConfig, HttpTransport
+from openlineage.client.uuid import generate_new_uuid
 from requests import Session
 
 if TYPE_CHECKING:
@@ -71,7 +71,7 @@ def test_client_with_http_transport_emits(mocker: MockerFixture) -> None:
     event = RunEvent(
         eventType=RunState.START,
         eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
+        run=Run(runId=str(generate_new_uuid())),
         job=Job(namespace="http", name="test"),
         producer="prod",
         schemaURL="schema",
@@ -102,7 +102,7 @@ def test_client_with_http_transport_emits_custom_endpoint(mocker: MockerFixture)
     event = RunEvent(
         eventType=RunState.START,
         eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
+        run=Run(runId=str(generate_new_uuid())),
         job=Job(namespace="http", name="test"),
         producer="prod",
         schemaURL="schema",

--- a/client/python/tests/test_msk_iam.py
+++ b/client/python/tests/test_msk_iam.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime
 import os
-import uuid
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -16,6 +15,7 @@ from openlineage.client.transport.msk_iam import (
     _detect_running_region,
     _oauth_cb,
 )
+from openlineage.client.uuid import generate_new_uuid
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -26,7 +26,7 @@ def event() -> RunEvent:
     return RunEvent(
         eventType=RunState.START,
         eventTime=datetime.datetime.now().isoformat(),
-        run=Run(runId=str(uuid.uuid4())),
+        run=Run(runId=str(generate_new_uuid())),
         job=Job(namespace="kafka", name="test"),
         producer="prod",
         schemaURL="schema",

--- a/client/python/tests/test_uuid.py
+++ b/client/python/tests/test_uuid.py
@@ -1,0 +1,50 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from openlineage.client.uuid import generate_new_uuid, generate_static_uuid
+
+
+def test_generate_new_uuid_returns_uuidv7():
+    assert generate_new_uuid().version == 7  # noqa: PLR2004
+
+
+def test_generate_static_uuid_returns_different_result_on_each_call():
+    instant = datetime.now()
+    result1 = generate_new_uuid(instant)
+    result2 = generate_new_uuid(instant)
+    assert result1 != result2
+
+
+def test_generate_new_uuid_result_is_increasing_with_instant_increment():
+    result1 = generate_new_uuid(datetime.now())
+    result2 = generate_new_uuid(datetime.now() + timedelta(seconds=0.001))
+    assert result1 != result2
+    assert result1 < result2
+
+
+def test_generate_static_uuid_returns_uuidv7():
+    assert generate_static_uuid(datetime.now(), b"some").version == 7  # noqa: PLR2004
+
+
+def test_generate_static_uuid_returns_same_result_for_same_input():
+    instant = datetime.now()
+    data = b"some"
+    assert generate_static_uuid(instant, data) == generate_static_uuid(instant, data)
+
+
+@pytest.mark.parametrize(
+    ("data1", "data2"),
+    [
+        (b"some", b"other"),
+        (b"some", b"some"),
+    ],
+)
+def test_generate_static_uuid_result_is_increasing_with_instant_increment(data1, data2):
+    result1 = generate_static_uuid(datetime.now(), data1)
+    result2 = generate_static_uuid(datetime.now() + timedelta(seconds=0.001), data2)
+    assert result1 != result2
+    assert result1 < result2

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -126,10 +126,16 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
         # we return here because Airflow 2.3 needs task from deferred state
         if ti.next_method is not None:
             return
-        parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
 
+        parent_run_id = OpenLineageAdapter.build_dag_run_id(
+            dag_id=dag.dag_id,
+            execution_date=dagrun.execution_date,
+        )
         task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            dag.dag_id, task.task_id, ti.execution_date, ti._try_number
+            dag_id=dag.dag_id,
+            task_id=task.task_id,
+            try_number=ti._try_number,
+            execution_date=ti.execution_date,
         )
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task, task_uuid=task_uuid)
@@ -165,10 +171,15 @@ def on_task_instance_success(previous_state, task_instance: "TaskInstance", sess
     dag = task.dag
     dagrun = task_instance.dag_run
 
-    parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
-
+    parent_run_id = OpenLineageAdapter.build_dag_run_id(
+        dag_id=dag.dag_id,
+        execution_date=dagrun.execution_date,
+    )
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        dag.dag_id, task.task_id, task_instance.execution_date, task_instance._try_number
+        dag_id=dag.dag_id,
+        task_id=task.task_id,
+        try_number=task_instance._try_number,
+        execution_date=task_instance.execution_date,
     )
 
     def on_success():
@@ -194,10 +205,15 @@ def on_task_instance_failed(previous_state, task_instance: "TaskInstance", sessi
     dag = task.dag
     dagrun = task_instance.dag_run
 
-    parent_run_id = OpenLineageAdapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
-
+    parent_run_id = OpenLineageAdapter.build_dag_run_id(
+        dag_id=dag.dag_id,
+        execution_date=dagrun.execution_date,
+    )
     task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-        dag.dag_id, task.task_id, task_instance.execution_date, task_instance._try_number
+        dag_id=dag.dag_id,
+        task_id=task.task_id,
+        try_number=task_instance._try_number,
+        execution_date=task_instance.execution_date,
     )
 
     def on_failure():

--- a/integration/airflow/openlineage/airflow/macros.py
+++ b/integration/airflow/openlineage/airflow/macros.py
@@ -59,10 +59,10 @@ def lineage_run_id(task_instance: TaskInstance):
     )
     """
     return OpenLineageAdapter.build_task_instance_run_id(
-        task_instance.dag_id,
-        task_instance.task_id,
-        task_instance.execution_date,
-        task_instance.try_number,
+        dag_id=task_instance.dag_id,
+        task_id=task_instance.task_id,
+        try_number=task_instance.try_number,
+        execution_date=task_instance.execution_date,
     )
 
 

--- a/integration/airflow/openlineage/lineage_backend/__init__.py
+++ b/integration/airflow/openlineage/lineage_backend/__init__.py
@@ -3,9 +3,9 @@
 
 import os
 import time
-import uuid
 from typing import Optional
 
+from openlineage.client.uuid import generate_new_uuid
 from packaging.version import Version
 
 from airflow.lineage.backend import LineageBackend
@@ -43,9 +43,12 @@ class Backend:
         dag = context["dag"]
         dagrun = context["dag_run"]
         task_instance = context["task_instance"]
-        dag_run_id = self.adapter.build_dag_run_id(dag.dag_id, dagrun.run_id)
+        dag_run_id = self.adapter.build_dag_run_id(
+            dag_id=dag.dag_id,
+            execution_date=dagrun.execution_date,
+        )
 
-        run_id = str(uuid.uuid4())
+        run_id = str(generate_new_uuid())
         job_name = get_job_name(operator)
 
         task_metadata = self.extractor_manager.extract_metadata(
@@ -53,7 +56,10 @@ class Backend:
         )
 
         task_uuid = OpenLineageAdapter.build_task_instance_run_id(
-            dag.dag_id, operator.task_id, task_instance.execution_date, task_instance.try_number
+            dag_id=dag.dag_id,
+            task_id=operator.task_id,
+            try_number=task_instance.try_number,
+            execution_date=task_instance.execution_date,
         )
         start, end = get_dagrun_start_end(dagrun, dag)
 

--- a/integration/airflow/tests/extractors/test_bigquery_extractor.py
+++ b/integration/airflow/tests/extractors/test_bigquery_extractor.py
@@ -5,7 +5,6 @@ import json
 import logging
 import random
 import unittest
-import uuid
 from datetime import datetime
 from unittest import mock
 
@@ -16,6 +15,7 @@ from openlineage.client.facet import (
     ExternalQueryRunFacet,
     OutputStatisticsOutputDatasetFacet,
 )
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.bigquery import (
     BigQueryErrorRunFacet,
     BigQueryJobRunFacet,
@@ -71,7 +71,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         execution_date = datetime.utcnow().replace(tzinfo=pytz.utc)
         dag = DAG(dag_id="TestBigQueryExtractorE2E")
-        dag.create_dagrun(run_id=str(uuid.uuid4()), state=State.QUEUED, execution_date=execution_date)
+        dag.create_dagrun(run_id=str(generate_new_uuid()), state=State.QUEUED, execution_date=execution_date)
 
         task = BigQueryExecuteQueryOperator(
             sql="select first_name, last_name from dataset.customers;",
@@ -171,7 +171,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         execution_date = datetime.utcnow().replace(tzinfo=pytz.utc)
         dag = DAG(dag_id="TestBigQueryExtractorE2E")
-        dag.create_dagrun(run_id=str(uuid.uuid4()), state=State.QUEUED, execution_date=execution_date)
+        dag.create_dagrun(run_id=str(generate_new_uuid()), state=State.QUEUED, execution_date=execution_date)
 
         task = BigQueryExecuteQueryOperator(
             sql="select first_name, last_name from dataset.customers;",
@@ -223,7 +223,7 @@ class TestBigQueryExtractorE2E(unittest.TestCase):
 
         execution_date = datetime.utcnow().replace(tzinfo=pytz.utc)
         dag = DAG(dag_id="TestBigQueryExtractorE2E")
-        dag.create_dagrun(run_id=str(uuid.uuid4()), state=State.QUEUED, execution_date=execution_date)
+        dag.create_dagrun(run_id=str(generate_new_uuid()), state=State.QUEUED, execution_date=execution_date)
 
         task = BigQueryExecuteQueryOperator(
             sql="select first_name, last_name from dataset.customers;",

--- a/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
+++ b/integration/airflow/tests/extractors/test_dbt_cloud_extractor.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import uuid
 from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
 import pytz
 from openlineage.airflow.utils import try_import_from_string
+from openlineage.client.uuid import generate_new_uuid
 from packaging.version import Version
 from pytest_mock import MockerFixture
 
@@ -138,7 +138,7 @@ class TestDbtCloudExtractorE2E:
         execution_date = datetime.utcnow().replace(tzinfo=pytz.utc)
         default_args = {"dbt_cloud_conn_id": "dbt_cloud"}
         dag = DAG(dag_id="TestDBTCloudExtractor", default_args=default_args)
-        dag.create_dagrun(run_id=str(uuid.uuid4()), state=State.QUEUED, execution_date=execution_date)
+        dag.create_dagrun(run_id=str(generate_new_uuid()), state=State.QUEUED, execution_date=execution_date)
 
         task = DbtCloudRunJobOperator(
             dag=dag,

--- a/integration/airflow/tests/extractors/test_redshift_data_extractor.py
+++ b/integration/airflow/tests/extractors/test_redshift_data_extractor.py
@@ -5,7 +5,6 @@ import json
 import logging
 import random
 import unittest
-import uuid
 from datetime import datetime
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -17,6 +16,7 @@ from openlineage.client.facet import (
     ErrorMessageRunFacet,
     OutputStatisticsOutputDatasetFacet,
 )
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
 from packaging.version import Version
@@ -67,7 +67,7 @@ log = logging.getLogger(__name__)
 class TestRedshiftDataExtractor(unittest.TestCase):
     def setUp(self):
         log.debug("TestRedshiftDataExtractor.setup(): ")
-        run_id = str(uuid.uuid4())
+        run_id = str(generate_new_uuid())
         self.task = TestRedshiftDataExtractor._get_redshift_task(run_id)
         self.ti = TestRedshiftDataExtractor._get_ti(task=self.task, run_id=run_id)
         self.extractor = RedshiftDataExtractor(operator=self.task)

--- a/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/event_order.py
@@ -3,10 +3,10 @@
 
 import datetime
 import os
-import uuid
 
 from openlineage.client import OpenLineageClient, set_producer
 from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_new_uuid
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
@@ -42,7 +42,7 @@ def emit_event():
         RunEvent(
             RunState.COMPLETE,
             datetime.datetime.now().isoformat(),
-            Run(runId=str(uuid.uuid4())),
+            Run(runId=str(generate_new_uuid())),
             Job(
                 namespace=os.getenv("OPENLINEAGE_NAMESPACE"),
                 name="emit_event.wait-for-me",

--- a/integration/airflow/tests/test_macros.py
+++ b/integration/airflow/tests/test_macros.py
@@ -1,6 +1,6 @@
 # Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
-import uuid
+from datetime import datetime, timezone
 from unittest import mock
 
 from openlineage.airflow.adapter import _DAG_NAMESPACE
@@ -20,7 +20,8 @@ def test_lineage_job_name():
     task_instance = mock.MagicMock(
         dag_id="dag_id",
         task_id="task_id",
-        execution_date="execution_date",
+        dag_run=mock.MagicMock(run_id="run_id"),
+        execution_date=datetime(2020, 1, 1, 1, 1, 1, 0, tzinfo=timezone.utc),
         try_number=1,
     )
     assert lineage_job_name(task_instance) == "dag_id.task_id"
@@ -30,37 +31,33 @@ def test_lineage_run_id():
     task_instance = mock.MagicMock(
         dag_id="dag_id",
         task_id="task_id",
-        execution_date="execution_date",
+        dag_run=mock.MagicMock(run_id="run_id"),
+        execution_date=datetime(2020, 1, 1, 1, 1, 1, 0, tzinfo=timezone.utc),
         try_number=1,
     )
 
-    actual = lineage_run_id(task_instance)
-    expected = str(
-        uuid.uuid3(
-            uuid.NAMESPACE_URL,
-            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
-        )
-    )
+    call_result1 = lineage_run_id(task_instance)
+    call_result2 = lineage_run_id(task_instance)
 
-    assert actual == expected
+    # random part value does not matter, it just have to be the same for the same TaskInstance
+    assert call_result1 == call_result2
+    # execution_date is used as most significant bits of UUID
+    assert call_result1.startswith("016f5e9e-c4c8-")
 
 
 def test_lineage_parent_id():
     task_instance = mock.MagicMock(
         dag_id="dag_id",
         task_id="task_id",
-        execution_date="execution_date",
+        dag_run=mock.MagicMock(run_id="run_id"),
+        execution_date=datetime(2020, 1, 1, 1, 1, 1, 0, tzinfo=timezone.utc),
         try_number=1,
     )
 
-    actual = lineage_parent_id(task_instance)
-    job_name = "dag_id.task_id"
-    run_id = str(
-        uuid.uuid3(
-            uuid.NAMESPACE_URL,
-            f"{_DAG_NAMESPACE}.dag_id.task_id.execution_date.1",
-        )
-    )
+    call_result1 = lineage_parent_id(task_instance)
+    call_result2 = lineage_parent_id(task_instance)
 
-    expected = f"{_DAG_NAMESPACE}/{job_name}/{run_id}"
-    assert actual == expected
+    # random part value does not matter, it just have to be the same for the same TaskInstance
+    assert call_result1 == call_result2
+    # execution_date is used as most significant bits of UUID
+    assert call_result1.startswith("default/dag_id.task_id/016f5e9e-c4c8-")

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -4,7 +4,6 @@
 import collections
 import datetime
 import logging
-import uuid
 from abc import abstractmethod
 from enum import Enum
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -22,6 +21,7 @@ from openlineage.client.facet import (
     SqlJobFacet,
 )
 from openlineage.client.run import Dataset, Job, OutputDataset, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.snowflake import fix_account_name
 from openlineage.common.schema import GITHUB_LOCATION
 from openlineage.common.utils import get_from_multiple_chains, get_from_nullable_chain
@@ -73,7 +73,7 @@ class DbtRun:
     output: Optional[Dataset] = attr.ib()
     job_name: str = attr.ib()
     namespace: str = attr.ib()
-    run_id: str = attr.ib(factory=lambda: str(uuid.uuid4()))
+    run_id: str = attr.ib(factory=lambda: str(generate_new_uuid()))
 
 
 @attr.s
@@ -250,7 +250,7 @@ class DbtArtifactProcessor:
                         )
                     )
 
-            run_id = str(uuid.uuid4())
+            run_id = str(generate_new_uuid())
             if name.startswith("snapshot."):
                 job_name = (
                     f"{output_node['database']}.{output_node['schema']}"
@@ -316,7 +316,7 @@ class DbtArtifactProcessor:
                 + (".build.test" if self.command == "build" else ".test")
             )
 
-            run_id = str(uuid.uuid4())
+            run_id = str(generate_new_uuid())
             events.add(
                 self.to_openlineage_events(
                     "success",

--- a/integration/common/openlineage/common/provider/great_expectations/action.py
+++ b/integration/common/openlineage/common/provider/great_expectations/action.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
-from uuid import uuid4
 
 from openlineage.client import OpenLineageClient, OpenLineageClientOptions
 from openlineage.client.facet import (
@@ -21,6 +20,7 @@ from openlineage.client.facet import (
 )
 from openlineage.client.run import Job, Run, RunEvent, RunState
 from openlineage.client.serde import Serde
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.dataset import Dataset as OLDataset
 from openlineage.common.provider.great_expectations.facets import (
@@ -41,10 +41,7 @@ from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
 )
 from great_expectations.dataset import Dataset as GEDataset
-from great_expectations.dataset import (
-    PandasDataset,
-    SqlAlchemyDataset,
-)
+from great_expectations.dataset import PandasDataset, SqlAlchemyDataset
 from great_expectations.execution_engine import (
     PandasExecutionEngine,
     SqlAlchemyExecutionEngine,
@@ -121,7 +118,7 @@ class OpenLineageValidationAction(ValidationAction):
         if openlineage_run_id is not None:
             self.run_id = openlineage_run_id
         else:
-            self.run_id = uuid4()
+            self.run_id = generate_new_uuid()
         self.parent_run_id = openlineage_parent_run_id
         self.parent_job_namespace = openlineage_parent_job_namespace
         self.parent_job_name = openlineage_parent_job_name

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -70,7 +70,7 @@ def test_dbt_parse_and_compare_event(path, parent_run_metadata):
         assert match(json.load(f), events)
 
 
-@mock.patch("uuid.uuid4")
+@mock.patch("openlineage.common.provider.dbt.processor.generate_new_uuid")
 @mock.patch("datetime.datetime")
 def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata):
     mock_datetime.now.return_value.isoformat.return_value = "2021-08-25T11:00:25.277467+00:00"
@@ -97,7 +97,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         assert match(json.load(f), events)
 
 
-@mock.patch("uuid.uuid4")
+@mock.patch("openlineage.common.provider.dbt.processor.generate_new_uuid")
 @mock.patch.dict(
     os.environ,
     {

--- a/integration/dagster/openlineage/dagster/utils.py
+++ b/integration/dagster/openlineage/dagster/utils.py
@@ -1,9 +1,10 @@
 # Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-import uuid
 from datetime import datetime
 from typing import Iterable, Optional, Set, Union
+
+from openlineage.client.uuid import generate_new_uuid
 
 from dagster import (  # type: ignore
     DagsterEventType,
@@ -20,7 +21,7 @@ def to_utc_iso_8601(timestamp: float) -> str:
 
 
 def make_step_run_id() -> str:
-    return str(uuid.uuid4())
+    return str(generate_new_uuid())
 
 
 def make_step_job_name(pipeline_name: str, step_key: str) -> str:

--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-import uuid
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster import __version__ as OPENLINEAGE_DAGSTER_VERSION
 from packaging.version import Version
 
@@ -164,7 +164,7 @@ class DagsterRunLatestProvider(DagsterRunProvider):
 def make_test_event_log_record(
     event_type: Optional[DagsterEventType] = None,
     pipeline_name: str = "a_job",
-    pipeline_run_id: str = str(uuid.uuid4()),
+    pipeline_run_id: str = str(generate_new_uuid()),
     timestamp: float = time.time(),
     step_key: Optional[str] = None,
     storage_id: int = 1,

--- a/integration/dagster/tests/test_adapter_pipeline.py
+++ b/integration/dagster/tests/test_adapter_pipeline.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-import uuid
 from unittest.mock import patch
 
 from openlineage.client.constants import DEFAULT_NAMESPACE_NAME
 from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster.adapter import OpenLineageAdapter
 
 from .conftest import PRODUCER
@@ -19,7 +19,7 @@ def test_start_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
     timestamp = time.time()
 
     adapter = OpenLineageAdapter()
@@ -46,7 +46,7 @@ def test_complete_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
     timestamp = time.time()
 
     adapter = OpenLineageAdapter()
@@ -73,7 +73,7 @@ def test_fail_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
     timestamp = time.time()
 
     adapter = OpenLineageAdapter()
@@ -100,7 +100,7 @@ def test_cancel_pipeline_run(mock_client_emit, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
     timestamp = time.time()
 
     adapter = OpenLineageAdapter()

--- a/integration/dagster/tests/test_adapter_step.py
+++ b/integration/dagster/tests/test_adapter_step.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-import uuid
 from unittest.mock import patch
 
 from openlineage.client.constants import DEFAULT_NAMESPACE_NAME
 from openlineage.client.facet import ParentRunFacet
 from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster.adapter import OpenLineageAdapter
 
 from .conftest import PRODUCER
@@ -20,8 +20,8 @@ def test_start_pipeline(mock_client, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
-    step_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
+    step_run_id = str(generate_new_uuid())
     step_key = "an_op"
     timestamp = time.time()
 
@@ -64,8 +64,8 @@ def test_complete_step(mock_client, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
-    step_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
+    step_run_id = str(generate_new_uuid())
     step_key = "an_op"
     timestamp = time.time()
 
@@ -108,8 +108,8 @@ def test_fail_step(mock_client, mock_to_utc_iso_8601):
     mock_to_utc_iso_8601.return_value = event_time
 
     pipeline_name = "a_pipeline"
-    pipeline_run_id = str(uuid.uuid4())
-    step_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
+    step_run_id = str(generate_new_uuid())
     step_key = "an_op"
     timestamp = time.time()
 

--- a/integration/dagster/tests/test_sensor_cursor.py
+++ b/integration/dagster/tests/test_sensor_cursor.py
@@ -3,9 +3,9 @@
 
 import json
 import os
-import uuid
 from unittest.mock import patch
 
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster.cursor import OpenLineageCursor, RunningPipeline, RunningStep
 
 from dagster import DagsterEventType, SensorDefinition, build_sensor_context
@@ -45,7 +45,7 @@ def test_cursor_update_with_successful_run(mock_event_log_records, mock_step_run
         ol_sensor_def = openlineage_sensor(record_filter_limit=1)
 
         # 1. pipeline start
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         mock_event_log_records.return_value = [
             make_test_event_log_record(DagsterEventType.RUN_START, pipeline_run_id=pipeline_run_id)
         ]
@@ -57,7 +57,7 @@ def test_cursor_update_with_successful_run(mock_event_log_records, mock_step_run
         )
 
         # 2. step start
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         step_key = "an_op"
         mock_step_run_id.return_value = step_run_id
         mock_event_log_records.return_value = [
@@ -124,7 +124,7 @@ def test_cursor_update_with_failing_run(mock_event_log_records, mock_step_run_id
         ol_sensor_def = openlineage_sensor(record_filter_limit=1)
 
         # 1. pipeline start
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         mock_event_log_records.return_value = [
             make_test_event_log_record(DagsterEventType.RUN_START, pipeline_run_id=pipeline_run_id)
         ]
@@ -136,7 +136,7 @@ def test_cursor_update_with_failing_run(mock_event_log_records, mock_step_run_id
         )
 
         # 2. step start
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         step_key = "an_op"
         mock_step_run_id.return_value = step_run_id
         mock_event_log_records.return_value = [
@@ -199,9 +199,9 @@ def test_cursor_update_with_exception_raised(mock_event_log_records, mock_step_r
     from openlineage.dagster.sensor import openlineage_sensor
 
     with instance_for_test() as instance:
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         step_key = "an_op"
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         mock_step_run_id.return_value = step_run_id
         mock_event_log_records.return_value = [
             make_test_event_log_record(

--- a/integration/dagster/tests/test_sensor_evaluation.py
+++ b/integration/dagster/tests/test_sensor_evaluation.py
@@ -3,10 +3,10 @@
 
 import tempfile
 import time
-import uuid
 from unittest import mock
 from unittest.mock import call, patch
 
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster.sensor import openlineage_sensor
 
 from dagster import (
@@ -51,7 +51,7 @@ def test_sensor_with_complete_job_run_and_repository(
             repository_name = "a_repository"
             pipeline_name = "a_job"
             step_key = "an_op"
-            step_run_id = str(uuid.uuid4())
+            step_run_id = str(generate_new_uuid())
             mock_step_run_id.return_value = step_run_id
             mock_get_repository_name.return_value = repository_name
 
@@ -96,7 +96,7 @@ def test_sensor_with_complete_job_run_and_repository(
 def test_sensor_start_pipeline(mock_event_log_records, mock_adapter):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
         mock_event_log_records.return_value = [
             make_test_event_log_record(DagsterEventType.RUN_START, pipeline_name, pipeline_run_id, timestamp)
@@ -115,7 +115,7 @@ def test_sensor_start_pipeline(mock_event_log_records, mock_adapter):
 def test_sensor_complete_pipeline(mock_event_log_records, mock_adapter):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
         mock_event_log_records.return_value = [
             make_test_event_log_record(
@@ -136,7 +136,7 @@ def test_sensor_complete_pipeline(mock_event_log_records, mock_adapter):
 def test_sensor_fail_pipeline(mock_event_log_records, mock_adapter):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
         mock_event_log_records.return_value = [
             make_test_event_log_record(
@@ -157,7 +157,7 @@ def test_sensor_fail_pipeline(mock_event_log_records, mock_adapter):
 def test_sensor_cancel_pipeline(mock_event_log_records, mock_adapter):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
         mock_event_log_records.return_value = [
             make_test_event_log_record(
@@ -179,9 +179,9 @@ def test_sensor_cancel_pipeline(mock_event_log_records, mock_adapter):
 def test_sensor_start_step(mock_event_log_records, mock_adapter, mock_new_step_run_id):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         step_key = "an_op"
         mock_event_log_records.return_value = [
             make_test_event_log_record(
@@ -217,9 +217,9 @@ def test_sensor_start_step(mock_event_log_records, mock_adapter, mock_new_step_r
 def test_sensor_complete_step(mock_event_log_records, mock_adapter, mock_new_step_run_id):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         step_key = "an_op"
         mock_new_step_run_id.return_value = step_run_id
         mock_event_log_records.return_value = [
@@ -255,9 +255,9 @@ def test_sensor_complete_step(mock_event_log_records, mock_adapter, mock_new_ste
 def test_sensor_fail_step(mock_event_log_records, mock_adapter, mock_new_step_run_id):
     with instance_for_test() as instance:
         pipeline_name = "a_job"
-        pipeline_run_id = str(uuid.uuid4())
+        pipeline_run_id = str(generate_new_uuid())
         timestamp = time.time()
-        step_run_id = str(uuid.uuid4())
+        step_run_id = str(generate_new_uuid())
         step_key = "an_op"
         mock_event_log_records.return_value = [
             make_test_event_log_record(

--- a/integration/dagster/tests/test_utils.py
+++ b/integration/dagster/tests/test_utils.py
@@ -4,6 +4,7 @@
 import uuid
 from unittest.mock import patch
 
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.dagster.utils import (
     get_event_log_records,
     get_repository_name,
@@ -24,7 +25,7 @@ def test_to_utc_iso_8601():
 
 def test_make_step_run_id():
     run_id = make_step_run_id()
-    assert uuid.UUID(run_id).version == 4
+    assert uuid.UUID(run_id).version == 7
 
 
 def test_make_step_job_name():
@@ -49,7 +50,7 @@ def test_get_event_log_records(mock_instance):
 @patch("openlineage.dagster.utils.DagsterInstance")
 def test_get_repository_name(mock_instance):
     expected_repo = "test_repo"
-    pipeline_run_id = str(uuid.uuid4())
+    pipeline_run_id = str(generate_new_uuid())
     pipeline_run = make_pipeline_run_with_external_pipeline_origin(expected_repo)
     mock_instance.get_run_by_id.return_value = pipeline_run
     actual_repo = get_repository_name(mock_instance, pipeline_run_id)

--- a/integration/dbt/scripts/dbt-ol
+++ b/integration/dbt/scripts/dbt-ol
@@ -8,23 +8,23 @@ import os
 import subprocess
 import sys
 import time
-import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
 from openlineage.client.client import OpenLineageClient
 from openlineage.client.facet import JobTypeJobFacet
 from openlineage.client.run import Job, Run, RunEvent, RunState
+from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt import (
     DbtLocalArtifactProcessor,
     ParentRunMetadata,
     UnsupportedDbtCommand,
 )
+from openlineage.common.utils import parse_multiple_args, parse_single_arg
 from tqdm import tqdm
 
 __version__ = "1.15.0"
 
-from openlineage.common.utils import parse_multiple_args, parse_single_arg
 
 PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integration/dbt"
 JOB_TYPE_FACET = JobTypeJobFacet(
@@ -38,7 +38,7 @@ def dbt_run_event(
     state: RunState,
     job_name: str,
     job_namespace: str,
-    run_id: str = str(uuid.uuid4()),
+    run_id: str = str(generate_new_uuid()),
     parent: Optional[ParentRunMetadata] = None,
 ) -> RunEvent:
     return RunEvent(


### PR DESCRIPTION
### Problem

See #2541.

### Solution

Introduce a new module `openlineage.client.uuid` with 2 functions `generate_new_uuid(instant | None)` and `generate_static_uuid(instant, data)`, which return UUIDv7. Replace all occurrences of `uuud.uuid4()` and `uuid.uuid3()` to these functions.

#### One-line summary:

Use UUIDv7 instead of UUIDv4 for runEvents. New UUID version produces monotonically increasing values, which leads to more performant queries on OL consumer side. **Note**: UUID version is an implementation detail, and can be changed in future.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project