### PR TITLE
Spark: Add SparkApplicationDetailsFacet

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/InternalEventHandlerFactory.java
@@ -21,6 +21,7 @@ import io.openlineage.spark.agent.facets.builder.ErrorFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.LogicalPlanRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OutputStatisticsOutputDatasetFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.OwnershipJobFacetBuilder;
+import io.openlineage.spark.agent.facets.builder.SparkApplicationDetailsFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkJobDetailsFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkProcessingEngineRunFacetBuilder;
 import io.openlineage.spark.agent.facets.builder.SparkPropertyFacetBuilder;
@@ -205,6 +206,7 @@ class InternalEventHandlerFactory implements OpenLineageEventHandlerFactory {
                 new DebugRunFacetBuilder(context),
                 new SparkPropertyFacetBuilder(context),
                 new SparkProcessingEngineRunFacetBuilder(context),
+                new SparkApplicationDetailsFacetBuilder(context),
                 new SparkJobDetailsFacetBuilder());
     if (DatabricksEnvironmentFacetBuilder.isDatabricksRuntime()) {
       listBuilder.add(new DatabricksEnvironmentFacetBuilder(context));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
@@ -86,7 +86,15 @@ public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
   @Value
   @Builder
   public static class SystemDebugFacet {
+    @Deprecated
+    /**
+     * @deprecated
+     *     <p>Since version 1.15.0.
+     *     <p>Will be removed in version 1.18.0.
+     *     <p>Please use {@link SparkApplicationDetailsFacet} instead
+     */
     String sparkDeployMode;
+
     String javaVersion;
     String javaVendor;
     String osArch;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkApplicationDetailsFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkApplicationDetailsFacet.java
@@ -1,0 +1,126 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets;
+
+import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptional;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+
+/** Captures information related to the Apache Spark application. */
+@Getter
+public class SparkApplicationDetailsFacet extends OpenLineage.DefaultRunFacet {
+  @JsonProperty("master")
+  @NonNull
+  private String master;
+
+  @JsonProperty("appName")
+  @NonNull
+  private String appName;
+
+  @JsonProperty("applicationId")
+  @NonNull
+  private String applicationId;
+
+  @JsonProperty("deployMode")
+  @NonNull
+  private String deployMode;
+
+  @JsonProperty("driverHost")
+  private String driverHost;
+
+  @JsonProperty("userName")
+  @NonNull
+  private String userName;
+
+  @JsonProperty("uiWebUrl")
+  private String uiWebUrl;
+
+  @JsonProperty("proxyUrl")
+  private String proxyUrl;
+
+  @JsonProperty("historyUrl")
+  private String historyUrl;
+
+  public SparkApplicationDetailsFacet(SparkContext sparkContext) {
+    super(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    this.master = sparkContext.master();
+    this.appName = sparkContext.appName();
+    this.applicationId = sparkContext.applicationId();
+    this.userName = sparkContext.sparkUser();
+    // don't use spark.driver.appUIAddress because it is filled up only by Yarn
+    this.uiWebUrl = asJavaOptional(sparkContext.uiWebUrl()).orElse(null);
+
+    SparkConf conf = sparkContext.getConf();
+    this.deployMode = conf.get("spark.submit.deployMode", "client");
+    this.driverHost = conf.get("spark.driver.host", null);
+
+    setProxyUrl(conf);
+    setHistoryUrl(sparkContext);
+  }
+
+  private void setProxyUrl(SparkConf conf) {
+    Optional<String> yarnProxyUrl =
+        asJavaOptional(
+            conf.getOption(
+                "spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES"));
+
+    if (yarnProxyUrl.isPresent()) {
+      proxyUrl = yarnProxyUrl.get();
+      return;
+    }
+
+    Boolean reverseProxyEnabled = conf.getBoolean("spark.ui.reverseProxy", false);
+    if (!reverseProxyEnabled) {
+      return;
+    }
+
+    String encodedId;
+    try {
+      encodedId = URLEncoder.encode(applicationId, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return;
+    }
+
+    asJavaOptional(conf.getOption("spark.ui.reverseProxyUrl"))
+        .ifPresent(
+            reverseProxyUrl ->
+                proxyUrl = StringUtils.stripEnd(reverseProxyUrl, "/") + "/proxy/" + encodedId);
+  }
+
+  private void setHistoryUrl(SparkContext sparkContext) {
+    String encodedId;
+    try {
+      encodedId = URLEncoder.encode(applicationId, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return;
+    }
+
+    SparkConf sparkConf = sparkContext.getConf();
+    Configuration hadoopConf = sparkContext.hadoopConfiguration();
+    asJavaOptional(sparkConf.getOption("spark.yarn.historyServer.address"))
+        .ifPresent(
+            historyServer -> {
+              if (!historyServer.startsWith("http")) {
+                String scheme =
+                    StringUtils.lowerCase(
+                        hadoopConf.get("yarn.http.policy", "HTTP_ONLY").replace("_ONLY", ""));
+                historyServer = scheme + "://" + historyServer;
+              }
+              historyUrl = StringUtils.stripEnd(historyServer, "/") + "/application/" + encodedId;
+            });
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilder.java
@@ -1,0 +1,37 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import io.openlineage.spark.agent.facets.SparkApplicationDetailsFacet;
+import io.openlineage.spark.api.CustomFacetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+
+/**
+ * {@link CustomFacetBuilder} that adds the {@link SparkApplicationDetailsFacet} to a run. This
+ * facet is generated for every {@link SparkListenerApplicationStart}.
+ */
+public class SparkApplicationDetailsFacetBuilder
+    extends CustomFacetBuilder<SparkListenerApplicationStart, SparkApplicationDetailsFacet> {
+
+  private Optional<SparkContext> sparkContext;
+
+  public SparkApplicationDetailsFacetBuilder(OpenLineageContext context) {
+    this.sparkContext = context.getSparkContext();
+  }
+
+  @Override
+  protected void build(
+      SparkListenerApplicationStart event,
+      BiConsumer<String, ? super SparkApplicationDetailsFacet> consumer) {
+    sparkContext.ifPresent(
+        context ->
+            consumer.accept("spark_applicationDetails", new SparkApplicationDetailsFacet(context)));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
@@ -1,0 +1,273 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.facets.SparkApplicationDetailsFacet;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class SparkApplicationDetailsFacetBuilderTest {
+  private SparkContext sparkContext;
+  private SparkConf sparkConf;
+  private Configuration hadoopConf;
+  private SparkApplicationDetailsFacetBuilder builder;
+
+  @BeforeEach
+  public void setupSparkContext() {
+    sparkContext = mock(SparkContext.class);
+    when(sparkContext.master()).thenReturn("local");
+    when(sparkContext.appName()).thenReturn("someapp");
+    when(sparkContext.applicationId()).thenReturn("app-123-456");
+    when(sparkContext.sparkUser()).thenReturn("dummy");
+    when(sparkContext.uiWebUrl()).thenReturn(Option.apply("http://driver.host:4040"));
+
+    sparkConf =
+        new SparkConf().set("spark.deploy.mode", "client").set("spark.driver.host", "some.host");
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+
+    hadoopConf = new Configuration();
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+
+    builder =
+        new SparkApplicationDetailsFacetBuilder(
+            OpenLineageContext.builder()
+                .sparkContext(sparkContext)
+                .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+                .meterRegistry(new SimpleMeterRegistry())
+                .openLineageConfig(new SparkOpenLineageConfig())
+                .build());
+  }
+
+  @Test
+  void testIsDefinedForSparkListenerApplicationStartEvent() {
+    assertThat(builder.isDefinedAt(mock(SparkListenerApplicationStart.class))).isTrue();
+  }
+
+  @Test
+  void testBuildNoUI() {
+    // spark.ui.enabled=false
+    when(sparkContext.uiWebUrl()).thenReturn(Option.apply(null));
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", null)
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue("historyUrl", null));
+  }
+
+  @Test
+  void testBuildWithUI() {
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue("historyUrl", null));
+  }
+
+  @Test
+  void testBuildWithYarnProxy() {
+    sparkConf =
+        sparkConf.set(
+            "spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES",
+            "http://yarn.server:8088/proxy/app-123-456");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue(
+                        "proxyUrl", "http://yarn.server:8088/proxy/app-123-456")
+                    .hasFieldOrPropertyWithValue("historyUrl", null));
+  }
+
+  @Test
+  void testBuildWithReverseProxyEnabled() {
+    sparkConf =
+        sparkConf
+            .set("spark.ui.reverseProxy", "true")
+            .set("spark.ui.reverseProxyUrl", "https://some.host/path/");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue(
+                        "proxyUrl", "https://some.host/path/proxy/app-123-456")
+                    .hasFieldOrPropertyWithValue("historyUrl", null));
+  }
+
+  @Test
+  void testBuildWithReverseProxyDisabled() {
+    sparkConf =
+        sparkConf
+            .set("spark.ui.reverseProxy", "false")
+            .set("spark.ui.reverseProxyUrl", "https://some.host/path/");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue("historyUrl", null));
+  }
+
+  @Test
+  void testBuildWithHistoryServerHttp() {
+    sparkConf = sparkConf.set("spark.yarn.historyServer.address", "history.server:18080");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue(
+                        "historyUrl", "http://history.server:18080/application/app-123-456"));
+  }
+
+  @Test
+  void testBuildWithHistoryServerHttps() {
+    sparkConf = sparkConf.set("spark.yarn.historyServer.address", "history.server:18080");
+    hadoopConf.set("yarn.http.policy", "HTTPS_ONLY");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue(
+                        "historyUrl", "https://history.server:18080/application/app-123-456"));
+  }
+
+  @Test
+  void testBuildWithHistoryServerWithSpecifiedUrl() {
+    // for case then HistoryServer is served in K8s
+    sparkConf =
+        sparkConf.set("spark.yarn.historyServer.address", "https://history.server.domain/path");
+
+    Map<String, OpenLineage.RunFacet> runFacetMap = new HashMap<>();
+    builder.build(mock(SparkListenerApplicationStart.class), runFacetMap::put);
+
+    assertThat(runFacetMap)
+        .hasEntrySatisfying(
+            "spark_applicationDetails",
+            facet ->
+                assertThat(facet)
+                    .isInstanceOf(SparkApplicationDetailsFacet.class)
+                    .hasFieldOrPropertyWithValue("master", "local")
+                    .hasFieldOrPropertyWithValue("appName", "someapp")
+                    .hasFieldOrPropertyWithValue("applicationId", "app-123-456")
+                    .hasFieldOrPropertyWithValue("userName", "dummy")
+                    .hasFieldOrPropertyWithValue("deployMode", "client")
+                    .hasFieldOrPropertyWithValue("driverHost", "some.host")
+                    .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
+                    .hasFieldOrPropertyWithValue("proxyUrl", null)
+                    .hasFieldOrPropertyWithValue(
+                        "historyUrl",
+                        "https://history.server.domain/path/application/app-123-456"));
+  }
+}


### PR DESCRIPTION
### Problem

Discussion: https://github.com/OpenLineage/OpenLineage/issues/2589#issuecomment-2102412275

### Solution

Add run facet containing Spark application information:
* `master: string`
* `appName: string`
* `applicationId: string`
* `deployMode: string`
* `userName: string`
* `driverHost: string`
* `webUiUrl: string | null` - URL of Spark driver WebUI. It can be null if `spark.ui.enabled` is false.
* `proxyUrl: string | null` - URL of Spark driver if it is served behind a reverse proxy (e.g. K8s ingress, YarnUI proxy), if any.
* `historyUrl: string | null` - URL of Spark history server, if any. Can be set only on Yarn, because K8s and standalone Spark instances does not populate option with Spark History address, only with event logs location.

#### One-line summary:

Add SparkApplicationDetailsFacet to runEvents emitted on Spark application start.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project