### PR TITLE
Remove needs-triage label from boring-cyborg.yml

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -47,8 +47,6 @@ labelPRBasedOnFilePath:
   language:scala:
     - "*.scala"
     - "*.sc"
-  state:needs-triage:
-    - "*"
 
 ##### Greetings ########################################################################################################
 # Comment to be posted to welcome users when they open their first PR


### PR DESCRIPTION
### Problem

Unfortunately, the cyborg refreshes the labels each time the PR is updated so the `state:needs-triage` keeps being added, and there is no option to disable that behaviour only for some labels. As we want to keep this behaviour for most labels, i think we should remove the one that is problematic.

### Solution

#### One-line summary:

Remove needs-triage label from boring-cyborg.yml

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project