### PR TITLE
Spark: Add jobType facet to Spark application events

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -295,8 +295,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
   }
 
   /**
-   * Getting the job type facet for Spark jobs. Values: job type: `JOB`, job integration: `SPARK`,
-   * processing type: can be `batch` or `streaming` based on
+   * Getting the job type facet for Spark jobs. Values: job type: `SQL_JOB`, job integration:
+   * `SPARK`, processing type: can be `batch` or `streaming` based on
    * queryExecution.optimizedPlan().isStreaming()
    *
    * @param queryExecution

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
@@ -139,4 +139,23 @@ class SparkApplicationExecutionContextTest {
           .isEqualTo(UUID.fromString("4e948e60-1639-4796-950e-cdc6d45915f4"));
     }
   }
+
+  @Test
+  void testJobTypeJobFacetIsSet(SparkSession spark) {
+    ArgumentCaptor<RunEvent> lineageEvent = ArgumentCaptor.forClass(OpenLineage.RunEvent.class);
+    try (MockedStatic<EventFilterUtils> ignored = mockStatic(EventFilterUtils.class)) {
+      when(EventFilterUtils.isDisabled(any(), any())).thenReturn(false);
+
+      context.start(mock(SparkListenerApplicationStart.class));
+      context.end(mock(SparkListenerApplicationEnd.class));
+    }
+
+    for (RunEvent runEvent : lineageEvent.getAllValues()) {
+      OpenLineage.Job job = runEvent.getJob();
+      OpenLineage.JobTypeJobFacet jobTypeFacet = job.getFacets().getJobType();
+      assertThat(jobTypeFacet.getJobType()).isEqualTo("APPLICATION");
+      assertThat(jobTypeFacet.getProcessingType()).isEqualTo("NONE");
+      assertThat(jobTypeFacet.getIntegration()).isEqualTo("SPARK");
+    }
+  }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CustomEnvironmentVariablesCaptureTest.java
@@ -87,7 +87,7 @@ class CustomEnvironmentVariablesCaptureTest {
                     e.getEventType().equals(EventType.START)
                         && e.getJob().getFacets() != null
                         // Exclude SparkApplication start event because env variable was set after
-                        && e.getJob().getFacets().getJobType() != null
+                        && e.getJob().getFacets().getJobType().getJobType() != "APPLICATION"
                         && e.getRun().getFacets() != null
                         && e.getRun()
                                 .getFacets()


### PR DESCRIPTION
### Problem

Currently runEvents for SparkSQL and RDD events have jobType facet, but Spark application events does not:
```json
{
  "eventTime": "2024-05-23T08:03:11.993Z",
  "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.15.0-SNAPSHOT/integration/spark",
  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
  "eventType": "START",
  "run": {
    "runId": "018fa479-c15d-74fd-a3b6-bf7a05eb2b01"
  },
  "job": {
    "namespace": "spark_integration",
    "name": "onetl"
  },
  "inputs": [],
  "outputs": []
}
```

So it's hard to distinguish events related to Spark application from other generic runEvents.

### Solution

Add `jobType` facet to runEvents emitted by SparkListenerApplicationStart:
```json
{
  "eventTime": "2024-05-23T08:03:11.993Z",
  "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.15.0-SNAPSHOT/integration/spark",
  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
  "eventType": "START",
  "run": {
    "runId": "018fa479-c15d-74fd-a3b6-bf7a05eb2b01"
  },
  "job": {
    "namespace": "spark_integration",
    "name": "onetl",
    "facets": {
      "jobType": {
        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.15.0-SNAPSHOT/integration/spark",
        "_schemaURL": "https://openlineage.io/spec/facets/2-0-2/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
        "processingType": "BATCH",
        "integration": "SPARK",
        "jobType": "APPLICATION"
      }
    }
  },
  "inputs": [],
  "outputs": []
}
```

#### One-line summary:

Add `jobType` job facet to Spark application events.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project