### PR TITLE
Tests: Properly cleanup MockServer

### DIFF
--- a/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/app/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -29,11 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.matchers.MatchType;
+import org.mockserver.model.ClearType;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.JsonBody;
 import org.mockserver.model.RequestDefinition;
@@ -91,12 +92,13 @@ class ContainerTest {
 
   private static GenericContainer taskManager;
 
-  @BeforeEach
-  public void setup() {
+  @BeforeAll
+  public static void setup() {
     mockServerClient =
         new MockServerClient(
             openLineageClientMockContainer.getHost(),
             openLineageClientMockContainer.getServerPort());
+
     mockServerClient
         .when(request("/api/v1/lineage"))
         .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
@@ -106,7 +108,8 @@ class ContainerTest {
 
   @AfterEach
   public void cleanup() {
-    mockServerClient.reset();
+    mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
+
     try {
       if (taskManager != null) taskManager.stop();
     } catch (Exception e2) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.ClearType;
 import org.mockserver.model.RegexBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,11 +59,12 @@ class SparkContainerIntegrationTest {
   private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
 
   @BeforeAll
-  public static void setup() {
+  public static void setupMockServer() {
     mockServerClient =
         new MockServerClient(
             openLineageClientMockContainer.getHost(),
             openLineageClientMockContainer.getServerPort());
+
     mockServerClient
         .when(request("/api/v1/lineage"))
         .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
@@ -71,8 +73,8 @@ class SparkContainerIntegrationTest {
   }
 
   @AfterEach
-  public void cleanupSpark() {
-    mockServerClient.reset();
+  public void cleanupEverything() {
+    mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
     try {
       if (pyspark != null) pyspark.stop();
     } catch (Exception e2) {
@@ -86,7 +88,7 @@ class SparkContainerIntegrationTest {
   }
 
   @AfterAll
-  public static void tearDown() {
+  public static void tearDownMockServer() {
     try {
       openLineageClientMockContainer.stop();
     } catch (Exception e2) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.ClearType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -77,6 +78,7 @@ class SparkScalaContainerTest {
         new MockServerClient(
             openLineageClientMockContainer.getHost(),
             openLineageClientMockContainer.getServerPort());
+
     mockServerClient
         .when(request("/api/v1/lineage"))
         .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
@@ -85,8 +87,8 @@ class SparkScalaContainerTest {
   }
 
   @AfterEach
-  public void cleanupSpark() {
-    mockServerClient.reset();
+  public void cleanup() {
+    mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
     try {
       if (spark != null) spark.stop();
     } catch (Exception e) {


### PR DESCRIPTION
### Problem

Issue I've found while investigating https://github.com/OpenLineage/OpenLineage/pull/2782#issuecomment-2180177723.

There are tests which start MockServer, configure it in `BeforeEach` section, and then reset it in `AfterEach` section. For example, this is the case for `SparkContainerIntegrationTest`.

This may lead to errors in log like:
```
    2024-06-21 09:30:01 ERROR io.openlineage.spark.agent.EventEmitter - Could not emit lineage w/ exception
    io.openlineage.client.transports.HttpTransportResponseException: code: 400, response: 
        at io.openlineage.client.transports.HttpTransport.throwOnHttpError(HttpTransport.java:171) ~[openlineage-spark-agent_2.12-1.17.0-SNAPSHOT-shadow.jar:1.17.0-SNAPSHOT]
```

This is because `.reset()` methods removes both recorded requests and expected responses (201). So first test got 201, but the other ones got 404.

### Solution

Instead of resetting the entire MockServer state, just clear up recorded requests.
Also update methods to start MockServer only once for the entire test suite, and properly tear it down.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project