### PR TITLE
Spark: Fix Iceberg dataset location

### DIFF
--- a/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCComplete.json
@@ -58,7 +58,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_1",
+                  "name": "/tmp/iceberg/default/v2_source_1",
                   "field": "k"
                 }
               ]
@@ -67,7 +67,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_2",
+                  "name": "/tmp/iceberg/default/v2_source_2",
                   "field": "v2"
                 },
                 {
@@ -80,7 +80,7 @@
                 },
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_1",
+                  "name": "/tmp/iceberg/default/v2_source_1",
                   "field": "v1"
                 }
               ]

--- a/integration/spark/app/integrations/container/columnLineageJDBCStart.json
+++ b/integration/spark/app/integrations/container/columnLineageJDBCStart.json
@@ -37,7 +37,7 @@
     },
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.v2_source_1",
+      "name": "/tmp/iceberg/default/v2_source_1",
       "facets": {
         "schema": {
           "fields": [
@@ -54,7 +54,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "/tmp/iceberg",
+              "namespace": "file:/tmp/iceberg",
               "name": "default.v2_source_1",
               "type": "TABLE"
             }
@@ -64,7 +64,7 @@
     },
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.v2_source_2",
+      "name": "/tmp/iceberg/default/v2_source_2",
       "facets": {
         "schema": {
           "fields": [
@@ -81,7 +81,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "/tmp/iceberg",
+              "namespace": "file:/tmp/iceberg",
               "name": "default.v2_source_2",
               "type": "TABLE"
             }
@@ -112,7 +112,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_1",
+                  "name": "/tmp/iceberg/default/v2_source_1",
                   "field": "k"
                 }
               ]
@@ -121,7 +121,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_2",
+                  "name": "/tmp/iceberg/default/v2_source_2",
                   "field": "v2"
                 },
                 {
@@ -134,7 +134,7 @@
                 },
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default.v2_source_1",
+                  "name": "/tmp/iceberg/default/v2_source_1",
                   "field": "v1"
                 }
               ]

--- a/integration/spark/app/integrations/container/pysparkV2AlterTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AlterTableCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.alter_table_test",
+    "name" : "/tmp/iceberg/default/alter_table_test",
     "facets" : {
       "dataSource" : {
         "name" : "file",

--- a/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
@@ -6,7 +6,7 @@
   },
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.append_table",
+    "name" : "/tmp/iceberg/default/append_table",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,12 +25,12 @@
             "inputFields": [
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.append_source1",
+                "name": "/tmp/iceberg/default/append_source1",
                 "field": "a"
               },
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.append_source2",
+                "name": "/tmp/iceberg/default/append_source2",
                 "field": "a"
               }
             ]
@@ -40,7 +40,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.append_table",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2AppendDataStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AppendDataStartEvent.json
@@ -6,7 +6,7 @@
   },
   "inputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.append_source1",
+    "name" : "/tmp/iceberg/default/append_source1",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -22,7 +22,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.append_source1",
             "type": "TABLE"
           }
@@ -31,7 +31,7 @@
     }
   }, {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.append_source2",
+    "name" : "/tmp/iceberg/default/append_source2",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -47,7 +47,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.append_source2",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.target",
+    "name" : "/tmp/iceberg/default/target",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.target",
             "type": "TABLE"
           }
@@ -38,12 +38,12 @@
             "inputFields": [
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.source1",
+                "name": "/tmp/iceberg/default/source1",
                 "field": "a"
               },
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.source2",
+                "name": "/tmp/iceberg/default/source2",
                 "field": "a"
               }
             ]
@@ -52,12 +52,12 @@
             "inputFields": [
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.source1",
+                "name": "/tmp/iceberg/default/source1",
                 "field": "b"
               },
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.source2",
+                "name": "/tmp/iceberg/default/source2",
                 "field": "b"
               }
             ]

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectStartEvent.json
@@ -6,7 +6,7 @@
   },
   "inputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.source1",
