### PR TITLE
Java: repair empty dataset name in java client

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifierUtils.java
@@ -35,11 +35,14 @@ public class DatasetIdentifierUtils {
       return new DatasetIdentifier(uri.getPath(), defaultScheme);
     }
 
+    String path = uri.getPath();
     String name =
-        Optional.of(uri.getPath())
-            .map(DatasetIdentifierUtils::removeLastSlash)
-            .map(DatasetIdentifierUtils::removeFirstSlashIfSingleSlashInString)
-            .get();
+        ("/".equals(path) || path.isEmpty())
+            ? "/"
+            : Optional.of(path)
+                .map(DatasetIdentifierUtils::removeLastSlash)
+                .map(DatasetIdentifierUtils::removeFirstSlashIfSingleSlashInString)
+                .get();
 
     String namespace =
         Optional.ofNullable(uri.getAuthority())

--- a/client/java/src/test/java/io/openlineage/client/utils/DatasetIdentifierUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/DatasetIdentifierUtilsTest.java
@@ -58,6 +58,24 @@ class DatasetIdentifierUtilsTest {
   }
 
   @Test
+  void testFromURIWithRootOrEmptyPath() throws URISyntaxException {
+    URI uri1 = new URI("s3://data-bucket/");
+    assertThat(DatasetIdentifierUtils.fromURI(uri1))
+        .hasFieldOrPropertyWithValue("name", "/")
+        .hasFieldOrPropertyWithValue("namespace", "s3://data-bucket");
+
+    URI uri2 = new URI("/");
+    assertThat(DatasetIdentifierUtils.fromURI(uri2))
+        .hasFieldOrPropertyWithValue("name", "/")
+        .hasFieldOrPropertyWithValue("namespace", FILE);
+
+    URI uri3 = new URI("");
+    assertThat(DatasetIdentifierUtils.fromURI(uri3))
+        .hasFieldOrPropertyWithValue("name", "/")
+        .hasFieldOrPropertyWithValue("namespace", FILE);
+  }
+
+  @Test
   @SneakyThrows
   void testFromURIWithSchema() {
     URI uri = new URI(HOME_TEST);


### PR DESCRIPTION
Closes: #2264

#### One-line summary:
fix: Dataset name should not be empty in Java client

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project