### PR TITLE
sql: catch TokenizerErrors, PanicException

### DIFF
--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -26,6 +26,7 @@ def parse(
         sql = [sql]
     try:
         return parse_sql(sql, dialect=dialect, default_schema=default_schema)
-    except Exception as e:
+    except BaseException as e:
+        # PanicException is a BaseException https://pyo3.rs/main/doc/pyo3/panic/struct.panicexception
         log.error(f"SQL parser failed: {e}")
         return None

--- a/integration/sql/impl/src/lib.rs
+++ b/integration/sql/impl/src/lib.rs
@@ -15,7 +15,7 @@ use visitor::Visit;
 
 use anyhow::{anyhow, Result};
 use sqlparser::parser::Parser;
-use sqlparser::parser::ParserError::ParserError;
+use sqlparser::parser::ParserError::{ParserError, RecursionLimitExceeded, TokenizerError};
 
 pub fn parse_multiple_statements(
     sql: Vec<&str>,
@@ -30,12 +30,20 @@ pub fn parse_multiple_statements(
     for (index, statement) in sql.iter().enumerate() {
         let ast = Parser::parse_sql(dialect.as_base(), statement);
 
-        if let Err(ParserError(s)) = ast {
+        if let Err(x) = ast {
+            let message = match x {
+                TokenizerError(s) => s.clone(),
+                ParserError(s) => s.clone(),
+                RecursionLimitExceeded => {
+                    { "Recursion limit exceeded when parsing SQL" }.to_string()
+                }
+            };
             errors.push(ExtractionError {
                 index,
-                message: s.clone(),
+                message,
                 origin_statement: statement.to_string(),
             });
+
             continue;
         }
         let ast = ast.unwrap();

--- a/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
@@ -42,3 +42,16 @@ fn test_failing_statement_with_insert() {
         }
     )
 }
+
+#[test]
+fn test_failing_statement_tokenizer_failes() {
+    let errors = test_multiple_sql(vec!["$$$"]).unwrap().errors;
+    assert_eq!(
+        errors,
+        vec![ExtractionError {
+            index: 0,
+            message: "Unterminated dollar-quoted string at Line: 1, Column 4".to_string(),
+            origin_statement: "$$$".to_string()
+        },],
+    )
+}


### PR DESCRIPTION
Currently, we don't catch `TokenizerErrors` and can panic on catching it. It's undesireable.

This PR catches all versions of `ParserError` and assigns meaningful error message. 

Additionally, Rust Panics are modeled in Python as subclass of BaseException, which we did not catch in our Python wrapper. Now we do.