### PR TITLE
Fix: convert scheme and authority to lowercase in JdbcLocation

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -52,7 +52,7 @@ public class JdbcDatasetUtils {
   public static DatasetIdentifier getDatasetIdentifier(
       String jdbcUrl, List<String> parts, Properties properties) {
 
-    String uri = jdbcUrl.replaceAll("^jdbc:", "");
+    String uri = jdbcUrl.replaceAll("^(?i)jdbc:", "");
     try {
       JdbcExtractor extractor = getExtractor(uri);
       JdbcLocation location = extractor.extract(uri, properties);

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +21,9 @@ public class JdbcLocation {
   @Getter @Setter private Optional<String> database;
 
   public String toNamespace() {
-    String result = String.format("%s://%s", scheme, authority);
+    String result =
+        String.format(
+            "%s://%s", scheme.toLowerCase(Locale.ROOT), authority.toLowerCase(Locale.ROOT));
     if (instance.isPresent()) {
       result = String.format("%s/%s", result, instance.get());
     }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -8,6 +8,7 @@ package io.openlineage.client.utils.jdbc;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -23,7 +24,7 @@ public class OracleJdbcExtractor implements JdbcExtractor {
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {
-    return jdbcUri.startsWith("oracle");
+    return jdbcUri.toLowerCase(Locale.ROOT).startsWith(SCHEME);
   }
 
   @Override
@@ -40,7 +41,7 @@ public class OracleJdbcExtractor implements JdbcExtractor {
   private JdbcLocation extractUri(String uri, Properties properties) throws URISyntaxException {
     // convert 'tcp://'' protocol to 'oracle://'', convert ':sid' format to '/sid'
     String normalizedUri = uri.replaceFirst(PROTOCOL_PART, "");
-    normalizedUri = "oracle://" + fixSidFormat(normalizedUri);
+    normalizedUri = SCHEME + "://" + fixSidFormat(normalizedUri);
 
     return new OverridingJdbcExtractor(SCHEME, DEFAULT_PORT).extract(normalizedUri, properties);
   }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,7 +28,7 @@ public class OverridingJdbcExtractor extends GenericJdbcExtractor implements Jdb
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {
-    return jdbcUri.startsWith(overrideScheme);
+    return jdbcUri.toLowerCase(Locale.ROOT).startsWith(overrideScheme);
   }
 
   @Override

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -16,10 +17,10 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
   // https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16
 
   private static final String SCHEME = "sqlserver";
-  private static final String SERVICE_PROPERTY = "serverName";
-  private static final String PORT_PROPERTY = "portNumber";
-  private static final String INSTANCE_PROPERTY = "instanceName";
-  private static final String DATABASE_NAME_PROPERTY = "databaseName";
+  private static final String SERVICE_PROPERTY = "servername";
+  private static final String PORT_PROPERTY = "portnumber";
+  private static final String INSTANCE_PROPERTY = "instancename";
+  private static final String DATABASE_NAME_PROPERTY = "databasename";
   private static final String DATABASE_PROPERTY = "database";
 
   private static final Pattern URL =
@@ -28,10 +29,11 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {
-    return jdbcUri.startsWith(SCHEME);
+    return jdbcUri.toLowerCase(Locale.ROOT).startsWith(SCHEME);
   }
 
   @Override
+  @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
     Matcher matcher = URL.matcher(rawUri);
     if (!matcher.matches()) {
@@ -57,14 +59,21 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
 
     for (String urlParam : urlParams) {
       String[] parts = urlParam.split("=");
-      if (parts.length == 2 && finalProperties.getProperty(parts[0]) == null) {
-        finalProperties.setProperty(parts[0], parts[1]);
+      if (parts.length == 2) {
+        // property names are case-insensitive
+        String key = parts[0].toLowerCase(Locale.ROOT);
+        String value = parts[1];
+        finalProperties.setProperty(key, value);
       }
     }
 
     for (String key : properties.stringPropertyNames()) {
-      if (finalProperties.getProperty(key) == null) {
-        finalProperties.setProperty(key, properties.getProperty(key));
+      // properties have higher priority than in-url params.
+      // property names are case-insensitive
+      // https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver16#remarks
+      String normalizedKey = key.toLowerCase(Locale.ROOT);
+      if (finalProperties.getProperty(normalizedKey) == null) {
+        finalProperties.setProperty(normalizedKey, properties.getProperty(key));
       }
     }
 

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -25,7 +26,7 @@ public class TeradataJdbcExtractor implements JdbcExtractor {
 
   @Override
   public boolean isDefinedAt(String jdbcUri) {
-    return jdbcUri.startsWith(SCHEME);
+    return jdbcUri.toLowerCase(Locale.ROOT).startsWith(SCHEME);
   }
 
   @Override
@@ -47,7 +48,10 @@ public class TeradataJdbcExtractor implements JdbcExtractor {
     for (String urlParam : rawParams) {
       String[] parts = urlParam.split("=");
       if (parts.length == 2) {
-        params.setProperty(parts[0], parts[1]);
+        // Teradata properties are always in uppercase
+        String key = parts[0].toUpperCase(Locale.ROOT);
+        String value = parts[1];
+        params.setProperty(key, value);
       }
     }
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
@@ -119,6 +119,15 @@ class JdbcDatasetUtilsTestForMySql {
   }
 
   @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:MYSQL://TEST.HOST.COM/MYDB", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "mysql://test.host.com:3306")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+  }
+
+  @Test
   void testGetDatasetIdentifierWithMultipleHostsInSimpleFormat() {
     // failover
     assertThat(

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -152,6 +152,21 @@ class JdbcDatasetUtilsTestForOracle {
   }
 
   @Test
+  void testGetDatasetIdentifierWithUppercaseURL() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:ORACLE:THIN:@//TEST.HOST.COM/SERVICENAME", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
+        .hasFieldOrPropertyWithValue("name", "SERVICENAME.SCHEMA.TABLE1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:ORACLE:THIN:@TEST.HOST.COM:SID", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://test.host.com:1521")
+        .hasFieldOrPropertyWithValue("name", "SID.SCHEMA.TABLE1");
+  }
+
+  @Test
   void testGetDatasetIdentifierWithMultipleHostsInSimpleFormat() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForPostgres.java
@@ -82,6 +82,15 @@ class JdbcDatasetUtilsTestForPostgres {
   }
 
   @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:POSTGRESQL://TEST.HOST.COM/MYDB", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "postgres://test.host.com:5432")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+  }
+
+  @Test
   void testGetDatasetIdentifierWithMultipleHosts() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServer.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServer.java
@@ -134,14 +134,14 @@ class JdbcDatasetUtilsTestForSqlServer {
   void testGetDatasetIdentifierWithServerName() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:sqlserver://;serverName=someServer", "schema.table1", new Properties()))
-        .hasFieldOrPropertyWithValue("namespace", "sqlserver://someServer")
+                "jdbc:sqlserver://;serverName=someserver", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://someserver")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
 
     Properties props = new Properties();
-    props.setProperty("serverName", "someServer");
+    props.setProperty("serverName", "someserver");
     assertThat(JdbcDatasetUtils.getDatasetIdentifier("jdbc:sqlserver://", "schema.table1", props))
-        .hasFieldOrPropertyWithValue("namespace", "sqlserver://someServer")
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://someserver")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
 
@@ -173,5 +173,16 @@ class JdbcDatasetUtilsTestForSqlServer {
                 new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jDBC:SQLSERVER://TEST.HOST.COM\\MYINSTANCE;DATABASENAME=MYDB",
+                "SCHEMA.TABLE1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://test.host.com/MYINSTANCE")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTeradata.java
@@ -80,4 +80,13 @@ class JdbcDatasetUtilsTestForTeradata {
         .hasFieldOrPropertyWithValue("namespace", "teradata://hostname:1025")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
   }
+
+  @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:TERADATA://TEST.HOST.COM/DATABASE=MYDB", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "teradata://test.host.com:1025")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+  }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForUnknown.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForUnknown.java
@@ -150,6 +150,15 @@ class JdbcDatasetUtilsTestForUnknown {
   }
 
   @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "JDBC:UNKNOWN://TEST.HOST.COM/MYDB", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "unknown://test.host.com")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+  }
+
+  @Test
   void testGetDatasetIdentifierWithMultipleHosts() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -132,14 +132,14 @@ class SQLDWDatabricksVisitorTest {
 
   @ParameterizedTest
   @CsvSource({
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;databaseName=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net,sqlserver://MYTESTSERVER.database.windows.net,schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net:1433,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;portNumber=1433;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net:1433,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net\\someinstance;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net/someinstance,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;instanceName=someinstance;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net/someinstance,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://;serverName=MYTESTSERVER.database.windows.net,sqlserver://MYTESTSERVER.database.windows.net,schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;database=MYTESTDB,sqlserver://mytestserver.database.windows.net,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;databaseName=MYTESTDB,sqlserver://mytestserver.database.windows.net,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net,sqlserver://mytestserver.database.windows.net,schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB,sqlserver://mytestserver.database.windows.net:1433,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;portNumber=1433;database=MYTESTDB,sqlserver://mytestserver.database.windows.net:1433,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net\\someinstance;database=MYTESTDB,sqlserver://mytestserver.database.windows.net/someinstance,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;instanceName=someinstance;database=MYTESTDB,sqlserver://mytestserver.database.windows.net/someinstance,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://;serverName=MYTESTSERVER.database.windows.net,sqlserver://mytestserver.database.windows.net,schema.table1",
   })
   void testSQLDWRelation(String inputJdbcUrl, String expectedNamespace, String expectedName) {
     String inputName = "\"schema\".\"table1\"";
@@ -173,14 +173,14 @@ class SQLDWDatabricksVisitorTest {
 
   @ParameterizedTest
   @CsvSource({
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;databaseName=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net,sqlserver://MYTESTSERVER.database.windows.net,schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net:1433,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;portNumber=1433;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net:1433,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net\\someinstance;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net/someinstance,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;instanceName=someinstance;database=MYTESTDB,sqlserver://MYTESTSERVER.database.windows.net/someinstance,MYTESTDB.schema.table1",
-    "jdbc:sqlserver://;serverName=MYTESTSERVER.database.windows.net,sqlserver://MYTESTSERVER.database.windows.net,schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;database=MYTESTDB,sqlserver://mytestserver.database.windows.net,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;databaseName=MYTESTDB,sqlserver://mytestserver.database.windows.net,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net,sqlserver://mytestserver.database.windows.net,schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB,sqlserver://mytestserver.database.windows.net:1433,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;portNumber=1433;database=MYTESTDB,sqlserver://mytestserver.database.windows.net:1433,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net\\someinstance;database=MYTESTDB,sqlserver://mytestserver.database.windows.net/someinstance,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://MYTESTSERVER.database.windows.net;instanceName=someinstance;database=MYTESTDB,sqlserver://mytestserver.database.windows.net/someinstance,MYTESTDB.schema.table1",
+    "jdbc:sqlserver://;serverName=MYTESTSERVER.database.windows.net,sqlserver://mytestserver.database.windows.net,schema.table1",
   })
   void testSpark2SQLDWRelation(String inputJdbcUrl, String expectedNamespace, String expectedName) {
     String inputName = "\"schema\".\"table1\"";
@@ -218,7 +218,7 @@ class SQLDWDatabricksVisitorTest {
     String inputJdbcUrl =
         "jdbc:sqlserver://MYTESTSERVER.database.windows.net:1433;database=MYTESTDB";
     String expectedName = "MYTESTDB.COMPLEX";
-    String expectedNamespace = "sqlserver://MYTESTSERVER.database.windows.net:1433";
+    String expectedNamespace = "sqlserver://mytestserver.database.windows.net:1433";
 
     // Instantiate a MockSQLDWRelation
     LogicalRelation lr =


### PR DESCRIPTION
### Problem

Closes: #2829

### Solution

Convert valid JDBC URL scheme and authority to lowercase. But left intact instance/database name, as different databases have different default case and case sensitivity rules.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project