### PR TITLE
[SPARK] upgrade supported versions to 3.4.2->3.4.3 and 3.5.0->3.5.1

### DIFF
--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -4,14 +4,14 @@ workflows:
       - build-integration-spark-scala-2_12:
           matrix:
             parameters:
-              spark-version: [ '2.4.8', '3.2.4', '3.3.4', '3.4.2', '3.5.0' ]
+              spark-version: [ '2.4.8', '3.2.4', '3.3.4', '3.4.3', '3.5.1' ]
           requires:
            - build-integration-sql-java
            - build-client-java
       - build-integration-spark-scala-2_13:
           matrix:
             parameters:
-              spark-version: [ '3.2.4', '3.3.4', '3.4.2', '3.5.0' ]
+              spark-version: [ '3.2.4', '3.3.4', '3.4.3', '3.5.1' ]
           requires:
            - build-integration-sql-java
            - build-client-java           
@@ -35,14 +35,14 @@ workflows:
           context: integration-tests
           matrix:
             parameters:
-              spark-version: [ '2.4.8', '3.2.4', '3.3.4', '3.4.2', '3.5.0' ]
+              spark-version: [ '2.4.8', '3.2.4', '3.3.4', '3.4.3', '3.5.1' ]
           requires:
             - approval-integration-spark
       - integration-test-integration-spark-scala-2_13:
           context: integration-tests
           matrix:
             parameters:
-              spark-version: [ '3.2.4', '3.3.4', '3.4.2', '3.5.0' ]
+              spark-version: [ '3.2.4', '3.3.4', '3.4.3', '3.5.1' ]
           requires:
             - approval-integration-spark
       - configurable-integration-test-spark:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 * **Spark: Configurable integration test.** [`#2755`](https://github.com/OpenLineage/OpenLineage/pull/2755) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Provide command line tool capable of running Spark integration tests that can be created without Java any experience.*
+* **Spark: Support latest versions 3.4.3 and 3.5.1.** [`#2743`](https://github.com/OpenLineage/OpenLineage/pull/2743) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Upgrade CI workflows to run tests against latest Spark versions: 3.4.2 -> 3.4.3 and 3.5.0 -> 3.5.1.*
 
 ## [1.17.1](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...1.17.1) - 2024-06-21
 ### Added

--- a/integration/README.md
+++ b/integration/README.md
@@ -4,7 +4,7 @@
 |Apache Airflow| 2.1.*, 2.2.*, 2.3.*                        |https://github.com/apache/airflow/releases|[README](./airflow/README.md)|Support for Airflow 1.x is deprecated|
 |Dagster| 0.13.8+                                    |https://github.com/dagster-io/dagster/releases|[README](./dagster/README.md)| |
 |dbt| 0.20+, 1.3                                 |https://github.com/dbt-labs/dbt-core/releases|[README](./dbt/README.md)| |
-|Apache Spark| 2.4.6, 3.1.2, 3.2.1+, 3.3.1+, 3.4.2, 3.5.1 |https://github.com/apache/spark/tags|[README](./spark/README.md)| |
+|Apache Spark| 2.4.6, 3.1.2, 3.2.1+, 3.3.1+, 3.4.3, 3.5.1 |https://github.com/apache/spark/tags|[README](./spark/README.md)| |
 |Apache Flink| 1.15.4, 1.16.2, 1.17.1, 1.18.1             |https://github.com/apache/flink/tags|[README](./flink/README.md)|  |
 
 ----

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,11 +1,11 @@
 # OpenLineage Integrations
-|Integration| Compatible Version(s)               |Latest Release Info|Docs|Notes|
-|-|-------------------------------------|-|-|-|
-|Apache Airflow| 2.1.*, 2.2.*, 2.3.*                 |https://github.com/apache/airflow/releases|[README](./airflow/README.md)|Support for Airflow 1.x is deprecated|
-|Dagster| 0.13.8+                             |https://github.com/dagster-io/dagster/releases|[README](./dagster/README.md)| |
-|dbt| 0.20+, 1.3                          |https://github.com/dbt-labs/dbt-core/releases|[README](./dbt/README.md)| |
-|Apache Spark| 2.4.6, 3.1.2, 3.2.1+, 3.3.1+, 3.4.1, 3.5.0 |https://github.com/apache/spark/tags|[README](./spark/README.md)| |
-|Apache Flink| 1.15.4, 1.16.2, 1.17.1, 1.18.1            |https://github.com/apache/flink/tags|[README](./flink/README.md)|  |
+|Integration| Compatible Version(s)                      |Latest Release Info|Docs|Notes|
+|-|--------------------------------------------|-|-|-|
+|Apache Airflow| 2.1.*, 2.2.*, 2.3.*                        |https://github.com/apache/airflow/releases|[README](./airflow/README.md)|Support for Airflow 1.x is deprecated|
+|Dagster| 0.13.8+                                    |https://github.com/dagster-io/dagster/releases|[README](./dagster/README.md)| |
+|dbt| 0.20+, 1.3                                 |https://github.com/dbt-labs/dbt-core/releases|[README](./dbt/README.md)| |
+|Apache Spark| 2.4.6, 3.1.2, 3.2.1+, 3.3.1+, 3.4.2, 3.5.1 |https://github.com/apache/spark/tags|[README](./spark/README.md)| |
+|Apache Flink| 1.15.4, 1.16.2, 1.17.1, 1.18.1             |https://github.com/apache/flink/tags|[README](./flink/README.md)|  |
 
 ----
 SPDX-License-Identifier: Apache-2.0\

--- a/integration/spark-docker/build.gradle.kts
+++ b/integration/spark-docker/build.gradle.kts
@@ -9,7 +9,7 @@ val destDir = layout.buildDirectory.dir("docker")
 val dockerfile = layout.projectDirectory.file("Dockerfile")
 val downloadDir = layout.projectDirectory.dir("bin")
 val manifestJsonFile = layout.projectDirectory.file("manifest.json")
-val platforms =
+val dockerBuildPlatforms =
     objects.setProperty(String::class.java).convention(setOf("linux/amd64", "linux/arm64"))
 val repository = objects.property(String::class.java).convention("openlineage/spark")
 
@@ -229,7 +229,7 @@ class DockerImageBuilderDelegate(private val m: DockerManifest) {
             dockerBuildContext.set(destDir.map { dir ->
                 dir.dir("spark-${sparkVersion}/scala-${scalaBinaryVersion}")
             })
-            platforms.set(platforms)
+            platforms.set(dockerBuildPlatforms)
         }
     }
 }

