### PR TITLE
Spark: fix Glue naming format

### DIFF
--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -169,18 +169,18 @@ class PathUtilsTest {
     TableIdentifier tableIdentifier = mock(TableIdentifier.class);
     when(catalogTable.identifier()).thenReturn(tableIdentifier);
     when(tableIdentifier.database()).thenReturn(Option.apply("database"));
-    when(tableIdentifier.table()).thenReturn("table");
+    when(tableIdentifier.table()).thenReturn("mytable");
     when(catalogStorageFormat.locationUri())
-        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/table")));
+        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
 
     DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
     assertThat(datasetIdentifier)
-        .hasFieldOrPropertyWithValue("name", "warehouse/table")
+        .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
         .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
     assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
     assertThat(datasetIdentifier.getSymlinks().get(0))
-        .hasFieldOrPropertyWithValue("name", "database.table")
-        .hasFieldOrPropertyWithValue("namespace", "aws:glue:us-west-2:123456789")
+        .hasFieldOrPropertyWithValue("name", "table/database/mytable")
+        .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-west-2:123456789")
         .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 


### PR DESCRIPTION
### Problem
Closes: #2765

### Solution

Change namespace format from `aws:glue:{region_id}:{account_id}` to `arn:aws:glue:{regionId}:{accountId}`, and also change name format from `{db}.{table}` to `table/{db}/{table}`. This matches [Glue ARN](https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html) documentation.

#### One-line summary:

Change AWS Glue namespace to match Glue ARN documentation.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project