### PR TITLE
Spark,Flink: Add OracleJdbcExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -17,7 +17,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JdbcDatasetUtils {
   private static final JdbcExtractor[] extractors = {
-    new PostgresJdbcExtractor(), new SqlServerJdbcExtractor(), new GenericJdbcExtractor()
+    new PostgresJdbcExtractor(),
+    new OracleJdbcExtractor(),
+    new SqlServerJdbcExtractor(),
+    new GenericJdbcExtractor()
   };
 
   private static JdbcExtractor getExtractor(String jdbcUri) throws URISyntaxException {

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -1,0 +1,61 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public class OracleJdbcExtractor implements JdbcExtractor {
+  // https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A
+
+  private static final String SCHEME = "oracle";
+  private static final String DEFAULT_PORT = "1521";
+  private static final String URI_START = "^.*@(//)?";
+  private static final String URI_END = "\\?.*$";
+  private static final String PROTOCOL_PART = "^\\w+://";
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return jdbcUri.startsWith("oracle");
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    // oracle:thin:@//host:1521:sid?... -> host:1521:sid
+    String uri = rawUri.replaceFirst(URI_START, "").replaceAll(URI_END, "");
+
+    if (uri.contains("(")) {
+      throw new URISyntaxException(uri, "TNS format is unsupported for now");
+    }
+    return extractUri(uri, properties);
+  }
+
+  private JdbcLocation extractUri(String uri, Properties properties) throws URISyntaxException {
+    // convert 'tcp://'' protocol to 'oracle://'', convert ':sid' format to '/sid'
+    String normalizedUri = uri.replaceFirst(PROTOCOL_PART, "");
+    normalizedUri = "oracle://" + fixSidFormat(normalizedUri);
+
+    return new OverridingJdbcExtractor(SCHEME, DEFAULT_PORT).extract(normalizedUri, properties);
+  }
+
+  private String fixSidFormat(String uri) {
+    if (!uri.contains(":")) {
+      return uri;
+    }
+    List<String> components = Arrays.stream(uri.split(":")).collect(Collectors.toList());
+    String last = components.remove(components.size() - 1);
+    if (last.contains("]") || last.matches("^\\d+$")) {
+      // '[ip:v:6]' or 'host:1521'
+      return uri;
+    }
+    // 'host:1521:sid' -> 'host:1521/sid'
+    return StringUtils.join(components, ":") + "/" + last;
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -12,20 +12,18 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 class JdbcDatasetUtilsTestForOracle {
-  // https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/data-sources-and-URLs.html#GUID-EF07727C-50AB-4DCE-8EDC-57F0927FF61A
-
   @Test
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@//test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//test.host.com")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@test.host.com")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -34,13 +32,13 @@ class JdbcDatasetUtilsTestForOracle {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@//192.168.1.1", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//192.168.1.1")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://192.168.1.1:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@192.168.1.1", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@192.168.1.1")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://192.168.1.1:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -52,7 +50,7 @@ class JdbcDatasetUtilsTestForOracle {
                 "schema.table1",
                 new Properties()))
         .hasFieldOrPropertyWithValue(
-            "namespace", "oracle:thin:@//[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            "namespace", "oracle://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
@@ -61,7 +59,7 @@ class JdbcDatasetUtilsTestForOracle {
                 "schema.table1",
                 new Properties()))
         .hasFieldOrPropertyWithValue(
-            "namespace", "oracle:thin:@[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]")
+            "namespace", "oracle://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -70,40 +68,40 @@ class JdbcDatasetUtilsTestForOracle {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:user/password@//hostname", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:user/password@hostname", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:fred/sec%40ret@//hostname", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:fred/sec%40ret@hostname", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test
-  void testGetDatasetIdentifierWithPort() {
+  void testGetDatasetIdentifierWithCustomPort() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@//hostname:1521", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//hostname:1521")
+                "jdbc:oracle:thin:@//hostname:1522", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@hostname:1521", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@hostname:1521")
+                "jdbc:oracle:thin:@hostname:1522", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -112,7 +110,7 @@ class JdbcDatasetUtilsTestForOracle {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@tcp://hostname", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@tcp://hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -121,8 +119,8 @@ class JdbcDatasetUtilsTestForOracle {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@//hostname/serviceName", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//hostname/serviceName")
-        .hasFieldOrPropertyWithValue("name", "schema.table1");
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
+        .hasFieldOrPropertyWithValue("name", "serviceName.schema.table1");
   }
 
   @Test
@@ -130,8 +128,8 @@ class JdbcDatasetUtilsTestForOracle {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@hostname:sid", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@hostname:sid")
-        .hasFieldOrPropertyWithValue("name", "schema.table1");
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
+        .hasFieldOrPropertyWithValue("name", "sid.schema.table1");
   }
 
   @Test
@@ -141,7 +139,7 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@//hostname?connect_timeout=30&retry_count=3",
                 "schema.table1",
                 new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
@@ -149,7 +147,7 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@hostname?connect_timeout=30&retry_count=3",
                 "schema.table1",
                 new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@hostname")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -157,19 +155,20 @@ class JdbcDatasetUtilsTestForOracle {
   void testGetDatasetIdentifierWithMultipleHostsInSimpleFormat() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@//myhost1:1521,myhost2:1521", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@//myhost1:1521,myhost2:1521")
+                "jdbc:oracle:thin:@//myhost1,myhost2", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://myhost1:1521,myhost2:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@myhost1:1521,myhost2:1521", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle:thin:@myhost1:1521,myhost2:1521")
+        .hasFieldOrPropertyWithValue("namespace", "oracle://myhost1:1521,myhost2:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
   @Test
   void testGetDatasetIdentifierWithTnsFormat() {
+    // Currently TNS format is not parsed properly. Just drop credentials
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=hostname)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=ORCL)))",

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -75,8 +75,8 @@ class LogicalRelationDatasetBuilderTest {
   @ParameterizedTest
   @CsvSource({
     "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432,sparkdata.my_spark_table",
-    "jdbc:oracle:oci8:@sparkdata,oracle:oci8:@sparkdata,my_spark_table",
-    "jdbc:oracle:thin@sparkdata:1521:orcl,oracle:thin@sparkdata:1521:orcl,my_spark_table",
+    "jdbc:oracle:oci8:@sparkdata,oracle://sparkdata:1521,my_spark_table",
+    "jdbc:oracle:thin@sparkdata:1522:orcl,oracle://sparkdata:1522,orcl.my_spark_table",
     "jdbc:mysql://localhost/sparkdata,mysql://localhost,sparkdata.my_spark_table"
   })
   void testApply(String connectionUri, String targetUri, String targetTableName) {


### PR DESCRIPTION
### Problem

See #2762

### Solution

Add `OracleJdbcExtractor` which can handle simple Oracle JDBC URLs, but not TNS format (at list yet).

#### One-line summary:

Handle simple Oracle JDBC URLs, like `oracle:thin:@//host:port/serviceName` and `oracle:thin@host:port:sid`, and convert them to dataset with namespace `oracle://host:port` and name `sid.schema.table` or `serviceName.schema.table`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project