### PR TITLE
Spark,Flink: Add MySqlJdbcExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -19,6 +19,7 @@ public class JdbcDatasetUtils {
   private static final JdbcExtractor[] extractors = {
     new PostgresJdbcExtractor(),
     new OracleJdbcExtractor(),
+    new MySqlJdbcExtractor(),
     new SqlServerJdbcExtractor(),
     new GenericJdbcExtractor()
   };

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/MySqlJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/MySqlJdbcExtractor.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+public class MySqlJdbcExtractor implements JdbcExtractor {
+  // https://dev.mysql.com/doc/connector-j/en/connector-j-reference-jdbc-url-format.html
+
+  private static final String PROTOCOL_PART = "^[\\w+:]+://";
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("mysql", "3306");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    // Schema could be 'mysql', 'mysql:part', 'mysql+srv:part'. Convert it to 'mysql'
+    String normalizedUri = rawUri.replaceFirst(PROTOCOL_PART, "mysql://");
+    return delegate().extract(normalizedUri, properties);
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -77,7 +77,7 @@ class LogicalRelationDatasetBuilderTest {
     "jdbc:postgresql://postgreshost:5432/sparkdata,postgres://postgreshost:5432,sparkdata.my_spark_table",
     "jdbc:oracle:oci8:@sparkdata,oracle://sparkdata:1521,my_spark_table",
     "jdbc:oracle:thin@sparkdata:1522:orcl,oracle://sparkdata:1522,orcl.my_spark_table",
-    "jdbc:mysql://localhost/sparkdata,mysql://localhost,sparkdata.my_spark_table"
+    "jdbc:mysql://localhost/sparkdata,mysql://localhost:3306,sparkdata.my_spark_table"
   })
   void testApply(String connectionUri, String targetUri, String targetTableName) {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);


### PR DESCRIPTION
### Problem

MySQL JDBC URLs can be in a few different formats:
* With or without port number (default port number for MySQL is 3306)
* With schemes like `mysql`, `mysql+srv`, `mysql:loadbalance` and so on

This produces datasets with different namespaces, although data is stored in the same MySQL instance.

Related to #2762.

### Solution

Add `MySqlJdbcExtractor` which could handle these cases, and convert JDBC URLs to format `mysql://host:port`. Excluding TNS-like format of JDBC URL (at list for now).

#### One-line summary:

Handle different formats of MySQL JDBC URL, and produce datasets with consistent namespaces, like `mysql://host:port`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project