### PR TITLE
Spark,Flink: Fix DBFS namespace format

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/filesystem/GenericFilesystemDatasetExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/filesystem/GenericFilesystemDatasetExtractor.java
@@ -9,6 +9,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.util.Optional;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 
 public class GenericFilesystemDatasetExtractor implements FilesystemDatasetExtractor {
   @Override
@@ -26,7 +27,12 @@ public class GenericFilesystemDatasetExtractor implements FilesystemDatasetExtra
 
   @Override
   public DatasetIdentifier extract(URI location, String rawName) {
-    String namespace = FilesystemUriSanitizer.removeLastSlash(location.toString());
+    String namespace =
+        Optional.of(location.toString())
+            .map(FilesystemUriSanitizer::removeLastSlash)
+            .map(scheme -> StringUtils.stripEnd(scheme, ":"))
+            .get();
+
     String name =
         Optional.of(rawName)
             .map(FilesystemUriSanitizer::removeLastSlash)

--- a/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForDBFS.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/filesystem/FilesystemDatasetUtilsTestForDBFS.java
@@ -1,0 +1,63 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.filesystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.net.URI;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class FilesystemDatasetUtilsTestForDBFS {
+  @Test
+  @SneakyThrows
+  void testFromLocation() {
+    assertThat(FilesystemDatasetUtils.fromLocation(new URI("dbfs:/warehouse/location")))
+        .hasFieldOrPropertyWithValue("namespace", "dbfs")
+        .hasFieldOrPropertyWithValue("name", "/warehouse/location");
+
+    assertThat(FilesystemDatasetUtils.fromLocation(new URI("dbfs:/warehouse/location/")))
+        .hasFieldOrPropertyWithValue("namespace", "dbfs")
+        .hasFieldOrPropertyWithValue("name", "/warehouse/location");
+
+    assertThat(FilesystemDatasetUtils.fromLocation(new URI("dbfs:///warehouse/location")))
+        .hasFieldOrPropertyWithValue("namespace", "dbfs")
+        .hasFieldOrPropertyWithValue("name", "/warehouse/location");
+  }
+
+  @Test
+  @SneakyThrows
+  void testFromLocationAndName() {
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("dbfs:/warehouse/location"), "default.table"))
+        .hasFieldOrPropertyWithValue("namespace", "dbfs:/warehouse/location")
+        .hasFieldOrPropertyWithValue("name", "default.table");
+
+    assertThat(
+            FilesystemDatasetUtils.fromLocationAndName(
+                new URI("dbfs:/warehouse/location/"), "default.table"))
+        .hasFieldOrPropertyWithValue("namespace", "dbfs:/warehouse/location")
+        .hasFieldOrPropertyWithValue("name", "default.table");
+  }
+
+  @Test
+  @SneakyThrows
+  void toLocation() {
+    assertThat(FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/", "dbfs")))
+        .isEqualTo(new URI("dbfs:/"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(new DatasetIdentifier("/warehouse/location", "dbfs")))
+        .isEqualTo(new URI("dbfs:/warehouse/location"));
+
+    assertThat(
+            FilesystemDatasetUtils.toLocation(
+                new DatasetIdentifier("default.table", "dbfs:/warehouse/location")))
+        .isEqualTo(new URI("dbfs:/warehouse/location/default.table"));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -81,6 +81,10 @@ class PathUtilsTest {
         .hasFieldOrPropertyWithValue("name", "/home/test")
         .hasFieldOrPropertyWithValue("namespace", "file");
 
+    assertThat(PathUtils.fromPath(new Path("dbfs:/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "dbfs");
+
     assertThat(PathUtils.fromPath(new Path("hdfs://namenode:8020/home/test")))
         .hasFieldOrPropertyWithValue("name", "/home/test")
         .hasFieldOrPropertyWithValue("namespace", "hdfs://namenode:8020");
@@ -92,9 +96,17 @@ class PathUtilsTest {
         .hasFieldOrPropertyWithValue("name", "/home/test")
         .hasFieldOrPropertyWithValue("namespace", "file");
 
+    assertThat(PathUtils.fromURI(new URI("file:/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "file");
+
     assertThat(PathUtils.fromURI(new URI("file:///home/test")))
         .hasFieldOrPropertyWithValue("name", "/home/test")
         .hasFieldOrPropertyWithValue("namespace", "file");
+
+    assertThat(PathUtils.fromURI(new URI("dbfs:/home/test")))
+        .hasFieldOrPropertyWithValue("name", "/home/test")
+        .hasFieldOrPropertyWithValue("namespace", "dbfs");
 
     assertThat(PathUtils.fromURI(new URI("hdfs://localhost:8020/home/test")))
         .hasFieldOrPropertyWithValue("name", "/home/test")


### PR DESCRIPTION
### Problem

#2782 introduced feature for custom extractors for specific FS types. But it haven't been tested on dbfs paths like `dbfs:/some/location` - in previous version namespace was `dbfs`, but now it is `dbfs:`.

This leads to errors like:
```
24/06/25 10:47:01 ERROR PlanUtils: Apply failed:
java.lang.IllegalArgumentException: Expected scheme-specific part at index 5: dbfs:
	at java.net.URI.create(URI.java:852)
	at io.openlineage.spark.agent.util.PlanUtils.datasourceFacet(PlanUtils.java:213)
	at io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder.handleCatalogTable(LogicalRelationDatasetBuilder.java:130)
	at io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder.apply(LogicalRelationDatasetBuilder.java:104)
	at io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder.apply(LogicalRelationDatasetBuilder.java:60)
```

This is because `PlanUtils.datasourceFacet` calls `URI.create(namespace)`, and `dbfs:` is not a valid URI, unlike `dbfs`.

### Solution

Remove final `:` from namespace, to convert `dbfs:` to `dbfs`.

#### One-line summary:

Fix DBFS namespace format.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project