### PR TITLE
Fix: handle dashes in hostname for JdbcExtractors

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 public class GenericJdbcExtractor implements JdbcExtractor {
   private static Pattern URL_FORMAT =
       Pattern.compile(
-          "^(?<scheme>\\w+)://(?<authority>[\\[\\]\\w\\d.,:]+)/?(?<database>[\\w\\d.]+)?(?:\\?.*)?");
+          "^(?<scheme>\\w+)://(?<authority>[\\w\\d\\.\\[\\]:,-]+)/?(?<database>[\\w\\d.]+)?(?:\\?.*)?");
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
@@ -15,7 +15,7 @@ public class OverridingJdbcExtractor extends GenericJdbcExtractor implements Jdb
   private String overrideScheme;
   private String defaultPort;
   private static Pattern HOST_PORT_FORMAT =
-      Pattern.compile("^(?<host>[\\[\\]\\w\\d.]+):(?<port>\\d+)?");
+      Pattern.compile("^(?<host>[\\[\\]\\w\\d.-]+):(?<port>\\d+)?");
 
   public OverridingJdbcExtractor(String overrideScheme) {
     this(overrideScheme, null);

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
@@ -25,7 +25,7 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
 
   private static final Pattern URL =
       Pattern.compile(
-          "(?:\\w+)://(?<host>[\\w\\d\\.]+)?(?:\\\\)?(?<instance>[\\w]+)?(?::)?(?<port>\\d+)?(?<params>.*)");
+          "(?:\\w+)://(?<host>[\\w\\d\\.-]+)?(?:\\\\)?(?<instance>[\\w]+)?(?::)?(?<port>\\d+)?(?<params>.*)");
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
@@ -22,7 +22,7 @@ public class TeradataJdbcExtractor implements JdbcExtractor {
   private static final String DATABASE_PROPERTY = "DATABASE";
 
   private static final Pattern URL =
-      Pattern.compile("(?:\\w+)://(?<host>[\\w\\d\\.\\[\\]:]+)?/?(?<params>.*)");
+      Pattern.compile("(?:\\w+)://(?<host>[\\w\\d\\.\\[\\]:-]+)?/?(?<params>.*)");
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
@@ -16,8 +16,8 @@ class JdbcDatasetUtilsTestForMySql {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:mysql://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "mysql://test.host.com:3306")
+                "jdbc:mysql://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "mysql://test-host.com:3306")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -16,14 +16,14 @@ class JdbcDatasetUtilsTestForOracle {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@//test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
+                "jdbc:oracle:thin:@//test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test-host.com:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
+                "jdbc:oracle:thin:@test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test-host.com:1521")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
@@ -16,8 +16,8 @@ class JdbcDatasetUtilsTestForPostgres {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:postgresql://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "postgres://test.host.com:5432")
+                "jdbc:postgresql://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "postgres://test-host.com:5432")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServer.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServer.java
@@ -16,8 +16,8 @@ class JdbcDatasetUtilsTestForSqlServer {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:sqlserver://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "sqlserver://test.host.com")
+                "jdbc:sqlserver://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://test-host.com")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
@@ -16,8 +16,8 @@ class JdbcDatasetUtilsTestForTeradata {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:teradata://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "teradata://test.host.com:1025")
+                "jdbc:teradata://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://test-host.com:1025")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForUnknown.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForUnknown.java
@@ -16,8 +16,8 @@ class JdbcDatasetUtilsTestForUnknown {
   void testGetDatasetIdentifierWithHost() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:unknown://test.host.com", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "unknown://test.host.com")
+                "jdbc:unknown://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "unknown://test-host.com")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 


### PR DESCRIPTION
### Problem

DNS names could contain dashes, e.g. `my-company.com`, but it is not an allowed symbol in JdbcExtractors implementation. This leads to producing datasets with namespaces like `postgres://my-company.com:5432:5432`.

### Solution

Properly handle dashes in JDBC URL hosts.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project