### PR TITLE
python: suppress warning on importing v1 module in __init__.py.

### DIFF
--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import warnings
+
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
 from openlineage.client.facet import set_producer as set_producer_v1
 from openlineage.client.facet_v2 import set_producer as set_producer_v2
 


### PR DESCRIPTION
### Problem

Whenever someone imports Python OL Client he gets deprecation warning on using v1 facets.

### Solution

Suppress warning on import in `__init__.py`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project