### PR TITLE
Spark: Fix Hive metastore namespace

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
@@ -15,6 +15,7 @@ import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
 import java.net.URI;
 import java.util.List;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -35,7 +36,9 @@ class CreateTableCommandVisitorTest {
 
   @BeforeEach
   public void setup() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
     command = new CreateTableCommand(CatalogTableTestUtils.getCatalogTable(table), true);
     visitor = new CreateTableCommandVisitor(SparkAgentTestExtension.newContext(session));
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
@@ -108,7 +109,9 @@ class KustoRelationVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
     when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddColumnsCommandVisitor.java
@@ -29,7 +29,7 @@ public class AlterTableAddColumnsCommandVisitor
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     Optional<CatalogTable> tableOption = catalogTableFor(((AlterTableAddColumnsCommand) x).table());
-    if (!tableOption.isPresent()) {
+    if (!tableOption.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
     CatalogTable catalogTable = tableOption.get();
@@ -41,7 +41,9 @@ public class AlterTableAddColumnsCommandVisitor
     if (tableColumns.containsAll(addedColumns)) {
       return Collections.singletonList(
           outputDataset()
-              .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+              .getDataset(
+                  PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
+                  catalogTable.schema()));
     } else {
       // apply triggered before applying the change - do not send an event
       return Collections.emptyList();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableAddPartitionCommandVisitor.java
@@ -30,7 +30,7 @@ public class AlterTableAddPartitionCommandVisitor
     Optional<CatalogTable> tableOption =
         catalogTableFor(((AlterTableAddPartitionCommand) x).tableName());
 
-    if (!tableOption.isPresent()) {
+    if (!tableOption.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
 
@@ -39,6 +39,8 @@ public class AlterTableAddPartitionCommandVisitor
     // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
-            .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+            .getDataset(
+                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
+                catalogTable.schema()));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -33,12 +33,12 @@ public class AlterTableRenameCommandVisitor
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
     Optional<CatalogTable> tableOpt = catalogTableFor(((AlterTableRenameCommand) x).newName());
-    if (!tableOpt.isPresent()) {
+    if (!tableOpt.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
     CatalogTable table = tableOpt.get();
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(table);
+    DatasetIdentifier di = PathUtils.fromCatalogTable(table, context.getSparkSession().get());
 
     AlterTableRenameCommand alterTableRenameCommand = (AlterTableRenameCommand) x;
     String previousName =

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitor.java
@@ -30,7 +30,7 @@ public class AlterTableSetLocationCommandVisitor
     Optional<CatalogTable> tableOption =
         catalogTableFor(((AlterTableSetLocationCommand) x).tableName());
 
-    if (!tableOption.isPresent()) {
+    if (!tableOption.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
 
@@ -39,6 +39,8 @@ public class AlterTableSetLocationCommandVisitor
     // The generated datasets will not include partition nor location information
     return Collections.singletonList(
         outputDataset()
-            .getDataset(PathUtils.fromCatalogTable(catalogTable), catalogTable.schema()));
+            .getDataset(
+                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
+                catalogTable.schema()));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitor.java
@@ -30,6 +30,10 @@ public class CreateDataSourceTableAsSelectCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     CreateDataSourceTableAsSelectCommand command = (CreateDataSourceTableAsSelectCommand) x;
     CatalogTable catalogTable = command.table();
 
@@ -41,7 +45,7 @@ public class CreateDataSourceTableAsSelectCommandVisitor
     return Collections.singletonList(
         outputDataset()
             .getDataset(
-                PathUtils.fromCatalogTable(catalogTable),
+                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
                 schema,
                 OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE));
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateDataSourceTableCommandVisitor.java
@@ -29,13 +29,17 @@ public class CreateDataSourceTableCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     CreateDataSourceTableCommand command = (CreateDataSourceTableCommand) x;
     CatalogTable catalogTable = command.table();
 
     return Collections.singletonList(
         outputDataset()
             .getDataset(
-                PathUtils.fromCatalogTable(catalogTable),
+                PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get()),
                 catalogTable.schema(),
                 OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE));
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitor.java
@@ -36,9 +36,13 @@ public class CreateHiveTableAsSelectCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     CreateHiveTableAsSelectCommand command = (CreateHiveTableAsSelectCommand) x;
     CatalogTable table = command.tableDesc();
-    DatasetIdentifier di = PathUtils.fromCatalogTable(table);
+    DatasetIdentifier di = PathUtils.fromCatalogTable(table, context.getSparkSession().get());
 
     // zip query outputs with attribute names
     LogicalPlan query = command.query();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/HiveTableRelationVisitor.java
@@ -35,8 +35,13 @@ public class HiveTableRelationVisitor<D extends Dataset>
 
   @Override
   public List<D> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     HiveTableRelation hiveTable = (HiveTableRelation) x;
-    DatasetIdentifier datasetId = PathUtils.fromCatalogTable(hiveTable.tableMeta());
+    DatasetIdentifier datasetId =
+        PathUtils.fromCatalogTable(hiveTable.tableMeta(), context.getSparkSession().get());
     return Collections.singletonList(factory.getDataset(datasetId, x.schema()));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LoadDataCommandVisitor.java
@@ -30,12 +30,19 @@ public class LoadDataCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     LoadDataCommand command = (LoadDataCommand) x;
     return catalogTableFor(command.table())
         .map(
             table ->
                 Collections.singletonList(
-                    outputDataset().getDataset(PathUtils.fromCatalogTable(table), table.schema())))
+                    outputDataset()
+                        .getDataset(
+                            PathUtils.fromCatalogTable(table, context.getSparkSession().get()),
+                            table.schema())))
         .orElseGet(Collections::emptyList);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -120,9 +120,14 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
   }
 
   private List<D> handleCatalogTable(LogicalRelation logRel) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     CatalogTable catalogTable = logRel.catalogTable().get();
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable);
+    DatasetIdentifier di =
+        PathUtils.fromCatalogTable(catalogTable, context.getSparkSession().get());
 
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         context.getOpenLineage().newDatasetFacetsBuilder();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitor.java
@@ -52,9 +52,14 @@ public class OptimizedCreateHiveTableAsSelectCommandVisitor
 
   @Override
   public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+    if (!context.getSparkSession().isPresent()) {
+      return Collections.emptyList();
+    }
+
     OptimizedCreateHiveTableAsSelectCommand command = (OptimizedCreateHiveTableAsSelectCommand) x;
     CatalogTable table = command.tableDesc();
-    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
+    DatasetIdentifier datasetIdentifier =
+        PathUtils.fromCatalogTable(table, context.getSparkSession().get());
     StructType schema = outputSchema(ScalaConversionUtils.fromSeq(command.outputColumns()));
 
     OpenLineage.OutputDataset outputDataset;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -38,42 +38,42 @@ public class TruncateTableCommandVisitor
     TruncateTableCommand command = (TruncateTableCommand) x;
 
     Optional<CatalogTable> tableOpt = catalogTableFor(command.tableName());
-    if (tableOpt.isPresent()) {
-      CatalogTable table = tableOpt.get();
-      DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
-
-      DatasetFactory<OutputDataset> datasetFactory = outputDataset();
-      return Collections.singletonList(
-          datasetFactory.getDataset(
-              datasetIdentifier,
-              new OpenLineage.DatasetFacetsBuilder()
-                  .schema(null)
-                  .dataSource(
-                      PlanUtils.datasourceFacet(
-                          context.getOpenLineage(), datasetIdentifier.getNamespace()))
-                  .lifecycleStateChange(
-                      context
-                          .getOpenLineage()
-                          .newLifecycleStateChangeDatasetFacet(
-                              OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                                  .TRUNCATE,
-                              null))));
-
-    } else {
-      // table does not exist, cannot prepare an event
+    if (!tableOpt.isPresent() || !context.getSparkSession().isPresent()) {
       return Collections.emptyList();
     }
+
+    CatalogTable table = tableOpt.get();
+    DatasetIdentifier datasetIdentifier =
+        PathUtils.fromCatalogTable(table, context.getSparkSession().get());
+
+    DatasetFactory<OutputDataset> datasetFactory = outputDataset();
+    return Collections.singletonList(
+        datasetFactory.getDataset(
+            datasetIdentifier,
+            new OpenLineage.DatasetFacetsBuilder()
+                .schema(null)
+                .dataSource(
+                    PlanUtils.datasourceFacet(
+                        context.getOpenLineage(), datasetIdentifier.getNamespace()))
+                .lifecycleStateChange(
+                    context
+                        .getOpenLineage()
+                        .newLifecycleStateChangeDatasetFacet(
+                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
+                                .TRUNCATE,
+                            null))));
   }
 
   @Override
   public Optional<String> jobNameSuffix(TruncateTableCommand command) {
     Optional<CatalogTable> tableOpt = catalogTableFor(command.tableName());
-    if (tableOpt.isPresent()) {
-      CatalogTable table = tableOpt.get();
-      DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(table);
-      return Optional.of(trimPath(datasetIdentifier.getName()));
+    if (!tableOpt.isPresent() || !context.getSparkSession().isPresent()) {
+      return Optional.empty();
     }
 
-    return Optional.empty();
+    CatalogTable table = tableOpt.get();
+    DatasetIdentifier datasetIdentifier =
+        PathUtils.fromCatalogTable(table, context.getSparkSession().get());
+    return Optional.of(trimPath(datasetIdentifier.getName()));
   }
 }

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
@@ -45,7 +46,9 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
   }
 
   @Test

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier$;
@@ -41,7 +42,9 @@ class CreateDataSourceTableCommandVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
   }
 
   @Test

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.Partition;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
@@ -57,7 +58,9 @@ class CreateHiveTableAsSelectCommandVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
   }
 
   @Test

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
 import lombok.SneakyThrows;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalog.Catalog;
