### PR TITLE
[SPARK] verify jar content after build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -277,6 +277,30 @@ jobs:
           paths:
             - ~/.gradle
 
+  jar-verification-spark:
+    working_directory: ~/openlineage/integration/spark
+    machine:
+      image: ubuntu-2004:current
+    resource_class: medium
+    environment:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
+      JDK8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    steps:
+      - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+      - restore_cache:
+          keys:
+            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+            - v1-integration-spark-{{ .Branch }}
+      - attach_workspace:
+          at: ~/.m2/repository/io/openlineage/
+      - run: |
+          sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+          sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+      - run: ./gradlew --no-daemon --console=plain clean clean jarVerification -Pscala.binary.version=2.12
+      - run: ./gradlew --no-daemon --console=plain clean clean jarVerification -Pscala.binary.version=2.13
 
   release-integration-flink:
     working_directory: ~/openlineage/integration/flink

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -35,6 +35,10 @@ workflows:
               spark-version: [ '3.4.2', '3.5.0' ]
           requires:
             - approval-integration-spark
+      - jar-verification-spark:
+          requires:
+            - build-integration-spark-scala-2_12
+            - build-integration-spark-scala-2_13
       - integration-test-integration-spark-scala-2_12:
           context: integration-tests
           matrix:
@@ -53,3 +57,4 @@ workflows:
           requires:
             - integration-test-integration-spark-scala-2_12
             - integration-test-integration-spark-scala-2_13
