### PR TITLE
Java: Add PostgresJdbcExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
@@ -9,8 +9,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GenericJdbcExtractor implements JdbcExtractor {
+  private static Pattern URL_FORMAT =
+      Pattern.compile(
+          "^(?<scheme>\\w+)://(?<authority>[\\[\\]\\w\\d.,:]+)/?(?<database>[\\w\\d.]+)?(?:\\?.*)?");
+
   @Override
   public boolean isDefinedAt(String jdbcUri) {
     return true;
@@ -18,6 +24,13 @@ public class GenericJdbcExtractor implements JdbcExtractor {
 
   @Override
   public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    if (!rawUri.contains(",")) {
+      return extractOneHost(rawUri);
+    }
+    return extractMultipleHosts(rawUri);
+  }
+
+  private JdbcLocation extractOneHost(String rawUri) throws URISyntaxException {
     URI uri = new URI(rawUri);
 
     if (uri.getHost() == null) {
@@ -26,12 +39,33 @@ public class GenericJdbcExtractor implements JdbcExtractor {
 
     String scheme = uri.getScheme();
     String host = uri.getHost();
-    Optional<String> port =
-        uri.getPort() > 0 ? Optional.of(String.format("%d", uri.getPort())) : Optional.empty();
+    String authority;
+    if (uri.getPort() > 0) {
+      authority = String.format("%s:%d", host, uri.getPort());
+    } else {
+      authority = host;
+    }
+
     Optional<String> database =
         Optional.ofNullable(uri.getPath())
             .map(db -> db.replaceFirst("/", ""))
             .filter(db -> !db.isEmpty());
-    return new JdbcLocation(scheme, host, port, Optional.empty(), database);
+
+    return new JdbcLocation(scheme, authority, Optional.empty(), database);
+  }
+
+  private JdbcLocation extractMultipleHosts(String rawUri) throws URISyntaxException {
+    // new URI() parses 'scheme://host1,host2' syntax as scheme-specific part instead of authority
+    // Using regex to extract URI components
+
+    Matcher matcher = URL_FORMAT.matcher(rawUri);
+    if (!matcher.matches()) {
+      throw new URISyntaxException(rawUri, "Failed to parse jdbc url");
+    }
+
+    String scheme = matcher.group("scheme");
+    String authority = matcher.group("authority");
+    String database = matcher.group("database");
+    return new JdbcLocation(scheme, authority, Optional.empty(), Optional.ofNullable(database));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.client.utils.jdbc;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,19 +15,22 @@ import lombok.Setter;
 @AllArgsConstructor
 public class JdbcLocation {
   @NonNull @Getter @Setter private String scheme;
-  @NonNull @Getter @Setter private String host;
-  @Getter @Setter private Optional<String> port;
+  @NonNull @Getter @Setter private String authority;
   @Getter @Setter private Optional<String> instance;
   @Getter @Setter private Optional<String> database;
 
-  public String getNamespace() {
-    String result = String.format("%s://%s", scheme, host);
-    if (port.isPresent()) {
-      result = String.format("%s:%s", result, port.get());
-    }
+  public String toNamespace() {
+    String result = String.format("%s://%s", scheme, authority);
     if (instance.isPresent()) {
       result = String.format("%s/%s", result, instance.get());
     }
     return result;
+  }
+
+  public String toName(List<String> parts) {
+    if (database.isPresent()) {
+      parts.add(0, database.get());
+    }
+    return String.join(".", parts);
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcUrlSanitizer.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcUrlSanitizer.java
@@ -16,19 +16,6 @@ class JdbcUrlSanitizer {
   private static final String QUERY_PARAMS_REGEX = "\\?.*$";
 
   /**
-   * Convert jdbcUrl scheme to compatible with naming convention
-   *
-   * @param jdbcUrl url to database
-   * @return String
-   */
-  public static String fixScheme(String jdbcUrl) {
-    return jdbcUrl
-        .replaceAll("^jdbc:", "")
-        // TODO: implement in PostgresJdbcExtractor
-        .replaceAll("^postgresql:", "postgres:");
-  }
-
-  /**
    * JdbcUrl can contain username and password this method clean-up credentials from jdbcUrl. Also
    * drop query params as they include a lot of useless options, like timeout
    *

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class OverridingJdbcExtractor extends GenericJdbcExtractor implements JdbcExtractor {
+  private String overrideScheme;
+  private String defaultPort;
+  private static Pattern HOST_PORT_FORMAT =
+      Pattern.compile("^(?<host>[\\[\\]\\w\\d.]+):(?<port>\\d+)?");
+
+  public OverridingJdbcExtractor(String overrideScheme) {
+    this(overrideScheme, null);
+  }
+
+  public OverridingJdbcExtractor(String overrideScheme, String defaultPort) {
+    this.overrideScheme = overrideScheme;
+    this.defaultPort = defaultPort;
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return jdbcUri.startsWith(overrideScheme);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    JdbcLocation result = super.extract(rawUri, properties);
+
+    String authority = result.getAuthority();
+    if (defaultPort != null) {
+      authority = appendDefaultPort(authority);
+    }
+
+    return new JdbcLocation(overrideScheme, authority, result.getInstance(), result.getDatabase());
+  }
+
+  private String appendDefaultPort(String authority) {
+    String[] hosts = authority.split(",");
+    for (int i = 0; i < hosts.length; i++) {
+      String host = hosts[i];
+      Matcher hostPortMatcher = HOST_PORT_FORMAT.matcher(host);
+      if (!hostPortMatcher.matches()) {
+        hosts[i] = host + ":" + defaultPort;
+      }
+    }
+    return String.join(",", hosts);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/PostgresJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/PostgresJdbcExtractor.java
@@ -1,0 +1,27 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+public class PostgresJdbcExtractor implements JdbcExtractor {
+  // https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("postgres", "5432");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    return delegate().extract(rawUri, properties);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
@@ -26,7 +26,7 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
 
   private static final Pattern URL =
       Pattern.compile(
-          "(?:\\w+)://(?<host>[\\w\\d\\.]+)?(?:\\\\)?(?<instance>[\\w]+)?(?:\\:)?(?<port>\\d+)?(?<params>.*)");
+          "(?:\\w+)://(?<host>[\\w\\d\\.]+)?(?:\\\\)?(?<instance>[\\w]+)?(?::)?(?<port>\\d+)?(?<params>.*)");
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {
@@ -79,13 +79,20 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
       host = "[" + host + "]";
     }
 
-    Optional<String> port = Optional.ofNullable(finalProperties.getProperty(PORT_PROPERTY));
+    String port = finalProperties.getProperty(PORT_PROPERTY);
+    String authority;
+    if (port != null) {
+      authority = host + ":" + port;
+    } else {
+      authority = host;
+    }
+
     Optional<String> instance = Optional.ofNullable(finalProperties.getProperty(INSTANCE_PROPERTY));
     Optional<String> database =
         Optional.ofNullable(finalProperties.getProperty(DATABASE_NAME_PROPERTY))
             .map(Optional::of)
             .orElseGet(() -> Optional.ofNullable(finalProperties.getProperty(DATABASE_PROPERTY)));
 
-    return new JdbcLocation(SCHEME, host, port, instance, database);
+    return new JdbcLocation(SCHEME, authority, instance, database);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
@@ -17,7 +17,7 @@ class JdbcDatasetUtilsTestForPostgres {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:postgresql://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://test.host.com")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://test.host.com:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -26,7 +26,7 @@ class JdbcDatasetUtilsTestForPostgres {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:postgresql://192.168.1.1", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://192.168.1.1")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://192.168.1.1:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -38,7 +38,7 @@ class JdbcDatasetUtilsTestForPostgres {
                 "schema.table1",
                 new Properties()))
         .hasFieldOrPropertyWithValue(
-            "namespace", "postgres://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            "namespace", "postgres://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -48,7 +48,7 @@ class JdbcDatasetUtilsTestForPostgres {
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:postgresql://hostname?user=fred&password=sec%40ret",
                 "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -56,8 +56,8 @@ class JdbcDatasetUtilsTestForPostgres {
   void testGetDatasetIdentifierWithPort() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:postgresql://hostname:5432", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5432")
+                "jdbc:postgresql://hostname:5433", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5433")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -66,7 +66,7 @@ class JdbcDatasetUtilsTestForPostgres {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:postgresql://hostname/mydb", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5432")
         .hasFieldOrPropertyWithValue("name", "mydb.schema.table1");
   }
 
@@ -77,7 +77,7 @@ class JdbcDatasetUtilsTestForPostgres {
                 "jdbc:postgresql://hostname?ssl=true&applicationName=MyApp",
                 "schema.table1",
                 new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -86,7 +86,7 @@ class JdbcDatasetUtilsTestForPostgres {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:postgresql://hostname1,hostname2", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname1,hostname2")
+        .hasFieldOrPropertyWithValue("namespace", "postgres://hostname1:5432,hostname2:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(


### PR DESCRIPTION
### Problem

See #2762.

Currently Postgres JDBC URLs like `jdbc:postgresql://host/mydb` and `jdbc:postgresql://host:5432/mydb` producing different namespaces `postgres://host` and `postgres://host:5432`, although this is the same connection string because port `5432` is default.

### Solution

* Replace `host` and `port` fields in `JdbcLocation` class with `authority` field, as some JDBC URLs could contain a list of `host:port`.
* Handle URIs with format `scheme://host1:port1,host2:port2` in `GenericJdbcExtractor`.
* Add `OverridingJdbcExtractor` which allows replacing scheme with a provided value (`postgresql` -> `postgres`), and also can set default port number.
* Add PostgreJdbcExtractor, build on top of `OverridingJdbcExtractor`

#### One-line summary:

Add default `5432` port to Postgres namespaces.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project