### PR TITLE
alias: allow self-recursive aliases

### DIFF
--- a/integration/sql/impl/src/context/alias_table.rs
+++ b/integration/sql/impl/src/context/alias_table.rs
@@ -32,9 +32,14 @@ impl AliasTable {
     }
 
     pub fn resolve_table<'a>(&'a self, name: &'a DbTableMeta) -> &'a DbTableMeta {
+        let mut max_iter = 20; // does anyone need more than 20 aliases?
         let mut current = name;
         while let Some(next) = self.get_table_from_alias(current.qualified_name()) {
             current = next;
+            max_iter -= 1;
+            if max_iter <= 0 {
+                return current;
+            }
         }
         current
     }

--- a/integration/sql/impl/tests/column_lineage/tests_aliases.rs
+++ b/integration/sql/impl/tests/column_lineage/tests_aliases.rs
@@ -144,3 +144,48 @@ fn test_deeply_nested_alias_chain() {
         },]
     );
 }
+
+#[test]
+fn test_circular_alias() {
+    assert_eq!(
+        test_sql("select * from test_orders as test_orders")
+            .unwrap()
+            .table_lineage
+            .in_tables,
+        vec![table("test_orders")],
+    )
+}
+
+#[test]
+fn test_long_alias_used() {
+    assert_eq!(
+        test_sql("with test_orders as (select * from a as a) select * from test_orders")
+            .unwrap()
+            .table_lineage
+            .in_tables,
+        vec![table("a")],
+    )
+}
+
+#[ignore] // https://github.com/OpenLineage/OpenLineage/issues/2752
+#[test]
+fn test_long_alias_not_used() {
+    assert_eq!(
+        test_sql("with test_orders as (select * from a as a) select * from other")
+            .unwrap()
+            .table_lineage
+            .in_tables,
+        vec![table("other")],
+    )
+}
+
+#[ignore] // https://github.com/OpenLineage/OpenLineage/issues/2752
+#[test]
+fn test_long_circular_alias() {
+    assert_eq!(
+        test_sql("with test_orders as (select * from test_orders as test_orders) select * from test_orders")
+            .unwrap()
+            .table_lineage.in_tables,
+        vec![table("test_orders")],
+    )
+}


### PR DESCRIPTION
We should allow expressions like `select * from test_orders as test_orders` to properly parse.

Also, added some for now ignored tests for issue that I've noticed while looking at this: 
https://github.com/OpenLineage/OpenLineage/issues/2752