### PR TITLE
Run pmd checks from pre-commit hooks.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1001,6 +1001,7 @@ jobs:
           name: Run pre-commit
           command: |
             . venv/bin/activate
+            SKIP= && [ -n "${CI}" ] && export SKIP="pmd"
             pre-commit run --show-diff-on-failure --all-files
 
   always_run:

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ __pycache__
 
 # Dev
 changes.txt
+
+# pre-commit pmd hook cache
+.pmd_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,11 @@ repos:
         entry: python ./.pre_commit/check-redactions.py
         always_run: true
         pass_filenames: false
+      - id: pmd
+        name: pmd
+        description: "Runs the PMD static code analyzer."
+        language: docker_image
+        entry: -v ./.pmd_cache:/opt/.pmd_cache --entrypoint .pre_commit/run-pmd.sh cimg/openjdk:8.0
+        files: ^client/java/src/.*\.java$|^integration/spark/spark-interfaces-scala/.*\.java$
+        exclude: ".*test.*"
+        require_serial: true

--- a/.pre_commit/run-pmd.sh
+++ b/.pre_commit/run-pmd.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+PMD_RELEASE="https://github.com/pmd/pmd/releases/download/pmd_releases%2F6.46.0/pmd-bin-6.46.0.zip"
+
+cd /opt/.pmd_cache
+
+# check if there is a pmd folder
+if [ ! -d "pmd" ]; then
+  wget -nc -O pmd.zip "$PMD_RELEASE" > /dev/null 2>&1 \
+    && unzip pmd.zip > /dev/null 2>&1 \
+    && rm pmd.zip > /dev/null 2>&1 \
+    && mv pmd-bin* pmd > /dev/null 2>&1 \
+    && chmod -R +x pmd > /dev/null 2>&1
+fi
+
+idx=1
+for (( i=1; i <= "$#"; i++ )); do
+    if [[ ${!i} == *.java ]]; then
+        idx=${i}
+        break
+    fi
+done
+
+# add default ruleset if not specified
+if [[ ! $pc_args == *"-R "* ]]; then
+  pc_args="$pc_args -R /src/client/java/pmd-openlineage.xml"
+fi
+
+# populate list of files to analyse
+files=""
+prefix="/src/"
+for arg in "${@:idx}"; do
+  files="$files $prefix$arg"
+done
+
+# Remove leading space (optional)
+files="${files:1}"
+eol=$'\n'
+echo "${files// /$eol}" > /tmp/list
+
+./pmd/bin/run.sh pmd -f textcolor -min 5 --file-list /tmp/list $pc_args


### PR DESCRIPTION
### Problem

Currently PMD checks require compiling code through Gradle which might be more time consuming and less convenient. There were also reports from MacOS users that PMD ran on local machine has some discrepancies between Linux and MacOS reports.

### Solution

Add pre-commit hook that runs PMD CLI command from Java container. To reduce network usage it also caches pmd binaries locally.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project