### PR TITLE
remodeled transformation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...HEAD)
 ### Added
-* **Spec: add transformation type info** [`#2756`](https://github.com/OpenLineage/OpenLineage/pull/2719) [@tnazarew](https://github.com/tnazarew)  
+* **Spec: add transformation type info** [`#2756`](https://github.com/OpenLineage/OpenLineage/pull/2756) [@tnazarew](https://github.com/tnazarew)  
   *Add information about transformation type in `ColumnLineageDatasetFacet`.*
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...HEAD)
 ### Added
 * **Spec: add transformation type info** [`#2756`](https://github.com/OpenLineage/OpenLineage/pull/2756) [@tnazarew](https://github.com/tnazarew)  
-  *Add information about transformation type in `ColumnLineageDatasetFacet`.*
+  *Add information about transformation type in `ColumnLineageDatasetFacet`. `transformationType` and `transformationDescription` marked deprecated*
 
 ### Fixed
 * **Spark: fix events emitted for `drop table` for Spark 3.4 and above** [`#2745`](https://github.com/OpenLineage/OpenLineage/pull/2745) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)[@savannavalgi](https://github.com/savannavalgi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...HEAD)
+### Added
+* **Spec: add transformation type info** [`#2756`](https://github.com/OpenLineage/OpenLineage/pull/2719) [@tnazarew](https://github.com/tnazarew)  
+  *Add information about transformation type in `ColumnLineageDatasetFacet`.*
 
 ### Fixed
 * **Spark: fix events emitted for `drop table` for Spark 3.4 and above** [`#2745`](https://github.com/OpenLineage/OpenLineage/pull/2745) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)[@savannavalgi](https://github.com/savannavalgi)

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -24,12 +24,12 @@ class ColumnLineageDatasetFacet(DatasetFacet):
 class Fields(RedactMixin):
     inputFields: list[InputField]  # noqa: N815
     transformationDescription: str | None = attr.field(default=None)  # noqa: N815
-    """a string representation of the transformation applied"""
+    """DEPRECATED; a string representation of the transformation applied"""
 
     transformationType: str | None = attr.field(default=None)  # noqa: N815
     """
-    IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no
-    original data available (like a hash of PII for example)
+    DEPRECATED; IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input;
+    MASKED: no original data available (like a hash of PII for example)
     """
 
 
@@ -51,7 +51,7 @@ class InputField(RedactMixin):
 @attr.define
 class Transformation(RedactMixin):
     type: str
-    """The type of the transformation. Allowed values are: IDENTITY, TRANSFORMED, INDIRECT"""
+    """The type of the transformation. Allowed values are: DIRECT, INDIRECT"""
 
     subtype: str | None = attr.field(default=None)
     """The subtype of the transformation"""

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -24,12 +24,12 @@ class ColumnLineageDatasetFacet(DatasetFacet):
 class Fields(RedactMixin):
     inputFields: list[InputField]  # noqa: N815
     transformationDescription: str | None = attr.field(default=None)  # noqa: N815
-    """DEPRECATED; a string representation of the transformation applied"""
+    """a string representation of the transformation applied"""
 
     transformationType: str | None = attr.field(default=None)  # noqa: N815
     """
-    DEPRECATED; IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input;
-    MASKED: no original data available (like a hash of PII for example)
+    IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no
+    original data available (like a hash of PII for example)
     """
 
 

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -61,3 +61,5 @@ class Transformation(RedactMixin):
 
     masking: bool | None = attr.field(default=None)
     """is transformation masking the data or not"""
+
+    _skip_redact: ClassVar[list[str]] = ["type", "subtype", "masking"]

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -50,7 +50,7 @@ class InputField(RedactMixin):
 
 @attr.define
 class Transformation(RedactMixin):
-    type: str | None = attr.field(default=None)
+    type: str
     """The type of the transformation. Allowed values are: IDENTITY, TRANSFORMED, INDIRECT"""
 
     subtype: str | None = attr.field(default=None)

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -17,7 +17,7 @@ class ColumnLineageDatasetFacet(DatasetFacet):
 
     @staticmethod
     def _get_schema() -> str:
-        return "https://openlineage.io/spec/facets/1-0-2/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet"
+        return "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet"
 
 
 @attr.define
@@ -44,4 +44,20 @@ class InputField(RedactMixin):
     field: str
     """The input field"""
 
+    transformations: list[Transformation] | None = attr.field(factory=list)
     _skip_redact: ClassVar[list[str]] = ["namespace", "name", "field"]
+
+
+@attr.define
+class Transformation(RedactMixin):
+    type: str | None = attr.field(default=None)
+    """The type of the transformation. Allowed values are: IDENTITY, TRANSFORMED, INDIRECT"""
+
+    subtype: str | None = attr.field(default=None)
+    """The subtype of the transformation"""
+
+    description: str | None = attr.field(default=None)
+    """a string representation of the transformation applied"""
+
+    masking: bool | None = attr.field(default=None)
+    """is transformation masking the data or not"""

--- a/client/python/redact_fields.yml
+++ b/client/python/redact_fields.yml
@@ -56,6 +56,8 @@
         - namespace
         - name
         - field
+    - class_name: Transformation
+      redact_fields: []
 - module: data_quality_assertions_dataset
   classes:
     - class_name: Assertion

--- a/client/python/redact_fields.yml
+++ b/client/python/redact_fields.yml
@@ -57,7 +57,10 @@
         - name
         - field
     - class_name: Transformation
-      redact_fields: []
+      redact_fields:
+        - type
+        - subtype
+        - masking
 - module: data_quality_assertions_dataset
   classes:
     - class_name: Assertion

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openlineage.io/spec/facets/1-0-2/ColumnLineageDatasetFacet.json",
+  "$id": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json",
   "$defs": {
     "ColumnLineageDatasetFacet": {
       "allOf": [
@@ -32,6 +32,32 @@
                         "field": {
                           "type": "string",
                           "description": "The input field"
+                        },
+                        "transformations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "description": "The type of the transformation. Allowed values are: IDENTITY, TRANSFORMED, INDIRECT",
+                                "type": "string"
+                              },
+                              "subtype": {
+                                "type": "string",
+                                "description": "The subtype of the transformation"
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "a string representation of the transformation applied"
+                              },
+                              "masking": {
+                                "type": "boolean",
+                                "description": "is transformation masking the data or not"
+                              }
+                            }
+                          },
+                          "additionalProperties": true,
+                          "required": ["type"]
                         }
                       },
                       "additionalProperties": true,

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -54,10 +54,10 @@
                                 "type": "boolean",
                                 "description": "is transformation masking the data or not"
                               }
-                            }
-                          },
-                          "additionalProperties": true,
-                          "required": ["type"]
+                            },
+                            "required": ["type"],
+                            "additionalProperties": true
+                          }
                         }
                       },
                       "additionalProperties": true,

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -66,11 +66,13 @@
                   },
                   "transformationDescription": {
                     "type": "string",
-                    "description": "DEPRECATED; a string representation of the transformation applied"
+                    "description": "a string representation of the transformation applied",
+                    "deprecated": true
                   },
                   "transformationType": {
                     "type": "string",
-                    "description": "DEPRECATED; IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no original data available (like a hash of PII for example)"
+                    "description": "IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no original data available (like a hash of PII for example)",
+                    "deprecated": true
                   }
                 },
                 "additionalProperties": true,

