### PR TITLE
Spark: Fix historyUrl format

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkApplicationDetailsFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/SparkApplicationDetailsFacet.java
@@ -120,7 +120,7 @@ public class SparkApplicationDetailsFacet extends OpenLineage.DefaultRunFacet {
                         hadoopConf.get("yarn.http.policy", "HTTP_ONLY").replace("_ONLY", ""));
                 historyServer = scheme + "://" + historyServer;
               }
-              historyUrl = StringUtils.stripEnd(historyServer, "/") + "/application/" + encodedId;
+              historyUrl = StringUtils.stripEnd(historyServer, "/") + "/history/" + encodedId;
             });
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
@@ -214,7 +214,7 @@ class SparkApplicationDetailsFacetBuilderTest {
                     .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
                     .hasFieldOrPropertyWithValue("proxyUrl", null)
                     .hasFieldOrPropertyWithValue(
-                        "historyUrl", "http://history.server:18080/application/app-123-456"));
+                        "historyUrl", "http://history.server:18080/history/app-123-456"));
   }
 
   @Test
@@ -240,7 +240,7 @@ class SparkApplicationDetailsFacetBuilderTest {
                     .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
                     .hasFieldOrPropertyWithValue("proxyUrl", null)
                     .hasFieldOrPropertyWithValue(
-                        "historyUrl", "https://history.server:18080/application/app-123-456"));
+                        "historyUrl", "https://history.server:18080/history/app-123-456"));
   }
 
   @Test
@@ -267,7 +267,6 @@ class SparkApplicationDetailsFacetBuilderTest {
                     .hasFieldOrPropertyWithValue("uiWebUrl", "http://driver.host:4040")
                     .hasFieldOrPropertyWithValue("proxyUrl", null)
                     .hasFieldOrPropertyWithValue(
-                        "historyUrl",
-                        "https://history.server.domain/path/application/app-123-456"));
+                        "historyUrl", "https://history.server.domain/path/history/app-123-456"));
   }
 }


### PR DESCRIPTION
### Problem

`spark_applicationDetails` facet now contains value like `http://history.server/application/app123`. But it should be `http://history.server/history/app123`.

### Solution

#### One-line summary:

Fix `historyUrl` format in `spark_applicationDetails`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project