+            - jar-verification-spark

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -83,7 +83,6 @@ dependencies {
     implementation(project(path: ":spark34", configuration: activeRuntimeElementsConfiguration))
     implementation(project(path: ":spark35", configuration: activeRuntimeElementsConfiguration))
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3")
-    implementation("io.micrometer:micrometer-core:${micrometerVersion}")
 
     compileOnly("org.apache.spark:spark-core_${scala}:${spark}")
     compileOnly("org.apache.spark:spark-sql_${scala}:${spark}")

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -125,7 +125,7 @@ public class ContextFactory {
   public static Optional<QueryExecution> executionFromCompleteEvent(
       SparkListenerSQLExecutionEnd event) {
     try {
-      return Optional.of((QueryExecution) MethodUtils.invokeMethod(event, "qe", null));
+      return Optional.of((QueryExecution) MethodUtils.invokeMethod(event, "qe", (Object[]) null));
     } catch (NoSuchMethodException e) {
       return Optional.empty();
     } catch (IllegalAccessException | InvocationTargetException | ClassCastException e) {

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id("java-library")
     id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
+    id("io.openlineage.jar-verification")
     id("maven-publish")
     id("signing")
     id("jacoco")
@@ -161,6 +162,7 @@ shadowJar {
     dependencies {
         exclude(dependency("org.slf4j::"))
         exclude("org/apache/commons/logging/**")
+        exclude("io/openlineage/server/**")
     }
 
     relocate "com.github.ok2c.hc5", "io.openlineage.spark.shaded.com.github.ok2c.hc5"
@@ -173,9 +175,8 @@ shadowJar {
     relocate "org.apache.http", "io.openlineage.spark.shaded.org.apache.http"
     relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
     relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
-    relocate 'org.yaml.snakeyaml', 'io.openlineage.spark.shaded.org.yaml.snakeyaml'
-    relocate "org.hdrhistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
-    relocate "org.latencyutils", "io.openlineage.spark.shaded.org.latencyutils"
+    relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
+    relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/buildSrc/README.md
+++ b/integration/spark/buildSrc/README.md
@@ -47,3 +47,20 @@ To execute the `printSourceSetConfiguration` task, use the following command:
 ```bash
 ./gradlew printSourceSetConfiguration
 ```
+
+## JarVerificationPlugin
+
+This plugin verifies jar prepared with `shadowJar` task. Currently, it checks: 
+
+ * If all `.java` files and classes within them are contained within the jar. This is useful as Spark integration contains several subprojects, and it's easy to forget packing subproject's classes to published jar.
+ * If all external classes are relocated (shaded) properly, allowing only specified packages remain unshaded. 
+
+Plugin shall be applied only once in `integration/spark/build.gradle`:
+
+```kotlin
+plugins {
+  id("io.openlineage.jar-verification")
+}
+```
+
+Please refer to `JarVerificationPluginExtension` for detailed configuration description.

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -34,5 +34,10 @@ gradlePlugin {
             id = "io.openlineage.scala-variants"
             implementationClass = "io.openlineage.gradle.plugin.ScalaVariantsPlugin"
         }
+
+        create("jarVerification") {
+            id = "io.openlineage.jar-verification"
+            implementationClass = "io.openlineage.gradle.plugin.JarVerificationPlugin"
+        }
     }
 }

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPlugin.kt
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import java.io.File
+import java.util.*
+
+/**
+ * A Gradle plugin for verifying content of a jar built. It can validate if specified classes are
+ * shaded, it verifies if certain classes are present, and can make sure that only given packages
+ * are available in the jar to guarantee jar does not contain non-shaded dependencies.
+ */
+class JarVerificationPlugin : Plugin<Project> {
+
+    private fun getPluginExtension(target: Project): JarVerificationPluginExtension =
+        target.extensions.getByType<JarVerificationPluginExtension>()
+
+    private fun configureExtension(target: Project) {
+       target.extensions.create<JarVerificationPluginExtension>("jar")
+            .apply {
+                packageName.set("io.openlineage.spark")
+                relocatePrefix.set("io.openlineage.spark.shaded")
+                assertJarContainsAllClasses.convention(true)
+                allowedUnshadedPackages.set(listOf(
+                    "io.openlineage.client",
+                    "io.openlineage.sql",
+                    "io.micrometer.core",
+                    "io.micrometer.common",
+                    "io.micrometer.observation"
+                ))
+            }
+    }
+
+    override fun apply(target: Project) {
+        configureExtension(target)
+        target.task("jarVerification") {
+            dependsOn("shadowJar", "jar")
+            outputs.dir("build/jar-verifier")
+            inputs.files(target.tasks.named("shadowJar").get().outputs)
+            doLast {
+                JarVerificationPluginDelegate(
+                    target = target,
+                    extension = getPluginExtension(target)
+                ).verify()
+            }
+            group = "verification"
+            description = "Verifies content of the jar produced."
+        }
+    }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginDelegate.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginDelegate.kt
@@ -1,0 +1,151 @@
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.kotlin.dsl.getByType
+import org.slf4j.LoggerFactory
+import java.io.File
+
+
+/**
+ * A delegate class to implement jar verification logic. By design, the class methods shall be
+ * agnostic to current project specifics which should be configurable.
+ */
+class JarVerificationPluginDelegate(
+    private val target: Project,
+    private val extension: JarVerificationPluginExtension
+) {
+    private fun getSourceSetContainer(target: Project) =
+        target.extensions.getByType<SourceSetContainer>()
+
+    val logger = LoggerFactory.getLogger("JarVerificationLogger")
+
+    fun verify() {
+        val identifiersFromJar: List<ClassIdentifier> =  classIdentifiersFromJar(target)
+        val identifiersFromSource: List<ClassIdentifier> =  classIdentifiersFromSource(target)
+
+        logger.info("Encountered ${identifiersFromSource.size} java source class files")
+
+        if (hasUnshadedPackages(identifiersFromJar)
+            .or(areMissingClasses(identifiersFromSource, identifiersFromJar))
+        ) {
+            throw GradleException("Jar verification task failed")
+        }
+    }
+
+    /**
+     * Given a list of `ClassIdentifier` from a build jar it verifies the packages contained.
+     * It logs an error if encountered package which does not start with configured packageName,
+     * does not start with relocate prefix and is not on the list of allowed unshaded packages.
+     *
+     * Method prints error for each violation and returns boolean with information if any violations
+     * have been encountered.
+     */
+    private fun hasUnshadedPackages(identifiersFromJar: List<ClassIdentifier>): Boolean {
+        return identifiersFromJar
+            .map { c -> c.packageName }
+            .distinct()
+            .filter { p -> !p.startsWith(extension.packageName.get()) }
+            .filter { p -> !p.startsWith(extension.relocatePrefix.get()) }
+            .filter { p ->
+                extension
+                    .allowedUnshadedPackages
+                    .get()
+                    .find { allowed -> p.startsWith(allowed) } == null
+            }
+            .map {
+                p -> logger.error("[ERROR] Package '$p' should not be present in jar")
+            }
+            .isNotEmpty()
+    }
+
+    /**
+     * List of `ClassIdentifier` from the source code is built by walking project root directory
+     * and looking for `.java` classes. All elements from that list has to be present in the list
+     * of `ClassIdentifier` created from a built jar.
+     */
+    private fun areMissingClasses(
+        fromSource: List<ClassIdentifier>,
+        fromJar: List<ClassIdentifier>
+    ): Boolean {
+        val packedClasses: Map<String, List<String>> = fromJar
+            .map { it.packageName to it.className }
+            .groupBy({ it.first }, { it.second })
+
+        val missingPackage = fromSource
+            .map { it.packageName }
+            .distinct()
+            .filter { !packedClasses.contains(it) }
+            .map { p ->
+                logger.error("[ERROR] Source code package '$p' is not present in jar")
+            }
+            .isNotEmpty()
+
+        val missingClass =
+            fromSource
+                .filter {
+                    !(packedClasses.get(it.packageName)
+                        ?.contains(it.className) ?: false)
+                }
+                .map { p ->
+                    logger.error(
+                        "[ERROR] Source code class '$p' not present in jar"
+                    )
+                }
+                .isNotEmpty()
+
+        return missingPackage.or(missingClass)
+    }
+
+    private fun classIdentifiersFromJar(target: Project): List<ClassIdentifier> {
+        return target
+            .zipTree(locateJar(target).toPath())
+            .files
+            .filter { it.extension == "class" }
+            .filter { !it.path.contains("META-INF") }
+            .map { file ->
+                val arr = file.parentFile.path.split(File.separator!!)
+                val startPathIndex = arr.indexOfFirst { it.startsWith("zip_") }
+                ClassIdentifier(
+                    arr.subList(startPathIndex + 1, arr.size).joinToString(separator = ".").lowercase(),
+                    file.nameWithoutExtension
+                )
+            }
+    }
+
+    private fun classIdentifiersFromSource(target: Project): List<ClassIdentifier> {
+        return target
+            .subprojects
+            .map { it.name + "/src/main/java"  }
+            .flatMap { t -> File(t).walkTopDown().filter { it.extension == "java" } }
+            .map { file ->
+                val arr = file.parentFile.path.split(File.separator!!)
+                val startPathIndex = arr.indexOfFirst { it.equals("java") }
+                ClassIdentifier(
+                    arr.subList(startPathIndex + 1, arr.size).joinToString(separator = ".").lowercase(),
+                    file.nameWithoutExtension
+                )
+            }
+            .toList()
+    }
+
+    private fun locateJar(target: Project): File {
+        return target
+            .tasks
+            .named("shadowJar")
+            .get()
+            .outputs
+            .files
+            .filter { it.extension == "jar" }
+            .find { it.name.contains(target.project.name)  }
+            ?: throw GradleException("Couldn't locat3e jar to verify")
+    }
+}
+
+/**
+ * Utilisty class to contain `package` and `class` tuple.
+ */
+class ClassIdentifier(val packageName: String, val className: String) {
+    override fun toString(): String { return "package $packageName, class $className" }
+}

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginExtension.kt
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018-2024 contributors to the OpenLineage project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.openlineage.gradle.plugin
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import java.util.Optional
+
+/**
+ * Extension for the [JarVerificationPlugin].
+ * Allows configuring how the shadow jar shall be verified
+ *
+ * Usage:
+ * ```
+ * shadowJarVerification {
+ *     packageName("io.openlineage.spark")
+ *     relocatePrefix.set("io.openlineage.spark.shaded")
+ *     allowedUnshadedPackages.set(listOf(
+ *          "io.micrometer.common"
+ *     ))
+ *     assertJarContainsAllClasses.set(true)
+ *     assertJarDoesNotContainUnshadedClasses.set(true)
+ * }
+ * ```
+ */
+interface JarVerificationPluginExtension {
+
+    /**
+     * Expected package name for the source classes
+     */
+    val packageName: Property<String>
+
+    /**
+     * Prefix configured within shading plugin to relocate bundled dependencies into packages
+     * with prefixed package names.
+     */
+    val relocatePrefix: Property<String>
+
+    /**
+     * List of packages that are allowed to be unshaded and contained within jar.
+     */
+    val allowedUnshadedPackages: ListProperty<String>
+
+    /**
+     * If set to true, plugin will check if java classes available in the project (without dependency
+     * classes) are present. This will allow making sure that JAR content contains compiled classes.
+     */
+    val assertJarContainsAllClasses: Property<Boolean>
+
+    /**
+     * If set to true, shadow jar should only contain classes from within the built project's
+     * package and classes with contained within shadingPrefix directories.
+     *
+     * Exceptions to this rule can be defined in allowedUnshadedPackages
+     */
+    val assertJarDoesNotContainUnshadedClasses: Property<Boolean>
+}

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -32,7 +32,6 @@ ext {
     postgresqlVersion = "42.7.1"
     sqlLiteVersion = "3.45.0.0"
     testcontainersVersion = "1.19.3"
-    micrometerVersion = "1.12.4"
 
     sparkVersion = project.findProperty("shared.spark.version")
     sparkSeries = sparkVersion.substring(0, 3)
@@ -44,7 +43,6 @@ dependencies {
     api("io.openlineage:openlineage-java:${project.version}")
     api("io.openlineage:openlineage-sql-java:${project.version}")
     api("io.openlineage:spark-interfaces-scala_${scalaBinaryVersion}:${project.version}")
-    api("io.micrometer:micrometer-core:${micrometerVersion}")
 
     compileOnly("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
     compileOnly("org.apache.spark:spark-sql-kafka-0-10_${scalaBinaryVersion}:${sparkVersion}")
@@ -96,7 +94,6 @@ dependencies {
     scala212Api("io.openlineage:openlineage-java:${project.version}")
     scala212Api("io.openlineage:openlineage-sql-java:${project.version}")
     scala212Api("io.openlineage:spark-interfaces-scala_2.12:${project.version}")
-    scala212Api("io.micrometer:micrometer-core:${micrometerVersion}")
 
     scala212CompileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}")
     scala212CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.12:${sparkVersion}")
@@ -148,7 +145,6 @@ dependencies {
     scala213Api("io.openlineage:openlineage-java:${project.version}")
     scala213Api("io.openlineage:openlineage-sql-java:${project.version}")
     scala213Api("io.openlineage:spark-interfaces-scala_2.13:${project.version}")
-    scala213Api("io.micrometer:micrometer-core:${micrometerVersion}")
 
     scala213CompileOnly("org.apache.spark:spark-hive_2.13:${sparkVersion}")
     scala213CompileOnly("org.apache.spark:spark-sql-kafka-0-10_2.13:${sparkVersion}")

--- a/integration/spark/spark2/build.gradle
+++ b/integration/spark/spark2/build.gradle
@@ -22,7 +22,6 @@ idea {
 
 ext {
     assertjVersion = "3.25.1"
-    micrometerVersion = '1.12.4'
     deltaVersion = "1.1.0"
     icebergVersion = "0.14.1"
     jacksonVersion = "2.15.3"
@@ -38,12 +37,10 @@ dependencies {
     compileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
     compileOnly("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
-    compileOnly("io.micrometer:micrometer-core:${micrometerVersion}")
 
     // TODO: Replace 'testFixturesApi' with 'testImplementation'
     // TODO: Remove the test dependency on 'shared'
     testFixturesApi(project(path: ":shared", configuration: "scala212RuntimeElements"))
-    testFixturesApi("io.micrometer:micrometer-core:${micrometerVersion}")
     testFixturesApi("com.fasterxml.jackson.module:jackson-module-scala_${scalaBinaryVersion}:${jacksonVersion}")
     testFixturesApi("org.apache.spark:spark-hive_${scalaBinaryVersion}:${sparkVersion}")
     testFixturesApi("org.apache.spark:spark-sql_${scalaBinaryVersion}:${sparkVersion}")
@@ -61,10 +58,8 @@ dependencies {
     scala211CompileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
     scala211CompileOnly("org.apache.spark:spark-sql_2.11:${sparkVersion}")
-    scala211CompileOnly("io.micrometer:micrometer-core:${micrometerVersion}")
 
     testScala211Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
-    testScala211Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
     testScala211Implementation("com.fasterxml.jackson.module:jackson-module-scala_2.11:${jacksonVersion}")
     testScala211Implementation("org.apache.spark:spark-hive_2.11:${sparkVersion}")
     testScala211Implementation("org.apache.spark:spark-sql_2.11:${sparkVersion}")
@@ -79,10 +74,8 @@ dependencies {
     scala212CompileOnly(project(path: ":shared", configuration: "scala212RuntimeElements"))
 
     scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
-    scala212CompileOnly("io.micrometer:micrometer-core:${micrometerVersion}")
 
     testScala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
-    testScala212Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
     testScala212Implementation("com.fasterxml.jackson.module:jackson-module-scala_2.12:${jacksonVersion}")
     testScala212Implementation("org.apache.spark:spark-hive_2.12:${sparkVersion}")
     testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -23,7 +23,6 @@ idea {
 ext {
     assertjVersion = "3.25.1"
     bigqueryVersion = "0.35.1"
-    micrometerVersion = "1.12.4"
     databricksVersion = "0.1.4"
     deltaVersion = "1.1.0"
     icebergVersion = "1.4.3"
@@ -84,7 +83,6 @@ dependencies {
 
     testScala212Implementation("org.apache.spark:spark-hive_2.12:${sparkVersion}")
     testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
-    testScala212Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
 
     testScala212Implementation("com.databricks:databricks-dbutils-scala_2.12:${databricksVersion}")
     testScala212Implementation("com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:${bigqueryVersion}") {
@@ -124,7 +122,6 @@ dependencies {
     }
     testScala213Implementation("io.delta:delta-core_2.13:${deltaVersion}")
     testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
-    testScala213Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
 
     testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
     testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")

--- a/integration/spark/spark31/build.gradle
+++ b/integration/spark/spark31/build.gradle
@@ -15,7 +15,6 @@ scalaVariants {
 }
 
 ext {
-    micrometerVersion = "1.12.4"
     assertjVersion = "3.25.1"
     junit5Version = "5.10.1"
     mockitoVersion = "4.11.0"
@@ -43,7 +42,6 @@ dependencies {
     scala212CompileOnly("org.apache.spark:spark-sql_2.12:${sparkVersion}")
 
     testScala212Implementation(project(path: ":shared"))
-    testScala212Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
     testScala212Implementation("org.apache.spark:spark-sql_2.12:${sparkVersion}")
     testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
     testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -124,7 +124,7 @@ public class CreateReplaceDatasetBuilder
 
   private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
     try {
-      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", null));
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
     } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
       log.error("Could not obtain catalog plugin", e);
       return Optional.empty();

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -132,7 +132,7 @@ public class CreateReplaceOutputDatasetBuilder
 
   private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
     try {
-      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", null));
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
     } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
       log.error("Could not obtain catalog plugin", e);
       return Optional.empty();


### PR DESCRIPTION
### Problem

Spark integration contains several subproject and it's important to guarantee that released jar contains  desired classes only. Common pitfalls we would like to avoid: 
 * releasing unshaded dependency to external library that could clash with classes user has on classpath, 
 * not-including openlineage-spark classes from some subproject we have.

In this PR, a tool is added to verify `shadowJar` content and prevent issues described from happening. Such issues are hard to prevent currently and require manual verification of manually unpacked jar content. 

PR contains gradle extension which runs the validation. Together with this PR, there is another PR #2715  which introduces possible jar issues in order to show the validation is working and proper error messages are produced. 

I was unable to verify if Scala version used in compilation matches scala version of the release artifact, although such check would be useful too. 