### PR TITLE
Add Atlan as OpenLineage contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@
 | Organization | Integration or Feature |
 | ------------ | ------------ |
 | [Astronomer](https://www.astronomer.io/) | Integrations, clients, spec, documentation, developer and user support, community management, talks |
+| [Atlan](https://atlan.com/) | Contributions to Airflow integration, Python client and documentation |
 
 For pointers on getting started as a contributor, see the [OpenLineage Contributing Guide](CONTRIBUTING.md).
 


### PR DESCRIPTION
Similar to #2728, i want to propose adding Atlan as a contributing company as they have inspired several changes (mostly in Airflow integration / provider and the docs) and demonstrated a commitment to the development of OpenLineage.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project