+    "name" : "/tmp/iceberg/default/source1",
     "facets" : {
       "dataSource": {
         "name": "file",
@@ -27,7 +27,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.source1",
             "type": "TABLE"
           }
@@ -36,7 +36,7 @@
     }
   }, {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.source2",
+    "name" : "/tmp/iceberg/default/source2",
     "facets" : {
       "dataSource": {
         "name": "file",
@@ -57,7 +57,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.source2",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.create_table_test",
+    "name" : "/tmp/iceberg/default/create_table_test",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.create_table_test",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2DeleteCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.tbl_delete",
+    "name" : "/tmp/iceberg/default/tbl_delete",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.tbl_delete",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableCompleteEvent.json
@@ -7,7 +7,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.iceberg_drop_table_test",
+      "name": "/tmp/iceberg/default/iceberg_drop_table_test",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -19,7 +19,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "/tmp/iceberg",
+              "namespace": "file:/tmp/iceberg",
               "name": "default.iceberg_drop_table_test",
               "type": "TABLE"
             }

--- a/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DropTableStartEvent.json
@@ -7,7 +7,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default.iceberg_drop_table_test",
+      "name": "/tmp/iceberg/default/iceberg_drop_table_test",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -19,7 +19,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "/tmp/iceberg",
+              "namespace": "file:/tmp/iceberg",
               "name": "default.iceberg_drop_table_test",
               "type": "TABLE"
             }

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [  ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.events",
+    "name" : "/tmp/iceberg/default/events",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -29,12 +29,12 @@
             "inputFields": [
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.events",
+                "name": "/tmp/iceberg/default/events",
                 "field": "event_id"
               },
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.updates",
+                "name": "/tmp/iceberg/default/updates",
                 "field": "event_id"
               }
             ]
@@ -43,7 +43,7 @@
             "inputFields": [
               {
                 "namespace": "file",
-                "name": "/tmp/iceberg/default.updates",
+                "name": "/tmp/iceberg/default/updates",
                 "field": "updated_at"
               }
             ]
@@ -53,7 +53,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.events",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableStartEvent.json
@@ -6,7 +6,7 @@
   },
   "inputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.updates",
