### PR TITLE
Airflow: Add log_url to AirflowRunFacet

### DIFF
--- a/integration/airflow/facets/AirflowRunFacet.json
+++ b/integration/airflow/facets/AirflowRunFacet.json
@@ -127,6 +127,10 @@
         },
         "map_index": {
           "type": "integer"
+        },
+        "log_url": {
+          "type": "string",
+          "format": "uri"
         }
       },
       "additionalProperties": true,

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -285,7 +285,7 @@ class DagRunInfo(InfoJsonEncodable):
 
 
 class TaskInstanceInfo(InfoJsonEncodable):
-    includes = ["duration", "try_number", "pool"]
+    includes = ["duration", "try_number", "pool", "log_url"]
     casts = {
         "map_index": lambda ti: ti.map_index if hasattr(ti, "map_index") and ti.map_index != -1 else None
     }


### PR DESCRIPTION
### Problem

It is quite useful to have an URL of Airflow task log as a part of `airflow` facet. Currently I have to reimplement the logic present in Airflow, and keep it in sync with a particular Airflow version, e.g.:
https://github.com/apache/airflow/blob/2.9.0/airflow/models/taskinstance.py#L1719-L1731
https://github.com/apache/airflow/blob/2.1.0/airflow/models/taskinstance.py#L524-L528

### Solution

#### One-line summary:

Add taskinstance's `log_url` field to `AirflowRunFacet`.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project