### PR TITLE
Dataset namespace resolver feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Added
 * **Spark: add `jobType` facet to Spark application events** [`#2719`](https://github.com/OpenLineage/OpenLineage/pull/2719) [@dolfinus](https://github.com/dolfinus)  
     *Add `jobType` facet to `runEvent`s emitted by `SparkListenerApplicationStart`.*
+* **Spark & Flink: Introduce dataset namespace resolver.** [`#2720`](https://github.com/OpenLineage/OpenLineage/pull/2720) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Enable resolving dataset namespace with predefined resolvers like: `HostListNamespaceResolver`, `PatternNamespaceResolver`, `PatternMatchingGroupNamespaceResolver` or custom implementation loaded with ServiceLoader. Feature is useful to resolve hostnames into cluster identifiers.*
 
 ### Fixed
 * **dbt: fix swapped namespace and name in dbt integration** [`#2735`](https://github.com/OpenLineage/OpenLineage/pull/2735) [@JDarDagran](https://github.com/JDarDagran)  

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
@@ -8,6 +8,7 @@ package io.openlineage.client;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
+import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
 import java.util.Map;
@@ -33,6 +34,9 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
   @JsonProperty("facets")
   protected FacetsConfig facetsConfig;
 
+  @JsonProperty("dataset")
+  protected DatasetConfig datasetConfig;
+
   @JsonProperty("circuitBreaker")
   protected CircuitBreakerConfig circuitBreaker;
 
@@ -50,6 +54,7 @@ public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConf
     return new OpenLineageConfig(
         mergePropertyWith(transportConfig, other.transportConfig),
         mergePropertyWith(facetsConfig, other.facetsConfig),
+        mergePropertyWith(datasetConfig, other.datasetConfig),
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig));
   }

--- a/client/java/src/main/java/io/openlineage/client/dataset/DatasetConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/DatasetConfig.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.MergeConfig;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceResolverConfig;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DatasetConfig implements MergeConfig<DatasetConfig> {
+
+  @Getter
+  @Setter
+  @JsonProperty("namespaceResolvers")
+  private Map<String, DatasetNamespaceResolverConfig> namespaceResolvers;
+
+  @Override
+  public DatasetConfig mergeWithNonNull(DatasetConfig other) {
+    return new DatasetConfig(mergePropertyWith(namespaceResolvers, other.namespaceResolvers));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolver.java
@@ -1,0 +1,90 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import io.openlineage.client.OpenLineageConfig;
+import io.openlineage.client.dataset.DatasetConfig;
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class to resolve hosts based on the dataset host resolver configured. Methods of the
+ * class should return original host address in case of no dataset host resolver defined
+ */
+public class DatasetNamespaceCombinedResolver {
+
+  private final List<DatasetNamespaceResolver> resolvers;
+
+  public DatasetNamespaceCombinedResolver(OpenLineageConfig config) {
+    if (config == null || config.getDatasetConfig() == null) {
+      this.resolvers = Collections.emptyList();
+    } else {
+      this.resolvers =
+          DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(config.getDatasetConfig());
+    }
+  }
+
+  public DatasetNamespaceCombinedResolver(DatasetConfig config) {
+    if (config == null) {
+      this.resolvers = Collections.emptyList();
+    } else {
+      this.resolvers = DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(config);
+    }
+  }
+
+  /**
+   * Resolves namespace by dataset host resolvers defined in dataset config. Whole namespace string
+   * is passed to dataset namespace resolvers.
+   *
+   * @param namespace namespace that may contain host address to be resolved
+   * @return resolved host address or the original one
+   */
+  public String resolve(String namespace) {
+    for (DatasetNamespaceResolver resolver : resolvers) {
+      String resolved = resolver.resolve(namespace);
+      if (!resolved.equals(namespace)) {
+        return resolved;
+      }
+    }
+    return namespace;
+  }
+
+  public DatasetIdentifier resolve(DatasetIdentifier identifier) {
+    return new DatasetIdentifier(
+        identifier.getName(), resolve(identifier.getNamespace()), identifier.getSymlinks());
+  }
+
+  /**
+   * Resolves namespace uri by dataset host resolvers defined in dataset config. Only host of the
+   * URI is passed to dataset namespace resolvers configured.
+   *
+   * @param namespace host address to be resolved
+   * @return resolved host address or the original one
+   */
+  public URI resolveHost(URI namespace) {
+    String resolvedHost = this.resolve(namespace.getHost());
+
+    if (!resolvedHost.equals(namespace.getHost())) {
+      try {
+        return new URI(
+            namespace.getScheme(),
+            namespace.getUserInfo(),
+            resolvedHost,
+            namespace.getPort(),
+            namespace.getPath(),
+            namespace.getQuery(),
+            namespace.getFragment());
+      } catch (URISyntaxException e) {
+        return namespace;
+      }
+    }
+
+    return namespace;
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolver.java
@@ -1,0 +1,23 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+/**
+ * Interface used to resolve host name into more meaningful name that just host address. Common use
+ * case for the interface is: resolve DB server into more descriptive name which is stable when
+ * migrating hosts. Other use case is cluster matching: given any hostname from available in
+ * cluster, a dataset identifier should be based on cluster name.
+ */
+public interface DatasetNamespaceResolver {
+
+  /**
+   * Method should always return original value if hostAdress is not to be modified
+   *
+   * @param namespace address of the host
+   * @return resolved namespace
+   */
+  String resolve(String namespace);
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverBuilder.java
@@ -1,0 +1,15 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+public interface DatasetNamespaceResolverBuilder {
+
+  String getType();
+
+  DatasetNamespaceResolverConfig getConfig();
+
+  DatasetNamespaceResolver build(String name, DatasetNamespaceResolverConfig config);
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverConfig.java
@@ -1,0 +1,13 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeIdResolver(DatasetNamespaceResolverConfigTypeIdResolver.class)
+public interface DatasetNamespaceResolverConfig {}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverConfigTypeIdResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverConfigTypeIdResolver.java
@@ -1,0 +1,43 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+public class DatasetNamespaceResolverConfigTypeIdResolver extends TypeIdResolverBase {
+  private JavaType superType;
+
+  @Override
+  public void init(JavaType baseType) {
+    superType = baseType;
+  }
+
+  @Override
+  public String idFromValue(Object value) {
+    return DatasetNamespaceResolverLoader.loadDatasetNamespaceResolverTypeByConfigClass(
+        value.getClass());
+  }
+
+  @Override
+  public String idFromValueAndType(Object value, Class<?> suggestedType) {
+    return idFromValue(value);
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    Class<? extends DatasetNamespaceResolverConfig> clazz =
+        DatasetNamespaceResolverLoader.loadDatasetNamespaceResolverConfigByType(id);
+    return context.constructSpecializedType(superType, clazz);
+  }
+
+  @Override
+  public JsonTypeInfo.Id getMechanism() {
+    return JsonTypeInfo.Id.CUSTOM;
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverLoader.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverLoader.java
@@ -1,0 +1,86 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.dataset.DatasetConfig;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class DatasetNamespaceResolverLoader {
+
+  private static List<DatasetNamespaceResolverBuilder> builders =
+      Arrays.asList(
+          new HostListNamespaceResolverBuilder(),
+          new PatternNamespaceResolverBuilder(),
+          new PatternMatchingGroupNamespaceResolverBuilder());
+
+  public static Class<? extends DatasetNamespaceResolverConfig>
+      loadDatasetNamespaceResolverConfigByType(String type) {
+    return getDatasetNamespaceResolverBuilder(b -> b.getType().equalsIgnoreCase(type))
+        .map(b -> b.getConfig().getClass())
+        .orElseThrow(
+            () ->
+                new OpenLineageClientException(
+                    "Invalid dataset namespace resolver type provided: " + type));
+  }
+
+  public static String loadDatasetNamespaceResolverTypeByConfigClass(
+      Class datasetNamespaceResolverConfigClass) {
+    return getDatasetNamespaceResolverBuilder(
+            b -> b.getConfig().getClass().equals(datasetNamespaceResolverConfigClass))
+        .map(b -> b.getType())
+        .orElseThrow(
+            () ->
+                new OpenLineageClientException(
+                    "Invalid dataset namespace resolver class provided: "
+                        + datasetNamespaceResolverConfigClass.getCanonicalName()));
+  }
+
+  public static List<DatasetNamespaceResolver> loadDatasetNamespaceResolvers(
+      DatasetConfig datasetConfig) {
+    if (datasetConfig.getNamespaceResolvers() == null) {
+      return Collections.emptyList();
+    }
+    return datasetConfig.getNamespaceResolvers().keySet().stream()
+        .map(
+            name -> {
+              DatasetNamespaceResolverConfig config =
+                  datasetConfig.getNamespaceResolvers().get(name);
+              return getDatasetNamespaceResolverBuilder(
+                      b -> b.getConfig().getClass().equals(config.getClass()))
+                  .map(b -> b.build(name, config))
+                  .orElseThrow(
+                      () ->
+                          new OpenLineageClientException(
+                              "Dataset namespace resolver shouldn't be called for invalid or null config"));
+            })
+        .collect(Collectors.toList());
+  }
+
+  private static Optional<DatasetNamespaceResolverBuilder> getDatasetNamespaceResolverBuilder(
+      Predicate<DatasetNamespaceResolverBuilder> predicate) {
+
+    return Stream.concat(
+            builders.stream(),
+            StreamSupport.stream(DatasetNamespaceResolverServiceLoader.load().spliterator(), false))
+        .filter(predicate)
+        .findFirst();
+  }
+
+  static class DatasetNamespaceResolverServiceLoader {
+    static ServiceLoader<DatasetNamespaceResolverBuilder> load() {
+      return ServiceLoader.load(DatasetNamespaceResolverBuilder.class);
+    }
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolver.java
@@ -1,0 +1,38 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class HostListNamespaceResolver implements DatasetNamespaceResolver {
+
+  private final String resolvedName;
+  private final HostListNamespaceResolverConfig config;
+
+  public HostListNamespaceResolver(String resolvedName, HostListNamespaceResolverConfig config) {
+    this.resolvedName = resolvedName;
+    this.config = config;
+  }
+
+  @Override
+  public String resolve(String namespace) {
+    if (config.getHosts() == null) {
+      return namespace;
+    }
+
+    if (StringUtils.isNotEmpty(config.getSchema())
+        && !namespace.startsWith(config.getSchema() + "://")) {
+      // schema configured but is not matching
+      return namespace;
+    }
+
+    return config.getHosts().stream()
+        .filter(h -> StringUtils.containsIgnoreCase(namespace, h))
+        .findAny()
+        .map(h -> StringUtils.replaceIgnoreCase(namespace, h, resolvedName))
+        .orElseGet(() -> namespace);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverBuilder.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+public class HostListNamespaceResolverBuilder implements DatasetNamespaceResolverBuilder {
+
+  @Override
+  public String getType() {
+    return "hostList";
+  }
+
+  @Override
+  public DatasetNamespaceResolverConfig getConfig() {
+    return new HostListNamespaceResolverConfig();
+  }
+
+  @Override
+  public HostListNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
+    return new HostListNamespaceResolver(name, (HostListNamespaceResolverConfig) config);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverConfig.java
@@ -1,0 +1,33 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import io.openlineage.client.MergeConfig;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+public class HostListNamespaceResolverConfig
+    implements DatasetNamespaceResolverConfig, MergeConfig<HostListNamespaceResolverConfig> {
+
+  @NonNull @Getter @Setter private List<String> hosts = null;
+  @Getter @Setter private String schema;
+
+  @Override
+  public HostListNamespaceResolverConfig mergeWithNonNull(HostListNamespaceResolverConfig t) {
+    return new HostListNamespaceResolverConfig(
+        mergePropertyWith(hosts, t.getHosts()), mergePropertyWith(schema, t.schema));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolver.java
@@ -1,0 +1,38 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class PatternMatchingGroupNamespaceResolver implements DatasetNamespaceResolver {
+
+  private final String matchingGroup;
+  private final Pattern pattern;
+  private final String schema;
+
+  public PatternMatchingGroupNamespaceResolver(PatternMatchingGroupNamespaceResolverConfig config) {
+    this.matchingGroup = config.getMatchingGroup();
+    this.pattern = Pattern.compile(config.getRegex());
+    this.schema = config.getSchema();
+  }
+
+  @Override
+  public String resolve(String namespace) {
+    if (StringUtils.isNotEmpty(schema) && !namespace.startsWith(schema + "://")) {
+      // schema configured but is not matching
+      return namespace;
+    }
+
+    Matcher matcher = pattern.matcher(namespace);
+    if (matcher.find()) {
+      return matcher.replaceAll(matcher.group(matchingGroup));
+    } else {
+      return namespace;
+    }
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverBuilder.java
@@ -1,0 +1,25 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+public class PatternMatchingGroupNamespaceResolverBuilder
+    implements DatasetNamespaceResolverBuilder {
+
+  @Override
+  public String getType() {
+    return "patternGroup";
+  }
+
+  @Override
+  public DatasetNamespaceResolverConfig getConfig() {
+    return new PatternMatchingGroupNamespaceResolverConfig();
+  }
+
+  @Override
+  public HostListNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
+    return new HostListNamespaceResolver(name, (HostListNamespaceResolverConfig) config);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverConfig.java
@@ -1,0 +1,37 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import io.openlineage.client.MergeConfig;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+public class PatternMatchingGroupNamespaceResolverConfig
+    implements DatasetNamespaceResolverConfig,
+        MergeConfig<PatternMatchingGroupNamespaceResolverConfig> {
+
+  @NonNull @Getter @Setter private String regex;
+  @NonNull @Getter @Setter private String matchingGroup;
+  @Getter @Setter private String schema;
+
+  @Override
+  public PatternMatchingGroupNamespaceResolverConfig mergeWithNonNull(
+      PatternMatchingGroupNamespaceResolverConfig t) {
+    return new PatternMatchingGroupNamespaceResolverConfig(
+        mergePropertyWith(regex, t.regex),
+        mergePropertyWith(matchingGroup, t.matchingGroup),
+        mergePropertyWith(schema, t.schema));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolver.java
@@ -1,0 +1,37 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class PatternNamespaceResolver implements DatasetNamespaceResolver {
+  private final String resolvedName;
+  private final Pattern pattern;
+  private final String schema;
+
+  public PatternNamespaceResolver(String resolvedName, PatternNamespaceResolverConfig config) {
+    this.resolvedName = resolvedName;
+    this.pattern = Pattern.compile(config.getRegex());
+    this.schema = config.getSchema();
+  }
+
+  @Override
+  public String resolve(String namespace) {
+    if (StringUtils.isNotEmpty(schema) && !namespace.startsWith(schema + "://")) {
+      // schema configured but is not matching
+      return namespace;
+    }
+
+    Matcher matcher = pattern.matcher(namespace);
+    if (matcher.find()) {
+      return matcher.replaceAll(resolvedName);
+    } else {
+      return namespace;
+    }
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverBuilder.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+public class PatternNamespaceResolverBuilder implements DatasetNamespaceResolverBuilder {
+
+  @Override
+  public String getType() {
+    return "pattern";
+  }
+
+  @Override
+  public DatasetNamespaceResolverConfig getConfig() {
+    return new PatternNamespaceResolverConfig();
+  }
+
+  @Override
+  public HostListNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
+    return new HostListNamespaceResolver(name, (HostListNamespaceResolverConfig) config);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverConfig.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import io.openlineage.client.MergeConfig;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+public class PatternNamespaceResolverConfig
+    implements DatasetNamespaceResolverConfig, MergeConfig<PatternNamespaceResolverConfig> {
+
+  @NonNull @Getter @Setter private String regex;
+  @Getter @Setter private String schema;
+
+  @Override
+  public PatternNamespaceResolverConfig mergeWithNonNull(PatternNamespaceResolverConfig t) {
+    return new PatternNamespaceResolverConfig(
+        mergePropertyWith(regex, t.regex), mergePropertyWith(schema, t.schema));
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
@@ -25,6 +25,12 @@ public class DatasetIdentifier {
     this.symlinks = new LinkedList<>();
   }
 
+  public DatasetIdentifier(String name, String namespace, List<Symlink> symlinks) {
+    this.name = name;
+    this.namespace = namespace;
+    this.symlinks = symlinks;
+  }
+
   public DatasetIdentifier withSymlink(String name, String namespace, SymlinkType type) {
     symlinks.add(new Symlink(name, namespace, type));
     return this;

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolverTest.java
@@ -1,0 +1,111 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.dataset.namespace.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.dataset.DatasetConfig;
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class DatasetNamespaceCombinedResolverTest {
+  HostListNamespaceResolver resolver1 = mock(HostListNamespaceResolver.class);
+  HostListNamespaceResolver resolver2 = mock(HostListNamespaceResolver.class);
+  DatasetConfig config = new DatasetConfig();
+
+  @Test
+  void testNoConfigProvided() {
+    config.setNamespaceResolvers(Collections.emptyMap());
+    assertThat(new DatasetNamespaceCombinedResolver((DatasetConfig) null).resolve("some-namespace"))
+        .isEqualTo("some-namespace");
+
+    config = new DatasetConfig();
+    config.setNamespaceResolvers(null);
+    assertThat(new DatasetNamespaceCombinedResolver(config).resolve("some-namespace"))
+        .isEqualTo("some-namespace");
+
+    HostListNamespaceResolverConfig resolverConfig =
+        new HostListNamespaceResolverConfig(Arrays.asList("host1", "host2"), null);
+    this.config = new DatasetConfig();
+    this.config.setNamespaceResolvers(Collections.singletonMap("cluster", resolverConfig));
+    assertThat(new DatasetNamespaceCombinedResolver(config).resolve("some-namespace"))
+        .isEqualTo("some-namespace");
+  }
+
+  @Test
+  void testResolveWhenNoResolversDefined() {
+    config.setNamespaceResolvers(Collections.emptyMap());
+    assertThat(new DatasetNamespaceCombinedResolver(config).resolve("host5")).isEqualTo("host5");
+  }
+
+  @Test
+  void testResolveWhenForSingleResolver() {
+    when(resolver1.resolve("host1")).thenReturn("cluster");
+    when(resolver1.resolve("host5")).thenReturn("host5");
+    try (MockedStatic loader = mockStatic(DatasetNamespaceResolverLoader.class)) {
+      when(DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(config))
+          .thenReturn(Collections.singletonList(resolver1));
+      DatasetNamespaceCombinedResolver resolvers = new DatasetNamespaceCombinedResolver(config);
+
+      Assertions.assertThat(
+              resolvers.resolve(new DatasetIdentifier("name", "host1")).getNamespace())
+          .isEqualTo("cluster");
+      assertThat(resolvers.resolve(new DatasetIdentifier("name", "host5")).getNamespace())
+          .isEqualTo("host5");
+    }
+  }
+
+  @Test
+  void testResolveWhenForMultipleResolvers() {
+    when(resolver1.resolve("host1")).thenReturn("cluster1");
+    when(resolver1.resolve("host2")).thenReturn("host2");
+    when(resolver1.resolve("host5")).thenReturn("host5");
+
+    when(resolver2.resolve("host1")).thenReturn("host1");
+    when(resolver1.resolve("host2")).thenReturn("cluster2");
+    when(resolver2.resolve("host5")).thenReturn("host5");
+
+    try (MockedStatic loader = mockStatic(DatasetNamespaceResolverLoader.class)) {
+      when(DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(config))
+          .thenReturn(Arrays.asList(resolver1, resolver2));
+      DatasetNamespaceCombinedResolver resolvers = new DatasetNamespaceCombinedResolver(config);
+
+      assertThat(resolvers.resolve("host1")).isEqualTo("cluster1");
+      assertThat(resolvers.resolve("host2")).isEqualTo("cluster2");
+      assertThat(resolvers.resolve("host5")).isEqualTo("host5");
+    }
+  }
+
+  @Test
+  void testResolveForUriString() throws URISyntaxException {
+    HostListNamespaceResolver resolver =
+        new HostListNamespaceResolver(
+            "kafka-prod",
+            new HostListNamespaceResolverConfig(Collections.singletonList("kafka"), null));
+
+    try (MockedStatic loader = mockStatic(DatasetNamespaceResolverLoader.class)) {
+      when(DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(config))
+          .thenReturn(Arrays.asList(resolver));
+      DatasetNamespaceCombinedResolver resolvers = new DatasetNamespaceCombinedResolver(config);
+
+      // assert that only host part of the URI gets resolved
+      assertThat(resolvers.resolveHost(new URI("kafka://kafka:9091")).toString())
+          .isEqualTo("kafka://kafka-prod:9091");
+
+      // assert non-matching uri is not changed
+      URI someUri = new URI("kafka://other-host:9091");
+      assertThat(resolvers.resolveHost(someUri)).isEqualTo(someUri);
+    }
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverLoaderTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceResolverLoaderTest.java
@@ -1,0 +1,45 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset.namespace.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.dataset.DatasetConfig;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceResolverLoader.DatasetNamespaceResolverServiceLoader;
+import java.util.Collections;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class DatasetNamespaceResolverLoaderTest {
+
+  @Test
+  void testBuilderLoadedWithServiceLoader() {
+    DatasetNamespaceResolverBuilder builder = mock(DatasetNamespaceResolverBuilder.class);
+    DatasetConfig datasetConfig = mock(DatasetConfig.class);
+    DatasetNamespaceResolverConfig config = mock(DatasetNamespaceResolverConfig.class);
+    DatasetNamespaceResolver resolver = mock(DatasetNamespaceResolver.class);
+    when(builder.getConfig()).thenReturn(config);
+    when(builder.build("name", config)).thenReturn(resolver);
+    when(datasetConfig.getNamespaceResolvers())
+        .thenReturn(Collections.singletonMap("name", config));
+
+    ServiceLoader<DatasetNamespaceResolverBuilder> serviceLoader = mock(ServiceLoader.class);
+    try (MockedStatic loader = mockStatic(DatasetNamespaceResolverServiceLoader.class)) {
+      when(DatasetNamespaceResolverServiceLoader.load()).thenReturn(serviceLoader);
+      when(serviceLoader.spliterator())
+          .thenReturn(Collections.singletonList(builder).spliterator());
+
+      assertThat(DatasetNamespaceResolverLoader.loadDatasetNamespaceResolvers(datasetConfig))
+          .hasSize(1)
+          .first()
+          .isEqualTo(resolver);
+    }
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/HostListNamespaceResolverTest.java
@@ -1,0 +1,60 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.dataset.namespace.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class HostListNamespaceResolverTest {
+
+  HostListNamespaceResolver resolver =
+      new HostListNamespaceResolver(
+          "cluster", new HostListNamespaceResolverConfig(Arrays.asList("host1", "host2"), null));
+
+  @Test
+  void testHostNotOnList() {
+    assertThat(resolver.resolve("postgres://host3:5432")).isEqualTo("postgres://host3:5432");
+  }
+
+  @Test
+  void testHostOnTheList() {
+    assertThat(resolver.resolve("postgres://host2:5432")).isEqualTo("postgres://cluster:5432");
+  }
+
+  @Test
+  void testHostOnTheListWithDifferentSchema() {
+    resolver =
+        new HostListNamespaceResolver(
+            "cluster",
+            new HostListNamespaceResolverConfig(Arrays.asList("host1", "host2"), "kafka"));
+    assertThat(resolver.resolve("postgres://host2:5432")).isEqualTo("postgres://host2:5432");
+  }
+
+  @Test
+  void testHostOnTheListWithSameSchema() {
+    resolver =
+        new HostListNamespaceResolver(
+            "cluster",
+            new HostListNamespaceResolverConfig(Arrays.asList("host1", "host2"), "postgres"));
+    assertThat(resolver.resolve("postgres://host2:5432")).isEqualTo("postgres://cluster:5432");
+  }
+
+  @Test
+  void testHostOnTheListWithDifferentCase() {
+    assertThat(resolver.resolve("postgres://HOST1:5432")).isEqualTo("postgres://cluster:5432");
+  }
+
+  @Test
+  void testResolveWhenNoHostsProvided() {
+    assertThat(
+            new HostListNamespaceResolver(
+                    "cluster", new HostListNamespaceResolverConfig(Collections.emptyList(), null))
+                .resolve("postgres://host3:5432"))
+        .isEqualTo("postgres://host3:5432");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverTest.java
@@ -1,0 +1,52 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.dataset.namespace.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PatternMatchingGroupNamespaceResolverTest {
+
+  PatternMatchingGroupNamespaceResolver resolver =
+      new PatternMatchingGroupNamespaceResolver(
+          new PatternMatchingGroupNamespaceResolverConfig(
+              "(?<cluster>[a-zA-Z-]+)-(\\d)+\\.company\\.com:[\\d]*", "cluster", null));
+
+  @Test
+  void testNonMatchingPattern() {
+    String namespace = "cassandra://cassandra-prod-893472.other-domain.com:8080/whatever";
+    assertThat(resolver.resolve(namespace)).isEqualTo(namespace);
+  }
+
+  @Test
+  void testMatchingPattern() {
+    String namespace = "cassandra://cassandra-prod-893472.company.com:8080/whatever";
+    assertThat(resolver.resolve(namespace)).isEqualTo("cassandra://cassandra-prod/whatever");
+  }
+
+  @Test
+  void testMatchingPatternWithDifferentSchema() {
+    resolver =
+        new PatternMatchingGroupNamespaceResolver(
+            new PatternMatchingGroupNamespaceResolverConfig(
+                "(?<cluster>[a-zA-Z-]+)-(\\d)+\\.company\\.com:[\\d]*", "cluster", "kafka"));
+
+    String namespace = "cassandra://cassandra-prod-893472.company.com:8080/whatever";
+    assertThat(resolver.resolve(namespace))
+        .isEqualTo("cassandra://cassandra-prod-893472.company.com:8080/whatever");
+  }
+
+  @Test
+  void testMatchingPatternWithSameSchema() {
+    resolver =
+        new PatternMatchingGroupNamespaceResolver(
+            new PatternMatchingGroupNamespaceResolverConfig(
+                "(?<cluster>[a-zA-Z-]+)-(\\d)+\\.company\\.com:[\\d]*", "cluster", "cassandra"));
+
+    String namespace = "cassandra://cassandra-prod-893472.company.com:8080/whatever";
+    assertThat(resolver.resolve(namespace)).isEqualTo("cassandra://cassandra-prod/whatever");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverTest.java
@@ -1,0 +1,52 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.dataset.namespace.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PatternNamespaceResolverTest {
+
+  PatternNamespaceResolver resolver =
+      new PatternNamespaceResolver(
+          "cassandra-cluster-prod",
+          new PatternNamespaceResolverConfig("cassandra-prod(\\d)+\\.company\\.com", null));
+
+  @Test
+  void testNonMatchingPattern() {
+    String namespace = "kafka://kafka-prod893472.company.com:9091";
+    assertThat(resolver.resolve(namespace)).isEqualTo(namespace);
+  }
+
+  @Test
+  void testMatchingPattern() {
+    String host = "cassandra://cassandra-prod893472.company.com";
+    assertThat(resolver.resolve(host)).isEqualTo("cassandra://cassandra-cluster-prod");
+  }
+
+  @Test
+  void testMatchingPatternWithDifferentSchema() {
+    resolver =
+        new PatternNamespaceResolver(
+            "cassandra-cluster-prod",
+            new PatternNamespaceResolverConfig("cassandra-prod(\\d)+\\.company\\.com", "kafka"));
+
+    String host = "cassandra://cassandra-prod893472.company.com";
+    assertThat(resolver.resolve(host)).isEqualTo("cassandra://cassandra-prod893472.company.com");
+  }
+
+  @Test
+  void testMatchingPatternWithSameSchema() {
+    resolver =
+        new PatternNamespaceResolver(
+            "cassandra-cluster-prod",
+            new PatternNamespaceResolverConfig(
+                "cassandra-prod(\\d)+\\.company\\.com", "cassandra"));
+
+    String host = "cassandra://cassandra-prod893472.company.com";
+    assertThat(resolver.resolve(host)).isEqualTo("cassandra://cassandra-cluster-prod");
+  }
+}

--- a/client/java/src/test/resources/config/datasetNamespaceResolver.yaml
+++ b/client/java/src/test/resources/config/datasetNamespaceResolver.yaml
@@ -1,0 +1,19 @@
+transport:
+  type: console
+dataset:
+  namespaceResolvers:
+      kafka-prod:
+        type: hostList
+        hosts: ['kafka-prod13.company.com', 'kafka-prod15.company.com']
+        schema: kafka
+      cassandra-prod:
+        type: pattern
+        # 'cassandra-prod7.company.com', 'cassandra-prod8.company.com'
+        regex: 'cassandra-prod(\d)+\.company\.com'
+        schema: cassandra
+      test-pattern:
+        type: patternGroup
+        # 'cassandra-test-7.company.com', 'cassandra-test-8.company.com', 'kafka-test-7.company.com', 'kafka-test-8.company.com'
+        regex: '(?<cluster>[a-zA-Z-]+)-(\d)+\.company\.com:[\d]*'
+        matchingGroup: "cluster"
+        schema: cassandra

--- a/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
@@ -14,6 +14,7 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineage.RunEventBuilder;
 import io.openlineage.client.circuitBreaker.CircuitBreaker;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.flink.SinkLineage;
 import io.openlineage.flink.TransformationUtils;
 import io.openlineage.flink.api.OpenLineageContext;
@@ -59,6 +60,7 @@ public class FlinkExecutionContext implements ExecutionContext {
   private final CircuitBreaker circuitBreaker;
   private final FlinkOpenLineageConfig config;
   @Getter private final MeterRegistry meterRegistry;
+  @Getter private final DatasetNamespaceCombinedResolver namespaceResolver;
 
   @Getter private final List<Transformation<?>> transformations;
 

--- a/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextFactory.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.circuitBreaker.CircuitBreakerFactory;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.client.metrics.MicrometerProvider;
 import io.openlineage.client.utils.UUIDUtils;
 import io.openlineage.flink.api.OpenLineageContext;
@@ -57,10 +58,12 @@ public class FlinkExecutionContextFactory {
         .openLineageContext(
             OpenLineageContext.builder()
                 .openLineage(new OpenLineage(EventEmitter.OPEN_LINEAGE_CLIENT_URI))
+                .config(config)
                 .build())
         .eventEmitter(eventEmitter)
         .config(config)
         .meterRegistry(initializeMetrics(config))
+        .namespaceResolver(new DatasetNamespaceCombinedResolver(config))
         .build();
   }
 

--- a/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -348,7 +348,9 @@ class ContainerTest {
                 "jobmanager.rpc.address: jobmanager\n"
                     + "execution.attached: true\n"
                     + "openlineage.transport.url: http://openlineageclient:1080\n"
-                    + "openlineage.transport.type: http\n")
+                    + "openlineage.transport.type: http\n"
+                    + "openlineage.dataset.namespaceResolvers.kafka-cluster-prod.type: hostList\n"
+                    + "openlineage.dataset.namespaceResolvers.kafka-cluster-prod.hosts: [kafka-host]\n")
             .withStartupTimeout(Duration.of(5, ChronoUnit.MINUTES))
             .dependsOn(Arrays.asList(generateEvents, openLineageClientMockContainer));
 

--- a/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -44,7 +44,7 @@ public class FlinkContainerUtils {
   static GenericContainer<?> makeSchemaRegistryContainer(Network network, Startable startable) {
     return genericContainer(network, SCHEMA_REGISTRY_IMAGE, "schema-registry")
         .withExposedPorts(28081)
-        .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+        .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka-host:9092")
         .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
         .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://schema-registry:8081,http://0.0.0.0:28081")
         .withEnv("SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL", "WARN")
@@ -52,17 +52,17 @@ public class FlinkContainerUtils {
   }
 
   static GenericContainer<?> makeKafkaContainer(Network network, Startable zookeeper) {
-    return genericContainer(network, KAFKA_IMAGE, "kafka")
+    return genericContainer(network, KAFKA_IMAGE, "kafka-host")
         .withExposedPorts(9092, 19092)
         .withEnv(
             "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
             "LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT")
         .withEnv(
             "KAFKA_LISTENERS",
-            "LISTENER_DOCKER_INTERNAL://kafka:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092")
+            "LISTENER_DOCKER_INTERNAL://kafka-host:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092")
         .withEnv(
             "KAFKA_ADVERTISED_LISTENERS",
-            "LISTENER_DOCKER_INTERNAL://kafka:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092")
+            "LISTENER_DOCKER_INTERNAL://kafka-host:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092")
         .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "LISTENER_DOCKER_INTERNAL")
         .withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:2181")
         .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")

--- a/integration/flink/app/src/test/resources/events/expected_cassandra.json
+++ b/integration/flink/app/src/test/resources/events/expected_cassandra.json
@@ -5,11 +5,11 @@
     "name": "flink_examples_cassandra"
   },
   "inputs": [{
-    "namespace": "cassandra://cassandra-server:9042",
+    "namespace": "cassandra://cassandra-cluster-prod:9042",
     "name": "flink.source_event"
   }],
   "outputs" : [{
-    "namespace" : "cassandra://cassandra-server:9042",
+    "namespace" : "cassandra://cassandra-cluster-prod:9042",
     "name" : "flink.sink_event"
   }]
 }

--- a/integration/flink/app/src/test/resources/events/expected_flink_conf.json
+++ b/integration/flink/app/src/test/resources/events/expected_flink_conf.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -28,7 +28,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -48,7 +48,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka.json
@@ -17,7 +17,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -35,7 +35,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -55,7 +55,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka_checkpoints.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka_checkpoints.json
@@ -19,7 +19,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -57,7 +57,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka_generic_record.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka_generic_record.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input_no_schema_registry",
       "facets": {
         "schema": {
@@ -30,7 +30,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka_multi_topic_sink.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka_multi_topic_sink.json
@@ -17,7 +17,7 @@
   },
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output1",
       "facets": {
         "schema": {
@@ -39,7 +39,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output2",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -10,7 +10,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -28,7 +28,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -48,7 +48,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
+++ b/integration/flink/app/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
@@ -19,7 +19,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -37,7 +37,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -57,7 +57,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_legacy_kafka.json
+++ b/integration/flink/app/src/test/resources/events/expected_legacy_kafka.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -44,7 +44,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
+++ b/integration/flink/app/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
@@ -6,7 +6,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1",
       "facets": {
         "schema": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2",
       "facets": {
         "schema": {
@@ -44,7 +44,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/events/expected_protobuf.json
+++ b/integration/flink/app/src/test/resources/events/expected_protobuf.json
@@ -17,7 +17,7 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.protobuf_input",
       "facets": {
         "schema": {
@@ -71,7 +71,7 @@
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.protobuf_output",
       "facets": {
         "schema": {

--- a/integration/flink/app/src/test/resources/generate_events.sh
+++ b/integration/flink/app/src/test/resources/generate_events.sh
@@ -1,17 +1,17 @@
 kafka-avro-console-producer \
   --topic io.openlineage.flink.kafka.input1 \
-  --broker-list kafka:9092 \
+  --broker-list kafka-host:9092 \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema="$(< /tmp/InputEvent.avsc)" < /tmp/events.json &&
 kafka-avro-console-producer \
   --topic io.openlineage.flink.kafka.input2 \
-  --broker-list kafka:9092 \
+  --broker-list kafka-host:9092 \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema="$(< /tmp/InputEvent.avsc)" < /tmp/events.json &&
 echo 'input1 and input2 produced' &&
 kafka-protobuf-console-producer \
   --topic io.openlineage.flink.kafka.protobuf_input \
-  --broker-list kafka:9092 \
+  --broker-list kafka-host:9092 \
   --property schema.registry.url=http://schema-registry:8081 \
   --property value.schema="$(< /tmp/InputEvent.proto)" < /tmp/events_proto.json &&
 echo 'input_protobuf produced'

--- a/integration/flink/app/src/test/resources/openlineage.yml
+++ b/integration/flink/app/src/test/resources/openlineage.yml
@@ -1,3 +1,11 @@
 transport:
   type: http
   url: http://openlineageclient:1080
+dataset:
+  namespaceResolvers:
+    kafka-cluster-prod:
+      type: hostList
+      hosts: [ 'kafka-host' ]
+    cassandra-cluster-prod:
+      type: hostList
+      hosts: [ 'cassandra-server' ]

--- a/integration/flink/examples/stateful/src/docker/docker-compose.yml
+++ b/integration/flink/examples/stateful/src/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "19092:19092"
     environment:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092
+      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka-host:9092,LISTENER_DOCKER_EXTERNAL://127.0.0.1:19092
       KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
@@ -38,7 +38,7 @@ services:
     ports:
       - "28081:28081"
     environment:
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka-host:9092
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081,http://0.0.0.0:28081
     depends_on:
@@ -58,14 +58,14 @@ services:
     command: |
       "
       # blocks until kafka is reachable
-      kafka-topics --bootstrap-server kafka:9092 --list
+      kafka-topics --bootstrap-server kafka-host:9092 --list
       
       echo -e 'Creating kafka topics'
-      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic io.openlineage.flink.kafka.input --replication-factor 1 --partitions 1
-      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic io.openlineage.flink.kafka.output --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka-host:9092 --create --if-not-exists --topic io.openlineage.flink.kafka.input --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka-host:9092 --create --if-not-exists --topic io.openlineage.flink.kafka.output --replication-factor 1 --partitions 1
       
       echo -e 'Topics list:'
-      kafka-topics --bootstrap-server kafka:9092 --list
+      kafka-topics --bootstrap-server kafka-host:9092 --list
       "
 
   jobmanager:

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkMultiTopicSinkApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkMultiTopicSinkApplication.java
@@ -44,7 +44,7 @@ public class FlinkMultiTopicSinkApplication {
             KafkaSink.<OutputEvent>builder()
                 .setRecordSerializer(new MultiTopicSerializationSchema(topics))
                 .setKafkaProducerConfig(fromResource("kafka-producer.conf").toProperties())
-                .setBootstrapServers("kafka:9092")
+                .setBootstrapServers("kafka-host:9092")
                 .build()
         )
         .name("kafka-sink")

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkProtobufApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkProtobufApplication.java
@@ -46,7 +46,7 @@ public class FlinkProtobufApplication {
     KafkaSource<InputEvent> source =
         KafkaSource.<InputEvent>builder()
             .setProperties(fromResource("kafka-consumer.conf").toProperties())
-            .setBootstrapServers("kafka:9092")
+            .setBootstrapServers("kafka-host:9092")
             .setValueOnlyDeserializer(
                 new DeserializationSchema<InputEvent>() {
                   @Override
@@ -85,7 +85,7 @@ public class FlinkProtobufApplication {
 
     KafkaSink<OutputEvent> sink = KafkaSink.<OutputEvent>builder()
         .setKafkaProducerConfig(fromResource("kafka-producer.conf").toProperties())
-        .setBootstrapServers("kafka:9092")
+        .setBootstrapServers("kafka-host:9092")
         .setRecordSerializer(
             KafkaRecordSerializationSchema.builder()
                 .setValueSerializationSchema(

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/flink/FlinkSourceWithGenericRecordApplication.java
@@ -45,7 +45,7 @@ public class FlinkSourceWithGenericRecordApplication {
     KafkaSourceBuilder<GenericRecord> builder =
         KafkaSource.<GenericRecord>builder()
             .setProperties(fromResource("kafka-consumer.conf").toProperties())
-            .setBootstrapServers("kafka:9092")
+            .setBootstrapServers("kafka-host:9092")
             .setValueOnlyDeserializer(
                 ConfluentRegistryAvroDeserializationSchema.forGeneric(InputEvent.getClassSchema()));
 

--- a/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
+++ b/integration/flink/examples/stateful/src/main/java/io/openlineage/kafka/KafkaClientProvider.java
@@ -30,7 +30,7 @@ public class KafkaClientProvider {
     KafkaSourceBuilder<InputEvent> builder =
         KafkaSource.<InputEvent>builder()
             .setProperties(fromResource("kafka-consumer.conf").toProperties())
-            .setBootstrapServers("kafka:9092")
+            .setBootstrapServers("kafka-host:9092")
             .setValueOnlyDeserializer(
                 ConfluentRegistryAvroDeserializationSchema.forSpecific(
                     InputEvent.class, SCHEMA_REGISTRY_URL));
@@ -67,7 +67,7 @@ public class KafkaClientProvider {
   public static KafkaSink<OutputEvent> aKafkaSink(String topic) {
     return KafkaSink.<OutputEvent>builder()
         .setKafkaProducerConfig(fromResource("kafka-producer.conf").toProperties())
-        .setBootstrapServers("kafka:9092")
+        .setBootstrapServers("kafka-host:9092")
         .setRecordSerializer(
             KafkaRecordSerializationSchema.builder()
                 .setValueSerializationSchema(

--- a/integration/flink/examples/stateful/src/main/resources/kafka-consumer.conf
+++ b/integration/flink/examples/stateful/src/main/resources/kafka-consumer.conf
@@ -1,4 +1,4 @@
-bootstrap.servers = "kafka:9092"
+bootstrap.servers = "kafka-host:9092"
 group.id = "flink-examples-stateful"
 request.timeout.ms = 60000
 auto.offset.reset = "earliest"

--- a/integration/flink/examples/stateful/src/main/resources/kafka-producer.conf
+++ b/integration/flink/examples/stateful/src/main/resources/kafka-producer.conf
@@ -1,4 +1,4 @@
-bootstrap.servers = "kafka:9092"
+bootstrap.servers = "kafka-host:9092"
 
 max.block.ms = 60000
 delivery.timeout.ms = 120000

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -7,6 +7,7 @@ package io.openlineage.flink.api;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.UUIDUtils;
+import io.openlineage.flink.client.FlinkOpenLineageConfig;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.NonNull;
@@ -31,4 +32,7 @@ public class OpenLineageContext {
    * model objects
    */
   @NonNull OpenLineage openLineage;
+
+  /** Flink OpenLineage config */
+  @NonNull FlinkOpenLineageConfig config;
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
@@ -126,8 +126,6 @@ public class FlinkConfigParser {
   }
 
   private static boolean isArrayType(String value) {
-    return value.startsWith(ARRAY_PREFIX_CHAR)
-        && value.endsWith(ARRAY_SUFFIX_CHAR)
-        && value.contains(ARRAY_ELEMENTS_SEPARATOR);
+    return value.startsWith(ARRAY_PREFIX_CHAR) && value.endsWith(ARRAY_SUFFIX_CHAR);
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkOpenLineageConfig.java
@@ -8,6 +8,7 @@ package io.openlineage.flink.client;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
+import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
 import java.util.HashMap;
@@ -27,10 +28,11 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
   public FlinkOpenLineageConfig(
       TransportConfig transportConfig,
       FacetsConfig facetsConfig,
+      DatasetConfig datasetConfig,
       CircuitBreakerConfig circuitBreaker,
       Map metricsConfig,
       JobConfig job) {
-    super(transportConfig, facetsConfig, circuitBreaker, metricsConfig);
+    super(transportConfig, facetsConfig, datasetConfig, circuitBreaker, metricsConfig);
     this.job = job;
   }
 
@@ -52,6 +54,7 @@ public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageCo
     return new FlinkOpenLineageConfig(
         mergePropertyWith(transportConfig, other.transportConfig),
         mergePropertyWith(facetsConfig, other.facetsConfig),
+        mergePropertyWith(datasetConfig, other.datasetConfig),
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig),
         mergePropertyWith(job, other.job));

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/KafkaUtils.java
@@ -10,6 +10,8 @@ import java.util.Properties;
 public class KafkaUtils {
 
   private static final String KAFKA_DATASET_PREFIX = "kafka://";
+  private static final String COMMA = ",";
+  private static final String SEMICOLON = ";";
 
   /**
    * Generate dataset identifier based on bootstrap servers in properties and topic name
@@ -20,6 +22,12 @@ public class KafkaUtils {
    */
   public static DatasetIdentifier datasetIdentifierOf(Properties properties, String topic) {
     String bootstrapServers = properties.getProperty("bootstrap.servers");
+
+    if (bootstrapServers.contains(COMMA)) {
+      bootstrapServers = bootstrapServers.split(COMMA)[0];
+    } else if (bootstrapServers.contains(SEMICOLON)) {
+      bootstrapServers = bootstrapServers.split(SEMICOLON)[0];
+    }
 
     return new DatasetIdentifier(topic, String.format(KAFKA_DATASET_PREFIX + bootstrapServers));
   }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/CassandraSinkVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/CassandraSinkVisitor.java
@@ -64,8 +64,8 @@ public class CassandraSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
     }
 
     return Collections.singletonList(
-        createOutputDataset(
-            context, (String) sinkWrapper.getNamespace().get(), sinkWrapper.getName()));
+        outputDataset()
+            .getDataset(sinkWrapper.getName(), (String) sinkWrapper.getNamespace().get()));
   }
 
   private CassandraSinkWrapper createWrapperForSink(Object object) {

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/CassandraSourceVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/CassandraSourceVisitor.java
@@ -42,7 +42,7 @@ public class CassandraSourceVisitor extends Visitor<OpenLineage.InputDataset> {
     }
 
     return Collections.singletonList(
-        createInputDataset(
-            context, (String) sourceWrapper.getNamespace().get(), sourceWrapper.getName()));
+        inputDataset()
+            .getDataset(sourceWrapper.getName(), (String) sourceWrapper.getNamespace().get()));
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/HybridSourceVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/HybridSourceVisitor.java
@@ -23,10 +23,11 @@ public class HybridSourceVisitor extends Visitor<OpenLineage.InputDataset> {
       "org.apache.flink.connector.base.source.hybrid.HybridSource$SourceListEntry";
   public static final String PASS_THROUGH_SOURCE_FACTORY_CLASS =
       "org.apache.flink.connector.base.source.hybrid.HybridSource$PassthroughSourceFactory";
-  private VisitorFactoryImpl visitorFactory = new VisitorFactoryImpl();
+  private final VisitorFactoryImpl visitorFactory;
 
   public HybridSourceVisitor(@NonNull OpenLineageContext context) {
     super(context);
+    visitorFactory = new VisitorFactoryImpl();
   }
 
   @Override

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSinkVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSinkVisitor.java
@@ -57,6 +57,6 @@ public class JdbcSinkVisitor extends Visitor<OpenLineage.OutputDataset> {
     DatasetIdentifier di =
         JdbcUtils.getDatasetIdentifierFromJdbcUrl(
             sinkWrapper.getConnectionUrl(), sinkWrapper.getTableName().get());
-    return Collections.singletonList(createOutputDataset(context, di.getNamespace(), di.getName()));
+    return Collections.singletonList(outputDataset().getDataset(di.getName(), di.getNamespace()));
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSourceVisitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/JdbcSourceVisitor.java
@@ -50,9 +50,10 @@ public class JdbcSourceVisitor extends Visitor<OpenLineage.InputDataset> {
           String.format("Unsupported JDBC Source type %s", object.getClass().getCanonicalName()));
     }
 
+    // TODO: implement namespace resolver
     DatasetIdentifier di =
         JdbcUtils.getDatasetIdentifierFromJdbcUrl(
             sourceWrapper.getConnectionUrl(), sourceWrapper.getTableName().get());
-    return Collections.singletonList(createInputDataset(context, di.getNamespace(), di.getName()));
+    return Collections.singletonList(inputDataset().getDataset(di.getName(), di.getNamespace()));
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/Visitor.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/Visitor.java
@@ -19,23 +19,11 @@ public abstract class Visitor<D extends OpenLineage.Dataset> {
   }
 
   protected DatasetFactory<OpenLineage.OutputDataset> outputDataset() {
-    return DatasetFactory.output(context.getOpenLineage());
+    return DatasetFactory.output(context);
   }
 
   protected DatasetFactory<OpenLineage.InputDataset> inputDataset() {
-    return DatasetFactory.input(context.getOpenLineage());
-  }
-
-  protected OpenLineage.InputDataset createInputDataset(
-      OpenLineageContext context, String namespace, String name) {
-    OpenLineage openLineage = context.getOpenLineage();
-    return openLineage.newInputDatasetBuilder().name(name).namespace(namespace).build();
-  }
-
-  protected OpenLineage.OutputDataset createOutputDataset(
-      OpenLineageContext context, String namespace, String name) {
-    OpenLineage openLineage = context.getOpenLineage();
-    return openLineage.newOutputDatasetBuilder().name(name).namespace(namespace).build();
+    return DatasetFactory.input(context);
   }
 
   public abstract boolean isDefinedAt(Object object);

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/visitor/VisitorFactoryImpl.java
@@ -19,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class VisitorFactoryImpl implements VisitorFactory {
-
   @Override
   public List<Visitor<OpenLineage.InputDataset>> getInputVisitors(OpenLineageContext context) {
     ArrayList<Visitor<InputDataset>> visitors =
@@ -27,8 +26,7 @@ public class VisitorFactoryImpl implements VisitorFactory {
             Arrays.asList(
                 new KafkaSourceVisitor(context),
                 new FlinkKafkaConsumerVisitor(context),
-                new LineageProviderVisitor<>(
-                    context, DatasetFactory.input(context.getOpenLineage()))));
+                new LineageProviderVisitor<>(context, DatasetFactory.input(context))));
 
     if (ClassUtils.hasIcebergClasses()) {
       visitors.add(new IcebergSourceVisitor(context));
@@ -54,8 +52,7 @@ public class VisitorFactoryImpl implements VisitorFactory {
             Arrays.asList(
                 new KafkaSinkVisitor(context),
                 new FlinkKafkaProducerVisitor(context),
-                new LineageProviderVisitor<>(
-                    context, DatasetFactory.output(context.getOpenLineage()))));
+                new LineageProviderVisitor<>(context, DatasetFactory.output(context))));
 
     if (ClassUtils.hasIcebergClasses()) {
       visitors.add(new IcebergSinkVisitor(context));

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/utils/KafkaUtilsTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/utils/KafkaUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.flink.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class KafkaUtilsTest {
+
+  Properties properties = mock(Properties.class);
+
+  @Test
+  void testDatasetIdentifierOfSingleServer() {
+    when(properties.getProperty("bootstrap.servers")).thenReturn("kafka-server1");
+
+    assertThat(KafkaUtils.datasetIdentifierOf(properties, "topic"))
+        .hasFieldOrPropertyWithValue("name", "topic")
+        .hasFieldOrPropertyWithValue("namespace", "kafka://kafka-server1");
+  }
+
+  @Test
+  void testDatasetIdentifierOfMultipleServersSeparatedBySemicolon() {
+    when(properties.getProperty("bootstrap.servers")).thenReturn("kafka-server1;kafka-server2");
+
+    assertThat(KafkaUtils.datasetIdentifierOf(properties, "topic"))
+        .hasFieldOrPropertyWithValue("name", "topic")
+        .hasFieldOrPropertyWithValue("namespace", "kafka://kafka-server1");
+  }
+
+  @Test
+  void testDatasetIdentifierOfMultipleServersSeparatedByComma() {
+    when(properties.getProperty("bootstrap.servers")).thenReturn("kafka-server1,kafka-server2");
+
+    assertThat(KafkaUtils.datasetIdentifierOf(properties, "topic"))
+        .hasFieldOrPropertyWithValue("name", "topic")
+        .hasFieldOrPropertyWithValue("namespace", "kafka://kafka-server1");
+  }
+}

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/FlinkKafkaConsumerVisitorTest.java
@@ -79,7 +79,7 @@ class FlinkKafkaConsumerVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/FlinkKafkaProducerVisitorTest.java
@@ -78,7 +78,7 @@ class FlinkKafkaProducerVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/HybridSourceVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/HybridSourceVisitorTest.java
@@ -109,7 +109,7 @@ class HybridSourceVisitorTest {
 
     // Validate Kafka
     assertEquals("topic1", inputDatasets.get(1).getName());
-    assertEquals("kafka://server1;server2", inputDatasets.get(1).getNamespace());
+    assertEquals("kafka://server1", inputDatasets.get(1).getNamespace());
 
     List<OpenLineage.SchemaDatasetFacetFields> kafkaFields =
         inputDatasets.get(1).getFacets().getSchema().getFields();

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSinkVisitorTest.java
@@ -77,7 +77,7 @@ class KafkaSinkVisitorTest {
           outputDataset.getFacets().getSchema().getFields();
 
       assertEquals("topic", outputDataset.getName());
-      assertEquals("kafka://server1;server2", outputDataset.getNamespace());
+      assertEquals("kafka://server1", outputDataset.getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/KafkaSourceVisitorTest.java
@@ -71,7 +71,7 @@ class KafkaSourceVisitorTest {
 
       assertEquals(2, inputDatasets.size());
       assertEquals("topic1", inputDatasets.get(0).getName());
-      assertEquals("kafka://server1;server2", inputDatasets.get(0).getNamespace());
+      assertEquals("kafka://server1", inputDatasets.get(0).getNamespace());
 
       assertEquals(1, fields.size());
       assertEquals("a", fields.get(0).getName());

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/visitor/LineageProviderVisitorTest.java
@@ -30,7 +30,7 @@ class LineageProviderVisitorTest {
   @SneakyThrows
   public void setup() {
     when(context.getOpenLineage()).thenReturn(openLineage);
-    visitor = new LineageProviderVisitor<>(context, DatasetFactory.input(openLineage));
+    visitor = new LineageProviderVisitor<>(context, DatasetFactory.input(context));
   }
 
   @Test

--- a/integration/spark/app/integrations/container/pysparkKafkaAssignReadCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaAssignReadCompleteEvent.json
@@ -13,12 +13,12 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topicA",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [
@@ -55,12 +55,12 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topicB",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/pysparkKafkaAssignReadStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaAssignReadStartEvent.json
@@ -15,12 +15,12 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topicA",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [
@@ -57,12 +57,12 @@
       }
     },
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topicB",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/pysparkKafkaReadCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaReadCompleteEvent.json
@@ -13,12 +13,12 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topic1",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/pysparkKafkaReadStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaReadStartEvent.json
@@ -15,12 +15,12 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topic1",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": [

--- a/integration/spark/app/integrations/container/pysparkKafkaWriteCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaWriteCompleteEvent.json
@@ -13,12 +13,12 @@
   "inputs": [],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topic1",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": []

--- a/integration/spark/app/integrations/container/pysparkKafkaWriteStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkKafkaWriteStartEvent.json
@@ -13,12 +13,12 @@
   "inputs": [],
   "outputs": [
     {
-      "namespace": "kafka://kafka:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "topic1",
       "facets": {
         "dataSource": {
-          "name": "kafka://kafka:9092",
-          "uri": "kafka://kafka:9092"
+          "name": "kafka://kafka-cluster-prod:9092",
+          "uri": "kafka://kafka-cluster-prod:9092"
         },
         "schema": {
           "fields": []

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -197,8 +197,6 @@ public class ArgumentParser {
   }
 
   private static boolean isArrayType(String value) {
-    return value.startsWith(ARRAY_PREFIX_CHAR)
-        && value.endsWith(ARRAY_SUFFIX_CHAR)
-        && value.contains(DISABLED_FACETS_SEPARATOR);
+    return value.startsWith(ARRAY_PREFIX_CHAR) && value.endsWith(ARRAY_SUFFIX_CHAR);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -12,12 +12,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.io.Resources;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.circuitBreaker.StaticCircuitBreakerConfig;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceResolverConfig;
 import io.openlineage.client.transports.ApiKeyTokenProvider;
 import io.openlineage.client.transports.ConsoleConfig;
 import io.openlineage.client.transports.HttpConfig;
 import io.openlineage.client.transports.KafkaConfig;
 import io.openlineage.client.transports.KinesisConfig;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Arrays;
+import java.util.Map;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
@@ -247,5 +250,32 @@ class ArgumentParserTest {
 
     Logger.getLogger(OpenLineageClientUtils.class).setLevel(Level.ERROR);
     assertThrows(RuntimeException.class, () -> ArgumentParser.parse(sparkConf));
+  }
+
+  @Test
+  void testMultipleDatasetNamespaceResolverConfigEntries() {
+    SparkConf sparkConf =
+        new SparkConf()
+            .set("spark.openlineage.dataset.namespaceResolvers.postgres-prod.type", "hostList")
+            .set(
+                "spark.openlineage.dataset.namespaceResolvers.postgres-prod.hosts",
+                "[postgres-host1-prod;postgres-host1-prod]")
+            .set("spark.openlineage.dataset.namespaceResolvers.postgres-test.type", "hostList")
+            .set(
+                "spark.openlineage.dataset.namespaceResolvers.postgres-test.hosts",
+                "[postgres-host1-test;postgres-host1-test]");
+
+    SparkOpenLineageConfig config = ArgumentParser.parse(sparkConf);
+
+    Map<String, DatasetNamespaceResolverConfig> namespaceResolvers =
+        config.getDatasetConfig().getNamespaceResolvers();
+    assertThat(namespaceResolvers.keySet()).hasSize(2);
+    assertThat(namespaceResolvers.get("postgres-prod"))
+        .hasFieldOrPropertyWithValue(
+            "hosts", Arrays.asList("postgres-host1-prod", "postgres-host1-prod"));
+
+    assertThat(namespaceResolvers.get("postgres-test"))
+        .hasFieldOrPropertyWithValue(
+            "hosts", Arrays.asList("postgres-host1-test", "postgres-host1-test"));
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -141,7 +141,7 @@ public class SparkContainerUtils {
 
   static GenericContainer<?> makeKafkaContainer(Network network) {
     return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.0"))
-        .withNetworkAliases("kafka")
+        .withNetworkAliases("kafka-host")
         .withNetwork(network);
   }
 
@@ -209,6 +209,11 @@ public class SparkContainerUtils {
     addSparkConfig(sparkConf, "spark.sql.warehouse.dir=/tmp/warehouse");
     addSparkConfig(sparkConf, "spark.jars.ivy=/tmp/.ivy2/");
     addSparkConfig(sparkConf, "spark.openlineage.facets.disabled=");
+    addSparkConfig(
+        sparkConf, "spark.openlineage.dataset.namespaceResolvers.kafka-cluster-prod.type=hostList");
+    addSparkConfig(
+        sparkConf,
+        "spark.openlineage.dataset.namespaceResolvers.kafka-cluster-prod.hosts=[kafka-host;kafka-host-other]");
 
     List<String> sparkSubmit =
         new ArrayList(Arrays.asList("./bin/spark-submit", "--master", "local"));

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_kafk_assign_read.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_kafk_assign_read.py
@@ -8,7 +8,7 @@ master = "local"
 
 spark = SparkSession.builder.master(master).appName(appName).getOrCreate()
 
-kafka_servers = "kafka:9092"
+kafka_servers = "kafka-host:9092"
 checkpointLocation = "/test_data/checkpoint"
 
 df = (

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_kafka.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_kafka.py
@@ -8,7 +8,7 @@ master = "local"
 
 spark = SparkSession.builder.master(master).appName(appName).getOrCreate()
 
-kafka_servers = "kafka:9092"
+kafka_servers = "kafka-host:9092"
 checkpointLocation = "/test_data/checkpoint"
 
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageContext.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.lifecycle.plan.column;
 
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.spark.api.OpenLineageContext;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +18,5 @@ public class ColumnLevelLineageContext {
   @NonNull @Getter final SparkListenerEvent event;
   @NonNull @Getter final OpenLineageContext olContext;
   @NonNull @Getter final ColumnLevelLineageBuilder builder;
+  @NonNull @Getter final DatasetNamespaceCombinedResolver namespaceResolver;
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
@@ -5,9 +5,6 @@
 
 package io.openlineage.spark.agent.util;
 
-import static io.openlineage.client.utils.JdbcUtils.sanitizeJdbcUrl;
-
-import com.google.common.base.CharMatcher;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.JdbcUtils;
@@ -18,8 +15,6 @@ import io.openlineage.sql.DbTableMeta;
 import io.openlineage.sql.ExtractionError;
 import io.openlineage.sql.OpenLineageSql;
 import io.openlineage.sql.SqlMeta;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,53 +30,6 @@ import org.apache.spark.sql.types.StructType;
 
 @Slf4j
 public class JdbcSparkUtils {
-
-  /**
-   * The algorithm for this method is as follows. First we parse URI and check if it includes path
-   * part of URI. If yes, then we check if it contains database. Database is the first part after
-   * slash in URI - the "db" in something like postgres://host:5432/db. If it does contain it, and
-   * provided parts list has less than three elements, then we use it as database part of name -
-   * this indicates that database is the default one in this context. Otherwise, we take database
-   * from parts list.
-   *
-   * @param jdbcUrl String URI we want to take dataset identifier from
-   * @param parts Provided list of delimited parts of table qualified name parts. Can include
-   *     database name.
-   * @return DatasetIdentifier
-   */
-  public static DatasetIdentifier getDatasetIdentifierFromJdbcUrl(
-      String jdbcUrl, List<String> parts) {
-    String namespace = sanitizeJdbcUrl(jdbcUrl);
-    String urlDatabase = null;
-
-    try {
-      URI uri = new URI(namespace);
-      String path = uri.getPath();
-      if (path != null) {
-        namespace = String.format("%s://%s", uri.getScheme(), uri.getAuthority());
-
-        if (path.startsWith("/")) {
-          path = path.substring(1);
-        }
-
-        if (path.length() > 1
-            && CharMatcher.forPredicate(Character::isAlphabetic).matchesAllOf(path)) {
-          urlDatabase = path;
-        }
-      }
-    } catch (URISyntaxException ignored) {
-      // If URI parsing fails, we can't do anything smart - let's return provided URI
-      // as a dataset namespace
-    }
-
-    if (urlDatabase != null && parts.size() <= 3) {
-      parts.add(0, urlDatabase);
-    }
-
-    String name = String.join(".", parts);
-
-    return new DatasetIdentifier(name, namespace);
-  }
 
   public static <D extends OpenLineage.Dataset> List<D> getDatasets(
       DatasetFactory<D> datasetFactory, SqlMeta meta, StructType schema, String url) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.api;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreakerConfig;
+import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
 import java.util.HashMap;
@@ -49,9 +50,10 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       JobConfig job,
       TransportConfig transportConfig,
       FacetsConfig facetsConfig,
+      DatasetConfig datasetConfig,
       CircuitBreakerConfig circuitBreaker,
       Map<String, Object> metricsConfig) {
-    super(transportConfig, facetsConfig, circuitBreaker, metricsConfig);
+    super(transportConfig, facetsConfig, datasetConfig, circuitBreaker, metricsConfig);
     this.namespace = namespace;
     this.parentJobName = parentJobName;
     this.parentJobNamespace = parentJobNamespace;
@@ -127,6 +129,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(job, other.job),
         mergePropertyWith(transportConfig, other.transportConfig),
         mergePropertyWith(facetsConfig, other.facetsConfig),
+        mergePropertyWith(datasetConfig, other.datasetConfig),
         mergePropertyWith(circuitBreaker, other.circuitBreaker),
         mergePropertyWith(metricsConfig, other.metricsConfig));
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/JdbcRelationHandlerTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.when;
 import io.openlineage.spark.agent.lifecycle.plan.handlers.JdbcRelationHandler;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap;
@@ -48,6 +50,7 @@ class JdbcRelationHandlerTest {
   String unknownUrl = "unknown://localhost:1234/test";
   StructType schema =
       new StructType().add("k", DataTypes.IntegerType).add("j", DataTypes.StringType);
+  OpenLineageContext context = mock(OpenLineageContext.class);
 
   @BeforeEach
   void setup() {
@@ -57,6 +60,7 @@ class JdbcRelationHandlerTest {
     when(jdbcOptions.url()).thenReturn("jdbc:" + url);
     when(relation.schema()).thenReturn(schema);
     jdbcRelationHandler = new JdbcRelationHandler(datasetFactory);
+    when(context.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
   }
 
   @Test

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -28,7 +28,7 @@ public class CatalogUtils3 {
             new DeltaHandler(context),
             new DatabricksDeltaHandler(context),
             new DatabricksUnityV2Handler(context),
-            new JdbcHandler(),
+            new JdbcHandler(context),
             new V2SessionCatalogHandler());
     return handlers.stream().filter(CatalogHandler::hasClasses).collect(Collectors.toList());
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -5,8 +5,10 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.JdbcSparkUtils;
+import io.openlineage.client.utils.JdbcUtils;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +23,12 @@ import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
 
 public class JdbcHandler implements CatalogHandler {
+  private final DatasetNamespaceCombinedResolver namespaceResolver;
+
+  public JdbcHandler(OpenLineageContext context) {
+    namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
+  }
+
   @Override
   public boolean hasClasses() {
     return true;
@@ -45,7 +53,8 @@ public class JdbcHandler implements CatalogHandler {
         Stream.concat(Arrays.stream(identifier.namespace()), Stream.of(identifier.name()))
             .collect(Collectors.toList());
 
-    return JdbcSparkUtils.getDatasetIdentifierFromJdbcUrl(options.url(), parts);
+    return namespaceResolver.resolve(
+        JdbcUtils.getDatasetIdentifierFromJdbcUrl(options.url(), parts));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan.column;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -41,7 +42,10 @@ public class ColumnLevelLineageUtils {
 
     ColumnLevelLineageContext context =
         new ColumnLevelLineageContext(
-            event, olContext, new ColumnLevelLineageBuilder(schemaFacet, olContext));
+            event,
+            olContext,
+            new ColumnLevelLineageBuilder(schemaFacet, olContext),
+            new DatasetNamespaceCombinedResolver(olContext.getOpenLineageConfig()));
 
     LogicalPlan plan = getAdjustedPlan(olContext);
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -68,7 +68,7 @@ public class ExpressionDependencyCollector {
           ScalaConversionUtils.<NamedExpression>fromSeq(((Aggregate) node).aggregateExpressions()));
     } else if (node instanceof LogicalRelation) {
       if (((LogicalRelation) node).relation() instanceof JDBCRelation) {
-        JdbcColumnLineageCollector.extractExpressionsFromJDBC(node, context.getBuilder());
+        JdbcColumnLineageCollector.extractExpressionsFromJDBC(context, node);
       }
     }
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.HashMap;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -17,14 +19,23 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JdbcHandlerTest {
 
+  OpenLineageContext context = mock(OpenLineageContext.class);
+
+  @BeforeEach
+  public void setup() {
+    context = mock(OpenLineageContext.class);
+    when(context.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
+  }
+
   @Test
   @SneakyThrows
   void testGetDatasetIdentifier() {
-    JdbcHandler handler = new JdbcHandler();
+    JdbcHandler handler = new JdbcHandler(context);
 
     JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
     JDBCOptions options = mock(JDBCOptions.class);
@@ -45,7 +56,7 @@ class JdbcHandlerTest {
   @Test
   @SneakyThrows
   void testGetDatasetIdentifierWithDatabase() {
-    JdbcHandler handler = new JdbcHandler();
+    JdbcHandler handler = new JdbcHandler(context);
 
     JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
     JDBCOptions options = mock(JDBCOptions.class);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/JdbcColumnLineageExpressionCollectorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.sql.ColumnMeta;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 class JdbcColumnLineageExpressionCollectorTest {
   ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+  ColumnLevelLineageContext context = mock(ColumnLevelLineageContext.class);
   ExprId exprId1 = ExprId.apply(20);
   ExprId exprId2 = ExprId.apply(21);
   ExprId dependencyId1 = ExprId.apply(0);
@@ -61,6 +63,7 @@ class JdbcColumnLineageExpressionCollectorTest {
         ScalaConversionUtils.<String, String>asScalaMapEmpty();
     when(jdbcOptions.parameters())
         .thenReturn(CaseInsensitiveMap$.MODULE$.<String>apply(properties));
+    when(context.getBuilder()).thenReturn(builder);
   }
 
   @Test
@@ -76,7 +79,7 @@ class JdbcColumnLineageExpressionCollectorTest {
         .thenAnswer(invocation -> mockMap.get(invocation.getArgument(0)));
 
     JdbcColumnLineageCollector.extractExpressionsFromJDBC(
-        relation, builder, Arrays.asList(expression1, expression2));
+        context, relation, Arrays.asList(expression1, expression2));
 
     verify(builder, times(1)).addDependency(exprId2, dependencyId1);
     verify(builder, times(1)).addDependency(exprId2, dependencyId2);
@@ -88,7 +91,7 @@ class JdbcColumnLineageExpressionCollectorTest {
     when(jdbcOptions.url()).thenReturn(url);
 
     JdbcColumnLineageCollector.extractExpressionsFromJDBC(
-        relation, builder, Arrays.asList(expression1, expression2));
+        context, relation, Arrays.asList(expression1, expression2));
 
     verify(builder, never()).addDependency(any(ExprId.class), any(ExprId.class));
   }


### PR DESCRIPTION
### Problem

Oftentimes a dataset's namespace is identified by host used to access it. For example, for Kafka clusters, a first element of bootstrap servers is used to create the namespace. This was the initial approach that deserves to improved and enhanced. 

This PR introduces dataset namespace resolving mechanism, which resolves dataset namespaces based on the resolvers configured. The core mechanism is implemented in `openlineage-java` and can be used within Flink and Spark integrations. 

It contains out-of-the-box resolvers like `hostList`, `pattern` or `patternGroup` type presented below:
```
dataset:
  namespaceResolvers:
      kafka-prod:
        type: hostList
        hosts: ['kafka-prod13.company.com', 'kafka-prod15.company.com']
      cassandra-prod:
        type: pattern
        # 'cassandra-prod7.company.com', 'cassandra-prod8.company.com'
        regex: 'cassandra-prod(\d)+\.company\.com'
      test-pattern:
        type: patternGroup
        # 'cassandra-test-7.company.com', 'cassandra-test-8.company.com', 'kafka-test-7.company.com', 'kafka-test-8.company.com'
        regex: '(?<cluster>[a-zA-Z-]+)-(\d)+\.company\.com:[\d]*'
        matchingGroup: "cluster"
```

and the ability to add custom namespace resolver through the Service Loader. More info will be put in the docs.

Related to: #560

Corresponding docs PR: https://github.com/OpenLineage/docs/pull/329

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project