### PR TITLE
[SPARK] configurable test with docker image provided

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -691,6 +691,7 @@ jobs:
                 keys:
                   - v1-configurable-integration-test
             - run: ./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf.yml --test ./integration/spark/cli/tests
+            - run: ./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf-docker.yml --test ./integration/spark/cli/tests
             - store_artifacts:
                 path: integration/spark/cli/runs
                 destination: test-report

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -46,6 +46,7 @@ workflows:
           requires:
             - approval-integration-spark
       - configurable-integration-test-spark:
+          context: integration-tests
       - workflow_complete:
           requires:
             - integration-test-integration-spark-scala-2_12

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/RunEventVerifier.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/util/RunEventVerifier.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -53,9 +54,14 @@ public class RunEventVerifier {
    * @param eventsFile
    * @return
    */
-  @SneakyThrows
   public static RunEventVerifier of(File eventsFile) {
-    return new RunEventVerifier(Files.readAllLines(eventsFile.toPath()));
+    List<String> lines;
+    try {
+      lines = Files.readAllLines(eventsFile.toPath());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read events files", e);
+    }
+    return new RunEventVerifier(lines);
   }
 
   @SneakyThrows

--- a/integration/spark/cli/configurable-test.sh
+++ b/integration/spark/cli/configurable-test.sh
@@ -29,6 +29,8 @@ usage() {
   title "EXAMPLES:"
   echo "  $ ./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf.yml --test ./integration/spark/cli/tests "
   echo
+  echo "  $ ./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf-docker.yml --test ./integration/spark/cli/tests "
+  echo
   echo "  $ ./integration/spark/cli/configurable-test.sh --help"
   echo
   echo
@@ -101,10 +103,16 @@ fi
 # (4) Get OpenLineage version to compute image tag and container tag
 SCALA_BINARY_VERSION=$(grep "^scalaBinaryVersion:" "$SPARK_CONF_YML" | cut -d':' -f2 | xargs)
 SPARK_VERSION=$(grep "^sparkVersion:" "$SPARK_CONF_YML" | cut -d':' -f2 | xargs)
+if test -z "$SPARK_VERSION"
+then
+  SPARK_VERSION='3.3.4'
+fi
 OPENLINEAGE_VERSION=$(grep "^version=" "integration/spark/gradle.properties" | cut -d'=' -f2)
 DOCKER_IMAGE_TAG="openlineage-test:$OPENLINEAGE_VERSION"
 CONTAINER_NAME="openlineage-test-$OPENLINEAGE_VERSION"
 NETWORK_NAME=openlineage
+
+echo "Spark version is '$SPARK_VERSION'"
 
 # (5) Remove container if exists
 if [ "$(docker ps -a | grep $CONTAINER_NAME 2> /dev/null)" ]; then

--- a/integration/spark/cli/spark-conf-docker.yml
+++ b/integration/spark/cli/spark-conf-docker.yml
@@ -1,0 +1,11 @@
+appName: "CLI test application"
+docker:
+  image: "apache/spark:3.3.3-scala2.12-java11-python3-ubuntu"
+  sparkSubmit: /opt/spark/bin/spark-submit
+  waitForLogMessage: ".*ShutdownHookManager: Shutdown hook called.*"
+scalaBinaryVersion: 2.12
+enableHiveSupport: true
+packages:
+  - org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.5.2
+sparkConf:
+  spark.openlineage.debugFacet: enabled

--- a/integration/spark/cli/tests/test_iceberg/create_table.json
+++ b/integration/spark/cli/tests/test_iceberg/create_table.json
@@ -2,7 +2,7 @@
   "eventType" : "COMPLETE",
   "outputs" : [ {
     "namespace" : "file",
-    "name" : "/tmp/iceberg/default.create_table_test",
+    "name" : "/tmp/iceberg/default/create_table_test",
     "facets" : {
       "dataSource" : {
         "name" : "file",
@@ -20,7 +20,7 @@
       "symlinks": {
         "identifiers": [
           {
-            "namespace": "/tmp/iceberg",
+            "namespace": "file:/tmp/iceberg",
             "name": "default.create_table_test",
             "type": "TABLE"
           }

--- a/integration/spark/cli/tests/test_pyspark/example_expected_event_complete.json
+++ b/integration/spark/cli/tests/test_pyspark/example_expected_event_complete.json
@@ -36,7 +36,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/opt/bitnami/spark/spark-warehouse/t2",
+      "name": "${json-unit.regex}.*/spark-warehouse/t2",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -60,7 +60,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/opt/bitnami/spark/spark-warehouse/t1",
+                  "name": "${json-unit.regex}.*/spark-warehouse/t1",
                   "field": "a"
                 }
               ]
@@ -69,7 +69,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/opt/bitnami/spark/spark-warehouse/t1",
+                  "name": "${json-unit.regex}.*/spark-warehouse/t1",
                   "field": "b"
                 }
               ]
@@ -79,7 +79,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "file:/opt/bitnami/spark/spark-warehouse",
+              "namespace": "${json-unit.regex}file:.*/spark-warehouse",
               "name": "default.t2",
               "type": "TABLE"
             }

--- a/integration/spark/cli/tests/test_pyspark/example_expected_event_start.json
+++ b/integration/spark/cli/tests/test_pyspark/example_expected_event_start.json
@@ -38,7 +38,7 @@
   "inputs": [
     {
       "namespace": "file",
-      "name": "/opt/bitnami/spark/spark-warehouse/t1",
+      "name": "${json-unit.regex}.*/spark-warehouse/t1",
       "facets": {
         "schema": {
           "fields": [
@@ -55,7 +55,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "file:/opt/bitnami/spark/spark-warehouse",
+              "namespace": "${json-unit.regex}file:.*/spark-warehouse",
               "name": "default.t1",
               "type": "TABLE"
             }

--- a/integration/spark/cli/tests/test_simple/example_expected_event_complete.json
+++ b/integration/spark/cli/tests/test_simple/example_expected_event_complete.json
@@ -36,7 +36,7 @@
   "outputs": [
     {
       "namespace": "file",
-      "name": "/opt/bitnami/spark/spark-warehouse/t2",
+      "name": "${json-unit.regex}.*/spark-warehouse/t2",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -60,7 +60,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/opt/bitnami/spark/spark-warehouse/t1",
+                  "name": "${json-unit.regex}.*/spark-warehouse/t1",
                   "field": "a"
                 }
               ]
@@ -69,7 +69,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/opt/bitnami/spark/spark-warehouse/t1",
+                  "name": "${json-unit.regex}.*/spark-warehouse/t1",
                   "field": "b"
                 }
               ]
@@ -79,7 +79,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "file:/opt/bitnami/spark/spark-warehouse",
+              "namespace": "${json-unit.regex}file:.*/spark-warehouse",
               "name": "default.t2",
               "type": "TABLE"
             }

--- a/integration/spark/cli/tests/test_simple/example_expected_event_start.json
+++ b/integration/spark/cli/tests/test_simple/example_expected_event_start.json
@@ -3,9 +3,7 @@
   "run": {
     "facets": {
       "parent": {
-        "run": {
-          "runId": "${json-unit.any-string}"
-        },
+        "run": { },
         "job": {
           "namespace": "default",
           "name": "cl_i_test_application"
@@ -39,7 +37,7 @@
   "inputs": [
     {
       "namespace": "file",
-      "name": "/opt/bitnami/spark/spark-warehouse/t1",
+      "name": "${json-unit.regex}.*/spark-warehouse/t1",
       "facets": {
         "schema": {
           "fields": [
@@ -56,7 +54,7 @@
         "symlinks": {
           "identifiers": [
             {
-              "namespace": "file:/opt/bitnami/spark/spark-warehouse",
+              "namespace": "${json-unit.regex}file:.*/spark-warehouse",
               "name": "default.t1",
               "type": "TABLE"
             }


### PR DESCRIPTION
Extend configurable integration test feature to be able to get Docker image name as a a name. 

Example config entries:]
```
docker:
  image: "apache/spark:3.3.3-scala2.12-java11-python3-ubuntu"
  sparkSubmit: /opt/spark/bin/spark-submit
  waitForLogMessage: ".*ShutdownHookManager: Shutdown hook called.*"
```

Related docs PR: https://github.com/OpenLineage/docs/pull/344/files