### PR TITLE
[SPARK] refactor OpenLineageRunEventBuilder

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -89,14 +89,17 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(toZonedTime(startEvent.time()))
-                .eventType(eventType),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            startEvent);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(startEvent)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(toZonedTime(startEvent.time()))
+                        .eventType(eventType))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
 
     log.debug("Posting event for start {}: {}", executionId, event);
     eventEmitter.emit(event);
@@ -131,14 +134,18 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(toZonedTime(endEvent.time()))
-                .eventType(eventType),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            endEvent);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(endEvent)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(toZonedTime(endEvent.time()))
+                        .eventType(eventType))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
+
     if (log.isDebugEnabled()) {
       log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
     }
@@ -159,14 +166,17 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
-                .eventType(RUNNING),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            stageSubmitted);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(stageSubmitted)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                        .eventType(RUNNING))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
 
     log.debug("Posting event for stage submitted {}: {}", executionId, event);
     eventEmitter.emit(event);
@@ -185,14 +195,17 @@ class SparkSQLExecutionContext implements ExecutionContext {
     }
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
-                .eventType(RUNNING),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            stageCompleted);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(stageCompleted)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                        .eventType(RUNNING))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
 
     log.debug("Posting event for stage completed {}: {}", executionId, event);
     eventEmitter.emit(event);
@@ -222,14 +235,17 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(toZonedTime(jobStart.time()))
-                .eventType(eventType),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            jobStart);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(jobStart)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(toZonedTime(jobStart.time()))
+                        .eventType(eventType))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
 
     log.debug("Posting event for start {}: {}", executionId, event);
     eventEmitter.emit(event);
