### PR TITLE
Reduce logging from MockServer events in GCPUtilsTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   *Add transformation type extraction mechanism to spark integration*
 * **Spec: add transformation type info** [`#2756`](https://github.com/OpenLineage/OpenLineage/pull/2756) [@tnazarew](https://github.com/tnazarew)  
   *Add information about transformation type in `ColumnLineageDatasetFacet`. `transformationType` and `transformationDescription` marked deprecated*
+* **Spark: add GCP run and job facets** [`#2643`](https://github.com/OpenLineage/OpenLineage/pull/2643) [@codelixir](https://github.com/codelixir)
+  *Add `GCPRunFacetBuilder` and `GCPJobFacetBuilder` to report additional facets when running on Google Cloud Platform.*
 
 ### Fixed
 * **Spark: fix events emitted for `drop table` for Spark 3.4 and above** [`#2745`](https://github.com/OpenLineage/OpenLineage/pull/2745) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)[@savannavalgi](https://github.com/savannavalgi)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GCPUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GCPUtilsTest.java
@@ -20,8 +20,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockserver.configuration.Configuration;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.slf4j.event.Level;
 import scala.Tuple2;
 
 class GCPUtilsTest {
@@ -49,7 +51,9 @@ class GCPUtilsTest {
 
   @BeforeAll
   public static void setup() {
-    mockServer = ClientAndServer.startClientAndServer();
+    Configuration config = Configuration.configuration();
+    config.logLevel(Level.ERROR);
+    mockServer = ClientAndServer.startClientAndServer(config);
     TEST_URI = String.format("http://localhost:%s", mockServer.getPort());
   }
 


### PR DESCRIPTION
### Problem

Unnecessarily verbose logging for MockServer interactions (expectations, requests) in [GCPUtilsTest](https://github.com/OpenLineage/OpenLineage/blob/main/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/GCPUtilsTest.java#L27) class, even when tests are passing.

### Solution

Change log level to ERROR so that passing tests do not create large logs.

#### One-line summary: Reduce logging from MockServer events in GCPUtilsTest. Also updates changelog for #2643.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project