### PR TITLE
Flink: handle Avro schema with nested and complex field types

### DIFF
--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/AvroSchemaUtils.java
@@ -8,10 +8,9 @@ package io.openlineage.flink.utils;
 import static org.apache.avro.Schema.Type.NULL;
 
 import io.openlineage.client.OpenLineage;
-import java.util.Collection;
-import java.util.LinkedList;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 
@@ -23,45 +22,91 @@ public class AvroSchemaUtils {
    * Converts Avro {@link Schema} to {@link OpenLineage.SchemaDatasetFacet}
    *
    * @param openLineage Openlineage instance
-   * @param avroSchema schema
+   * @param schema Avro schema
    * @return schema dataset facet
    */
-  public static OpenLineage.SchemaDatasetFacet convert(OpenLineage openLineage, Schema avroSchema) {
-    OpenLineage.SchemaDatasetFacetBuilder builder = openLineage.newSchemaDatasetFacetBuilder();
-    List<OpenLineage.SchemaDatasetFacetFields> fields = new LinkedList<>();
-
-    avroSchema.getFields().stream()
-        .forEach(
-            avroField -> {
-              log.debug("Converting avro field {} to OpenLineage field", avroField);
-              fields.add(
-                  openLineage
-                      .newSchemaDatasetFacetFieldsBuilder()
-                      .name(avroField.name())
-                      .type(getTypeName(avroField.schema()))
-                      .description(avroField.doc())
-                      .build());
-            });
-
-    return builder.fields(fields).build();
+  public static OpenLineage.SchemaDatasetFacet convert(OpenLineage openLineage, Schema schema) {
+    return openLineage
+        .newSchemaDatasetFacetBuilder()
+        .fields(transformFields(openLineage, schema.getFields()))
+        .build();
   }
 
-  private static String getTypeName(Schema fieldSchema) {
-    // In case of union type containing some type and null type, non-null type name is returned.
-    // For example, Avro type `"type": ["null", "long"]` is converted to `long`.
-    return Optional.of(fieldSchema)
-        .filter(Schema::isUnion)
-        .map(Schema::getTypes)
-        .filter(types -> types.size() == 2) // check if schema field contains two types
-        .filter(
-            types ->
-                types.get(0).getType().equals(NULL)
-                    || types.get(1).getType().equals(NULL)) // check if one of the two types is NULL
-        .stream()
-        .flatMap(Collection::stream)
-        .filter(type -> !type.getType().equals(NULL)) // if so, choose the non-null type
-        .map(type -> type.getType().getName())
-        .findAny()
-        .orElse(fieldSchema.getType().getName());
+  private static List<SchemaDatasetFacetFields> transformFields(
+      OpenLineage openLineage, List<Schema.Field> fields) {
+    return fields.stream()
+        .map(field -> transformField(openLineage, field))
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
+  private static SchemaDatasetFacetFields transformField(
+      OpenLineage openLineage, Schema.Field field) {
+    log.debug("Converting avro field {} to OpenLineage field", field);
+    OpenLineage.SchemaDatasetFacetFieldsBuilder builder =
+        openLineage
+            .newSchemaDatasetFacetFieldsBuilder()
+            .name(field.name())
+            .description(field.doc());
+
+    List<Schema> fieldSchemas = excludeNulls(field.schema());
+    if (fieldSchemas.size() > 1) {
+      return builder
+          .type("union")
+          .fields(
+              fieldSchemas.stream()
+                  .map(
+                      schema ->
+                          transformField(
+                              openLineage,
+                              new Schema.Field("_" + schema.getType().getName(), schema)))
+                  .collect(Collectors.toList()))
+          .build();
+    }
+
+    Schema fieldSchema = fieldSchemas.get(0);
+    Schema.Type fieldType = fieldSchema.getType();
+    if (fieldType.equals(Schema.Type.RECORD)) {
+      return builder
+          .type("record")
+          .fields(transformFields(openLineage, fieldSchema.getFields()))
+          .build();
+    }
+    if (fieldType.equals(Schema.Type.MAP)) {
+      return builder
+          .type("map")
+          .fields(
+              transformFields(
+                  openLineage,
+                  List.of(
+                      new Schema.Field("key", Schema.create(Schema.Type.STRING)),
+                      new Schema.Field("value", fieldSchema.getValueType()))))
+          .build();
+    }
+    if (fieldType.equals(Schema.Type.ARRAY)) {
+      return builder
+          .type("array")
+          .fields(
+              transformFields(
+                  openLineage, List.of(new Schema.Field("_element", fieldSchema.getElementType()))))
+          .build();
+    }
+    if (fieldType.equals(Schema.Type.FIXED)) {
+      int size = fieldSchema.getFixedSize();
+      return builder.type("fixed(" + size + ")").build();
+    }
+    return builder.type(fieldType.getName()).build();
+  }
+
+  private static List<Schema> excludeNulls(Schema fieldSchema) {
+    // In case of union type containing some type and null type, only non-null types are returned.
+    // For example, Avro type `"type": ["null", "long", "string"]` is converted to ["long",
+    // "string"].
+    if (!fieldSchema.isUnion()) {
+      return List.of(fieldSchema);
+    }
+    return fieldSchema.getTypes().stream()
+        .filter(type -> type.getType() != NULL)
+        .collect(Collectors.toList());
   }
 }

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/AvroSchemaUtilsTest.java
@@ -5,7 +5,7 @@
 
 package io.openlineage.flink.utils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.openlineage.client.OpenLineage;
@@ -16,45 +16,358 @@ import org.apache.avro.SchemaBuilder;
 import org.junit.jupiter.api.Test;
 
 class AvroSchemaUtilsTest {
-
-  Schema schema =
-      SchemaBuilder.record("InputEvent")
-          .namespace("io.openlineage.flink.avro.event")
-          .fields()
-          .name("a")
-          .doc("some-doc")
-          .type()
-          .nullable()
-          .longType()
-          .noDefault()
-          .name("b")
-          .type()
-          .nullable()
-          .intType()
-          .noDefault()
-          .name("c")
-          .type()
-          .nullable()
-          .stringType()
-          .stringDefault("")
-          .endRecord();
-
   OpenLineage openLineage = new OpenLineage(mock(URI.class));
 
   @Test
-  void testConvert() {
+  void testConvertSchemaPrimitives() {
+    Schema schema =
+        SchemaBuilder.record("InputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("optional_int_field")
+            .doc("some-doc")
+            .type()
+            .nullable()
+            .intType()
+            .noDefault()
+            .name("long_field")
+            .type()
+            .longType()
+            .noDefault()
+            .name("float_field")
+            .type()
+            .floatType()
+            .noDefault()
+            .name("double_field")
+            .type()
+            .doubleType()
+            .noDefault()
+            .name("string_field")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("bytes_field")
+            .type()
+            .bytesType()
+            .noDefault()
+            .name("boolean_field")
+            .type()
+            .booleanType()
+            .noDefault()
+            .name("fixed_field")
+            .type(Schema.createFixed("md5", null, "io.openlineage.flink.avro.event", 16))
+            .noDefault()
+            .name("enum_field")
+            .type(
+                Schema.createEnum(
+                    "status",
+                    null,
+                    "io.openlineage.flink.avro.event",
+                    List.of("started", "finished")))
+            .withDefault("finished")
+            .endRecord();
+
     OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
         AvroSchemaUtils.convert(openLineage, schema);
 
     List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
 
-    assertEquals(3, fields.size());
+    assertThat(fields.size()).isEqualTo(9);
 
-    assertEquals("a", fields.get(0).getName());
-    assertEquals("some-doc", fields.get(0).getDescription());
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "optional_int_field")
+        .hasFieldOrPropertyWithValue("type", "int")
+        .hasFieldOrPropertyWithValue("description", "some-doc")
+        .hasFieldOrPropertyWithValue("fields", null);
 
-    assertEquals("long", fields.get(0).getType());
-    assertEquals("int", fields.get(1).getType());
-    assertEquals("string", fields.get(2).getType());
+    assertThat(fields.get(1))
+        .hasFieldOrPropertyWithValue("name", "long_field")
+        .hasFieldOrPropertyWithValue("type", "long")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(2))
+        .hasFieldOrPropertyWithValue("name", "float_field")
+        .hasFieldOrPropertyWithValue("type", "float")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(3))
+        .hasFieldOrPropertyWithValue("name", "double_field")
+        .hasFieldOrPropertyWithValue("type", "double")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(4))
+        .hasFieldOrPropertyWithValue("name", "string_field")
+        .hasFieldOrPropertyWithValue("type", "string")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(5))
+        .hasFieldOrPropertyWithValue("name", "bytes_field")
+        .hasFieldOrPropertyWithValue("type", "bytes")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(6))
+        .hasFieldOrPropertyWithValue("name", "boolean_field")
+        .hasFieldOrPropertyWithValue("type", "boolean")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(7))
+        .hasFieldOrPropertyWithValue("name", "fixed_field")
+        .hasFieldOrPropertyWithValue("type", "fixed(16)")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(fields.get(8))
+        .hasFieldOrPropertyWithValue("name", "enum_field")
+        .hasFieldOrPropertyWithValue("type", "enum")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+  }
+
+  @Test
+  void testConvertSchemaUnion() {
+    Schema schema =
+        SchemaBuilder.record("InputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("union_field")
+            .doc("some-doc")
+            .type(
+                Schema.createUnion(
+                    Schema.create(Schema.Type.STRING),
+                    Schema.create(Schema.Type.INT),
+                    Schema.create(Schema.Type.FLOAT),
+                    Schema.create(Schema.Type.NULL)))
+            .withDefault("a")
+            .endRecord();
+
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+        AvroSchemaUtils.convert(openLineage, schema);
+
+    List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
+
+    assertThat(fields.size()).isEqualTo(1);
+
+    OpenLineage.SchemaDatasetFacetFields unionField = fields.get(0);
+
+    assertThat(unionField)
+        .hasFieldOrPropertyWithValue("name", "union_field")
+        .hasFieldOrPropertyWithValue("type", "union")
+        .hasFieldOrPropertyWithValue("description", "some-doc");
+
+    List<OpenLineage.SchemaDatasetFacetFields> nestedFields = unionField.getFields();
+
+    assertThat(nestedFields.size()).isEqualTo(3);
+
+    assertThat(nestedFields.get(0))
+        .hasFieldOrPropertyWithValue("name", "_string")
+        .hasFieldOrPropertyWithValue("type", "string")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(nestedFields.get(1))
+        .hasFieldOrPropertyWithValue("name", "_int")
+        .hasFieldOrPropertyWithValue("type", "int")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(nestedFields.get(2))
+        .hasFieldOrPropertyWithValue("name", "_float")
+        .hasFieldOrPropertyWithValue("type", "float")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+  }
+
+  @Test
+  void testConvertSchemaStruct() {
+    Schema subSubInputEvent =
+        SchemaBuilder.record("SubSubInputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("sub_sub_input_value")
+            .type()
+            .stringType()
+            .noDefault()
+            .endRecord();
+
+    Schema subInputEvent =
+        SchemaBuilder.record("SubInputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("sub_input_value")
+            .doc("another-doc")
+            .type()
+            .nullable()
+            .longType()
+            .noDefault()
+            .name("sub_sub_input")
+            .type(subSubInputEvent)
+            .noDefault()
+            .endRecord();
+
+    Schema schema =
+        SchemaBuilder.record("InputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("value")
+            .doc("some-doc")
+            .type()
+            .nullable()
+            .intType()
+            .noDefault()
+            .name("sub_input")
+            .type(subInputEvent)
+            .noDefault()
+            .endRecord();
+
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+        AvroSchemaUtils.convert(openLineage, schema);
+
+    List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
+
+    assertThat(fields.size()).isEqualTo(2);
+
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "value")
+        .hasFieldOrPropertyWithValue("type", "int")
+        .hasFieldOrPropertyWithValue("description", "some-doc")
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    OpenLineage.SchemaDatasetFacetFields nestedField = fields.get(1);
+    assertThat(nestedField)
+        .hasFieldOrPropertyWithValue("name", "sub_input")
+        .hasFieldOrPropertyWithValue("type", "record")
+        .hasFieldOrPropertyWithValue("description", null);
+
+    List<OpenLineage.SchemaDatasetFacetFields> subFields = nestedField.getFields();
+
+    assertThat(subFields.size()).isEqualTo(2);
+
+    assertThat(subFields.get(0))
+        .hasFieldOrPropertyWithValue("name", "sub_input_value")
+        .hasFieldOrPropertyWithValue("type", "long")
+        .hasFieldOrPropertyWithValue("description", "another-doc")
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    OpenLineage.SchemaDatasetFacetFields superNestedField = subFields.get(1);
+    assertThat(superNestedField)
+        .hasFieldOrPropertyWithValue("name", "sub_sub_input")
+        .hasFieldOrPropertyWithValue("type", "record")
+        .hasFieldOrPropertyWithValue("description", null);
+
+    List<OpenLineage.SchemaDatasetFacetFields> subSubFields = superNestedField.getFields();
+
+    assertThat(subSubFields.size()).isEqualTo(1);
+
+    assertThat(subSubFields.get(0))
+        .hasFieldOrPropertyWithValue("name", "sub_sub_input_value")
+        .hasFieldOrPropertyWithValue("type", "string")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+  }
+
+  @Test
+  void testConvertSchemaMap() {
+    Schema schema =
+        SchemaBuilder.record("InputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("optional_int_field")
+            .doc("some-doc")
+            .type()
+            .nullable()
+            .intType()
+            .noDefault()
+            .name("map_field")
+            .type(Schema.createMap(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .endRecord();
+
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+        AvroSchemaUtils.convert(openLineage, schema);
+
+    List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
+
+    assertThat(fields.size()).isEqualTo(2);
+
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "optional_int_field")
+        .hasFieldOrPropertyWithValue("type", "int")
+        .hasFieldOrPropertyWithValue("description", "some-doc")
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    OpenLineage.SchemaDatasetFacetFields mapField = fields.get(1);
+    assertThat(mapField)
+        .hasFieldOrPropertyWithValue("name", "map_field")
+        .hasFieldOrPropertyWithValue("type", "map")
+        .hasFieldOrPropertyWithValue("description", null);
+
+    List<OpenLineage.SchemaDatasetFacetFields> mapSubFields = mapField.getFields();
+
+    assertThat(mapSubFields.size()).isEqualTo(2);
+
+    assertThat(mapSubFields.get(0))
+        .hasFieldOrPropertyWithValue("name", "key")
+        .hasFieldOrPropertyWithValue("type", "string")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    assertThat(mapSubFields.get(1))
+        .hasFieldOrPropertyWithValue("name", "value")
+        .hasFieldOrPropertyWithValue("type", "long")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
+  }
+
+  @Test
+  void testConvertSchemaArray() {
+    Schema schema =
+        SchemaBuilder.record("InputEvent")
+            .namespace("io.openlineage.flink.avro.event")
+            .fields()
+            .name("optional_int_field")
+            .doc("some-doc")
+            .type()
+            .nullable()
+            .intType()
+            .noDefault()
+            .name("array_field")
+            .type(Schema.createArray(Schema.create(Schema.Type.STRING)))
+            .noDefault()
+            .endRecord();
+
+    OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+        AvroSchemaUtils.convert(openLineage, schema);
+
+    List<OpenLineage.SchemaDatasetFacetFields> fields = schemaDatasetFacet.getFields();
+
+    assertThat(fields.size()).isEqualTo(2);
+
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "optional_int_field")
+        .hasFieldOrPropertyWithValue("type", "int")
+        .hasFieldOrPropertyWithValue("description", "some-doc")
+        .hasFieldOrPropertyWithValue("fields", null);
+
+    OpenLineage.SchemaDatasetFacetFields listField = fields.get(1);
+    assertThat(listField)
+        .hasFieldOrPropertyWithValue("name", "array_field")
+        .hasFieldOrPropertyWithValue("type", "array")
+        .hasFieldOrPropertyWithValue("description", null);
+
+    List<OpenLineage.SchemaDatasetFacetFields> listSubFields = listField.getFields();
+
+    assertThat(listSubFields.size()).isEqualTo(1);
+
+    assertThat(listSubFields.get(0))
+        .hasFieldOrPropertyWithValue("name", "_element")
+        .hasFieldOrPropertyWithValue("type", "string")
+        .hasFieldOrPropertyWithValue("description", null)
+        .hasFieldOrPropertyWithValue("fields", null);
   }
 }


### PR DESCRIPTION
### Problem

### Solution

#### One-line summary:

Create `SchemaDatasetFacet` with nested fields for Avro schemas with complex types (union, record, map, array, fixed).

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project