### PR TITLE
Add log info when emitting lineage from spark (following 2650)

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -61,7 +61,10 @@ public class EventEmitter {
       this.client.emit(event);
       if (log.isDebugEnabled()) {
         log.debug(
-            "Emitting lineage completed successfully: {}", OpenLineageClientUtils.toJson(event));
+                "Emitting lineage completed successfully  with run id: {}: {}", event.getRun().getRunId(), OpenLineageClientUtils.toJson(event));
+      } else {
+        log.info(
+                "Emitting lineage completed successfully with run id: {}", event.getRun().getRunId());
       }
     } catch (OpenLineageClientException exception) {
       log.error("Could not emit lineage w/ exception", exception);


### PR DESCRIPTION
(I accidentally closed my PR [2650](https://github.com/OpenLineage/OpenLineage/pull/2650), I am resubmitting the same PR here.

Overview

This pull request introduces enhancements to logging within the Spark integration of OpenLineage. The goal is to enable clear and accessible logs that indicate whether an event has been successfully sent to the backend API.

Importance

Accurate logging is crucial for monitoring and verifying the reliability of event dispatching.

Changes Proposed

Implement additional logging statements that confirm the dispatch of events.
These logs will provide immediate feedback in the Spark execution logs, aiding in quick diagnostics and status checks by administrators and developers.
Your feedback and suggestions on this enhancement are welcome.

One-line summary:

Checklist

 [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
 [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
 [] Your changes are accompanied by tests (if relevant)
 [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
 [] You've updated any relevant documentation (if relevant)
 [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (if necessary)
 [] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (if relevant)
[] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (if relevant)