### PR TITLE
Spark: Fix glue symlinks formatting bug

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -70,7 +70,7 @@ public class PathUtils {
       URI hiveUri = prepareHiveUri(metastoreUri.get());
       String tableName = nameFromTableIdentifier(catalogTable.identifier());
       symlinkDataset = Optional.of(FilesystemDatasetUtils.fromLocationAndName(hiveUri, tableName));
-    }  else {
+    } else {
       Optional<URI> warehouseLocation =
           getWarehouseLocation(sparkConf, hadoopConf)
               // perform normalization
@@ -160,8 +160,10 @@ public class PathUtils {
     Optional<String> clientFactory =
         SparkConfUtils.findHadoopConfigKey(hadoopConf, "hive.metastore.client.factory.class");
     // Fetch from spark config if set.
-    clientFactory = clientFactory.isPresent() ? clientFactory :
-            SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.client.factory.class");
+    clientFactory =
+        clientFactory.isPresent()
+            ? clientFactory
+            : SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.client.factory.class");
     if (!clientFactory.isPresent()
         || !"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
             .equals(clientFactory.get())) {
@@ -177,15 +179,17 @@ public class PathUtils {
     Optional<String> accountId =
         SparkConfUtils.findSparkConfigKey(sparkConf, "spark.glue.accountId");
     // For AWS Glue catalog in EMR spark
-    // Glue catalog with EMR guide: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-glue.html
+    // Glue catalog with EMR guide:
+    // https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-glue.html
     Optional<String> glueCatalogIdForEMR =
-            SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.glue.catalogid");
+        SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.glue.catalogid");
     // For AWS Glue access in Athena for Spark
     // Guide: https://docs.aws.amazon.com/athena/latest/ug/spark-notebooks-cross-account-glue.html
     Optional<String> glueCatalogIdForAthena =
-            SparkConfUtils.findSparkConfigKey(sparkConf, "spark.hadoop.hive.metastore.glue.catalogid");
+        SparkConfUtils.findSparkConfigKey(sparkConf, "spark.hadoop.hive.metastore.glue.catalogid");
 
-    Optional<String> glueCatalogId = Stream.of(glueCatalogIdForEMR, glueCatalogIdForAthena, accountId)
+    Optional<String> glueCatalogId =
+        Stream.of(glueCatalogIdForEMR, glueCatalogIdForAthena, accountId)
             .filter(Optional::isPresent)
             .findFirst()
             .orElse(Optional.empty());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -25,6 +25,7 @@ import org.apache.spark.sql.internal.StaticSQLConf;
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 public class PathUtils {
   private static final String DEFAULT_DB = "default";
+  private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
 
   public static DatasetIdentifier fromPath(Path path) {
     return fromURI(path.toUri());
@@ -182,11 +183,13 @@ public class PathUtils {
     // Glue catalog with EMR guide:
     // https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-glue.html
     Optional<String> glueCatalogIdForEMR =
-        SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.glue.catalogid");
+        SparkConfUtils.findSparkConfigKey(sparkConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
     // For AWS Glue access in Athena for Spark
     // Guide: https://docs.aws.amazon.com/athena/latest/ug/spark-notebooks-cross-account-glue.html
+    // spark config "spark.hadoop.hive.metastore.glue.catalogid" is copied to hadoop
+    // "hive.metastore.glue.catalogid" by SparkHadoopUtil (removing the prefix spark.hadoop)
     Optional<String> glueCatalogIdForAthena =
-        SparkConfUtils.findSparkConfigKey(sparkConf, "spark.hadoop.hive.metastore.glue.catalogid");
+        SparkConfUtils.findHadoopConfigKey(hadoopConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
 
     Optional<String> glueCatalogId =
         Stream.of(glueCatalogIdForEMR, glueCatalogIdForAthena, accountId)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -200,8 +200,8 @@ class PathUtilsTest {
   @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-east-1")
   void testFromCatalogTableWithEMRGlue() throws URISyntaxException {
     hadoopConf.set(
-            "hive.metastore.client.factory.class",
-            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+        "hive.metastore.client.factory.class",
+        "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
     sparkConf.set("spark.sql.catalogImplementation", "hive");
     sparkConf.set("hive.metastore.glue.catalogid", "123456789012");
 
@@ -212,25 +212,25 @@ class PathUtilsTest {
     when(tableIdentifier.database()).thenReturn(Option.apply("database"));
     when(tableIdentifier.table()).thenReturn("mytable");
     when(catalogStorageFormat.locationUri())
-            .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
+        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
 
     DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
     assertThat(datasetIdentifier)
-            .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
-            .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+        .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
     assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
     assertThat(datasetIdentifier.getSymlinks().get(0))
-            .hasFieldOrPropertyWithValue("name", "table/database/mytable")
-            .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
-            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+        .hasFieldOrPropertyWithValue("name", "table/database/mytable")
+        .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 
   @Test
   @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-east-1")
   void testFromCatalogTableWithAthenaGlue() throws URISyntaxException {
     sparkConf.set(
-            "hive.metastore.client.factory.class",
-            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+        "hive.metastore.client.factory.class",
+        "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
     sparkConf.set("spark.sql.catalogImplementation", "hive");
     sparkConf.set("spark.hadoop.hive.metastore.glue.catalogid", "123456789012");
 
@@ -241,17 +241,17 @@ class PathUtilsTest {
     when(tableIdentifier.database()).thenReturn(Option.apply("database"));
     when(tableIdentifier.table()).thenReturn("mytable");
     when(catalogStorageFormat.locationUri())
-            .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
+        .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
 
     DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
     assertThat(datasetIdentifier)
-            .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
-            .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+        .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
     assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
     assertThat(datasetIdentifier.getSymlinks().get(0))
-            .hasFieldOrPropertyWithValue("name", "table/database/mytable")
-            .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
-            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+        .hasFieldOrPropertyWithValue("name", "table/database/mytable")
+        .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -197,6 +197,64 @@ class PathUtilsTest {
   }
 
   @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-east-1")
+  void testFromCatalogTableWithEMRGlue() throws URISyntaxException {
+    hadoopConf.set(
+            "hive.metastore.client.factory.class",
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+    sparkConf.set("spark.sql.catalogImplementation", "hive");
+    sparkConf.set("hive.metastore.glue.catalogid", "123456789012");
+
+    when(catalogTable.provider()).thenReturn(Option.apply("hive"));
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("mytable");
+    when(catalogStorageFormat.locationUri())
+            .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
+
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+            .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
+            .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+            .hasFieldOrPropertyWithValue("name", "table/database/mytable")
+            .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
+            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-east-1")
+  void testFromCatalogTableWithAthenaGlue() throws URISyntaxException {
+    sparkConf.set(
+            "hive.metastore.client.factory.class",
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+    sparkConf.set("spark.sql.catalogImplementation", "hive");
+    sparkConf.set("spark.hadoop.hive.metastore.glue.catalogid", "123456789012");
+
+    when(catalogTable.provider()).thenReturn(Option.apply("hive"));
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("mytable");
+    when(catalogStorageFormat.locationUri())
+            .thenReturn(Option.apply(new URI("s3://bucket/warehouse/mytable")));
+
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+    assertThat(datasetIdentifier)
+            .hasFieldOrPropertyWithValue("name", "warehouse/mytable")
+            .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+            .hasFieldOrPropertyWithValue("name", "table/database/mytable")
+            .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-east-1:123456789012")
+            .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+  }
+
+  @Test
   void testFromCatalogWithDefaultStorage() throws URISyntaxException {
     when(catalogStorageFormat.locationUri())
         .thenReturn(Option.apply(new URI("hdfs://namenode:8020/warehouse/database.db/table")));

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -232,7 +232,7 @@ class PathUtilsTest {
         "hive.metastore.client.factory.class",
         "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
     sparkConf.set("spark.sql.catalogImplementation", "hive");
-    sparkConf.set("spark.hadoop.hive.metastore.glue.catalogid", "123456789012");
+    hadoopConf.set("hive.metastore.glue.catalogid", "123456789012");
 
     when(catalogTable.provider()).thenReturn(Option.apply("hive"));
     when(catalogTable.storage()).thenReturn(catalogStorageFormat);


### PR DESCRIPTION
Use the correct spark and hadoop configuration params for populating symlinks when using Glue catalog in EMR Spark or Athena Spark jobs. This fixes the symlinks with correct Glue ARNs for namespace and name formats.

Fixes: [#2766](https://github.com/OpenLineage/OpenLineage/pull/2766/commits)
Fixes: [#2765](https://github.com/OpenLineage/OpenLineage/issues/2765)

### Problem


When using AWS Glue catalogId in the spark configuration - EMR and Athena, it is not picked up and the symlinks point to hive urls instead of glue ARNs. 

### Solution

Use the correct spark and hadoop configuration params for populating symlinks when using Glue catalog in EMR Spark or Athena Spark jobs. This fixes the symlinks with correct Glue ARNs for namespace and name formats.

Code changes: 
- Reorder the Symlink fetching order to start from glueArn instead of hive metastore URI since hive metastore URIs are present for glue catalog configurations as well.
- Read params for glue catalog id specified in various formats - EMR spark, Athena spark, etc and use them for glue ARNs

Before: 
```
     ....
        "symlinks": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/...integration/spark",
          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
          "identifiers": [
            {
              "namespace": "hive://ip-10-1-114-149.ec2.internal:9083",
              "name": "datalake_akash.products",
              "type": "TABLE"
            }
          ]
        }
    ....    
 ```
 
 After: 
```
     ....
        "symlinks": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/.../integration/spark",
          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
          "identifiers": [
            {
              "namespace": "arn:aws:glue:us-east-1:123456789012",
              "name": "datalake_akash.products",
              "type": "TABLE"
            }
          ]
        }
    ....    
 ```
 Tested with actual EMR spark jobs with Glue catalog       

#### One-line summary:

Bug fix: Fixes glue symlinks with config parsing for glue catalog Id

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project