### PR TITLE
remove shaded dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.18.0...HEAD)
 
+### Fixed
+* **Remove shaded dependency in `ColumnLevelLineageBuilder`** [`#2850`](https://github.com/OpenLineage/OpenLineage/pull/2850) [@tnazarew](https://github.com/tnazarew)  
+  *Remove shaded `Streams` dependency in `ColumnLevelLineageBuilder` causing `ClassNotFoundException`*
+
 ## [1.18.0](https://github.com/OpenLineage/OpenLineage/compare/1.17.1...1.18.0) - 2024-07-11
 ### Added
 * **Spark: configurable integration test** [`#2755`](https://github.com/OpenLineage/OpenLineage/pull/2755) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -187,8 +187,10 @@ public class ColumnLevelLineageBuilder {
   private List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetInputFields(
       List<TransformedInput> inputFields, List<TransformedInput> datasetDependencyInputs) {
     Map<Input, List<TransformedInput>> combinedInputs = new HashMap<>();
-    inputFields.stream().forEach(e->combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
-    datasetDependencyInputs.stream().forEach(e->combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
+    inputFields.stream()
+        .forEach(e -> combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
+    datasetDependencyInputs.stream()
+        .forEach(e -> combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
 
     return combinedInputs.entrySet().stream()
         .map(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -22,12 +22,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.shaded.com.google.common.collect.Streams;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
 import org.jetbrains.annotations.NotNull;
 
@@ -188,13 +186,11 @@ public class ColumnLevelLineageBuilder {
 
   private List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetInputFields(
       List<TransformedInput> inputFields, List<TransformedInput> datasetDependencyInputs) {
+    Map<Input, List<TransformedInput>> combinedInputs = new HashMap<>();
+    inputFields.stream().forEach(e->combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
+    datasetDependencyInputs.stream().forEach(e->combinedInputs.computeIfAbsent(e.getInput(), k -> new LinkedList<>()).add(e));
 
-    Stream<TransformedInput> concat =
-        Streams.concat(inputFields.stream(), datasetDependencyInputs.stream());
-    Map<Input, List<TransformedInput>> collect =
-        concat.collect(Collectors.groupingBy(TransformedInput::getInput, Collectors.toList()));
-
-    return collect.entrySet().stream()
+    return combinedInputs.entrySet().stream()
         .map(
             field ->
                 new OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFieldsBuilder()


### PR DESCRIPTION
### Problem

CLL collection can throw exceptions like
```
24/07/15 13:46:49 ERROR ColumnLevelLineageUtils: Error when invoking static method 'buildColumnLineageDatasetFacet' for Spark3
java.lang.reflect.InvocationTargetException
.
.
.
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.shaded.com.google.common.collect.Streams
```

Closes:

### Solution

Refactor code so it no longer uses `org.apache.hadoop.shaded.com.google.common.collect.Streams` and remove the dependency.

#### One-line summary:

Remove the `org.apache.hadoop.shaded.com.google.common.collect.Streams` so it doesn't throw `ClassNotFoundException`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project