--- a/spec/facets/ColumnLineageDatasetFacet.json
+++ b/spec/facets/ColumnLineageDatasetFacet.json
@@ -39,7 +39,7 @@
                             "type": "object",
                             "properties": {
                               "type": {
-                                "description": "The type of the transformation. Allowed values are: IDENTITY, TRANSFORMED, INDIRECT",
+                                "description": "The type of the transformation. Allowed values are: DIRECT, INDIRECT",
                                 "type": "string"
                               },
                               "subtype": {
@@ -66,11 +66,11 @@
                   },
                   "transformationDescription": {
                     "type": "string",
-                    "description": "a string representation of the transformation applied"
+                    "description": "DEPRECATED; a string representation of the transformation applied"
                   },
                   "transformationType": {
                     "type": "string",
-                    "description": "IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no original data available (like a hash of PII for example)"
+                    "description": "DEPRECATED; IDENTITY|MASKED reflects a clearly defined behavior. IDENTITY: exact same as input; MASKED: no original data available (like a hash of PII for example)"
                   }
                 },
                 "additionalProperties": true,


### PR DESCRIPTION
### Problem

The tranformation type information inside ColumnLineageDatasetFacet is not very useful in its current state. Because of its place in the facet it can only describe one transformation type per output field and that doesn't cover indirect dependencies and some cases of direct dependencies.

Closes: #2186 and #2187 

### Solution
Make transformation type more verbose and change granularity by creating object `transports` inside `inputFields` which contains information about type, subtype, description and masking of the transformation. That way each input field can have multiple direct and indirect transformations linked to it

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [X] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:



### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [X] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project