### PR TITLE
Spark: fallback to spark.sql.warehouse.dir as table namespace

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtils.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.filesystem;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
+import lombok.SneakyThrows;
 
 public class FilesystemDatasetUtils {
   private static final FilesystemDatasetExtractor[] extractors = {
@@ -46,5 +47,30 @@ public class FilesystemDatasetUtils {
   public static DatasetIdentifier fromLocationAndName(URI location, String name) {
     FilesystemDatasetExtractor extractor = getExtractor(location);
     return extractor.extract(location, name);
+  }
+
+  /**
+   * Get URI from DatasetIdentifier
+   *
+   * @param di dataset identifier
+   * @return URI
+   */
+  @SneakyThrows
+  public static URI toLocation(DatasetIdentifier di) {
+    String namespace = di.getNamespace();
+    if (!namespace.contains(":/")) {
+      // 'file'
+      namespace = namespace + ":/";
+    }
+    String name = di.getName();
+    if ("/".equals(name)) {
+      return new URI(namespace);
+    }
+
+    String location =
+        FilesystemUriSanitizer.removeLastSlash(namespace)
+            + "/"
+            + FilesystemUriSanitizer.removeFirstSlash(name);
+    return new URI(location);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForGCS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForGCS.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class FilesystemDatasetUtilsTestForGCS {
 
   @Test
   @SneakyThrows
-  void testfromLocationAndName() {
+  void testFromLocationAndName() {
     assertThat(
             FilesystemDatasetUtils.fromLocationAndName(
                 new URI("gs://bucket/warehouse"), "default.table"))
@@ -50,5 +51,25 @@ class FilesystemDatasetUtilsTestForGCS {
     assertThat(FilesystemDatasetUtils.fromLocationAndName(new URI("gs://bucket/warehouse"), ""))
         .hasFieldOrPropertyWithValue("namespace", "gs://bucket/warehouse")
         .hasFieldOrPropertyWithValue("name", "/");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/", "gs://bucket")))
+        .isEqualTo(new URI("gs://bucket"));
+
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("warehouse", "gs://bucket")))
+        .isEqualTo(new URI("gs://bucket/warehouse"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("warehouse/location", "gs://bucket")))
+        .isEqualTo(new URI("gs://bucket/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("default.table", "gs://bucket/warehouse/location")))
+        .isEqualTo(new URI("gs://bucket/warehouse/location/default.table"));
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForHDFS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForHDFS.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ class FilesystemDatasetUtilsTestForHDFS {
 
   @Test
   @SneakyThrows
-  void testfromLocationAndName() {
+  void testFromLocationAndName() {
     assertThat(
             FilesystemDatasetUtils.fromLocationAndName(
                 new URI("hdfs://namenode:8020/warehouse"), "default.table"))
@@ -55,5 +56,28 @@ class FilesystemDatasetUtilsTestForHDFS {
                 new URI("hdfs://namenode:8020/warehouse"), ""))
         .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020/warehouse")
         .hasFieldOrPropertyWithValue("name", "/");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(
+            FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/", "hdfs://namenode:8020")))
+        .isEqualTo(new URI("hdfs://namenode:8020"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("/warehouse", "hdfs://namenode:8020")))
+        .isEqualTo(new URI("hdfs://namenode:8020/warehouse"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("/warehouse/location", "hdfs://namenode:8020")))
+        .isEqualTo(new URI("hdfs://namenode:8020/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("default.table", "hdfs://namenode:8020/warehouse/location")))
+        .isEqualTo(new URI("hdfs://namenode:8020/warehouse/location/default.table"));
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForLocal.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForLocal.java
@@ -8,6 +8,7 @@ package io.openlineage.client.utils.filesystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ class FilesystemDatasetUtilsTestForLocal {
 
   @Test
   @SneakyThrows
-  void testfromLocationAndName() {
+  void testFromLocationAndName() {
     assertThat(FilesystemDatasetUtils.fromLocationAndName(new URI(""), "default.table"))
         .hasFieldOrPropertyWithValue("namespace", "file")
         .hasFieldOrPropertyWithValue("name", "default.table");
@@ -118,5 +119,21 @@ class FilesystemDatasetUtilsTestForLocal {
     assertThat(FilesystemDatasetUtils.fromLocationAndName(uri, "default.table"))
         .hasFieldOrPropertyWithValue("namespace", "file:C:/home/test")
         .hasFieldOrPropertyWithValue("name", "default.table");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/", "file")))
+        .isEqualTo(new URI("file:/"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/warehouse/location", "file")))
+        .isEqualTo(new URI("file:/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("default.table", "file:/warehouse/location")))
+        .isEqualTo(new URI("file:/warehouse/location/default.table"));
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForS3.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForS3.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class FilesystemDatasetUtilsTestForS3 {
 
   @Test
   @SneakyThrows
-  void testfromLocationAndName() {
+  void testFromLocationAndName() {
     assertThat(
             FilesystemDatasetUtils.fromLocationAndName(
                 new URI("s3://bucket/warehouse"), "default.table"))
@@ -78,5 +79,25 @@ class FilesystemDatasetUtilsTestForS3 {
                 new URI("s3n://bucket/warehouse/location"), "default.table"))
         .hasFieldOrPropertyWithValue("namespace", "s3://bucket/warehouse/location")
         .hasFieldOrPropertyWithValue("name", "default.table");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/", "s3://bucket")))
+        .isEqualTo(new URI("s3://bucket"));
+
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("warehouse", "s3://bucket")))
+        .isEqualTo(new URI("s3://bucket/warehouse"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("warehouse/location", "s3://bucket")))
+        .isEqualTo(new URI("s3://bucket/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("default.table", "s3://bucket/warehouse/location")))
+        .isEqualTo(new URI("s3://bucket/warehouse/location/default.table"));
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForWASBS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForWASBS.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.filesystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ class FilesystemDatasetUtilsTestForWASBS {
 
   @Test
   @SneakyThrows
-  void testfromLocationAndName() {
+  void testFromLocationAndName() {
     assertThat(
             FilesystemDatasetUtils.fromLocationAndName(
                 new URI("wasbs://container@bucket/warehouse"), "default.table"))
@@ -56,5 +57,30 @@ class FilesystemDatasetUtilsTestForWASBS {
                 new URI("wasbs://container@bucket/warehouse"), ""))
         .hasFieldOrPropertyWithValue("namespace", "wasbs://container@bucket/warehouse")
         .hasFieldOrPropertyWithValue("name", "/");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("/", "wasbs://container@bucket")))
+        .isEqualTo(new URI("wasbs://container@bucket"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("warehouse", "wasbs://container@bucket")))
+        .isEqualTo(new URI("wasbs://container@bucket/warehouse"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("warehouse/location", "wasbs://container@bucket")))
+        .isEqualTo(new URI("wasbs://container@bucket/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier(
+                    "default.table", "wasbs://container@bucket/warehouse/location")))
+        .isEqualTo(new URI("wasbs://container@bucket/warehouse/location/default.table"));
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -206,7 +206,6 @@ public class SparkContainerUtils {
     addSparkConfig(sparkConf, "spark.sql.warehouse.dir=/tmp/warehouse");
     addSparkConfig(sparkConf, "spark.sql.shuffle.partitions=1");
     addSparkConfig(sparkConf, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-    addSparkConfig(sparkConf, "spark.sql.warehouse.dir=/tmp/warehouse");
     addSparkConfig(sparkConf, "spark.jars.ivy=/tmp/.ivy2/");
     addSparkConfig(sparkConf, "spark.openlineage.facets.disabled=");
     addSparkConfig(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -175,9 +175,10 @@ class SparkScalaContainerTest {
                       .map(r -> r.getBodyAsString())
                       .map(event -> OpenLineageClientUtils.runEventFromJson(event))
                       .collect(Collectors.toList());
-              RunEvent lastEvent = events.get(events.size() - 2);
 
               assertThat(events).isNotEmpty();
+
+              RunEvent lastEvent = events.get(events.size() - 2);
               assertThat(lastEvent.getOutputs().get(0))
                   .hasFieldOrPropertyWithValue("namespace", "file")
                   .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableSetLocationCommandVisitorTest.java
@@ -6,7 +6,6 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
@@ -79,12 +78,13 @@ class AlterTableSetLocationCommandVisitorTest {
 
     assertThat(visitor.isDefinedAt(command)).isTrue();
     List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
-    assertEquals(1, datasets.get(0).getFacets().getSchema().getFields().size());
-    assertThat(datasets.get(0).getFacets().getSymlinks().getIdentifiers().get(0).getName())
-        .endsWith("default.table1");
     assertThat(datasets)
         .singleElement()
         .hasFieldOrPropertyWithValue("name", "/tmp/dir")
         .hasFieldOrPropertyWithValue("namespace", "file");
+
+    assertThat(datasets.get(0).getFacets().getSchema().getFields()).hasSize(1);
+    // custom location, no metastore -> no symlinks
+    assertThat(datasets.get(0).getFacets().getSymlinks()).isNull();
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -5,15 +5,14 @@
 
 package io.openlineage.spark.agent.util;
 
+import static io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -25,145 +24,135 @@ import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
 import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.apache.spark.sql.internal.SessionState;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
-import org.mockito.MockedStatic;
 import scala.Option;
-import scala.Some;
-import scala.Tuple2;
 
 @Slf4j
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PathUtilsTest {
 
-  private static final String HOME_TEST = "/home/test";
-  private static final String SCHEME = "scheme";
-  private static final String FILE = "file";
-  private static final String TABLE = "table";
-
-  SparkSession sparkSession = mock(SparkSession.class);
-  SparkContext sparkContext = mock(SparkContext.class);
-  SparkConf sparkConf = new SparkConf();
-  Configuration hadoopConf = new Configuration();
-  CatalogTable catalogTable = mock(CatalogTable.class);
-  CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
+  SparkSession sparkSession;
+  SparkContext sparkContext;
+  SparkConf sparkConf;
+  Configuration hadoopConf;
+  CatalogTable catalogTable;
+  CatalogStorageFormat catalogStorageFormat;
+  SessionState sessionState;
+  SessionCatalog sessionCatalog;
 
   @BeforeEach
   void setConf() {
+    sparkSession = mock(SparkSession.class);
+    sparkContext = mock(SparkContext.class);
+    sparkConf = new SparkConf();
+    hadoopConf = new Configuration();
+    catalogTable = mock(CatalogTable.class);
+    catalogStorageFormat = mock(CatalogStorageFormat.class);
+    sessionState = mock(SessionState.class);
+    sessionCatalog = mock(SessionCatalog.class);
+
     when(sparkContext.getConf()).thenReturn(sparkConf);
-    when(sparkSession.sparkContext()).thenReturn(sparkContext);
     when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
-  }
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
 
-  @AfterEach
-  void clearConf() {
-    Tuple2<String, String>[] configuration = sparkConf.getAll();
-    Arrays.stream(configuration).forEach(tuple -> sparkConf.remove(tuple._1()));
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    when(catalogTable.provider()).thenReturn(Option.empty());
 
-    hadoopConf.clear();
-  }
-
-  @Test
-  void testPathSeparation() {
-    Path path = new Path("scheme:/asdf/fdsa");
-    assertThat(path.toUri().getScheme()).isEqualTo(SCHEME);
-    assertThat(path.toUri().getAuthority()).isNull();
-    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
-
-    path = new Path("scheme://asdf/fdsa");
-    assertThat(path.toUri().getScheme()).isEqualTo(SCHEME);
-    assertThat(path.toUri().getAuthority()).isEqualTo("asdf");
-    assertThat(path.toUri().getPath()).isEqualTo("/fdsa");
-  }
-
-  @Test
-  void testPathSeparationWithNullAuthority() {
-    Path path = new Path("scheme:///asdf/fdsa");
-    assertThat(path.toUri().getScheme()).isEqualTo(SCHEME);
-    assertThat(path.toUri().getAuthority()).isNull();
-    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
-
-    path = new Path("scheme:////asdf/fdsa");
-    assertThat(path.toUri().getScheme()).isEqualTo(SCHEME);
-    assertThat(path.toUri().getAuthority()).isNull();
-    assertThat(path.toUri().getPath()).isEqualTo("/asdf/fdsa");
+    when(sparkSession.sessionState()).thenReturn(sessionState);
+    when(sessionState.catalog()).thenReturn(sessionCatalog);
   }
 
   @Test
   void testFromPathWithoutSchema() {
-    DatasetIdentifier di = PathUtils.fromPath(new Path(HOME_TEST));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo(FILE);
+    assertThat(PathUtils.fromPath(new Path("/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
 
-    di = PathUtils.fromPath(new Path("home/test"));
-    assertThat(di.getName()).isEqualTo("home/test");
-    assertThat(di.getNamespace()).isEqualTo(FILE);
+    assertThat(PathUtils.fromPath(new Path("home/test")))
+        .hasFieldOrPropertyWithValue("name", "home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
   }
 
   @Test
   void testFromPathWithSchema() {
-    DatasetIdentifier di = PathUtils.fromPath(new Path("file:/home/test"));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo(FILE);
+    assertThat(PathUtils.fromPath(new Path("file:/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
 
-    di = PathUtils.fromPath(new Path("hdfs://namenode:8020/home/test"));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo("hdfs://namenode:8020");
+    assertThat(PathUtils.fromPath(new Path("hdfs://namenode:8020/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020");
   }
 
   @Test
   void testFromURI() throws URISyntaxException {
-    DatasetIdentifier di = PathUtils.fromURI(new URI("file:///home/test"));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo(FILE);
+    assertThat(PathUtils.fromURI(new URI("/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
 
-    di = PathUtils.fromURI(new URI(null, null, HOME_TEST, null));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo(FILE);
+    assertThat(PathUtils.fromURI(new URI("file:///home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
 
-    di = PathUtils.fromURI(new URI("hdfs", null, "localhost", 8020, HOME_TEST, null, null));
-    assertThat(di.getName()).isEqualTo(HOME_TEST);
-    assertThat(di.getNamespace()).isEqualTo("hdfs://localhost:8020");
+    assertThat(PathUtils.fromURI(new URI("hdfs://localhost:8020/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://localhost:8020");
 
-    di = PathUtils.fromURI(new URI("s3://data-bucket/path"));
-    assertThat(di.getName()).isEqualTo("path");
-    assertThat(di.getNamespace()).isEqualTo("s3://data-bucket");
+    assertThat(PathUtils.fromURI(new URI("s3://data-bucket/home/test")))
+        .hasFieldOrPropertyWithValue("name", "home/test")
+        .hasFieldOrPropertyWithValue("namespace", "s3://data-bucket");
 
-    di = PathUtils.fromURI(new URI("gs://gs-bucket/test.csv"));
-    assertThat(di.getName()).isEqualTo("test.csv");
-    assertThat(di.getNamespace()).isEqualTo("gs://gs-bucket");
+    assertThat(PathUtils.fromURI(new URI("gs://gs-bucket/test.csv")))
+        .hasFieldOrPropertyWithValue("name", "test.csv")
+        .hasFieldOrPropertyWithValue("namespace", "gs://gs-bucket");
   }
 
   @Test
-  void testFromCatalogTableWithStorage() throws URISyntaxException {
+  void testFromCatalogTableWithHiveMetastore() throws URISyntaxException {
     sparkConf.set("spark.sql.catalogImplementation", "hive");
     sparkConf.set("spark.sql.hive.metastore.uris", "thrift://10.1.0.1:9083");
-    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
-    when(catalogTable.identifier()).thenReturn(TableIdentifier.apply(TABLE));
-    when(catalogStorageFormat.locationUri()).thenReturn(Option.apply(new URI("/tmp/warehouse")));
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("table");
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(Option.apply(new URI("/tmp/warehouse/database.db/table")));
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getName()).isEqualTo("/tmp/warehouse");
-    assertThat(di.getNamespace()).isEqualTo("file");
-    assertThat(di.getSymlinks()).hasSize(1);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://10.1.0.1:9083");
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "hive://10.1.0.1:9083")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
 
     sparkConf.set(
         "spark.sql.hive.metastore.uris", "anotherprotocol://127.0.0.1:1010,yetanother://something");
-    di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://127.0.0.1:1010");
+    datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "hive://127.0.0.1:1010")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
 
     sparkConf.remove("spark.sql.hive.metastore.uris");
-
-    hadoopConf.set("hive.metastore.uris", "thrift://10.1.0.1:9083");
-    di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hive://10.1.0.1:9083");
+    hadoopConf.set("hive.metastore.uris", "thrift://10.1.0.1:9084");
+    datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "hive://10.1.0.1:9084")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 
   @Test
@@ -174,173 +163,100 @@ class PathUtilsTest {
         "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
     sparkConf.set("spark.sql.catalogImplementation", "hive");
     sparkConf.set("spark.glue.accountId", "123456789");
-    when(sparkContext.getConf()).thenReturn(sparkConf);
-    when(sparkSession.sparkContext()).thenReturn(sparkContext);
 
     when(catalogTable.provider()).thenReturn(Option.apply("hive"));
     when(catalogTable.storage()).thenReturn(catalogStorageFormat);
-    when(catalogTable.identifier()).thenReturn(TableIdentifier.apply(TABLE));
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("table");
     when(catalogStorageFormat.locationUri())
-        .thenReturn(Option.apply(new URI("s3://bucket/directory")));
+        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/table")));
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getName()).isEqualTo("directory");
-    assertThat(di.getNamespace()).isEqualTo("s3://bucket");
-    assertThat(di.getSymlinks()).hasSize(1);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo(TABLE);
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("aws:glue:us-west-2:123456789");
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "warehouse/table")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "aws:glue:us-west-2:123456789")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 
   @Test
   void testFromCatalogWithDefaultStorage() throws URISyntaxException {
-    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
-    when(catalogTable.provider()).thenReturn(Option.empty());
     when(catalogStorageFormat.locationUri())
-        .thenReturn(Option.apply(new URI("hdfs://namenode:8020/warehouse/table")));
+        .thenReturn(Option.apply(new URI("hdfs://namenode:8020/warehouse/database.db/table")));
+    sparkConf.set("spark.sql.warehouse.dir", "hdfs://namenode:8020/warehouse");
+
     TableIdentifier tableIdentifier = mock(TableIdentifier.class);
     when(catalogTable.identifier()).thenReturn(tableIdentifier);
-    when(tableIdentifier.database()).thenReturn(Option.apply("db"));
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
     when(tableIdentifier.table()).thenReturn("table");
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getName()).isEqualTo("/warehouse/table");
-    assertThat(di.getNamespace()).isEqualTo("hdfs://namenode:8020");
-    assertThat(di.getSymlinks()).hasSize(1);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo("db.table");
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("hdfs://namenode:8020/warehouse");
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020");
+
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020/warehouse")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+
+    sparkConf.remove("spark.sql.warehouse.dir");
+    hadoopConf.set("hive.metastore.warehouse.dir", "hdfs://namenode:8020/warehouse");
+    datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020");
+
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020/warehouse")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 
   @Test
   void testFromCatalogWithDefaultStorageAndNoWarehouse() throws URISyntaxException {
-    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
-    when(catalogTable.provider()).thenReturn(Option.empty());
-    when(catalogStorageFormat.locationUri()).thenReturn(Option.apply(new URI("s3://s3-db/table")));
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/database.db/table")));
 
     TableIdentifier tableIdentifier = mock(TableIdentifier.class);
     when(catalogTable.identifier()).thenReturn(tableIdentifier);
-    when(tableIdentifier.database()).thenReturn(Option.apply("db"));
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
     when(tableIdentifier.table()).thenReturn("table");
 
-    DatasetIdentifier di = PathUtils.fromCatalogTable(catalogTable, sparkSession);
-    assertThat(di.getName()).isEqualTo("table");
-    assertThat(di.getNamespace()).isEqualTo("s3://s3-db");
-    assertThat(di.getSymlinks()).hasSize(1);
-    assertThat(di.getSymlinks().get(0).getName()).isEqualTo("db.table");
-    assertThat(di.getSymlinks().get(0).getNamespace()).isEqualTo("s3://s3-db");
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "warehouse/database.db/table")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+
+    // without warehouse other Spark sessions can access this table only by location
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
 
-  static class FromCatalogTableShouldReturnTheCorrectScheme {
-    private final SparkConf sparkConf;
-    private final URI tableUri;
-    private final String tableName;
-    private final String databaseName;
-    private final String expectedNamespace;
-    private final String expectedName;
-    private final String expectedSymlinkNamespace;
-    private final String expectedSymlinkName;
+  @Test
+  void testFromCatalogWithDefaultStorageAndCustomLocation() throws URISyntaxException {
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(Option.apply(new URI("hdfs://namenode:8020/custom/path/table")));
+    sparkConf.set("spark.sql.warehouse.dir", "hdfs://namenode:8020/warehouse");
 
-    public FromCatalogTableShouldReturnTheCorrectScheme(
-        SparkConf sparkConf,
-        URI tableUri,
-        String tableName,
-        String databaseName,
-        String expectedNamespace,
-        String expectedName,
-        String expectedSymlinkNamespace,
-        String expectedSymlinkName) {
-      this.sparkConf = sparkConf;
-      this.tableUri = tableUri;
-      this.tableName = tableName;
-      this.databaseName = databaseName;
-      this.expectedNamespace = expectedNamespace;
-      this.expectedName = expectedName;
-      this.expectedSymlinkNamespace = expectedSymlinkNamespace;
-      this.expectedSymlinkName = expectedSymlinkName;
-    }
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("table");
 
-    public void performTest() {
-      try (MockedStatic<SparkSession> mockedStatic = mockStatic(SparkSession.class)) {
-        // Mock the dependencies
-        SparkSession sparkSession = mock(SparkSession.class);
-        SparkContext sparkContext = mock(SparkContext.class);
-        SessionState sessionState = mock(SessionState.class);
-        SessionCatalog sessionCatalog = mock(SessionCatalog.class);
-        CatalogTable catalogTable = mock(CatalogTable.class);
-        TableIdentifier tableIdentifier =
-            TableIdentifier.apply(tableName, Some.apply(databaseName));
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("name", "/custom/path/table")
+        .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020");
 
-        // **intensive sweating commences**
-        // TODO - We need to have PathUtils decide which accessor we should use
-        mockedStatic.when(SparkSession::active).thenReturn(sparkSession);
-        mockedStatic.when(SparkSession::getDefaultSession).thenReturn(Option.empty());
-        mockedStatic.when(SparkSession::getActiveSession).thenReturn(Some.apply(sparkSession));
-
-        // Mock the chain of method calls
-        when(sparkContext.getConf()).thenReturn(sparkConf);
-        when(sparkSession.sparkContext()).thenReturn(sparkContext);
-        when(sparkSession.sessionState()).thenReturn(sessionState);
-        when(sessionState.catalog()).thenReturn(sessionCatalog);
-
-        when(sessionCatalog.defaultTablePath(tableIdentifier)).thenReturn(tableUri);
-        when(catalogTable.identifier()).thenReturn(tableIdentifier);
-        when(catalogTable.provider()).thenReturn(Option.empty());
-
-        DatasetIdentifier datasetIdentifier =
-            PathUtils.fromCatalogTable(catalogTable, sparkSession);
-
-        assertThat(datasetIdentifier).isNotNull();
-        assertThat(datasetIdentifier.getNamespace()).isEqualTo(expectedNamespace);
-        assertThat(datasetIdentifier.getName()).isEqualTo(expectedName);
-        assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
-        assertThat(datasetIdentifier.getSymlinks().get(0)).isNotNull();
-        // The namespace in the symlink should be equal to the database name
-        assertThat(datasetIdentifier.getSymlinks().get(0).getNamespace())
-            .isEqualTo(expectedSymlinkNamespace);
-        // The name in the symlink should be equal to the table name
-        assertThat(datasetIdentifier.getSymlinks().get(0).getName()).isEqualTo(expectedSymlinkName);
-      }
-    }
-  }
-
-  @Nested
-  class WithHiveSupport {
-    @Test
-    @SuppressWarnings("PMD")
-    void testFromCatalogTableShouldReturnADatasetIdentifierWithTheActualScheme() {
-      SparkConf sparkConf = new SparkConf();
-      sparkConf.set("spark.sql.hive.metastore.uris", "thrift://127.0.0.1:9876");
-      sparkConf.set("spark.sql.catalogImplementation", "hive");
-      URI tableUri = URI.create("hdfs://namenode/user/hive/warehouse/foo.db/bar");
-      new FromCatalogTableShouldReturnTheCorrectScheme(
-              sparkConf,
-              tableUri,
-              "bar",
-              "foo",
-              "hdfs://namenode",
-              tableUri.getPath(),
-              "hive://127.0.0.1:9876",
-              "foo.bar")
-          .performTest();
-    }
-  }
-
-  @Nested
-  class WithoutHiveSupport {
-    @Test
-    @SuppressWarnings("PMD")
-    void testFromCatalogTableShouldReturnADatasetIdentifierWithTheActualScheme() {
-      SparkConf sparkConf = new SparkConf();
-      URI tableUri = URI.create("hdfs://namenode/user/hive/warehouse/foo.db/bar");
-      new FromCatalogTableShouldReturnTheCorrectScheme(
-              sparkConf,
-              tableUri,
-              "bar",
-              "foo",
-              "hdfs://namenode",
-              tableUri.getPath(),
-              "hdfs://namenode/user/hive/warehouse/foo.db",
-              "foo.bar")
-          .performTest();
-    }
+    // without metastore other Spark sessions can access this table only by custom location, not by
+    // name
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
 }

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -47,7 +47,9 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
   @BeforeEach
   public void setUp() {
     SparkContext sparkContext = mock(SparkContext.class);
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
+    when(sparkContext.getConf()).thenReturn(conf);
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 
@@ -66,10 +68,11 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
     CreateDataSourceTableAsSelectCommand command =
         new CreateDataSourceTableAsSelectCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.apply("database")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.apply(URI.create("s3://bucket/directory")),
+                    Option.apply(
+                        URI.create("s3://bucket/warehouse/location/database.db/tablename")),
                     null,
                     null,
                     null,
@@ -95,7 +98,7 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
     assertEquals(
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE,
         outputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
-    assertEquals("directory", outputDataset.getName());
+    assertEquals("warehouse/location/database.db/tablename", outputDataset.getName());
     assertEquals("s3://bucket", outputDataset.getNamespace());
   }
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -43,7 +43,9 @@ class CreateDataSourceTableCommandVisitorTest {
   @BeforeEach
   public void setUp() {
     SparkContext sparkContext = mock(SparkContext.class);
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
+    when(sparkContext.getConf()).thenReturn(conf);
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 
@@ -62,10 +64,11 @@ class CreateDataSourceTableCommandVisitorTest {
     CreateDataSourceTableCommand command =
         new CreateDataSourceTableCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.apply("database")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.apply(URI.create("s3://bucket/directory")),
+                    Option.apply(
+                        URI.create("s3://bucket/warehouse/location/database.db/tablename")),
                     null,
                     null,
                     null,
@@ -89,7 +92,7 @@ class CreateDataSourceTableCommandVisitorTest {
     assertEquals(
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE,
         outputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
-    assertEquals("directory", outputDataset.getName());
+    assertEquals("warehouse/location/database.db/tablename", outputDataset.getName());
     assertEquals("s3://bucket", outputDataset.getNamespace());
   }
 }

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -59,7 +59,9 @@ class CreateHiveTableAsSelectCommandVisitorTest {
   @BeforeEach
   public void setUp() {
     SparkContext sparkContext = mock(SparkContext.class);
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
+    when(sparkContext.getConf()).thenReturn(conf);
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 
@@ -78,10 +80,11 @@ class CreateHiveTableAsSelectCommandVisitorTest {
     CreateHiveTableAsSelectCommand command =
         new CreateHiveTableAsSelectCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("database")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.<URI>apply(URI.create("s3://bucket/directory")),
+                    Option.<URI>apply(
+                        URI.create("s3://bucket/warehouse/location/database.db/tablename")),
                     null,
                     null,
                     null,
@@ -148,7 +151,7 @@ class CreateHiveTableAsSelectCommandVisitorTest {
     assertEquals(
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.CREATE,
         outputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
-    assertEquals("directory", outputDataset.getName());
+    assertEquals("warehouse/location/database.db/tablename", outputDataset.getName());
     assertEquals("s3://bucket", outputDataset.getNamespace());
   }
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateTableLikeCommandVisitorTest.java
@@ -59,7 +59,9 @@ class CreateTableLikeCommandVisitorTest {
   @BeforeEach
   public void setUp() {
     SparkContext sparkContext = mock(SparkContext.class);
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.warehouse.dir", "file:/tmp/warehouse");
+    when(sparkContext.getConf()).thenReturn(conf);
     when(session.sparkContext()).thenReturn(sparkContext);
     when(session.catalog()).thenReturn(catalog);
     when(catalog.currentDatabase()).thenReturn("default");

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -59,7 +59,9 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
   @BeforeEach
   public void setUp() {
     SparkContext sparkContext = mock(SparkContext.class);
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    SparkConf conf = new SparkConf();
+    conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
+    when(sparkContext.getConf()).thenReturn(conf);
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 
@@ -78,10 +80,11 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
     OptimizedCreateHiveTableAsSelectCommand command =
         new OptimizedCreateHiveTableAsSelectCommand(
             SparkUtils.catalogTable(
-                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("db")),
+                TableIdentifier$.MODULE$.apply("tablename", Option.<String>apply("database")),
                 CatalogTableType.EXTERNAL(),
                 CatalogStorageFormat$.MODULE$.apply(
-                    Option.<URI>apply(URI.create("s3://bucket/directory")),
+                    Option.<URI>apply(
+                        URI.create("s3://bucket/warehouse/location/database.db/tablename")),
                     null,
                     null,
                     null,
@@ -148,7 +151,7 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
     assertEquals(
         OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE,
         outputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
-    assertEquals("directory", outputDataset.getName());
+    assertEquals("warehouse/location/database.db/tablename", outputDataset.getName());
     assertEquals("s3://bucket", outputDataset.getNamespace());
   }
 }


### PR DESCRIPTION
### Problem

Before swapping dataset (name+namespace=location) and symlink (name=table, namespace=metastoreUri or warehouseDir) in #2718, make value of warehouseDir consistent.

See https://github.com/OpenLineage/OpenLineage/issues/2718#issuecomment-2152697956.

### Solution

* If there is no metastore, use `spark.sql.warehouse.dir` or `hive.metastore.warehouse.dir` as symlink namespace. But only if table location matches the warehouse.
* If there is no metastore, and table has a custom location, do not create symlink at all - other Spark sessions can access such a table only using location, as it is not stored in warehouse. Previously symlink was just the same as location, but in different format.
* If table is created within custom database, symlink still points to warehouse location. Previously it included path to a database dir.
* Rewrite `PathUtilsTests`

Before:
```yaml
datasets:
  - namespace: hdfs://namenode:8020
    name: /warehouse/with/metastore/database.db/table
    facets:
      symlinks:
        - namespace: hive://metastore:port
          name: database.table
          type: TABLE

  - namespace: hdfs://namenode:8020
    name: /warehouse/without/metastore/database.db/table
    facets:
      symlinks:
        - namespace: hdfs://namehode:8020/warehouse/without/metastore/database.db
          name: database.table
          type: TABLE

  - namespace: hdfs://namenode:8020
    name: /some/custom/location
    facets:
      symlinks:
        - namespace: hdfs://namenode:8020/some/custom/location
          name: database.table
          type: TABLE
```

After:
```yaml
datasets:
  - namespace: hdfs://namenode:8020
    name: /warehouse/with/metastore/database.db/table
    facets:
      symlinks:
        - namespace: hive://metastore:port
          name: database.table
          type: TABLE

  - namespace: hdfs://namenode:8020
    name: /warehouse/without/metastore/database.db/table
    facets:
      symlinks:
        - namespace: hdfs://namehode:8020/warehouse/without/metastore  # no /database.db in the path
          name: database.table
          type: TABLE

  - namespace: hdfs://namenode:8020
    name: /some/custom/location
    # no symlinks for locations not matching warehouse
```

#### One-line summary:

In case then metastore is not used, fallback to `spark.sql.warehouse.dir` or `hive.metastore.warehouse.dir` as table namespace, instead of duplicating table's location.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project