### PR TITLE
Spark,Flink: Add TeradataJdbcExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -21,6 +21,7 @@ public class JdbcDatasetUtils {
     new OracleJdbcExtractor(),
     new MySqlJdbcExtractor(),
     new SqlServerJdbcExtractor(),
+    new TeradataJdbcExtractor(),
     new GenericJdbcExtractor()
   };
 

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
@@ -10,10 +10,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-@Slf4j
 public class SqlServerJdbcExtractor implements JdbcExtractor {
   // https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16
 

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
@@ -1,0 +1,61 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class TeradataJdbcExtractor implements JdbcExtractor {
+  // https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#URL_DATABASE
+
+  private static final String SCHEME = "teradata";
+  private static final String PORT_PROPERTY = "DBS_PORT";
+  private static final String DEFAULT_PORT = "1025";
+  private static final String DATABASE_PROPERTY = "DATABASE";
+
+  private static final Pattern URL =
+      Pattern.compile("(?:\\w+)://(?<host>[\\w\\d\\.\\[\\]:]+)?/?(?<params>.*)");
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return jdbcUri.startsWith(SCHEME);
+  }
+
+  @Override
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    Matcher matcher = URL.matcher(rawUri);
+    if (!matcher.matches()) {
+      throw new URISyntaxException(rawUri, "Failed to parse jdbc url");
+    }
+
+    String host = matcher.group("host");
+    if (host == null) {
+      throw new URISyntaxException(rawUri, "Missing host");
+    }
+
+    String[] rawParams = StringUtils.defaultString(matcher.group("params")).split(",");
+
+    Properties params = new Properties();
+    for (String urlParam : rawParams) {
+      String[] parts = urlParam.split("=");
+      if (parts.length == 2) {
+        params.setProperty(parts[0], parts[1]);
+      }
+    }
+
+    String port = Optional.ofNullable(params.getProperty(PORT_PROPERTY)).orElse(DEFAULT_PORT);
+    String authority = host + ":" + port;
+
+    Optional<String> database = Optional.ofNullable(params.getProperty(DATABASE_PROPERTY));
+
+    return new JdbcLocation(SCHEME, authority, Optional.empty(), database);
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
@@ -1,0 +1,83 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForTeradata {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://test.host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://test.host.com:1025")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIPv4() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://192.168.1.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://192.168.1.1:1025")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIPv6() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "teradata://[3ffe:8311:eeee:f70f:0:5eae:10.203.31.9]:1025")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCredentials() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://hostname/USER=fred,PASSWORD=sec%40ret",
+                "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://hostname:1025")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCustomPort() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://hostname/DBS_PORT=1111", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://hostname:1111")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithDatabase() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://hostname/DATABASE=mydb", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://hostname:1025")
+        .hasFieldOrPropertyWithValue("name", "mydb.schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithExtraProperties() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:teradata://hostname/TMODE=TERADATA,APPNAME=MyApp",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://hostname:1025")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}


### PR DESCRIPTION
### Problem

See #2762.

### Solution

#### One-line summary:

Convert JDBC URLs like `jdbc:teradata/host/DBS_PORT=1024,DATABASE=somedb` to datasets with namespace `teradata://host:1024` and name `somedb.table`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project