### PR TITLE
Java: Remove deprecated localServerId option from Kafka config

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaConfig.java
@@ -28,28 +28,6 @@ public final class KafkaConfig implements TransportConfig, MergeConfig<KafkaConf
     properties = new Properties();
   }
 
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #getMessageKey()} instead
-   */
-  @Deprecated
-  String getLocalServerId() {
-    return messageKey;
-  }
-
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #setMessageKey()} instead
-   */
-  @Deprecated
-  void setLocalServerId(String localServerId) {
-    this.messageKey = localServerId;
-  }
-
   @Override
   public KafkaConfig mergeWithNonNull(io.openlineage.client.transports.KafkaConfig other) {
     Properties p = new Properties();

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -125,7 +125,6 @@ class ArgumentParserTest {
     SparkOpenLineageConfig config = ArgumentParser.parse(sparkConf);
     KafkaConfig transportConfig = (KafkaConfig) config.getTransportConfig();
     assertEquals("test", transportConfig.getTopicName());
-    // Legacy LocalServerId should be mapped to messageKey
     assertEquals("explicit-key", transportConfig.getMessageKey());
     assertEquals("test1", transportConfig.getProperties().get("test1"));
     assertEquals("test2", transportConfig.getProperties().get("test2"));

--- a/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
+++ b/proxy/backend/src/main/java/io/openlineage/proxy/api/models/KafkaConfig.java
@@ -19,26 +19,4 @@ public final class KafkaConfig implements ProxyStreamConfig {
   @Getter @Setter private String messageKey;
   @Getter @Setter private String bootstrapServerUrl;
   @Getter @Setter private Properties properties;
-
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #getMessageKey()} instead
-   */
-  @Deprecated
-  String getLocalServerId() {
-    return messageKey;
-  }
-
-  /**
-   * @deprecated
-   *     <p>Since version 1.13.0.
-   *     <p>Will be removed in version 1.16.0.
-   *     <p>Please use {@link #setMessageKey()} instead
-   */
-  @Deprecated
-  void setLocalServerId(String localServerId) {
-    this.messageKey = localServerId;
-  }
 }


### PR DESCRIPTION
### Problem

### Solution

#### One-line summary:

Remove `localServerId` from Kafka config, deprecated since 1.13.0. 

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project