### PR TITLE
fix: Empty dataset name for AthenaExtractor

### DIFF
--- a/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
@@ -77,7 +77,7 @@ class AthenaExtractor(BaseExtractor):
         parsed = urlparse(output_location)
         outputs.append(
             Dataset(
-                name=parsed.path,
+                name=parsed.path or "/",
                 source=Source(
                     scheme=parsed.scheme,
                     authority=parsed.netloc,

--- a/integration/airflow/tests/extractors/test_athena_extractor.py
+++ b/integration/airflow/tests/extractors/test_athena_extractor.py
@@ -152,7 +152,7 @@ def test_extract_create():
             aws_conn_id="aws_conn_id",
             query=sql,
             database=DB_SCHEMA_NAME,
-            output_location=OUTPUT_LOCATION,
+            output_location="s3://bucket",
             dag=dag,
         )
         task_metadata = AthenaExtractor(create_task).extract()
@@ -186,7 +186,7 @@ def test_extract_create():
         assert len(task_metadata.outputs) == 2
         assert task_metadata.outputs[0] == first_expected_output
         assert task_metadata.outputs[1].namespace == "s3://bucket"
-        assert task_metadata.outputs[1].name == "/output"
+        assert task_metadata.outputs[1].name == "/"
         assert task_metadata.job_facets["sql"].query == sql
 
 


### PR DESCRIPTION
### Problem

Closes: #2699

#### One-line summary:

fix: Dataset name should not be empty when passing only bucket as S3 output in Athena

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project