### PR TITLE
[SPARK] Remove entrypoint build & release of `spark-extension-entrypoint` module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ jobs:
               check_change client/java/ openlineage-java.yml openlineage-flink.yml openlineage-spark.yml
               check_change integration/spark/ openlineage-java.yml openlineage-spark.yml
               check_change integration/spark-extension-interfaces/ openlineage-java.yml openlineage-spark.yml
-              check_change integration/spark-extension-entrypoint/ openlineage-java.yml openlineage-spark.yml
               check_change integration/flink/ openlineage-java.yml openlineage-flink.yml
               check_change client/python/ openlineage-integration-python.yml openlineage-integration-dbt.yml openlineage-integration-dagster.yml openlineage-integration-airflow.yml
               check_change integration/common/ openlineage-integration-python.yml openlineage-integration-airflow.yml openlineage-integration-dbt.yml

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1214,15 +1214,6 @@ workflows:
           context: release
           requires:
             - release-client-java
-      - release-integration-spark-extension-entrypoint:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-            branches:
-              ignore: /.*/
-          context: release
-          requires:
-            - release-client-java
       - release-integration-flink:
           filters:
             tags:

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -4,9 +4,6 @@ workflows:
       - build-integration-spark-extension-interfaces:
           requires:
             - build-client-java
-      - build-integration-spark-extension-entrypoint:
-          requires:
-            - build-client-java
       - build-integration-spark-scala-2_12:
           matrix:
             parameters:
@@ -15,7 +12,6 @@ workflows:
            - build-integration-sql-java
            - build-client-java
            - build-integration-spark-extension-interfaces
-           - build-integration-spark-extension-entrypoint
       - build-integration-spark-scala-2_13:
           matrix:
             parameters:
@@ -24,7 +20,6 @@ workflows:
            - build-integration-sql-java
            - build-client-java           
            - build-integration-spark-extension-interfaces
-           - build-integration-spark-extension-entrypoint
       - approval-integration-spark:
           type: approval
           requires:


### PR DESCRIPTION
### Problem

`spark-extension-entrypoint` module should be built and released only once

### Solution

Removes `spark-extension-entrypoint` build & release process from CI as this a one-time-build-never-change module. 

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project