### PR TITLE
[dev] adjust bots after label changes

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -2,47 +2,53 @@
 # Enable "labeler" for your PR that would add labels to PRs based on the paths that are modified in the PR.
 labelPRBasedOnFilePath:
   # Add '' to any changes within '' folder or any subfolders
-  ci:
+  area:ci:
     - .circleci/**/*
-  client/java:
+    - .pre_commit/**/*
+  area:client/java:
     - client/java/**/*
-  client/python:
+  area:client/python:
     - client/python/**/*
-  common:
-    - integration/common/**/*
-  dev/ops:
+  area:dev:
     - dev/**/*
-  documentation:
+    - .github/**/*
+  area:documentation:
     - doc/*
     - "*.md"
-  extractor:
-    - integration/airflow/openlineage/airflow/extractors/*
-  integration/airflow:
+  area:integration/airflow:
     - integration/airflow/**/*
-  integration/bigquery:
-    - integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
-  integration/dagster:
+  area:integration/common:
+    - integration/common/**/*
+  area:integration/dagster:
     - integration/dagster/**/*
-  integration/dbt:
+  area:integration/dbt:
     - integration/dbt/**/*
-  integration/flink:
+  area:integration/flink:
     - integration/flink/**/*
-  integration/great-expectations:
-    - integration/common/openlineage/common/provider/great_expectations/*
-  integration/spark:
+  area:integration/spark:
     - integration/spark/**/*
-  integration/sql:
+  area:integration/sql:
     - integration/sql/**/*
-  proposal:
-    - proposals/**/*
-  proxy:
+  area:proxy:
     - proxy/**/*
-  spec:
+  area:spec:
     - spec/**/*
-  streaming:
-    - integration/flink/**/*
-  tests:
-    - .circleci/workflows/*
+  area:tests:
+    - "**/*test*"
+  kind:proposal:
+    - proposals/**/*
+  language:java:
+    - "*.java"
+    - "*.jar"
+  language:python:
+    - "*.py"
+  language:rust:
+    - "*.rs"
+  language:scala:
+    - "*.scala"
+    - "*.sc"
+  state:needs-triage:
+    - *
 
 ##### Greetings ########################################################################################################
 # Comment to be posted to welcome users when they open their first PR

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "org.slf4j.slf4j-api"
@@ -40,7 +39,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "org.slf4j.slf4j-api"
@@ -51,7 +49,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "com.fasterxml.jackson*"
@@ -70,7 +67,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
 
   - package-ecosystem: "pip"
@@ -79,7 +75,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "great-expectations"
@@ -91,7 +86,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
     ignore:
       - dependency-name: "great-expectations"
@@ -102,7 +96,6 @@ updates:
       interval: "weekly"
       day: "sunday"
     labels:
-      - "dependencies"
       - "dependabot"
 
   - package-ecosystem: "cargo"
@@ -110,5 +103,4 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "dependencies"
       - "dependabot"

--- a/.github/header_templates.md
+++ b/.github/header_templates.md
@@ -4,7 +4,7 @@
 
 ```
 /* 
-* Copyright 2018-2023 contributors to the Marquez project
+* Copyright 2018-2024 contributors to the Marquez project
 * SPDX-License-Identifier: Apache-2.0
 */
 ```
@@ -14,21 +14,21 @@
 ```   
 #!/bin/bash
 #
-# Copyright 2018-2023 contributors to the Marquez project
+# Copyright 2018-2024 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 ```
 
 `py`
 
 ```
-# Copyright 2018-2023 contributors to the Marquez project
+# Copyright 2018-2024 contributors to the Marquez project
 # SPDX-License-Identifier: Apache-2.0
 ```
 
 `rust`
 
 ```
-// Copyright 2018-2023 contributors to the OpenLineage project
+// Copyright 2018-2024 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
 ```
 
@@ -36,4 +36,4 @@
 
 ----
 SPDX-License-Identifier: Apache-2.0\
-Copyright 2018-2023 contributors to the OpenLineage project
+Copyright 2018-2024 contributors to the OpenLineage project

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,4 +30,4 @@ If you're contributing a new integration, please specify the scope of the integr
 
 ----
 SPDX-License-Identifier: Apache-2.0\
-Copyright 2018-2023 contributors to the OpenLineage project
+Copyright 2018-2024 contributors to the OpenLineage project


### PR DESCRIPTION
### Problem

Closes: #2666

#### One-line summary:

Adjusting boring-cyborg and dependabot after label names have changed.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2023 contributors to the OpenLineage project