### PR TITLE
Java: Remove deprecated Transport.emit(String)

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
@@ -31,16 +31,7 @@ public final class ConsoleTransport extends Transport {
     emit(OpenLineageClientUtils.toJson(jobEvent));
   }
 
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #emit(OpenLineage.DatasetEvent)} or {@link
-   *     #emit(OpenLineage.JobEvent)} instead
-   */
-  @Deprecated
-  @Override
-  public void emit(String eventJson) {
+  private void emit(String eventJson) {
     // if DEBUG loglevel is enabled, this will double-log even due to OpenLineageClient also logging
     log.info(eventJson);
   }

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
@@ -44,16 +44,7 @@ public class FileTransport extends Transport {
     emit(OpenLineageClientUtils.toJson(jobEvent));
   }
 
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #emit(OpenLineage.DatasetEvent)} or {@link
-   *     #emit(OpenLineage.JobEvent)} instead
-   */
-  @Deprecated
-  @Override
-  public void emit(String eventAsJson) {
+  private void emit(String eventAsJson) {
     try {
       FileUtils.writeStringToFile(
           file,

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -128,16 +128,7 @@ public final class HttpTransport extends Transport implements Closeable {
     emit(OpenLineageClientUtils.toJson(jobEvent));
   }
 
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #emit(OpenLineage.DatasetEvent)} or {@link
-   *     #emit(OpenLineage.JobEvent)} instead
-   */
-  @Deprecated
-  @Override
-  public void emit(String eventAsJson) {
+  private void emit(String eventAsJson) {
     log.debug("POST event on URL {}", uri);
     try {
       final HttpPost request = new HttpPost();

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -6,7 +6,6 @@
 package io.openlineage.client.transports;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineageClientUtils;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -26,25 +25,7 @@ public abstract class Transport {
 
   public abstract void emit(@NonNull OpenLineage.RunEvent runEvent);
 
-  public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
-    emit(OpenLineageClientUtils.toJson(datasetEvent));
-  }
+  public abstract void emit(@NonNull OpenLineage.DatasetEvent datasetEvent);
 
-  public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
-    emit(OpenLineageClientUtils.toJson(jobEvent));
-  }
-
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #emit(OpenLineage.DatasetEvent)} or {@link
-   *     #emit(OpenLineage.JobEvent)} instead
-   * @param eventAsJson string json event
-   */
-  @Deprecated
-  public void emit(String eventAsJson) {
-    throw new UnsupportedOperationException(
-        "Please implement emit(OpenLineage.DatasetEvent) and emit(OpenLineage.JobEvent)");
-  }
+  public abstract void emit(@NonNull OpenLineage.JobEvent jobEvent);
 }


### PR DESCRIPTION
### Problem

### Solution

#### One-line summary:

Remove `Transport.emit(String)` support, deprecated since 1.13.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project