### PR TITLE
[SPARK] fix NPE in column level lineage

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
@@ -63,10 +63,12 @@ public class Rdds {
     deps.add(rdd);
     while (!deps.isEmpty()) {
       RDD<?> cur = deps.pop();
-      deps.addAll(
-          ScalaConversionUtils.fromSeq(cur.getDependencies()).stream()
-              .map(Dependency::rdd)
-              .collect(Collectors.toList()));
+      if (cur.getDependencies() != null) {
+        deps.addAll(
+            ScalaConversionUtils.fromSeq(cur.getDependencies()).stream()
+                .map(Dependency::rdd)
+                .collect(Collectors.toList()));
+      }
       if (cur instanceof HadoopRDD) {
         ret.add(cur);
       } else if (cur instanceof FileScanRDD) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/RddsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/RddsTest.java
@@ -1,0 +1,23 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.spark.rdd.RDD;
+import org.junit.jupiter.api.Test;
+
+class RddsTest {
+  @Test
+  void testFindFileLikeRddsWhenDependeciesAreNull() {
+    RDD<?> rdd = mock(RDD.class);
+    when(rdd.getDependencies()).thenReturn(null);
+
+    assertThat(Rdds.findFileLikeRdds(rdd)).isEmpty();
+  }
+}


### PR DESCRIPTION
### Problem

Based on Slack link -> https://openlineage.slack.com/archives/C01CK9T7HKR/p1716951736587709, 

there is a `NullPointerException`:
```
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173046375Z Caused by: java.lang.NullPointerException
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173049282Z 	at io.openlineage.spark.agent.util.ScalaConversionUtils.fromSeq(ScalaConversionUtils.java:61)
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173051877Z 	at io.openlineage.spark.agent.lifecycle.Rdds.findFileLikeRdds(Rdds.java:69)
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173054714Z 	at io.openlineage.spark3.agent.lifecycle.plan.column.InputFieldsCollector.extractDatasetIdentifier(InputFieldsCollector.java:149)
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173058077Z 	at io.openlineage.spark3.agent.lifecycle.plan.column.InputFieldsCollector.extractDatasetIdentifier(InputFieldsCollector.java:124)
[2023-06-12, 15:26:37 UTC] {subprocess.py:93} INFO - 2023-06-12T15:26:37.173060779Z 	at io.openlineage.spark3.agent.lifecycle.plan.column.InputFieldsCollector.discoverInputsFromNode(InputFieldsCollector.java:70)
```