@@ -57,7 +58,9 @@ class CreateTableLikeCommandVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
     when(session.catalog()).thenReturn(catalog);
     when(catalog.currentDatabase()).thenReturn("default");
     when(session.sessionState()).thenReturn(sessionState);

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.spark.Partition;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
@@ -57,7 +58,9 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
 
   @BeforeEach
   public void setUp() {
-    when(session.sparkContext()).thenReturn(mock(SparkContext.class));
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(session.sparkContext()).thenReturn(sparkContext);
   }
 
   @Test

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -126,7 +126,7 @@ public class IcebergHandler implements CatalogHandler {
     URI uri;
     if (confUri == null) {
       uri =
-          SparkConfUtils.getMetastoreUri(session.sparkContext().conf())
+          SparkConfUtils.getMetastoreUri(session.sparkContext())
               .orElseThrow(() -> new UnsupportedCatalogException("hive"));
     } else {
       uri = new URI(confUri);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -118,7 +118,7 @@ class LogicalRelationDatasetBuilderTest {
 
     try (MockedStatic pathUtils = mockStatic(PathUtils.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PathUtils.fromCatalogTable(catalogTable)).thenReturn(di);
+        when(PathUtils.fromCatalogTable(catalogTable, session)).thenReturn(di);
         when(DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(logicalRelation))
             .thenReturn(Optional.of(SOME_VERSION));
         when(logicalRelation.schema()).thenReturn(schema);


### PR DESCRIPTION
### Problem

Reading keys like `spark.hadoop.*` from SparkConf returns the value only if some Hadoop configuration option was set via Spark config. But if option was set using Hadoop config files, e.g. `$SPARK_CONF_DIR/core-site.xml` or `$SPARK_CONF_DIR/hive-site.xml`, Spark config will not contain such keys at all. This may result to producing wrong Hive metastore URL.

Closes: #2708

### Solution

Instead of reading `spark.hadoop.*` keys from SparkConf, read them from Hadoop's Configuration class (without prefix).

Before:
![изображение](https://github.com/OpenLineage/OpenLineage/assets/4661021/f6a759d8-2832-4ac3-a0fb-71d92a8e9aa6)

After:
![изображение](https://github.com/OpenLineage/OpenLineage/assets/4661021/4f9d0eda-99b7-4385-b0e8-004b27c10a98)

#### One-line summary:

Fix dataset namespace for case then Hive metastore URL is set using `$SPARK_CONF_DIR/hive-site.xml` file.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project