### PR TITLE
Spark/transformation type masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   *Provide command line tool capable of running Spark integration tests that can be created without Java any experience.*
 * **Spark: Support latest versions 3.4.3 and 3.5.1.** [`#2743`](https://github.com/OpenLineage/OpenLineage/pull/2743) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Upgrade CI workflows to run tests against latest Spark versions: 3.4.2 -> 3.4.3 and 3.5.0 -> 3.5.1.*
+* **Spark: add extraction of the masking property in column level lineage** [`#2789`](https://github.com/OpenLineage/OpenLineage/pull/2789) [@tnazarew](https://github.com/tnazarew)  
+  *Add extraction of the masking property during collection of dependencies for ColumnLineageDatasetFacet creation*
 
 ## [1.17.1](https://github.com/OpenLineage/OpenLineage/compare/1.16.0...1.17.1) - 2024-06-21
 ### Added

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -193,19 +193,20 @@ class ColumnLineageWithTransformationTypesTest {
     assertColumnDependsOnType(
         facet, "tat", FILE, T1_EXPECTED_NAME, "b", TransformationInfo.aggregation());
   }
+
   @Test
   void simpleQueryMasking() {
     createTable("t1", "a;int", "b;int");
     OpenLineage.ColumnLineageDatasetFacet facet =
         getFacetForQuery(
             getSchemaFacet("i;int", "t;int", "mt;string", "a;int", "ma;string"),
-            "SELECT " +
-                    "a as i, " +
-                    "a + 1 as t, " +
-                    "sha1(string(a + 1)) as mt, " +
-                    "sum(b) as a, " +
-                    "sha1(string(sum(b))) as ma " +
-                    "FROM t1 GROUP BY a");
+            "SELECT "
+                + "a as i, "
+                + "a + 1 as t, "
+                + "sha1(string(a + 1)) as mt, "
+                + "sum(b) as a, "
+                + "sha1(string(sum(b))) as ma "
+                + "FROM t1 GROUP BY a");
 
     assertColumnDependsOnType(
         facet, "i", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.identity());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -193,6 +193,31 @@ class ColumnLineageWithTransformationTypesTest {
     assertColumnDependsOnType(
         facet, "tat", FILE, T1_EXPECTED_NAME, "b", TransformationInfo.aggregation());
   }
+  @Test
+  void simpleQueryMasking() {
+    createTable("t1", "a;int", "b;int");
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        getFacetForQuery(
+            getSchemaFacet("i;int", "t;int", "mt;string", "a;int", "ma;string"),
+            "SELECT " +
+                    "a as i, " +
+                    "a + 1 as t, " +
+                    "sha1(string(a + 1)) as mt, " +
+                    "sum(b) as a, " +
+                    "sha1(string(sum(b))) as ma " +
+                    "FROM t1 GROUP BY a");
+
+    assertColumnDependsOnType(
+        facet, "i", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.identity());
+    assertColumnDependsOnType(
+        facet, "t", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.transformation());
+    assertColumnDependsOnType(
+        facet, "mt", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.transformation(true));
+    assertColumnDependsOnType(
+        facet, "a", FILE, T1_EXPECTED_NAME, "b", TransformationInfo.aggregation());
+    assertColumnDependsOnType(
+        facet, "ma", FILE, T1_EXPECTED_NAME, "b", TransformationInfo.aggregation(true));
+  }
 
   @Test
   void simpleQueryWithConditional() {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -109,8 +109,9 @@ class ColumnLineageWithTransformationTypesTest {
   @Test
   void simpleQueryOnlyIdentity() {
     createTable("t1", "a;int");
+    spark.sql("DROP TABLE IF EXISTS res");
     OpenLineage.ColumnLineageDatasetFacet facet =
-        getFacetForQuery(getSchemaFacet("a;int"), "SELECT a FROM t1");
+        getFacetForQuery(getSchemaFacet("a;int"), "CREATE TABLE res AS SELECT a FROM t1");
 
     assertColumnDependsOnType(
         facet, "a", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.identity());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -109,9 +109,8 @@ class ColumnLineageWithTransformationTypesTest {
   @Test
   void simpleQueryOnlyIdentity() {
     createTable("t1", "a;int");
-    spark.sql("DROP TABLE IF EXISTS res");
     OpenLineage.ColumnLineageDatasetFacet facet =
-        getFacetForQuery(getSchemaFacet("a;int"), "CREATE TABLE res AS SELECT a FROM t1");
+        getFacetForQuery(getSchemaFacet("a;int"), "SELECT a FROM t1");
 
     assertColumnDependsOnType(
         facet, "a", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.identity());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -138,7 +138,7 @@ class ColumnLineageWithTransformationTypesTest {
         getFacetForQuery(getSchemaFacet("a;int"), "SELECT count(a) AS a FROM t1");
 
     assertColumnDependsOnType(
-        facet, "a", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.aggregation());
+        facet, "a", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.aggregation(true));
   }
 
   @Test

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
@@ -60,7 +60,8 @@ public class TransformationInfo {
    * Method that simplifies the creation of {@link TransformationInfo} object representing {@link
    * Types#DIRECT}, {@link Subtypes#TRANSFORMATION} transformation.
    *
-   * @param isMasking - is transformation masking
+   * @param isMasking - is transformation masking e.g. {@link
+   *     org.apache.spark.sql.catalyst.expressions.Sha1}
    */
   public static TransformationInfo transformation(Boolean isMasking) {
     return new TransformationInfo(Types.DIRECT, Subtypes.TRANSFORMATION, "", isMasking);
@@ -76,7 +77,8 @@ public class TransformationInfo {
    * Method that simplifies the creation of {@link TransformationInfo} object representing {@link
    * Types#DIRECT}, {@link Subtypes#AGGREGATION} transformation.
    *
-   * @param isMasking - is transformation masking
+   * @param isMasking - is transformation masking e.g. {@link
+   *     org.apache.spark.sql.catalyst.expressions.aggregate.Count}
    */
   public static TransformationInfo aggregation(Boolean isMasking) {
     return new TransformationInfo(Types.DIRECT, Subtypes.AGGREGATION, "", isMasking);
@@ -99,7 +101,8 @@ public class TransformationInfo {
    * @param subType - the subtype of the transformation viable subtypes: {@link
    *     Subtypes#CONDITIONAL},{@link Subtypes#SORT},{@link Subtypes#GROUP_BY},{@link
    *     Subtypes#JOIN},{@link Subtypes#FILTER},
-   * @param isMasking - is transformation masking
+   * @param isMasking - is transformation masking (no indirect transformation is masking, but their
+   *     dependencies can be)
    */
   public static TransformationInfo indirect(Subtypes subType, Boolean isMasking) {
     return new TransformationInfo(Types.INDIRECT, subType, "", isMasking);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
@@ -11,6 +11,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Stores information about transformation type of the dependency between two expressions. The
+ * transformation is described by 3 attributes: type, subtype and masking. {@link
+ * TransformationInfo#type} indicate whether the transformation is direct (target value was derived
+ * from source value) or indirect (target value was influenced by source value). {@link
+ * TransformationInfo#subType} further divide the transformations. {@link
+ * TransformationInfo#masking} indicates whether the transformation obfuscated the source value
+ */
 @AllArgsConstructor
 public class TransformationInfo {
 
@@ -34,31 +42,65 @@ public class TransformationInfo {
   @Getter @Setter private Subtypes subType;
   @Getter @Setter private String description;
   @Getter @Setter private Boolean masking;
-
+  /**
+   * Method that simplifies the creation of an {@link TransformationInfo} object representing {@link
+   * Types#DIRECT}, {@link Subtypes#IDENTITY} transformation.
+   */
   public static TransformationInfo identity() {
     return new TransformationInfo(Types.DIRECT, Subtypes.IDENTITY, "", false);
   }
-
+  /**
+   * Method that simplifies the creation of an {@link TransformationInfo} object representing
+   * non-masking, {@link Types#DIRECT}, {@link Subtypes#TRANSFORMATION} transformation.
+   */
   public static TransformationInfo transformation() {
     return transformation(false);
   }
-
+  /**
+   * Method that simplifies the creation of {@link TransformationInfo} object representing {@link
+   * Types#DIRECT}, {@link Subtypes#TRANSFORMATION} transformation.
+   *
+   * @param isMasking - is transformation masking
+   */
   public static TransformationInfo transformation(Boolean isMasking) {
     return new TransformationInfo(Types.DIRECT, Subtypes.TRANSFORMATION, "", isMasking);
   }
-
+  /**
+   * Method that simplifies the creation of an {@link TransformationInfo} object representing
+   * non-masking, {@link Types#DIRECT}, {@link Subtypes#AGGREGATION} transformation.
+   */
   public static TransformationInfo aggregation() {
     return aggregation(false);
   }
-
+  /**
+   * Method that simplifies the creation of {@link TransformationInfo} object representing {@link
+   * Types#DIRECT}, {@link Subtypes#AGGREGATION} transformation.
+   *
+   * @param isMasking - is transformation masking
+   */
   public static TransformationInfo aggregation(Boolean isMasking) {
     return new TransformationInfo(Types.DIRECT, Subtypes.AGGREGATION, "", isMasking);
   }
-
+  /**
+   * Method that simplifies the creation of {@link TransformationInfo} object representing
+   * non-masking, {@link Types#INDIRECT} transformation.
+   *
+   * @param subType - the subtype of the transformation viable subtypes: {@link
+   *     Subtypes#CONDITIONAL},{@link Subtypes#SORT},{@link Subtypes#GROUP_BY},{@link
+   *     Subtypes#JOIN},{@link Subtypes#FILTER},
+   */
   public static TransformationInfo indirect(Subtypes subType) {
     return TransformationInfo.indirect(subType, false);
   }
-
+  /**
+   * Method that simplifies the creation of {@link TransformationInfo} object representing {@link
+   * Types#INDIRECT} transformation.
+   *
+   * @param subType - the subtype of the transformation viable subtypes: {@link
+   *     Subtypes#CONDITIONAL},{@link Subtypes#SORT},{@link Subtypes#GROUP_BY},{@link
+   *     Subtypes#JOIN},{@link Subtypes#FILTER},
+   * @param isMasking - is transformation masking
+   */
   public static TransformationInfo indirect(Subtypes subType, Boolean isMasking) {
     return new TransformationInfo(Types.INDIRECT, subType, "", isMasking);
   }
@@ -78,16 +120,30 @@ public class TransformationInfo {
   public int hashCode() {
     return Objects.hash(type, subType, description, masking);
   }
-
-  public TransformationInfo merge(TransformationInfo t) {
+  /**
+   * Merges current {@link TransformationInfo} with another e.g. given two dependencies with
+   * transformation types a -> b, t1 and b -> c, t2 the result of merge is transformation type for
+   * dependency a -> c
+   *
+   * <pre> Rules applied here are:
+   * 1. if current transformation is indirect, new type and subtype is taken from current
+   * 2. if current is not indirect and another is null we can't deduce result so we return null
+   * 3. if another is indirect, new type and subtype is taken from another
+   * 4. otherwise the the type and subtype are taken from the one with lower {@link Subtypes#ordinal()}
+   * 5. if any {@link TransformationInfo} has masking set to true, the result has masking set to true
+   * </pre>
+   *
+   * @param another - {@link TransformationInfo} object to be merged with
+   */
+  public TransformationInfo merge(TransformationInfo another) {
     TransformationInfo res;
-    if (this.type.equals(Types.INDIRECT)) {
+    if (Types.INDIRECT.equals(this.type)) {
       res = this;
-    } else if (t != null) {
-      if (t.type.ordinal() < this.type.ordinal()) {
-        res = t;
-      } else if (t.subType.ordinal() < this.subType.ordinal()) {
-        res = t;
+    } else if (another != null) {
+      if (Types.INDIRECT.equals(another.type)) {
+        res = another;
+      } else if (another.subType.ordinal() < this.subType.ordinal()) {
+        res = another;
       } else {
         res = this;
       }
@@ -95,7 +151,10 @@ public class TransformationInfo {
       return null;
     }
     return new TransformationInfo(
-        res.getType(), res.getSubType(), res.getDescription(), this.getMasking() || t.getMasking());
+        res.getType(),
+        res.getSubType(),
+        res.getDescription(),
+        this.getMasking() || another.getMasking());
   }
 
   public OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFieldsTransformations

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
@@ -40,15 +40,27 @@ public class TransformationInfo {
   }
 
   public static TransformationInfo transformation() {
-    return new TransformationInfo(Types.DIRECT, Subtypes.TRANSFORMATION, "", false);
+    return transformation(false);
+  }
+
+  public static TransformationInfo transformation(Boolean isMasking) {
+    return new TransformationInfo(Types.DIRECT, Subtypes.TRANSFORMATION, "", isMasking);
   }
 
   public static TransformationInfo aggregation() {
-    return new TransformationInfo(Types.DIRECT, Subtypes.AGGREGATION, "", false);
+    return aggregation(false);
+  }
+
+  public static TransformationInfo aggregation(Boolean isMasking) {
+    return new TransformationInfo(Types.DIRECT, Subtypes.AGGREGATION, "", isMasking);
   }
 
   public static TransformationInfo indirect(Subtypes subType) {
-    return new TransformationInfo(Types.INDIRECT, subType, "", false);
+    return TransformationInfo.indirect(subType, false);
+  }
+
+  public static TransformationInfo indirect(Subtypes subType, Boolean isMasking) {
+    return new TransformationInfo(Types.INDIRECT, subType, "", isMasking);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -68,7 +68,9 @@ public class ExpressionDependencyCollector {
         || expression instanceof Sha1
         || expression instanceof Sha2
         || expression instanceof XxHash64
-        || expression instanceof Count;
+        || expression instanceof Count
+        || "org.apache.spark.sql.catalyst.expressions.Mask"
+            .equals(expression.getClass().getCanonicalName()); // available since Spark 3.5.0
   }
 
   private static final List<ExpressionDependencyVisitor> expressionDependencyVisitors =

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.HiveHash;
 import org.apache.spark.sql.catalyst.expressions.If;
-
 import org.apache.spark.sql.catalyst.expressions.Md5;
 import org.apache.spark.sql.catalyst.expressions.Murmur3Hash;
 import org.apache.spark.sql.catalyst.expressions.NamedExpression;

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -365,10 +365,10 @@ class ExpressionDependencyCollectorTest {
   @Test
   void testCollectMaskingExpressions() {
     If ifExpr =
-            new If(
-                    new EqualTo((Expression) expression1, (Expression) expression2),
-                    field(NAME3, exprId3),
-                    new Sha1(field("name4", exprId4)));
+        new If(
+            new EqualTo((Expression) expression1, (Expression) expression2),
+            field(NAME3, exprId3),
+            new Sha1(field("name4", exprId4)));
 
     Alias res = alias(exprId5, "name5", ifExpr);
 
@@ -377,13 +377,14 @@ class ExpressionDependencyCollectorTest {
     ExpressionDependencyCollector.collect(context, plan);
 
     verify(builder, times(1))
-            .addDependency(
-                    exprId5, exprId1, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
+        .addDependency(
+            exprId5, exprId1, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
     verify(builder, times(1))
-            .addDependency(
-                    exprId5, exprId2, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
+        .addDependency(
+            exprId5, exprId2, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
     verify(builder, times(1)).addDependency(exprId5, exprId3, TransformationInfo.identity());
-    verify(builder, times(1)).addDependency(exprId5, exprId4, TransformationInfo.transformation(true));
+    verify(builder, times(1))
+        .addDependency(exprId5, exprId4, TransformationInfo.transformation(true));
   }
 
   @Test

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -119,7 +119,8 @@ class ExpressionDependencyCollectorTest {
 
       ExpressionDependencyCollector.collect(context, plan);
 
-      verify(builder, times(1)).addDependency(exprId5, exprId2, TransformationInfo.aggregation());
+      verify(builder, times(1))
+          .addDependency(exprId5, exprId2, TransformationInfo.aggregation(true));
       verify(builder, times(1)).addDatasetDependency(datasetDependencyExpression);
       verify(builder, times(1))
           .addDependency(

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -1,0 +1,143 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
+import io.openlineage.spark.agent.lifecycle.plan.column.TransformationInfo;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier;
+import org.apache.spark.sql.catalyst.expressions.Alias;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.EqualTo;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.If;
+import org.apache.spark.sql.catalyst.expressions.Mask;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.Project;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.Metadata$;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import scala.Option;
+import scala.collection.immutable.Seq;
+
+class ExpressionDependencyCollectorTest {
+
+  final String NAME1 = "name1";
+  final String NAME2 = "name2";
+  final String NAME3 = "name3";
+  ColumnLevelLineageBuilder builder = Mockito.mock(ColumnLevelLineageBuilder.class);
+  ColumnLevelLineageContext context = mock(ColumnLevelLineageContext.class);
+  LongAccumulator exprIdAccumulator = new LongAccumulator(Long::sum, 0L);
+  ExprId exprId1 = ExprId.apply(21);
+  ExprId exprId2 = ExprId.apply(22);
+  ExprId exprId3 = ExprId.apply(23);
+  ExprId exprId4 = ExprId.apply(24);
+  ExprId exprId5 = ExprId.apply(25);
+
+  NamedExpression expression1 = field(NAME1, exprId1);
+  NamedExpression expression2 = field(NAME2, exprId2);
+
+  @BeforeEach
+  void setup() {
+    when(context.getBuilder()).thenReturn(builder);
+    when(context.getOlContext()).thenReturn(mock(OpenLineageContext.class));
+    exprIdAccumulator.reset();
+  }
+
+  @Test
+  void testCollectMaskExpressions() {
+    If ifExpr =
+        new If(
+            new EqualTo((Expression) expression1, (Expression) expression2),
+            field(NAME3, exprId3),
+            new Mask(field("name4", exprId4)));
+
+    Alias res = alias(exprId5, "name5", ifExpr);
+
+    Project project = new Project(getNamedExpressionSeq(res), mock(LogicalPlan.class));
+    LogicalPlan plan =
+        new CreateTableAsSelect(
+            new UnresolvedIdentifier(
+                ScalaConversionUtils.fromList(Collections.singletonList("test")), false),
+            null,
+            project,
+            null,
+            null,
+            false,
+            false);
+    ExpressionDependencyCollector.collect(context, plan);
+
+    verify(builder, times(1))
+        .addDependency(
+            exprId5, exprId1, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
+    verify(builder, times(1))
+        .addDependency(
+            exprId5, exprId2, TransformationInfo.indirect(TransformationInfo.Subtypes.CONDITIONAL));
+    verify(builder, times(1)).addDependency(exprId5, exprId3, TransformationInfo.identity());
+    verify(builder, times(1))
+        .addDependency(exprId5, exprId4, TransformationInfo.transformation(true));
+  }
+
+  private static Seq<NamedExpression> getNamedExpressionSeq(NamedExpression... expressions) {
+    return ScalaConversionUtils.fromList(Arrays.stream(expressions).collect(Collectors.toList()));
+  }
+
+  private static Seq<Expression> getExpressionSeq(Expression... expressions) {
+    return ScalaConversionUtils.fromList(Arrays.stream(expressions).collect(Collectors.toList()));
+  }
+
+  @NotNull
+  private AttributeReference field(String name, ExprId exprId) {
+    return new AttributeReference(
+        name, IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId, null);
+  }
+
+  private static Alias alias(ExprId aliasExprId, String aliasName, NamedExpression child) {
+    return alias(aliasExprId, aliasName, (Expression) child);
+  }
+
+  @NotNull
+  private static Alias alias(ExprId aliasExprId, String aliasName, Expression child) {
+    return new Alias(
+        child,
+        aliasName,
+        aliasExprId,
+        ScalaConversionUtils.asScalaSeqEmpty(),
+        Option.empty(),
+        ScalaConversionUtils.asScalaSeqEmpty());
+  }
+
+  private static void mockNewExprId(LongAccumulator id, MockedStatic<NamedExpression> utilities) {
+    utilities
+        .when(NamedExpression::newExprId)
+        .thenAnswer(
+            (Answer<ExprId>)
+                invocation -> {
+                  ExprId exprId = ExprId.apply(id.get());
+                  id.accumulate(1);
+                  return exprId;
+                });
+  }
+}

--- a/integration/spark/spark35/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
+++ b/integration/spark/spark35/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollectorTest.java
@@ -36,9 +36,7 @@ import org.apache.spark.sql.types.Metadata$;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 import scala.Option;
 import scala.collection.immutable.Seq;
 
@@ -104,18 +102,10 @@ class ExpressionDependencyCollectorTest {
     return ScalaConversionUtils.fromList(Arrays.stream(expressions).collect(Collectors.toList()));
   }
 
-  private static Seq<Expression> getExpressionSeq(Expression... expressions) {
-    return ScalaConversionUtils.fromList(Arrays.stream(expressions).collect(Collectors.toList()));
-  }
-
   @NotNull
   private AttributeReference field(String name, ExprId exprId) {
     return new AttributeReference(
         name, IntegerType$.MODULE$, false, Metadata$.MODULE$.empty(), exprId, null);
-  }
-
-  private static Alias alias(ExprId aliasExprId, String aliasName, NamedExpression child) {
-    return alias(aliasExprId, aliasName, (Expression) child);
   }
 
   @NotNull
@@ -127,17 +117,5 @@ class ExpressionDependencyCollectorTest {
         ScalaConversionUtils.asScalaSeqEmpty(),
         Option.empty(),
         ScalaConversionUtils.asScalaSeqEmpty());
-  }
-
-  private static void mockNewExprId(LongAccumulator id, MockedStatic<NamedExpression> utilities) {
-    utilities
-        .when(NamedExpression::newExprId)
-        .thenAnswer(
-            (Answer<ExprId>)
-                invocation -> {
-                  ExprId exprId = ExprId.apply(id.get());
-                  id.accumulate(1);
-                  return exprId;
-                });
   }
 }


### PR DESCRIPTION
### Problem

Spark integration doesn't have a mechanism to extract information about whether or not function is masking.



### Solution
Implement mechanism to extract imformation about masking expressions.

#### One-line summary:

Spark integration can't extract information about `masking` property value of the field, so implement it

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project