### PR TITLE
[SPARK] fix drop table for Spark 3.4 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...HEAD)
 
+### Fixed
+* **Spark: fix events emitted for `drop table` for Spark 3.4 and above** [`#2745`](https://github.com/OpenLineage/OpenLineage/pull/2745) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Include dataset being dropped within the event, as it used to be prior to Spark 3.4.*
+
 ## [1.16.0](https://github.com/OpenLineage/OpenLineage/compare/1.15.0...1.16.0) - 2024-05-28
 ### Added
 * **Spark: add `jobType` facet to Spark application events** [`#2719`](https://github.com/OpenLineage/OpenLineage/pull/2719) [@dolfinus](https://github.com/dolfinus)  

--- a/integration/spark/app/integrations/container/pysparkDropTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkDropTableCompleteEvent.json
@@ -1,8 +1,0 @@
-{
-  "eventType": "COMPLETE",
-  "job": {
-    "namespace": "testDropTable"
-  },
-  "inputs": [],
-  "outputs": [ ]
-}

--- a/integration/spark/app/integrations/container/pysparkDropTableEvent.json
+++ b/integration/spark/app/integrations/container/pysparkDropTableEvent.json
@@ -1,0 +1,29 @@
+{
+  "job": {
+    "namespace": "testDropTable"
+  },
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/drop_test/drop_table_test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/drop_test",
+              "name": "default.drop_table_test",
+              "type": "TABLE"
+            }
+          ]
+        },
+        "lifecycleStateChange": {
+          "lifecycleStateChange": "DROP"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -33,6 +33,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuild
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import java.util.Collection;
 import java.util.List;
@@ -81,6 +82,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new TableContentChangeDatasetBuilder(context))
             .add(getCreateReplaceDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
+            .add(new DropTableDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new AlterTableCommandDatasetBuilder(context));

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -32,6 +32,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuild
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import java.util.Collection;
 import java.util.List;
@@ -79,6 +80,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new CreateReplaceOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
+            .add(new DropTableDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
             .add(new AlterTableCommandDatasetBuilder(context));
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -290,7 +290,7 @@ class SparkContainerIntegrationTest {
   void testDropTable() {
     SparkContainerUtils.runPysparkContainerWithDefaultConf(
         network, openLineageClientMockContainer, "testDropTable", "spark_drop_table.py");
-    verifyEvents(mockServerClient, "pysparkDropTableCompleteEvent.json");
+    verifyEvents(mockServerClient, "pysparkDropTableEvent.json");
   }
 
   @Test

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -30,14 +30,14 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
   }
 
   @Override
+  public boolean isDefinedAt(LogicalPlan x) {
+    // differs for Spark versions 3.4 and higher
+    return (x instanceof DropTable) && (((DropTable) x).child() instanceof ResolvedTable);
+  }
+
+  @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     DropTable dropTable = (DropTable) x;
-
-    if (!(dropTable.child() instanceof ResolvedTable)) {
-      log.warn(
-          "Unexpected child type. Expected ResolvedTable, got {}", dropTable.child().getClass());
-      return Collections.emptyList();
-    }
 
     ResolvedTable resolvedTable = ((ResolvedTable) (dropTable).child());
     TableCatalog tableCatalog = resolvedTable.catalog();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandler.java
@@ -5,13 +5,20 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.Symlink;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import io.openlineage.spark.agent.util.PathUtils;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
 
+@Slf4j
 public class V2SessionCatalogHandler implements CatalogHandler {
 
   @Override
@@ -30,7 +37,17 @@ public class V2SessionCatalogHandler implements CatalogHandler {
       TableCatalog tableCatalog,
       Identifier identifier,
       Map<String, String> properties) {
-    throw new UnsupportedCatalogException(V2SessionCatalog.class.getCanonicalName());
+    V2SessionCatalog catalog = (V2SessionCatalog) tableCatalog;
+    Map<String, String> namespaceMetadata = catalog.loadNamespaceMetadata(identifier.namespace());
+    if (namespaceMetadata.containsKey("location")) {
+      DatasetIdentifier di =
+          PathUtils.fromPath(new Path(namespaceMetadata.get("location"), identifier.name()));
+      di.withSymlink(
+          new Symlink(identifier.toString(), namespaceMetadata.get("location"), SymlinkType.TABLE));
+      return di;
+    }
+    throw new OpenLineageClientException(
+        "Unable to extract DatasetIdentifier from V2SessionCatalog");
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/V2SessionCatalogHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
+import java.util.Collections;
+import java.util.HashMap;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class V2SessionCatalogHandlerTest {
+  private V2SessionCatalogHandler catalogHandler = new V2SessionCatalogHandler();
+  private V2SessionCatalog catalog = mock(V2SessionCatalog.class);
+
+  @Test
+  void testGetDatasetIdentifierWhenLocationPresent() {
+    Identifier id = Identifier.of(new String[] {"db", "schema"}, "table");
+    when(catalog.loadNamespaceMetadata(id.namespace()))
+        .thenReturn(Collections.singletonMap("location", "file:/tmp/warehouse/location"));
+
+    DatasetIdentifier datasetIdentifier =
+        catalogHandler.getDatasetIdentifier(mock(SparkSession.class), catalog, id, new HashMap<>());
+
+    assertThat(datasetIdentifier.getName()).isEqualTo("/tmp/warehouse/location/table");
+    assertThat("file").isEqualTo(datasetIdentifier.getNamespace());
+    assertThat("db.schema.table").isEqualTo(datasetIdentifier.getSymlinks().get(0).getName());
+    assertThat("file:/tmp/warehouse/location")
+        .isEqualTo(datasetIdentifier.getSymlinks().get(0).getNamespace());
+    assertThat(datasetIdentifier.getSymlinks().get(0).getType()).isEqualTo(SymlinkType.TABLE);
+  }
+
+  @Test
+  void testGetDatasetIdentifierWhenNoLocationPresent() {
+    Identifier id = Identifier.of(new String[] {"db", "schema"}, "table");
+    when(catalog.loadNamespaceMetadata(id.namespace())).thenReturn(Collections.emptyMap());
+
+    OpenLineageClientException thrown =
+        assertThrows(
+            OpenLineageClientException.class,
+            () ->
+                catalogHandler.getDatasetIdentifier(
+                    mock(SparkSession.class), catalog, id, new HashMap<>()));
+
+    assertThat(thrown.getMessage())
+        .contains("Unable to extract DatasetIdentifier from V2SessionCatalog");
+  }
+}

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/DropTableDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/column/DropTableDatasetBuilder.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan.column;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier;
+import org.apache.spark.sql.catalyst.plans.logical.DropTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+@Slf4j
+public class DropTableDatasetBuilder extends AbstractQueryPlanOutputDatasetBuilder<DropTable> {
+
+  public DropTableDatasetBuilder(@NonNull OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof DropTable) && (((DropTable) x).child() instanceof ResolvedIdentifier);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(DropTable dropTable) {
+    ResolvedIdentifier resolvedIdentifier = ((ResolvedIdentifier) (dropTable).child());
+
+    return Optional.of(resolvedIdentifier.catalog())
+        .filter(catalogPlugin -> catalogPlugin instanceof TableCatalog)
+        .map(TableCatalog.class::cast)
+        .flatMap(
+            catalogPlugin ->
+                PlanUtils3.getDatasetIdentifier(
+                    context, catalogPlugin, resolvedIdentifier.identifier(), new LinkedHashMap<>()))
+        .map(
+            di ->
+                outputDataset()
+                    .getDataset(
+                        di,
+                        resolvedIdentifier.schema(),
+                        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP))
+        .map(d -> Collections.singletonList(d))
+        .orElseGet(() -> Collections.emptyList());
+  }
+}


### PR DESCRIPTION
### Problem

`Drop table` does not emit OL events properly for Spark >= 3.4. 

Closes: #2716

### Solution

Modify the visitor/ dataset builder and turn on the tests which verify output dataset

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project