+    "name" : "/tmp/iceberg/default/updates",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.updates",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
@@ -6,7 +6,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.tbl",
+    "name" : "/tmp/iceberg/default/tbl",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -24,7 +24,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.tbl",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.partitioned_tbl",
+    "name" : "/tmp/iceberg/default/partitioned_tbl",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -28,7 +28,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.partitioned_tbl",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwritePartitionsStartEvent.json
@@ -6,7 +6,7 @@
   },
   "inputs" : [  {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.source",
+    "name" : "/tmp/iceberg/default/source",
     "facets" : {
       "dataSource": {
         "name": "file",
@@ -27,7 +27,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.source",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2ReplaceTableAsSelectCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2ReplaceTableAsSelectCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.tbl_replace",
+    "name" : "/tmp/iceberg/default/tbl_replace",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.tbl_replace",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkV2UpdateCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateCompleteEvent.json
@@ -7,7 +7,7 @@
   "inputs" : [ ],
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.tbl_update",
+    "name" : "/tmp/iceberg/default/tbl_update",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -25,7 +25,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.tbl_update",
             "type": "TABLE"
           }

--- a/integration/spark/app/integrations/container/pysparkWriteIcebergTableVersionEnd.json
+++ b/integration/spark/app/integrations/container/pysparkWriteIcebergTableVersionEnd.json
@@ -6,7 +6,7 @@
   },
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.table",
+    "name" : "/tmp/iceberg/default/table",
     "facets" : {
       "schema" : {
         "fields" : [ {
@@ -20,7 +20,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.table",
             "type": "TABLE"
           }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageIcebergTest.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent.column;
 import static io.openlineage.spark.agent.column.ColumnLevelLineageTestUtils.assertColumnDependsOn;
 import static io.openlineage.spark.agent.column.ColumnLevelLineageTestUtils.assertColumnDependsOnInputs;
 import static org.apache.spark.sql.functions.col;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -62,8 +63,8 @@ class ColumnLevelLineageIcebergTest {
 
   private static final String INT_TYPE = "int";
   private static final String FILE = "file";
-  private static final String T1_EXPECTED_NAME = "/tmp/column_level_lineage/db.t1";
-  private static final String T2_EXPECTED_NAME = "/tmp/column_level_lineage/db.t2";
+  private static final String T1_EXPECTED_NAME = "/tmp/column_level_lineage/db/t1";
+  private static final String T2_EXPECTED_NAME = "/tmp/column_level_lineage/db/t2";
   private static final String CREATE_T1_FROM_TEMP =
       "CREATE TABLE local.db.t1 USING iceberg AS SELECT * FROM temp";
   SparkSession spark;
@@ -158,9 +159,16 @@ class ColumnLevelLineageIcebergTest {
             .get();
 
     assertColumnDependsOn(facet, "a", FILE, T1_EXPECTED_NAME, "a");
-    assertColumnDependsOn(facet, "a", FILE, "/tmp/column_level_lineage/db.t2", "a");
-    assertColumnDependsOn(facet, "b", FILE, "/tmp/column_level_lineage/db.t2", "b");
+    assertColumnDependsOn(facet, "a", FILE, T2_EXPECTED_NAME, "a");
+    assertColumnDependsOn(facet, "b", FILE, T2_EXPECTED_NAME, "b");
     assertColumnDependsOn(facet, "b", FILE, T1_EXPECTED_NAME, "b");
+
+    // check that dataset name is a real path
+    FileSystem local = FileSystem.get(spark.sparkContext().hadoopConfiguration());
+    assertThat(local.exists(new Path(T1_EXPECTED_NAME))).isTrue();
+    assertThat(local.exists(new Path(T1_EXPECTED_NAME))).isTrue();
+    assertThat(local.listStatus(new Path(T1_EXPECTED_NAME)).length).isGreaterThan(0);
+    assertThat(local.listStatus(new Path(T2_EXPECTED_NAME)).length).isGreaterThan(0);
   }
 
   @Test
@@ -320,7 +328,7 @@ class ColumnLevelLineageIcebergTest {
         ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(event, context, outputSchema).get();
 
     assertColumnDependsOn(facet, "c", FILE, T1_EXPECTED_NAME, "a");
-    assertColumnDependsOn(facet, "c", FILE, "/tmp/column_level_lineage/db.t2", "a");
+    assertColumnDependsOn(facet, "c", FILE, T2_EXPECTED_NAME, "a");
     assertColumnDependsOnInputs(facet, "c", 2);
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -7,21 +7,23 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.util.SparkConfUtils;
 import io.openlineage.spark.api.OpenLineageContext;
-import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -65,7 +67,39 @@ public class IcebergHandler implements CatalogHandler {
       Identifier identifier,
       Map<String, String> properties) {
     String catalogName = tableCatalog.name();
+    Map<String, String> catalogConf = getCatalogConf(session, catalogName);
+    String catalogType = getCatalogType(catalogConf);
+    if (catalogType == null) {
+      throw new UnsupportedCatalogException(catalogName);
+    }
 
+    Path warehouseLocation = new Path(catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION));
+    Optional<Table> table = getIcebergTable(tableCatalog, identifier);
+    Path tableLocation;
+    if (table.isPresent()) {
+      tableLocation = new Path(table.get().location());
+    } else {
+      tableLocation = reconstructDefaultLocation(warehouseLocation, identifier);
+    }
+    DatasetIdentifier di = PathUtils.fromPath(tableLocation);
+
+    DatasetIdentifier symlink;
+    String tableName = identifier.toString();
+    if ("hive".equals(catalogType)) {
+      symlink = getHiveIdentifier(session, catalogConf.get(CatalogProperties.URI), tableName);
+    } else if ("rest".equals(catalogType)) {
+      symlink = getRestIdentifier(catalogConf.get(CatalogProperties.URI), tableName);
+    } else if ("nessie".equals(catalogType)) {
+      symlink = getNessieIdentifier(catalogConf.get(CatalogProperties.URI), tableName);
+    } else {
+      symlink = FilesystemDatasetUtils.fromLocationAndName(warehouseLocation.toUri(), tableName);
+    }
+
+    return di.withSymlink(
+        symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  private Map<String, String> getCatalogConf(SparkSession session, String catalogName) {
     String prefix = String.format("spark.sql.catalog.%s", catalogName);
     Map<String, String> conf =
         ScalaConversionUtils.<String, String>fromMap(session.conf().getAll());
@@ -77,50 +111,11 @@ public class IcebergHandler implements CatalogHandler {
                 Collectors.toMap(
                     x -> x.getKey().substring(prefix.length() + 1), // handle dot after prefix
                     Map.Entry::getValue));
-
-    String catalogType = getCatalogType(catalogConf);
-    if (catalogType == null) {
-      throw new UnsupportedCatalogException(catalogName);
-    }
-
-    String warehouse = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
-    DatasetIdentifier di = PathUtils.fromPath(new Path(warehouse, identifier.toString()));
-
-    if ("hive".equals(catalogType)) {
-      di.withSymlink(
-          getHiveIdentifier(
-              session, catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if ("hadoop".equals(catalogType)) {
-      di.withSymlink(
-          identifier.toString(),
-          StringUtils.substringBeforeLast(
-              di.getName(), File.separator), // parent location from a name becomes a namespace
-          DatasetIdentifier.SymlinkType.TABLE);
-    } else if ("rest".equals(catalogType)) {
-      di.withSymlink(
-          getRestIdentifier(catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if ("nessie".equals(catalogType)) {
-      di.withSymlink(
-          getNessieIdentifier(catalogConf.get(CatalogProperties.URI), identifier.toString()));
-    } else if ("glue".equals(catalogType)) {
-      di.withSymlink(
-          identifier.toString(),
-          StringUtils.substringBeforeLast(di.getName(), File.separator),
-          DatasetIdentifier.SymlinkType.TABLE);
-    }
-
-    return di;
+    return catalogConf;
   }
 
   @SneakyThrows
-  private DatasetIdentifier.Symlink getNessieIdentifier(@Nullable String confUri, String table) {
-
-    String uri = new URI(confUri).toString();
-    return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
-  }
-
-  @SneakyThrows
-  private DatasetIdentifier.Symlink getHiveIdentifier(
+  private DatasetIdentifier getHiveIdentifier(
       SparkSession session, @Nullable String confUri, String table) {
     URI metastoreUri;
     if (confUri == null) {
@@ -131,16 +126,19 @@ public class IcebergHandler implements CatalogHandler {
       metastoreUri = new URI(confUri);
     }
 
-    return new DatasetIdentifier.Symlink(
-        table,
-        PathUtils.prepareHiveUri(metastoreUri).toString(),
-        DatasetIdentifier.SymlinkType.TABLE);
+    return new DatasetIdentifier(table, PathUtils.prepareHiveUri(metastoreUri).toString());
   }
 
   @SneakyThrows
-  private DatasetIdentifier.Symlink getRestIdentifier(@Nullable String confUri, String table) {
+  private DatasetIdentifier getNessieIdentifier(@Nullable String confUri, String table) {
     String uri = new URI(confUri).toString();
-    return new DatasetIdentifier.Symlink(table, uri, DatasetIdentifier.SymlinkType.TABLE);
+    return new DatasetIdentifier(table, uri);
+  }
+
+  @SneakyThrows
+  private DatasetIdentifier getRestIdentifier(@Nullable String confUri, String table) {
+    String uri = new URI(confUri).toString();
+    return new DatasetIdentifier(table, uri);
   }
 
   @Override
@@ -155,18 +153,38 @@ public class IcebergHandler implements CatalogHandler {
   @Override
   public Optional<String> getDatasetVersion(
       TableCatalog tableCatalog, Identifier identifier, Map<String, String> properties) {
-    SparkTable table;
+    return getIcebergTable(tableCatalog, identifier)
+        .map(table -> table.currentSnapshot())
+        .map(snapshot -> Long.toString(snapshot.snapshotId()));
+  }
+
+  @SneakyThrows
+  private Optional<Table> getIcebergTable(TableCatalog tableCatalog, Identifier identifier) {
     try {
-      table = (SparkTable) tableCatalog.loadTable(identifier);
+      if (tableCatalog instanceof SparkCatalog) {
+        SparkCatalog sparkCatalog = (SparkCatalog) tableCatalog;
+        SparkTable sparkTable = (SparkTable) sparkCatalog.loadTable(identifier);
+        return Optional.ofNullable(sparkTable.table());
+      } else {
+        TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
+        SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
+        return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
+      }
     } catch (NoSuchTableException | ClassCastException e) {
       log.error("Failed to load table from catalog: {}", identifier, e);
       return Optional.empty();
     }
+  }
 
-    if (table.table() != null && table.table().currentSnapshot() != null) {
-      return Optional.of(Long.toString(table.table().currentSnapshot().snapshotId()));
+  private Path reconstructDefaultLocation(Path warehouseLocation, Identifier identifier) {
+    // namespace1.namespace2.table -> /warehouseLocation/namespace1/namespace2/table
+    String[] namespace = identifier.namespace();
+    ArrayList<String> pathComponents = new ArrayList(namespace.length + 1);
+    for (String component : namespace) {
+      pathComponents.add(component);
     }
-    return Optional.empty();
+    pathComponents.add(identifier.name());
+    return new Path(warehouseLocation, String.join(Path.SEPARATOR, pathComponents));
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -5,8 +5,7 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,7 +17,8 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.RuntimeConfig;
@@ -27,7 +27,9 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import scala.collection.immutable.Map;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -40,10 +42,12 @@ class IcebergHandlerTest {
 
   @ParameterizedTest
   @CsvSource({
-    "hdfs://namenode:8020/tmp/warehouse,hdfs://namenode:8020,/tmp/warehouse/database.schema.table",
-    "/tmp/warehouse,file,/tmp/warehouse/database.schema.table"
+    "hdfs://namenode:8020/tmp/warehouse,hdfs://namenode:8020/tmp/warehouse,hdfs://namenode:8020,/tmp/warehouse/database/table",
+    "/tmp/warehouse,file:/tmp/warehouse,file,/tmp/warehouse/database/table"
   })
-  void testGetDatasetIdentifierForHadoop(String warehouseConf, String namespace, String name) {
+  @SneakyThrows
+  void testGetDatasetIdentifierForHadoop(
+      String warehouseConf, String warehouseLocation, String namespace, String name) {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())
         .thenReturn(
@@ -54,24 +58,30 @@ class IcebergHandlerTest {
                 warehouseConf));
 
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
     when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn(warehouseLocation + "/database/table");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
-            sparkSession,
-            sparkCatalog,
-            Identifier.of(new String[] {"database", "schema"}, "table"),
-            new HashMap<>());
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
 
-    assertEquals(name, datasetIdentifier.getName());
-    assertEquals(namespace, datasetIdentifier.getNamespace());
-    assertEquals("database.schema.table", datasetIdentifier.getSymlinks().get(0).getName());
-    assertEquals(
-        StringUtils.substringBeforeLast(name, "/"),
-        datasetIdentifier.getSymlinks().get(0).getNamespace());
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", namespace)
+        .hasFieldOrPropertyWithValue("name", name);
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", warehouseLocation)
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Test
+  @SneakyThrows
   void testGetDatasetIdentifierForHive() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())
@@ -83,91 +93,75 @@ class IcebergHandlerTest {
                 "thrift://metastore-host:10001",
                 "spark.sql.catalog.test.warehouse",
                 "/tmp/warehouse"));
+
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
     when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
             sparkSession,
             sparkCatalog,
-            Identifier.of(new String[] {"database", "schema"}, "table"),
+            Identifier.of(new String[] {"database"}, "table"),
             new HashMap<>());
 
-    DatasetIdentifier.Symlink symlink = datasetIdentifier.getSymlinks().get(0);
-    assertEquals("/tmp/warehouse/database.schema.table", datasetIdentifier.getName());
-    assertEquals("file", datasetIdentifier.getNamespace());
-    assertEquals("database.schema.table", symlink.getName());
-    assertEquals("hive://metastore-host:10001", symlink.getNamespace());
-    assertEquals("TABLE", symlink.getType().toString());
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "hive://metastore-host:10001")
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Test
+  @SneakyThrows
   void testGetDatasetIdentifierForRest() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())
         .thenReturn(
             new Map.Map3<>(
-                "spark.sql.catalog.iceberg.type",
+                "spark.sql.catalog.test.type",
                 "rest",
-                "spark.sql.catalog.iceberg.uri",
+                "spark.sql.catalog.test.uri",
                 "http://lakehouse-host:8080",
-                "spark.sql.catalog.iceberg.warehouse",
-                "s3a://lakehouse/"));
+                "spark.sql.catalog.test.warehouse",
+                "s3a://lakehouse/warehouse"));
+
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
-    when(sparkCatalog.name()).thenReturn("iceberg");
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("s3a://lakehouse/warehouse/database/table");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
             sparkSession,
             sparkCatalog,
-            Identifier.of(new String[] {"schema"}, "table"),
+            Identifier.of(new String[] {"database"}, "table"),
             new HashMap<>());
 
-    DatasetIdentifier.Symlink symlink = datasetIdentifier.getSymlinks().get(0);
-    assertEquals("schema.table", datasetIdentifier.getName());
-    assertEquals("s3://lakehouse", datasetIdentifier.getNamespace());
-    // symlink
-    assertEquals("schema.table", symlink.getName());
-    assertEquals("http://lakehouse-host:8080", symlink.getNamespace());
-    assertEquals("TABLE", symlink.getType().toString());
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "s3://lakehouse")
+        .hasFieldOrPropertyWithValue("name", "warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "http://lakehouse-host:8080")
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
   @Test
-  void testGetStorageDatasetFacet() {
-    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
-    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
-        icebergHandler.getStorageDatasetFacet(
-            Collections.singletonMap("format", "iceberg/parquet"));
-    assertEquals("iceberg", storageDatasetFacet.get().getStorageLayer());
-    assertEquals("parquet", storageDatasetFacet.get().getFileFormat());
-  }
-
-  @Test
-  void testStorageDatasetFacetWhenFormatNotProvided() {
-    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
-    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
-        icebergHandler.getStorageDatasetFacet(new HashMap<>());
-    assertEquals("iceberg", storageDatasetFacet.get().getStorageLayer());
-    assertEquals("", storageDatasetFacet.get().getFileFormat());
-  }
-
-  @Test
-  void testGetVersionString() throws NoSuchTableException {
-    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
-    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
-    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
-
-    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
-    when(sparkTable.table().currentSnapshot().snapshotId()).thenReturn(1500100900L);
-
-    Optional<String> version =
-        icebergHandler.getDatasetVersion(sparkCatalog, identifier, Collections.emptyMap());
-
-    assertTrue(version.isPresent());
-    assertEquals(version.get(), "1500100900");
-  }
-
-  @Test
+  @SneakyThrows
   void testGetDatasetIdentifierForGlue() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
     when(runtimeConfig.getAll())
@@ -179,18 +173,116 @@ class IcebergHandlerTest {
                 "/tmp/warehouse"));
 
     SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
     when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
             sparkSession,
             sparkCatalog,
-            Identifier.of(new String[] {"database", "schema"}, "table"),
+            Identifier.of(new String[] {"database"}, "table"),
             new HashMap<>());
 
-    assertEquals("/tmp/warehouse/database.schema.table", datasetIdentifier.getName());
-    assertEquals("file", datasetIdentifier.getNamespace());
-    assertEquals("database.schema.table", datasetIdentifier.getSymlinks().get(0).getName());
-    assertEquals("/tmp/warehouse", datasetIdentifier.getSymlinks().get(0).getNamespace());
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
+        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  private static Stream<Arguments> missingTableOptions() {
+    return Stream.of(
+        Arguments.of(Identifier.of(new String[] {}, "table"), "table", "/tmp/iceberg/table"),
+        Arguments.of(
+            Identifier.of(new String[] {"database"}, "table"),
+            "database.table",
+            "/tmp/iceberg/database/table"),
+        Arguments.of(
+            Identifier.of(new String[] {"nested", "namespace"}, "table"),
+            "nested.namespace.table",
+            "/tmp/iceberg/nested/namespace/table"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("missingTableOptions")
+  @SneakyThrows
+  void testGetDatasetIdentifierMissingTable(Identifier identifier, String name, String location) {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.test.type",
+                "hadoop",
+                "spark.sql.catalog.test.warehouse",
+                "file:/tmp/iceberg"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", location);
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/iceberg")
+        .hasFieldOrPropertyWithValue("name", name)
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetStorageDatasetFacet() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
+        icebergHandler.getStorageDatasetFacet(
+            Collections.singletonMap("format", "iceberg/parquet"));
+
+    assertThat(storageDatasetFacet.get())
+        .hasFieldOrPropertyWithValue("storageLayer", "iceberg")
+        .hasFieldOrPropertyWithValue("fileFormat", "parquet");
+  }
+
+  @Test
+  @SneakyThrows
+  void testStorageDatasetFacetWhenFormatNotProvided() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    Optional<OpenLineage.StorageDatasetFacet> storageDatasetFacet =
+        icebergHandler.getStorageDatasetFacet(new HashMap<>());
+
+    assertThat(storageDatasetFacet.get())
+        .hasFieldOrPropertyWithValue("storageLayer", "iceberg")
+        .hasFieldOrPropertyWithValue("fileFormat", "");
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetVersionString() {
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().currentSnapshot().snapshotId()).thenReturn(1500100900L);
+
+    Optional<String> version =
+        icebergHandler.getDatasetVersion(sparkCatalog, identifier, Collections.emptyMap());
+
+    assertThat(version.isPresent()).isTrue();
+    assertThat(version.get()).isEqualTo("1500100900");
   }
 }


### PR DESCRIPTION
### Problem
Closes: #2625

### Solution

* Use real table location for dataset namespace and name, instead of building them from warehouse location + table full name. This is allows to keep Flink and Spark datasets in sync.
* For `TABLE` symlink use warehouse location instead of warehouse + "/database"

#### One-line summary:

Fix Iceberg dataset namespace, instead of `file:/some/path/database.table` use `file:/some/path/database/table`. For dataset TABLE symlink, use warehouse location instead of database location.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project