### PR TITLE
[SPARK] Add support for window functions in ColumnLineage

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression;
 import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.catalyst.plans.logical.Window;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
 import scala.collection.Seq;
@@ -66,6 +67,9 @@ public class ExpressionDependencyCollector {
     } else if (node instanceof Aggregate) {
       expressions.addAll(
           ScalaConversionUtils.<NamedExpression>fromSeq(((Aggregate) node).aggregateExpressions()));
+    } else if (node instanceof Window) {
+      expressions.addAll(
+          ScalaConversionUtils.<NamedExpression>fromSeq(((Window) node).windowExpressions()));
     } else if (node instanceof LogicalRelation) {
       if (((LogicalRelation) node).relation() instanceof JDBCRelation) {
         JdbcColumnLineageCollector.extractExpressionsFromJDBC(node, context.getBuilder());

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Aggregate;
 import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.catalyst.plans.logical.Window;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.Metadata$;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,6 +108,21 @@ class ExpressionDependencyCollectorTest {
             ScalaConversionUtils.fromList(Collections.singletonList((NamedExpression) alias1)),
             mock(LogicalPlan.class));
     LogicalPlan plan = new CreateTableAsSelect(null, null, null, aggregate, null, null, false);
+
+    ExpressionDependencyCollector.collect(context, plan);
+
+    verify(builder, times(1)).addDependency(aliasExprId1, exprId1);
+  }
+
+  @Test
+  void testCollectFromWindowPlan() {
+    Window window =
+        new Window(
+            ScalaConversionUtils.fromList(Collections.singletonList((NamedExpression) alias1)),
+            ScalaConversionUtils.asScalaSeqEmpty(),
+            ScalaConversionUtils.asScalaSeqEmpty(),
+            mock(LogicalPlan.class));
+    LogicalPlan plan = new CreateTableAsSelect(null, null, null, window, null, null, false);
 
     ExpressionDependencyCollector.collect(context, plan);
 


### PR DESCRIPTION
### Problem
When SQL contains window functions, it can result in missing blood relationships in the window function fields, as shown in the following columns, where blood relationships in the **rank** field are missing:

```
insert overwrite table student_rank 
select name, class, age, row_number()over(partition by class order by age desc) as rank from students;
```
explain extended this sql：

```
== Optimized Logical Plan ==
InsertIntoHiveTable `dap_dev`.`student_rank`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, true, false, [name, class, age, rank]
+- Window [row_number() windowspecdefinition(class#22, age#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank#12], [class#22], [age#21 DESC NULLS LAST]
   +- Project [name#20, class#22, age#21]
      +- HiveTableRelation [`dap_dev`.`students`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, Data Cols: [id#19, name#20, age#21, class#22], Partition Cols: []]
```

Rank should rely on class and age

### Solution
For window logicalPlan, handle windowExpressions and  addDependency
