### PR TITLE
Spark: Collect table name from InsertIntoHadoopFsRelationCommand

### DIFF
--- a/integration/spark/app/integrations/container/pysparkHadoopFSEndEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHadoopFSEndEvent.json
@@ -1,0 +1,66 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testPysparkSQLHadoopFSTest",
+    "name": "open_lineage_integration_hadoop_f_s_relation.execute_insert_into_hadoop_fs_relation_command.warehouse_target"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "inputFacets": {}
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/target",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/warehouse",
+              "name": "default.target",
+              "type": "TABLE"
+            }
+          ]
+        }
+      },
+      "outputFacets": {}
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkHadoopFSStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHadoopFSStartEvent.json
@@ -1,0 +1,66 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "testPysparkSQLHadoopFSTest",
+    "name": "open_lineage_integration_hadoop_f_s_relation.execute_insert_into_hadoop_fs_relation_command.warehouse_target"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/test",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "inputFacets": {}
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/warehouse/target",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "key",
+              "type": "integer"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/warehouse",
+              "name": "default.target",
+              "type": "TABLE"
+            }
+          ]
+        }
+      },
+      "outputFacets": {}
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkRDDWithParquetComplete.json
+++ b/integration/spark/app/integrations/container/pysparkRDDWithParquetComplete.json
@@ -1,36 +1,46 @@
 {
-  "eventType" : "COMPLETE",
-  "job" : {
-    "namespace" : "testRddWithParquet",
-    "name" : "open_lineage_integration_rd_d_with_parquet.execute_insert_into_hadoop_fs_relation_command.tmp_rdd_c"
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "testRddWithParquet",
+    "name": "open_lineage_integration_rd_d_with_parquet.execute_insert_into_hadoop_fs_relation_command.tmp_rdd_c"
   },
-  "inputs" : [ {
-    "namespace" : "file",
-    "name" : "/tmp/rdd_a",
-    "facets" : {
-      "schema" : {
-        "fields" : [ ]
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/rdd_a",
+      "facets": {
+        "schema": {
+          "fields": []
+        }
+      }
+    },
+    {
+      "namespace": "file",
+      "name": "/tmp/rdd_b",
+      "facets": {
+        "schema": {
+          "fields": []
+        }
       }
     }
-  }, {
-    "namespace" : "file",
-    "name" : "/tmp/rdd_b",
-    "facets" : {
-      "schema" : {
-        "fields" : [ ]
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/rdd_c",
+      "facets": {
+        "schema": {
+          "fields": [
+            {
+              "name": "_1",
+              "type": "string"
+            }
+          ]
+        },
+        "lifecycleStateChange": {
+          "lifecycleStateChange": "OVERWRITE"
+        }
       }
     }
-  } ],
-  "outputs" : [ {
-    "namespace" : "file",
-    "name" : "/tmp/rdd_c",
-    "facets" : {
-      "schema" : {
-        "fields" : [ {
-          "name" : "_1",
-          "type" : "string"
-        } ]
-      }
-    }
-  } ]
+  ]
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerIntegrationTest.java
@@ -194,6 +194,19 @@ class SparkContainerIntegrationTest {
 
   @Test
   @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3) // Spark version >= 3.*
+  void testPysparkSQLHadoopFSTest() {
+    SparkContainerUtils.runPysparkContainerWithDefaultConf(
+        network,
+        openLineageClientMockContainer,
+        "testPysparkSQLHadoopFSTest",
+        "spark_hadoop_fs_relation.py");
+
+    verifyEvents(
+        mockServerClient, "pysparkHadoopFSStartEvent.json", "pysparkHadoopFSEndEvent.json");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3) // Spark version >= 3.*
   void testOverwriteName() {
     SparkContainerUtils.runPysparkContainerWithDefaultConf(
         network,

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_hadoop_fs_relation.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_hadoop_fs_relation.py
@@ -1,0 +1,23 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/warehouse", exist_ok=True)
+
+
+spark = (
+    SparkSession.builder.master("local")
+    .appName("Open Lineage Integration HadoopFS relation")
+    .enableHiveSupport()
+    .getOrCreate()
+)
+spark.sparkContext.setLogLevel("info")
+
+spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING parquet")
+spark.sql("CREATE TABLE IF NOT EXISTS target (key INT, value STRING) USING parquet")
+spark.sql("INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+spark.sql("INSERT INTO target SELECT * from test WHERE value > 1")

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_with_parquet.py
@@ -18,4 +18,4 @@ rdd_a = spark.read.parquet("/tmp/rdd_a").rdd
 rdd_b = spark.read.parquet("/tmp/rdd_b").rdd
 
 # make a union, some map on RDDs, convert to dataframe and save as parquet
-rdd_a.union(rdd_b).map(lambda x: (x["a"] + x["b"],)).toDF().write.parquet("/tmp/rdd_c")
+rdd_a.union(rdd_b).map(lambda x: (x["a"] + x["b"],)).toDF().write.mode("overwrite").parquet("/tmp/rdd_c")


### PR DESCRIPTION
### Problem

I have a bunch of tables created using `CREATE TABLE ... USING orc` syntax. Inserting data into these tables is performed by InsertIntoHadoopFSRelationCommand instead of InsertIntoHiveTableCommand (it is used for tables created with `... USING hive`). In this case, OpenLineage integration for Spark does not record table name, although InsertIntoHadoopFSRelationCommand has optional `catalogTable` field.

### Solution

#### One-line summary:

Collect table name for `INSERT INTO` command for tables created without `USING hive` syntax.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project