--- a/integration/spark-docker/build.gradle.kts
+++ b/integration/spark-docker/build.gradle.kts
@@ -11,7 +11,7 @@ val downloadDir = layout.projectDirectory.dir("bin")
 val manifestJsonFile = layout.projectDirectory.file("manifest.json")
 val dockerBuildPlatforms =
     objects.setProperty(String::class.java).convention(setOf("linux/amd64", "linux/arm64"))
-val repository = objects.property(String::class.java).convention("openlineage/spark")
+val repository = objects.property(String::class.java).convention("quay.io/openlineage/spark")
 
 val manifests = loadManifests()
 

--- a/integration/spark-docker/manifest.json
+++ b/integration/spark-docker/manifest.json
@@ -40,35 +40,35 @@
     "sparkVersion": "3.3.4"
   },
   {
-    "baseImageTag": "3.4.2",
+    "baseImageTag": "3.4.3",
     "scalaBinaryVersion": "2.12",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3.tgz.asc",
-    "sparkVersion": "3.4.2"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3.tgz.asc",
+    "sparkVersion": "3.4.3"
   },
   {
-    "baseImageTag": "3.4.2",
+    "baseImageTag": "3.4.3",
     "scalaBinaryVersion": "2.13",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3-scala2.13.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.4.2/spark-3.4.2-bin-hadoop3-scala2.13.tgz.asc",
-    "sparkVersion": "3.4.2"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3-scala2.13.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.4.3/spark-3.4.3-bin-hadoop3-scala2.13.tgz.asc",
+    "sparkVersion": "3.4.3"
   },
   {
-    "baseImageTag": "3.5.0",
+    "baseImageTag": "3.5.1",
     "scalaBinaryVersion": "2.12",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz.asc",
-    "sparkVersion": "3.5.0"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.1/spark-3.5.1-bin-hadoop3.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.1/spark-3.5.1-bin-hadoop3.tgz.asc",
+    "sparkVersion": "3.5.1"
   },
   {
-    "baseImageTag": "3.5.0",
+    "baseImageTag": "3.5.1",
     "scalaBinaryVersion": "2.13",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3-scala2.13.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3-scala2.13.tgz.asc",
-    "sparkVersion": "3.5.0"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.1/spark-3.5.1-bin-hadoop3-scala2.13.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.1/spark-3.5.1-bin-hadoop3-scala2.13.tgz.asc",
+    "sparkVersion": "3.5.1"
   }
 ]

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -480,7 +480,7 @@ List<Dependency> icebergDependencies(String spark, String scala) {
                     dependencies.create("org.scala-lang:scala-reflect:${scalaVersion}"),
                     dependencies.create("org.scala-lang.modules:scala-collection-compat_${scala}:2.11.0"),
             ],
