### PR TITLE
ci: use uv in Python client tox.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -51,7 +51,7 @@ jobs:
       - image: cimg/python:<< parameters.py_env >>
     steps:
       - *checkout_project_root
-      - run: python -m pip install tox
+      - run: python -m pip install tox uv
       - run: python -m tox r -e "<< parameters.tox_env >>" --notest
       - run: python -m tox r -e "<< parameters.tox_env >>" --skip-pkg-install
 

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -14,6 +14,8 @@ skip_missing_interpreters = true
 description = run the unit tests with pytest under {basepython}
 package = wheel
 wheel_build_env = .pkg
+allowlist_externals = uv
+install_command = uv pip install {opts} {packages}
 extras =
     kafka
     msk-iam


### PR DESCRIPTION
### Problem

uv is a faster alternative to pip installer. We already use it in common package unit tests.

### Solution

Add uv in `install_command` tox configuration.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project