### PR TITLE
spark: make sure debug logging is guarded when it can cause function call

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -59,8 +59,10 @@ public class EventEmitter {
   public void emit(OpenLineage.RunEvent event) {
     try {
       this.client.emit(event);
-      log.debug(
-          "Emitting lineage completed successfully: {}", OpenLineageClientUtils.toJson(event));
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Emitting lineage completed successfully: {}", OpenLineageClientUtils.toJson(event));
+      }
     } catch (OpenLineageClientException exception) {
       log.error("Could not emit lineage w/ exception", exception);
     }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -91,7 +91,7 @@ class RddExecutionContext implements ExecutionContext {
   public void end(SparkListenerApplicationEnd applicationEnd) {}
 
   @Override
-  @SuppressWarnings("PMD") //  f.setAccessible(true);
+  @SuppressWarnings("PMD") // f.setAccessible(true);
   public void setActiveJob(ActiveJob activeJob) {
     log.debug("setActiveJob within RddExecutionContext {}", activeJob);
     RDD<?> finalRDD = activeJob.finalStage().rdd();
@@ -226,7 +226,6 @@ class RddExecutionContext implements ExecutionContext {
                     .build())
             .job(buildJob(jobStart.jobId()))
             .build();
-
     log.debug("Posting event for start {}: {}", jobStart, event);
     eventEmitter.emit(event);
   }
@@ -235,8 +234,10 @@ class RddExecutionContext implements ExecutionContext {
   public void end(SparkListenerJobEnd jobEnd) {
     log.debug("end SparkListenerJobEnd {}", jobEnd);
     if (outputs.isEmpty() && !(jobEnd.jobResult() instanceof JobFailed)) {
-      // Oftentimes SparkListener is triggered for actions which do not contain any meaningful
-      // lineage data and are useless in the context of lineage graph. We assume this occurs
+      // Oftentimes SparkListener is triggered for actions which do not contain any
+      // meaningful
+      // lineage data and are useless in the context of lineage graph. We assume this
+      // occurs
       // for RDD operations which have no output dataset
       log.info("Output RDDs are empty: skipping sending OpenLineage event");
       return;
@@ -256,7 +257,6 @@ class RddExecutionContext implements ExecutionContext {
                     .build())
             .job(buildJob(jobEnd.jobId()))
             .build();
-
     log.debug("Posting event for end {}: {}", jobEnd, event);
     eventEmitter.emit(event);
   }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -71,7 +71,9 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void start(SparkListenerSQLExecutionStart startEvent) {
-    log.debug("SparkListenerSQLExecutionStart - executionId: {}", startEvent.executionId());
+    if (log.isDebugEnabled()) {
+      log.debug("SparkListenerSQLExecutionStart - executionId: {}", startEvent.executionId());
+    }
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
@@ -102,7 +104,9 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerSQLExecutionEnd endEvent) {
-    log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
+    if (log.isDebugEnabled()) {
+      log.debug("SparkListenerSQLExecutionEnd - executionId: {}", endEvent.executionId());
+    }
     // TODO: can we get failed event here?
     // If not, then we probably need to use this only for LogicalPlans that emit no Job events.
     // Maybe use QueryExecutionListener?
@@ -135,8 +139,9 @@ class SparkSQLExecutionContext implements ExecutionContext {
             buildJob(),
             getJobFacetsBuilder(olContext.getQueryExecution().get()),
             endEvent);
-
-    log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    if (log.isDebugEnabled()) {
+      log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    }
     eventEmitter.emit(event);
   }
 
@@ -200,7 +205,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void start(SparkListenerJobStart jobStart) {
-    log.debug("SparkListenerJobStart - executionId: " + executionId);
+    log.debug("SparkListenerJobStart - executionId: {}", executionId);
     if (!olContext.getQueryExecution().isPresent()) {
       log.info(NO_EXECUTION_INFO, olContext);
       return;
@@ -232,7 +237,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
   @Override
   public void end(SparkListenerJobEnd jobEnd) {
-    log.debug("SparkListenerJobEnd - executionId: " + executionId);
+    log.debug("SparkListenerJobEnd - executionId: {}", executionId);
     if (!finished.compareAndSet(false, true)) {
       log.debug("Event already finished, returning");
       return;

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -81,8 +81,13 @@ public class SparkContainerUtils {
   }
 
   static void mountPath(GenericContainer<?> container, Path sourcePath, Path targetPath) {
-    log.debug(
-        "[image={}]: Mount volume '{}:{}'", container.getDockerImageName(), sourcePath, targetPath);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "[image={}]: Mount volume '{}:{}'",
+          container.getDockerImageName(),
+          sourcePath,
+          targetPath);
+    }
     container.withFileSystemBind(sourcePath.toString(), targetPath.toString(), BindMode.READ_ONLY);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -405,10 +405,12 @@ class OpenLineageRunEventBuilder {
                 log.debug("Physical plan executed {}", qe.executedPlan().toJSON());
               }
             });
-    log.debug(
-        "Visiting query plan {} with input dataset builders {}",
-        openLineageContext.getQueryExecution(),
-        inputDatasetBuilders);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Visiting query plan {} with input dataset builders {}",
+          openLineageContext.getQueryExecution(),
+          inputDatasetBuilders);
+    }
 
     Function1<LogicalPlan, Collection<InputDataset>> inputVisitor =
         visitLogicalPlan(PlanUtils.merge(inputDatasetQueryPlanVisitors));
@@ -482,10 +484,12 @@ class OpenLineageRunEventBuilder {
   }
 
   private List<OutputDataset> buildOutputDatasets(List<Object> nodes) {
-    log.debug(
-        "Visiting query plan {} with output dataset builders {}",
-        openLineageContext.getQueryExecution(),
-        outputDatasetBuilders);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Visiting query plan {} with output dataset builders {}",
+          openLineageContext.getQueryExecution(),
+          outputDatasetBuilders);
+    }
     Function1<LogicalPlan, Collection<OutputDataset>> visitor =
         visitLogicalPlan(
             PlanUtils.merge(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaRelationVisitor.java
@@ -79,7 +79,7 @@ public class KafkaRelationVisitor<D extends OpenLineage.Dataset>
                   || checkWithCurrentThreadContextClassLoader(KAFKA_SOURCE_PROVIDER_CLASS_NAME);
           KAFKA_PROVIDER_CLASS_PRESENT.set(available);
           KAFKA_PROVIDER_CHECKED.set(true);
-          log.debug("Kafka classes availability: " + available);
+          log.debug("Kafka classes availability: {}", available);
         }
       }
     }
@@ -97,7 +97,7 @@ public class KafkaRelationVisitor<D extends OpenLineage.Dataset>
                   || checkWithCurrentThreadContextClassLoader(KAFKA_RELATION_CLASS_NAME);
           KAFKA_RELATION_CLASS_PRESENT.set(available);
           KAFKA_RELATION_CHECKED.set(true);
-          log.debug("KafkaRelation class availability: " + available);
+          log.debug("KafkaRelation class availability: {}", available);
         }
       }
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -116,7 +116,7 @@ public class RddPathUtils {
     public Stream<Path> extract(ParallelCollectionRDD rdd) {
       try {
         Object data = FieldUtils.readField(rdd, "data", true);
-        log.debug("ParallelCollectionRDD data: {} {}", data);
+        log.debug("ParallelCollectionRDD data: {}", data);
         if (data instanceof Seq) {
           return ScalaConversionUtils.fromSeq((Seq) data).stream()
               .map(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -69,7 +69,6 @@ public class IcebergHandler implements CatalogHandler {
     String prefix = String.format("spark.sql.catalog.%s", catalogName);
     Map<String, String> conf =
         ScalaConversionUtils.<String, String>fromMap(session.conf().getAll());
-    log.debug(conf.toString());
     Map<String, String> catalogConf =
         conf.entrySet().stream()
             .filter(x -> x.getKey().startsWith(prefix))
@@ -79,12 +78,10 @@ public class IcebergHandler implements CatalogHandler {
                     x -> x.getKey().substring(prefix.length() + 1), // handle dot after prefix
                     Map.Entry::getValue));
 
-    log.debug(catalogConf.toString());
     String catalogType = getCatalogType(catalogConf);
     if (catalogType == null) {
       throw new UnsupportedCatalogException(catalogName);
     }
-    log.debug(catalogConf.get(TYPE));
 
     String warehouse = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
     DatasetIdentifier di = PathUtils.fromPath(new Path(warehouse, identifier.toString()));

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/CreateReplaceInputDatasetBuilder.java
@@ -40,7 +40,10 @@ public class CreateReplaceInputDatasetBuilder
 
   @Override
   public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
-    log.debug("Calling isDefinedAtLogicalPlan on {} with children {}", x.getClass(), x.children());
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Calling isDefinedAtLogicalPlan on {} with children {}", x.getClass(), x.children());
+    }
     return ((x instanceof CreateTableAsSelect)
             || (x instanceof ReplaceTable)
             || (x instanceof ReplaceTableAsSelect)
@@ -50,7 +53,9 @@ public class CreateReplaceInputDatasetBuilder
 
   @Override
   public List<OpenLineage.InputDataset> apply(SparkListenerEvent event, LogicalPlan x) {
-    log.debug("Calling apply on {}", x.getClass());
+    if (log.isDebugEnabled()) {
+      log.debug("Calling apply on {}", x.getClass());
+    }
     return extractChildren(x).stream()
         .flatMap(
             plan ->


### PR DESCRIPTION
If loglevel is higher than debug, then there's no point in having to call methods result of which won't be used - especially if they are rather heavy, like `OpenLineageClientUtils.toJson(event)`