@@ -266,14 +282,17 @@ class SparkSQLExecutionContext implements ExecutionContext {
 
     RunEvent event =
         runEventBuilder.buildRun(
-            buildApplicationParentFacet(),
-            openLineage
-                .newRunEventBuilder()
-                .eventTime(toZonedTime(jobEnd.time()))
-                .eventType(eventType),
-            buildJob(),
-            getJobFacetsBuilder(olContext.getQueryExecution().get()),
-            jobEnd);
+            OpenLineageRunEventContext.builder()
+                .applicationParentRunFacet(buildApplicationParentFacet())
+                .event(jobEnd)
+                .runEventBuilder(
+                    openLineage
+                        .newRunEventBuilder()
+                        .eventTime(toZonedTime(jobEnd.time()))
+                        .eventType(eventType))
+                .jobBuilder(buildJob())
+                .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
+                .build());
 
     log.debug("Posting event for end {}: {}", executionId, event);
     eventEmitter.emit(event);

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
@@ -60,6 +60,8 @@ class SparkApplicationExecutionContextTest {
     when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
     when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
     when(olContext.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
+    when(olContext.getApplicationUuid())
+        .thenReturn(UUID.fromString("993426b3-1ca7-44af-8473-8e58c757ebd1"));
 
     when(eventEmitter.getOverriddenAppName()).thenReturn(Optional.of("app-name"));
     when(eventEmitter.getApplicationRunId())

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -14,14 +14,11 @@ import io.openlineage.client.OpenLineage.DatasetFacets;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.OpenLineage.InputDatasetFacet;
 import io.openlineage.client.OpenLineage.InputDatasetInputFacets;
-import io.openlineage.client.OpenLineage.JobBuilder;
 import io.openlineage.client.OpenLineage.JobFacet;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.OpenLineage.OutputDatasetFacet;
 import io.openlineage.client.OpenLineage.OutputDatasetOutputFacets;
-import io.openlineage.client.OpenLineage.ParentRunFacet;
 import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineage.RunEventBuilder;
 import io.openlineage.client.OpenLineage.RunFacet;
 import io.openlineage.client.OpenLineage.RunFacets;
 import io.openlineage.client.OpenLineage.RunFacetsBuilder;
@@ -35,8 +32,6 @@ import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.QueryPlanVisitor;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,17 +46,11 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.scheduler.ActiveJob;
-import org.apache.spark.scheduler.SparkListenerApplicationEnd;
-import org.apache.spark.scheduler.SparkListenerApplicationStart;
 import org.apache.spark.scheduler.SparkListenerEvent;
-import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.SparkListenerStageCompleted;
-import org.apache.spark.scheduler.SparkListenerStageSubmitted;
 import org.apache.spark.scheduler.Stage;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
-import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
-import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import scala.Function1;
 import scala.PartialFunction;
 
@@ -194,181 +183,15 @@ class OpenLineageRunEventBuilder {
                 }));
   }
 
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerStageSubmitted event) {
-    Stage stage = stageMap.get(event.stageInfo().stageId());
-    RDD<?> rdd = stage.rdd();
-
-    List<Object> nodes = new ArrayList<>();
-    nodes.addAll(Arrays.asList(event.stageInfo(), stage));
-
-    nodes.addAll(Rdds.flattenRDDs(rdd));
-
-    return populateRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        nodes);
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerStageCompleted event) {
-    Stage stage = stageMap.get(event.stageInfo().stageId());
-    RDD<?> rdd = stage.rdd();
-
-    List<Object> nodes = new ArrayList<>();
-    nodes.addAll(Arrays.asList(event.stageInfo(), stage));
-
-    nodes.addAll(Rdds.flattenRDDs(rdd));
-
-    return populateRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        nodes);
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerSQLExecutionStart event) {
-    return buildRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.empty());
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerSQLExecutionEnd event) {
-    return buildRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.empty());
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet parentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerJobStart event) {
-    return buildRun(
-        parentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.ofNullable(jobMap.get(event.jobId())));
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerJobEnd event) {
-    return buildRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getRunUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.ofNullable(jobMap.get(event.jobId())));
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet parentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerApplicationStart event) {
-    return buildRun(
-        parentRunFacet,
-        runEventBuilder,
-        openLineageContext.getApplicationUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.empty());
-  }
-
-  RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      SparkListenerApplicationEnd event) {
-    return buildRun(
-        applicationParentRunFacet,
-        runEventBuilder,
-        openLineageContext.getApplicationUuid(),
-        jobBuilder,
-        jobFacetsBuilder,
-        event,
-        Optional.empty());
-  }
-
-  private RunEvent buildRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      UUID runId,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      Object event,
-      Optional<ActiveJob> job) {
-    List<Object> nodes = new ArrayList<>();
-    nodes.add(event);
-    job.ifPresent(
-        j -> {
-          nodes.add(j);
-          nodes.addAll(Rdds.flattenRDDs(j.finalStage().rdd()));
-        });
-
-    return populateRun(
-        applicationParentRunFacet, runEventBuilder, runId, jobBuilder, jobFacetsBuilder, nodes);
-  }
-
-  private RunEvent populateRun(
-      ParentRunFacet applicationParentRunFacet,
-      RunEventBuilder runEventBuilder,
-      UUID runId,
-      JobBuilder jobBuilder,
-      OpenLineage.JobFacetsBuilder jobFacetsBuilder,
-      List<Object> nodes) {
+  RunEvent buildRun(OpenLineageRunEventContext context) {
     OpenLineage openLineage = openLineageContext.getOpenLineage();
-
+    List<Object> nodes = context.loadNodes(stageMap, jobMap);
+    UUID runId = context.getOverwriteRunId().orElse(openLineageContext.getRunUuid());
     RunFacetsBuilder runFacetsBuilder = openLineage.newRunFacetsBuilder();
 
-    runFacetsBuilder.parent(applicationParentRunFacet);
-    OpenLineage.JobFacets jobFacets = buildJobFacets(nodes, jobFacetBuilders, jobFacetsBuilder);
+    runFacetsBuilder.parent(context.getApplicationParentRunFacet());
+    OpenLineage.JobFacets jobFacets =
+        buildJobFacets(nodes, jobFacetBuilders, context.getJobFacetsBuilder());
     List<InputDataset> inputDatasets = buildInputDatasets(nodes);
     List<OutputDataset> outputDatasets = buildOutputDatasets(nodes);
     openLineageContext
@@ -385,14 +208,15 @@ class OpenLineageRunEventBuilder {
 
     RunFacets runFacets = buildRunFacets(nodes, runFacetBuilders, runFacetsBuilder);
     OpenLineage.RunBuilder runBuilder = openLineage.newRunBuilder().runId(runId).facets(runFacets);
-    runEventBuilder
+    context
+        .getRunEventBuilder()
         .run(runBuilder.build())
-        .job(jobBuilder.facets(jobFacets).build())
+        .job(context.getJobBuilder().facets(jobFacets).build())
         .inputs(RemovePathPatternUtils.removeInputsPathPattern(openLineageContext, inputDatasets))
         .outputs(
             RemovePathPatternUtils.removeOutputsPathPattern(openLineageContext, outputDatasets));
 
-    return runEventBuilder.build();
+    return context.getRunEventBuilder().build();
   }
 
   private List<InputDataset> buildInputDatasets(List<Object> nodes) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
@@ -1,0 +1,120 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.JobBuilder;
+import io.openlineage.client.OpenLineage.ParentRunFacet;
+import io.openlineage.client.OpenLineage.RunEventBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
+import org.apache.spark.scheduler.Stage;
+import org.apache.spark.scheduler.StageInfo;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+
+/**
+ * Class to contain properties for building a single OpenLineage event. Should be passed to {@link
+ * OpenLineageRunEventBuilder}.
+ */
+@Getter
+@Builder
+public class OpenLineageRunEventContext {
+
+  private ParentRunFacet applicationParentRunFacet;
+  private RunEventBuilder runEventBuilder;
+  private JobBuilder jobBuilder;
+  private OpenLineage.JobFacetsBuilder jobFacetsBuilder;
+  private Optional<StageInfo> stageInfo;
+  private Optional<Integer> jobId;
+  private Optional<UUID> overwriteRunId;
+  private SparkListenerEvent event;
+
+  public List<Object> loadNodes(Map<Integer, Stage> stageMap, Map<Integer, ActiveJob> jobMap) {
+    List<Object> nodes = new ArrayList<>();
+    nodes.add(event);
+
+    if (stageInfo.isPresent()) {
+      Stage stage = stageMap.get(stageInfo.get().stageId());
+      RDD<?> rdd = stage.rdd();
+
+      nodes.addAll(Arrays.asList(stageInfo, stage));
+      nodes.addAll(Rdds.flattenRDDs(rdd));
+    } else if (jobId.isPresent() && jobMap.containsKey(jobId.get())) {
+      ActiveJob activeJob = jobMap.get(jobId.get());
+      nodes.add(activeJob);
+      nodes.addAll(Rdds.flattenRDDs(activeJob.finalStage().rdd()));
+    }
+
+    return nodes;
+  }
+
+  @SuppressWarnings("PMD.UnusedPrivateField")
+  public static class OpenLineageRunEventContextBuilder {
+    private Optional<StageInfo> stageInfo = Optional.empty();
+    private Optional<Integer> jobId = Optional.empty();
+    private Optional<UUID> overwriteRunId = Optional.empty();
+
+    OpenLineageRunEventContextBuilder event(SparkListenerStageSubmitted event) {
+      this.stageInfo = Optional.of(event.stageInfo());
+      this.event = event;
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerStageCompleted event) {
+      this.stageInfo = Optional.of(event.stageInfo());
+      this.event = event;
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerSQLExecutionStart event) {
+      this.event = event;
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerSQLExecutionEnd event) {
+      this.event = event;
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerJobStart event) {
+      this.event = event;
+      this.jobId = Optional.of(event.jobId());
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerJobEnd event) {
+      this.event = event;
+      this.jobId = Optional.of(event.jobId());
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerApplicationStart event) {
+      this.event = event;
+      return this;
+    }
+
+    OpenLineageRunEventContextBuilder event(SparkListenerApplicationEnd event) {
+      this.event = event;
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
### Problem

`OpenLineageRunEventBuilder` becomes difficult to manage due to its size, it has no tests and is constantly expanding. This PR introduces refactoring, which replaces eight methods with the same name and different arguments list into a single 
`RunEvent buildRun(OpenLineageRunEventBuilder context)`

Introducing `EventBuilderContext` assures the list of input arguments for this class will not grow as it used to.
This has no functional change. 

### Solution

Add separate class which contains all the input arguments to call `OpenLineageRunEventBuilder::buildRun` 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project