-            "3.4.2": [
+            "3.4.3": [
                     dependencies.create("org.apache.iceberg:iceberg-spark-runtime-3.4_${scala}:1.3.0"),
                     dependencies.create("org.scala-lang:scala-library:${scalaVersion}"),
                     dependencies.create("org.scala-lang:scala-reflect:${scalaVersion}"),
@@ -495,7 +495,7 @@ List<Dependency> deltaDependencies(String spark, String scala) {
     final def registry = [
             "3.2.4": "1.1.0",
             "3.3.4": "2.1.0",
-            "3.4.2": "2.4.0",
+            "3.4.3": "2.4.0",
     ]
 
     def delta = registry.get(spark)
@@ -512,8 +512,8 @@ List<Dependency> gcsDependencies(String spark, String scala) {
             "2.4.8": "hadoop2-2.2.9",
             "3.2.4": "hadoop3-2.2.9",
             "3.3.4": "hadoop3-2.2.9",
-            "3.4.2": "hadoop3-2.2.9",
-            "3.5.0": "hadoop3-2.2.9",
+            "3.4.3": "hadoop3-2.2.9",
+            "3.5.1": "hadoop3-2.2.9",
     ]
 
     def gcs = registry.get(spark)
@@ -532,8 +532,8 @@ List<Dependency> hadoopClientDependencies(String spark, String scala) {
             "2.4.8": "2.10.2",
             "3.2.4": "3.3.4",
             "3.3.4": "3.3.2",
-            "3.4.2": "3.3.4",
-            "3.5.0": "3.3.4",
+            "3.4.3": "3.3.4",
+            "3.5.1": "3.3.4",
     ]
 
     def hadoopClient = registry.get(spark)
@@ -582,12 +582,12 @@ List<Dependency> additionalJars(String spark, String scala) {
                         exclude(group: "org.slf4j")
                     }),
             ],
-            "3.4.2": [
+            "3.4.3": [
                     dependencies.create("org.apache.spark:spark-mllib_${scala}:${spark}", {
                         exclude(group: "org.slf4j")
                     }),
             ],
-            "3.5.0": [
+            "3.5.1": [
                     dependencies.create("org.slf4j:slf4j-api:2.0.10"),
                     dependencies.create("org.slf4j:slf4j-reload4j:2.0.10"),
                     dependencies.create("org.apache.spark:spark-mllib_${scala}:${spark}", {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -23,6 +23,7 @@ import io.openlineage.spark.api.JobNameBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.ActiveJob;
@@ -55,7 +56,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
   private boolean emittedOnSqlExecutionEnd = false;
   private boolean emittedOnJobStart = false;
   private boolean emittedOnJobEnd = false;
-
+  private Integer activeJobId;
   private AtomicBoolean finished = new AtomicBoolean(false);
 
   public SparkSQLExecutionContext(
@@ -83,6 +84,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
       return;
     }
 
+    olContext.setActiveJobId(activeJobId);
     // only one START event is expected, in case it was already sent with jobStart, we send running
     EventType eventType = emittedOnJobStart ? RUNNING : START;
     emittedOnSqlExecutionStart = true;
@@ -113,6 +115,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
     // TODO: can we get failed event here?
     // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
     // Maybe use QueryExecutionListener?
+    olContext.setActiveJobId(activeJobId);
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
@@ -212,8 +215,20 @@ class SparkSQLExecutionContext implements ExecutionContext {
   }
 
   @Override
+  public Optional<Integer> getActiveJobId() {
+    return Optional.ofNullable(activeJobId);
+  }
+
+  @Override
+  public void setActiveJobId(Integer activeJobId) {
+    this.activeJobId = activeJobId;
+  }
+
+  @Override
   public void setActiveJob(ActiveJob activeJob) {
+    olContext.setActiveJobId(activeJob.jobId());
     runEventBuilder.registerJob(activeJob);
+    log.debug("Registering jobId: {} into runUid: {}", activeJob, olContext.getRunUuid());
   }
 
   @Override
@@ -254,6 +269,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
     log.debug("SparkListenerJobEnd - executionId: {}", executionId);
+    olContext.setActiveJobId(jobEnd.jobId());
     if (!finished.compareAndSet(false, true)) {
       log.debug("Event already finished, returning");
       return;

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -11,5 +11,5 @@ spark3.spark.version=3.2.4
 spark31.spark.version=3.1.3
 spark32.spark.version=3.2.4
 spark33.spark.version=3.3.4
-spark34.spark.version=3.4.2
-spark35.spark.version=3.5.0
+spark34.spark.version=3.4.3
+spark35.spark.version=3.5.1

--- a/integration/spark/scala-fixtures/build.gradle.kts
+++ b/integration/spark/scala-fixtures/build.gradle.kts
@@ -8,11 +8,11 @@ repositories {
 }
 
 configureScalaVariant("2.11", "2.4.8")
-configureScalaVariant("2.12", "3.5.0")
-configureScalaVariant("2.13", "3.5.0")
+configureScalaVariant("2.12", "3.5.1")
+configureScalaVariant("2.13", "3.5.1")
 
 dependencies {
-    compileOnly("org.apache.spark:spark-sql_2.12:3.5.0")
+    compileOnly("org.apache.spark:spark-sql_2.12:3.5.1")
 }
 
 fun configureScalaVariant(scalaBinaryVersion: String, sparkVersion: String) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
@@ -12,13 +12,17 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 
 /**
  * Write {@link OutputStatisticsOutputDatasetFacet} if statistics are present in the job metrics.
  */
+@Slf4j
 public class OutputStatisticsOutputDatasetFacetBuilder
-    extends CustomFacetBuilder<SparkListenerJobEnd, OutputStatisticsOutputDatasetFacet> {
+    extends CustomFacetBuilder<SparkListenerEvent, OutputStatisticsOutputDatasetFacet> {
 
   private final JobMetricsHolder jobMetricsHolder = JobMetricsHolder.getInstance();
   private final OpenLineageContext context;
@@ -28,11 +32,21 @@ public class OutputStatisticsOutputDatasetFacetBuilder
   }
 
   @Override
-  protected void build(
-      SparkListenerJobEnd event,
-      BiConsumer<String, ? super OutputStatisticsOutputDatasetFacet> consumer) {
-    Map<JobMetricsHolder.Metric, Number> metrics = jobMetricsHolder.pollMetrics(event.jobId());
+  public boolean isDefinedAt(Object x) {
+    return (x instanceof SparkListenerJobEnd) || (x instanceof SparkListenerSQLExecutionEnd);
+  }
 
+  @Override
+  protected void build(
+      SparkListenerEvent event,
+      BiConsumer<String, ? super OutputStatisticsOutputDatasetFacet> consumer) {
+    if (!context.getActiveJobId().isPresent()) {
+      log.warn("No jobId found in context");
+      return;
+    }
+
+    Map<JobMetricsHolder.Metric, Number> metrics =
+        jobMetricsHolder.pollMetrics(context.getActiveJobId().get());
     if (metrics.containsKey(JobMetricsHolder.Metric.WRITE_BYTES)
         || metrics.containsKey(JobMetricsHolder.Metric.WRITE_RECORDS)) {
       consumer.accept(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import java.util.Optional;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
@@ -42,4 +43,10 @@ public interface ExecutionContext {
   void end(SparkListenerSQLExecutionEnd sqlEnd);
 
   void end(SparkListenerStageCompleted stageCompleted);
+
+  default Optional<Integer> getActiveJobId() {
+    return Optional.empty();
+  }
+
+  default void setActiveJobId(Integer activeJobId) {}
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
@@ -126,9 +126,7 @@ public class KafkaRelationVisitor<D extends OpenLineage.Dataset>
   }
 
   public static boolean isKafkaSource(CreatableRelationProvider provider) {
-    log.debug("Checking if provider is KafkaSourceProvider");
     if (!hasKafkaClasses()) {
-      log.debug("Kafka classes are not available to check whether provider is KafkaSourceProvider");
       return false;
     }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -131,6 +131,12 @@ public class OpenLineageContext {
    */
   @Getter @Setter String jobName;
 
+  @Setter Integer activeJobId;
+
+  public Optional<Integer> getActiveJobId() {
+    return Optional.ofNullable(activeJobId);
+  }
+
   /**
    * Contains the vendors like Snowflake to separate the dependencies from the app and shared
    * project.

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -14,11 +14,14 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.PlanUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -129,6 +132,7 @@ class AbstractQueryPlanDatasetBuilderTest {
   void testApplyWhenExceptionIsThrown() {
     OpenLineageContext context = mock(OpenLineageContext.class);
     when(context.getQueryExecution()).thenReturn(Optional.of(mock(QueryExecution.class)));
+    Logger.getLogger(PlanUtils.class).setLevel(Level.ERROR);
     AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset> builder =
         new AbstractQueryPlanDatasetBuilder<SparkListenerJobEnd, LocalRelation, InputDataset>(
             context, false) {

--- a/integration/spark/shared/src/testScala212/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer212Test.java
+++ b/integration/spark/shared/src/testScala212/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer212Test.java
@@ -15,6 +15,8 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import java.io.IOException;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry;
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalog;
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
@@ -69,6 +71,7 @@ class LogicalPlanSerializer212Test {
 
     final ObjectMapper mapper = new ObjectMapper();
     try {
+      Logger.getLogger(logicalPlanSerializer.getClass()).setLevel(Level.ERROR);
       mapper.readTree(logicalPlanSerializer.serialize(notSerializablePlan));
     } catch (IOException e) {
       fail();

--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -17,12 +17,12 @@ ext {
             '3.1.3': '2.11.0',
             '3.2.4': '2.11.0',
             '3.3.4': '2.11.0',
-            '3.4.2': '2.15.0'
+            '3.4.3': '2.15.0'
     ]
 
     sparkProp = project.findProperty('spark.version').toString()
     // because snowflake doesn't have a 3.5.0 connector yet
-    spark = sparkProp == "3.5.0" ? "3.4.2" : sparkProp
+    spark = sparkProp == "3.5.1" ? "3.4.3" : sparkProp
 
     series = spark.substring(0, 3)
     scala = project.findProperty('scala.binary.version').toString()


### PR DESCRIPTION
### Problem

Upgrade to latest Spark versions used by the integration.


Issue encountered: 
 * For a job writing to JDBC table, although the job is uses `SparkSqlExecutionContext`, it is also using rdd job to when writing to jdbc. As a result, some of the listener calls run through `SparkSqlExecutionContext` while other run with `RddExecutionContext` which is makes the test fail because `setActiveJob` method that is necessary for output statistics to be up an running. 
 * As a solution to this `OpenLineageSparkListener` will store `Integer activeJobId` property to share jobId among SparkSQL and RDD execution contexts. 