### PR TITLE
[SPARK] Use Table's properties during column level lineage construction

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
@@ -9,8 +9,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -47,6 +47,7 @@ public class DataSourceV2RelationInputDatasetBuilder
         context.getOpenLineage().newDatasetFacetsBuilder();
 
     DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, relation);
-    return PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder);
+    return DataSourceV2RelationDatasetExtractor.extract(
+        factory, context, relation, datasetFacetsBuilder);
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -9,8 +9,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +53,8 @@ public class DataSourceV2RelationOutputDatasetBuilder
       DatasetVersionDatasetFacetUtils.includeDatasetVersion(
           context, datasetFacetsBuilder, relation);
     }
-    return PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder);
+    return DataSourceV2RelationDatasetExtractor.extract(
+        factory, context, relation, datasetFacetsBuilder);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilder.java
@@ -9,8 +9,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -41,6 +41,7 @@ public class DataSourceV2ScanRelationInputDatasetBuilder
         context.getOpenLineage().newDatasetFacetsBuilder();
 
     DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, relation);
-    return PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder);
+    return DataSourceV2RelationDatasetExtractor.extract(
+        factory, context, relation, datasetFacetsBuilder);
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -9,8 +9,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.IcebergHandler;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +84,7 @@ public class TableContentChangeDatasetBuilder
           context, datasetFacetsBuilder, returnTable);
     }
 
-    return PlanUtils3.fromDataSourceV2Relation(
+    return DataSourceV2RelationDatasetExtractor.extract(
         outputDataset(), context, returnTable, datasetFacetsBuilder);
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -167,7 +167,7 @@ public class InputFieldsCollector {
 
   private static List<DatasetIdentifier> extractDatasetIdentifier(
       ColumnLevelLineageContext context, DataSourceV2Relation relation) {
-    return PlanUtils3.getDatasetIdentifier(context.getOlContext(), relation)
+    return PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation)
         .map(Collections::singletonList)
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -16,7 +16,7 @@ import io.openlineage.spark.agent.util.JdbcSparkUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.sql.SqlMeta;
 import java.net.URI;
 import java.util.ArrayList;
@@ -167,7 +167,8 @@ public class InputFieldsCollector {
 
   private static List<DatasetIdentifier> extractDatasetIdentifier(
       ColumnLevelLineageContext context, DataSourceV2Relation relation) {
-    return PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation)
+    return DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
+            context.getOlContext(), relation)
         .map(Collections::singletonList)
         .orElse(Collections.emptyList());
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -1,0 +1,124 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+public class DataSourceV2RelationDatasetExtractor {
+
+  public static <D extends OpenLineage.Dataset> List<D> extract(
+      DatasetFactory<D> datasetFactory, OpenLineageContext context, DataSourceV2Relation relation) {
+    return extract(
+        datasetFactory, context, relation, context.getOpenLineage().newDatasetFacetsBuilder());
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> extract(
+      DatasetFactory<D> datasetFactory,
+      OpenLineageContext context,
+      DataSourceV2Relation relation,
+      OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder) {
+
+    OpenLineage openLineage = context.getOpenLineage();
+    Optional<DatasetIdentifier> di = getDatasetIdentifierExtended(context, relation);
+    return di.map(
+            identifier -> {
+              if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
+                ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
+              } else {
+                TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
+
+                Map<String, String> tableProperties = relation.table().properties();
+                CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
+                    .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
+              }
+              datasetFacetsBuilder
+                  .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
+                  .dataSource(PlanUtils.datasourceFacet(openLineage, identifier.getNamespace()));
+
+              return Collections.singletonList(
+                  datasetFactory.getDataset(identifier, datasetFacetsBuilder));
+            })
+        .orElse(Collections.emptyList());
+  }
+
+  public static Optional<DatasetIdentifier> getDatasetIdentifier(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+
+    if (relation.identifier() == null || relation.identifier().isEmpty()) {
+      // Since identifier is null, short circuit and check if we can get the dataset identifier
+      // from the relation itself.
+      return getDatasetIdentifierFromRelation(relation);
+    }
+    return Optional.of(relation)
+        .filter(r -> r.identifier() != null)
+        .filter(r -> r.identifier().isDefined())
+        .filter(r -> r.catalog() != null)
+        .filter(r -> r.catalog().isDefined())
+        .filter(r -> r.catalog().get() instanceof TableCatalog)
+        .flatMap(
+            r ->
+                PlanUtils3.getDatasetIdentifier(
+                    context,
+                    (TableCatalog) r.catalog().get(),
+                    r.identifier().get(),
+                    r.table().properties()));
+  }
+
+  public static Optional<DatasetIdentifier> getDatasetIdentifierExtended(
+      OpenLineageContext context, DataSourceV2Relation relation) {
+    // Check if the dataset has extension lineage
+    if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
+      return Optional.of(ExtensionDataSourceV2Utils.getDatasetIdentifier(relation));
+    }
+
+    // Check if the relation identifier is empty
+    if (relation.identifier().isEmpty()) {
+      log.warn("Couldn't find identifier for dataset in plan {}", relation);
+      return getDatasetIdentifier(context, relation);
+    }
+
+    // Check if the catalog is present and is an instance of TableCatalog
+    if (relation.catalog().isEmpty() || !(relation.catalog().get() instanceof TableCatalog)) {
+      log.warn("Couldn't find catalog for dataset in plan {}", relation);
+      return Optional.empty();
+    }
+
+    Identifier identifier = relation.identifier().get();
+    TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
+    Map<String, String> tableProperties = relation.table().properties();
+
+    // Get the dataset identifier
+    return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+  }
+
+  private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
+      DataSourceV2Relation relation) {
+
+    try {
+      return (Optional.of(CatalogUtils3.getDatasetIdentifierFromRelation(relation)));
+    } catch (UnsupportedCatalogException ex) {
+      log.error(
+          String.format("Catalog %s is unsupported", ex.getMessage()),
+          ex); // update this if change the exception thrown in catalogutils
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 /** Utility class to load serialized facets json string into a dataset builder */
 @Slf4j
-class ExtesionDataSourceV2Utils {
+class ExtensionDataSourceV2Utils {
 
   public static final String OPENLINEAGE_DATASET_FACETS_PREFIX = "openlineage.dataset.facets.";
   private static Map<String, TypeReference> predefinedFacets;

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/PlanUtils3.java
@@ -5,16 +5,11 @@
 
 package io.openlineage.spark3.agent.utils;
 
-import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +22,6 @@ import org.apache.spark.sql.execution.CacheManager;
 import org.apache.spark.sql.execution.CachedData;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.columnar.InMemoryRelation;
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.internal.SharedState;
 import scala.collection.IndexedSeq;
 
@@ -37,29 +31,6 @@ import scala.collection.IndexedSeq;
  */
 @Slf4j
 public class PlanUtils3 {
-
-  public static Optional<DatasetIdentifier> getDatasetIdentifier(
-      OpenLineageContext context, DataSourceV2Relation relation) {
-
-    if (relation.identifier() == null || relation.identifier().isEmpty()) {
-      // Since identifier is null, short circuit and check if we can get the dataset identifier
-      // from the relation itself.
-      return getDatasetIdentifierFromRelation(relation);
-    }
-    return Optional.of(relation)
-        .filter(r -> r.identifier() != null)
-        .filter(r -> r.identifier().isDefined())
-        .filter(r -> r.catalog() != null)
-        .filter(r -> r.catalog().isDefined())
-        .filter(r -> r.catalog().get() instanceof TableCatalog)
-        .flatMap(
-            r ->
-                PlanUtils3.getDatasetIdentifier(
-                    context,
-                    (TableCatalog) r.catalog().get(),
-                    r.identifier().get(),
-                    r.table().properties()));
-  }
 
   // Ensure that resources like this SparkSession object are closed after use -> we
   // don't want to close SparkSession
@@ -87,84 +58,6 @@ public class PlanUtils3 {
       }
       throw e;
     }
-  }
-
-  private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
-      DataSourceV2Relation relation) {
-
-    try {
-      return (Optional.of(CatalogUtils3.getDatasetIdentifierFromRelation(relation)));
-    } catch (UnsupportedCatalogException ex) {
-      log.error(
-          String.format("Catalog %s is unsupported", ex.getMessage()),
-          ex); // update this if change the exception thrown in catalogutils
-      return Optional.empty();
-    }
-  }
-
-  public static <D extends OpenLineage.Dataset> List<D> fromDataSourceV2Relation(
-      DatasetFactory<D> datasetFactory, OpenLineageContext context, DataSourceV2Relation relation) {
-    return fromDataSourceV2Relation(
-        datasetFactory, context, relation, context.getOpenLineage().newDatasetFacetsBuilder());
-  }
-
-  public static <D extends OpenLineage.Dataset> List<D> fromDataSourceV2Relation(
-      DatasetFactory<D> datasetFactory,
-      OpenLineageContext context,
-      DataSourceV2Relation relation,
-      OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder) {
-
-    OpenLineage openLineage = context.getOpenLineage();
-    Optional<DatasetIdentifier> di = getDatasetIdentifierExtended(context, relation);
-    return di.map(
-            identifier -> {
-              if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
-                ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
-              } else {
-                TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
-
-                Map<String, String> tableProperties = relation.table().properties();
-                CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-                    .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
-              }
-              datasetFacetsBuilder
-                  .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
-                  .dataSource(PlanUtils.datasourceFacet(openLineage, identifier.getNamespace()));
-
-              return Collections.singletonList(
-                  datasetFactory.getDataset(identifier, datasetFacetsBuilder));
-            })
-        .orElse(Collections.emptyList());
-  }
-
-  public static Optional<DatasetIdentifier> getDatasetIdentifierExtended(
-      OpenLineageContext context, DataSourceV2Relation relation) {
-    // Check if the dataset has extension lineage
-    if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
-      return Optional.of(ExtensionDataSourceV2Utils.getDatasetIdentifier(relation));
-    }
-
-    // Check if the relation identifier is empty
-    if (relation.identifier().isEmpty()) {
-      log.warn("Couldn't find identifier for dataset in plan {}", relation);
-      return PlanUtils3.getDatasetIdentifier(context, relation);
-    }
-
-    // Get the identifier from the relation
-    Identifier identifier = relation.identifier().get();
-
-    // Check if the catalog is present and is an instance of TableCatalog
-    if (relation.catalog().isEmpty() || !(relation.catalog().get() instanceof TableCatalog)) {
-      log.warn("Couldn't find catalog for dataset in plan {}", relation);
-      return Optional.empty();
-    }
-
-    // Get the catalog and table properties
-    TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
-    Map<String, String> tableProperties = relation.table().properties();
-
-    // Get the dataset identifier
-    return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
   }
 
   /**

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -23,8 +23,8 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -65,12 +65,13 @@ class AppendDataDatasetBuilderTest {
     OpenLineage.OutputDataset dataset = mock(OpenLineage.OutputDataset.class);
     when(appendData.table()).thenReturn(relation);
 
-    try (MockedStatic mockedPlanUtils3 = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic mockedPlanUtils3 = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
         when(DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
                 context, relation))
             .thenReturn(Optional.of("v2"));
-        when(PlanUtils3.fromDataSourceV2Relation(eq(factory), eq(context), eq(relation), any()))
+        when(DataSourceV2RelationDatasetExtractor.extract(
+                eq(factory), eq(context), eq(relation), any()))
             .thenReturn(Collections.singletonList(dataset));
 
         List<OpenLineage.OutputDataset> datasets =

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
@@ -16,8 +16,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -66,10 +66,12 @@ class DataSourceV2RelationDatasetBuilderTest {
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(context.getOpenLineage()).thenReturn(openLineage);
 
-    try (MockedStatic planUtils3MockedStatic = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic planUtils3MockedStatic =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic facetUtilsMockedStatic =
           mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder))
+        when(DataSourceV2RelationDatasetExtractor.extract(
+                factory, context, relation, datasetFacetsBuilder))
             .thenReturn(datasets);
 
         if (builder instanceof DataSourceV2RelationOutputDatasetBuilder) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationInputDatasetBuilderTest.java
@@ -13,8 +13,8 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.List;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
@@ -49,10 +49,12 @@ class DataSourceV2ScanRelationInputDatasetBuilderTest {
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(scanRelation.relation()).thenReturn(relation);
 
-    try (MockedStatic planUtils3MockedStatic = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic planUtils3MockedStatic =
+        mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic facetUtilsMockedStatic =
           mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PlanUtils3.fromDataSourceV2Relation(factory, context, relation, datasetFacetsBuilder))
+        when(DataSourceV2RelationDatasetExtractor.extract(
+                factory, context, relation, datasetFacetsBuilder))
             .thenReturn(datasets);
 
         Assertions.assertEquals(datasets, builder.apply(scanRelation));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -137,7 +137,7 @@ class TableContentChangeDatasetBuilderTest {
   private void verify(
       LogicalPlan logicalPlan,
       OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange) {
-    try (MockedStatic mockedPlanUtils3 = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic mockedPlanUtils3 = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic mockedVersions = mockStatic(CatalogUtils3.class)) {
         OpenLineage.Dataset dataset = mock(OpenLineage.OutputDataset.class);
         OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
@@ -159,7 +159,7 @@ class TableContentChangeDatasetBuilderTest {
         when(openLineage.newDatasetVersionDatasetFacet("v2"))
             .thenReturn(datasetVersionDatasetFacet);
 
-        when(PlanUtils3.fromDataSourceV2Relation(
+        when(DataSourceV2RelationDatasetExtractor.extract(
                 any(), eq(openLineageContext), eq(dataSourceV2Relation), eq(datasetFacetsBuilder)))
             .thenReturn(Collections.singletonList(dataset));
         when(CatalogUtils3.getDatasetVersion(any(), any(), any(), any()))

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -85,7 +85,7 @@ class InputFieldsCollectorTest {
                 .toSeq());
 
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      when(PlanUtils3.getDatasetIdentifier(context.getOlContext(), relation))
+      when(PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation))
           .thenReturn(Optional.of(di));
       InputFieldsCollector.collect(context, plan);
     }
@@ -108,7 +108,7 @@ class InputFieldsCollectorTest {
                 .toSeq());
 
     try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      when(PlanUtils3.getDatasetIdentifier(context.getOlContext(), relation))
+      when(PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation))
           .thenReturn(Optional.of(di));
       InputFieldsCollector.collect(context, plan);
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -21,7 +21,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,8 +84,9 @@ class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      when(PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation))
+    try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      when(DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
+              context.getOlContext(), relation))
           .thenReturn(Optional.of(di));
       InputFieldsCollector.collect(context, plan);
     }
@@ -107,8 +108,9 @@ class InputFieldsCollectorTest {
                 .asScala()
                 .toSeq());
 
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
-      when(PlanUtils3.getDatasetIdentifierExtended(context.getOlContext(), relation))
+    try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      when(DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
+              context.getOlContext(), relation))
           .thenReturn(Optional.of(di));
       InputFieldsCollector.collect(context, plan);
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -1,0 +1,218 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class DataSourceV2RelationDatasetExtractorTest {
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  SparkSession sparkSession = mock(SparkSession.class);
+  DatasetFactory<OpenLineage.Dataset> datasetFactory = mock(DatasetFactory.class);
+  DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
+  OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
+      mock(OpenLineage.DatasetFacetsBuilder.class);
+  TableCatalog tableCatalog = mock(TableCatalog.class);
+  Identifier identifier = mock(Identifier.class);
+  StructType schema = mock(StructType.class);
+  Table table = mock(Table.class);
+  Map<String, String> tableProperties;
+  OpenLineage openLineage = mock(OpenLineage.class);
+
+  @BeforeEach
+  void setUp() {
+    tableProperties = new HashMap<>();
+    when(openLineageContext.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
+    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
+    when(dataSourceV2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(identifier));
+    when(dataSourceV2Relation.schema()).thenReturn(schema);
+    when(dataSourceV2Relation.table()).thenReturn(table);
+    when(table.properties()).thenReturn(tableProperties);
+  }
+
+  @Test
+  void testExtractFromDataSourceV2Relation() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      try (MockedStatic<PlanUtils> mockedPlanUtils = mockStatic(PlanUtils.class)) {
+        DatasetIdentifier di = mock(DatasetIdentifier.class);
+        when(di.getNamespace()).thenReturn("file://tmp");
+        when(di.getName()).thenReturn("name");
+
+        OpenLineage.DatasetFacets datasetFacets = mock(OpenLineage.DatasetFacets.class);
+        OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
+        OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
+            mock(OpenLineage.SchemaDatasetFacet.class);
+        OpenLineage.DatasourceDatasetFacet datasourceDatasetFacet =
+            mock(OpenLineage.DatasourceDatasetFacet.class);
+        when(PlanUtils.schemaFacet(openLineage, schema)).thenReturn(schemaDatasetFacet);
+        when(PlanUtils.datasourceFacet(openLineage, di.getNamespace()))
+            .thenReturn(datasourceDatasetFacet);
+        when(datasetFacetsBuilder.schema(schemaDatasetFacet)).thenReturn(datasetFacetsBuilder);
+        when(datasetFacetsBuilder.dataSource(datasourceDatasetFacet))
+            .thenReturn(datasetFacetsBuilder);
+        when(datasetFacetsBuilder.build()).thenReturn(datasetFacets);
+
+        when(CatalogUtils3.getDatasetIdentifier(
+                openLineageContext, tableCatalog, identifier, tableProperties))
+            .thenReturn(di);
+        when(datasetFactory.getDataset(di, datasetFacetsBuilder)).thenReturn(dataset);
+
+        assertEquals(
+            Collections.singletonList(dataset),
+            DataSourceV2RelationDatasetExtractor.extract(
+                datasetFactory, openLineageContext, dataSourceV2Relation));
+      }
+    }
+  }
+
+  @Test
+  void testExtractFromDataSourceV2RelationWhenDatasetIdentifierEmpty() {
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      DatasetIdentifier di = mock(DatasetIdentifier.class);
+      OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
+
+      when(CatalogUtils3.getDatasetIdentifier(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenThrow(new UnsupportedCatalogException("exception"));
+      when(datasetFactory.getDataset(di, schema)).thenReturn(dataset);
+
+      assertEquals(
+          Collections.emptyList(),
+          DataSourceV2RelationDatasetExtractor.extract(
+              datasetFactory, openLineageContext, dataSourceV2Relation));
+    }
+  }
+
+  @Test
+  void testExtractFromDataSourceV2RelationWhenIdentifierEmpty() {
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.empty());
+    final List<OpenLineage.Dataset> result =
+        DataSourceV2RelationDatasetExtractor.extract(
+            datasetFactory, openLineageContext, dataSourceV2Relation);
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void testExtractFromDataSourceV2RelationWhenCatalogEmpty() {
+    when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(mock(Identifier.class)));
+    when(dataSourceV2Relation.catalog()).thenReturn(Option.empty());
+    final List<OpenLineage.Dataset> result =
+        DataSourceV2RelationDatasetExtractor.extract(
+            datasetFactory, openLineageContext, dataSourceV2Relation);
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  void testGetDatasetIdentifierFromV2Relation() {
+    DatasetIdentifier di = mock(DatasetIdentifier.class);
+    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
+      when(CatalogUtils3.getDatasetIdentifier(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(di);
+      assertEquals(
+          di,
+          DataSourceV2RelationDatasetExtractor.getDatasetIdentifier(
+                  openLineageContext, dataSourceV2Relation)
+              .get());
+    }
+  }
+
+  @Test
+  void testGetDatasetIdentifierFromV2RelationWithMissingIdentifier() {
+    when(dataSourceV2Relation.identifier()).thenReturn(null).thenReturn(Option.empty());
+    assertEquals(
+        Optional.empty(),
+        DataSourceV2RelationDatasetExtractor.getDatasetIdentifier(
+            openLineageContext, dataSourceV2Relation));
+  }
+
+  @Test
+  void testGetDatasetIdentifierFromV2RelationWithMissingCatalog() {
+    when(dataSourceV2Relation.catalog())
+        .thenReturn(null)
+        .thenReturn(Option.empty())
+        .thenReturn(Option.apply(mock(CatalogPlugin.class)));
+
+    assertEquals(
+        Optional.empty(),
+        DataSourceV2RelationDatasetExtractor.getDatasetIdentifier(
+            openLineageContext, dataSourceV2Relation));
+  }
+
+  @Test
+  void testExtractFromDataSourceV2RelationForExtensionLineage() throws URISyntaxException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("openlineage.dataset.name", "some-name");
+    properties.put("openlineage.dataset.namespace", "some-namespace");
+    properties.put(
+        "openlineage.dataset.facets.customFacet",
+        "{"
+            + "\"property\": \"value\","
+            + "\"_producer\": \"https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client\""
+            + "}");
+
+    StructType schema =
+        new StructType(
+            new StructField[] {new StructField("key", IntegerType$.MODULE$, false, null)});
+
+    when(dataSourceV2Relation.schema()).thenReturn(schema);
+    when(table.properties()).thenReturn(properties);
+    when(openLineageContext.getOpenLineage())
+        .thenReturn(
+            new OpenLineage(
+                new URI("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client")));
+
+    DatasetFactory<OpenLineage.OutputDataset> datasetFactory =
+        DatasetFactory.output(openLineageContext);
+
+    final List<OpenLineage.OutputDataset> result =
+        DataSourceV2RelationDatasetExtractor.extract(
+            datasetFactory, openLineageContext, dataSourceV2Relation);
+
+    assertEquals(1, result.size());
+    assertThat(result.get(0))
+        .hasFieldOrPropertyWithValue("name", "some-name")
+        .hasFieldOrPropertyWithValue("namespace", "some-namespace");
+
+    OpenLineage.DatasetFacet datasetFacet =
+        result.get(0).getFacets().getAdditionalProperties().get("customFacet");
+    assertThat(datasetFacet.getAdditionalProperties())
+        .hasFieldOrPropertyWithValue("property", "value");
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2UtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2UtilsTest.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ExtesionDataSourceV2UtilsTest {
+class ExtensionDataSourceV2UtilsTest {
   static final String DATASET_NAME = "some-dataset-name";
   static final String DATASET_NAMESPACE = "some-dataset-name";
 
@@ -52,20 +52,20 @@ class ExtesionDataSourceV2UtilsTest {
 
   @Test
   void testHasExtensionLineage() {
-    assertTrue(ExtesionDataSourceV2Utils.hasExtensionLineage(relation));
+    assertTrue(ExtensionDataSourceV2Utils.hasExtensionLineage(relation));
     properties.clear();
-    assertFalse(ExtesionDataSourceV2Utils.hasExtensionLineage(relation));
+    assertFalse(ExtensionDataSourceV2Utils.hasExtensionLineage(relation));
   }
 
   @Test
   void testHasExtensionLineageWhenPropertiesAreNull() {
     when(table.properties()).thenReturn(null);
-    assertFalse(ExtesionDataSourceV2Utils.hasExtensionLineage(relation));
+    assertFalse(ExtensionDataSourceV2Utils.hasExtensionLineage(relation));
   }
 
   @Test
   void testGetDatasetName() {
-    assertThat(ExtesionDataSourceV2Utils.getDatasetIdentifier(relation))
+    assertThat(ExtensionDataSourceV2Utils.getDatasetIdentifier(relation))
         .hasFieldOrPropertyWithValue("name", DATASET_NAME)
         .hasFieldOrPropertyWithValue("namespace", DATASET_NAMESPACE);
   }
@@ -82,7 +82,7 @@ class ExtesionDataSourceV2UtilsTest {
                     .build()));
     properties.put("openlineage.dataset.facets.schema", OpenLineageClientUtils.toJson(schema));
 
-    ExtesionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
+    ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
     OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
         openLineage.newSchemaDatasetFacet(
             Arrays.asList(
@@ -121,7 +121,7 @@ class ExtesionDataSourceV2UtilsTest {
 
     properties.put("openlineage.dataset.facets.customFacet", facetJson);
 
-    ExtesionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
+    ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
 
     DatasetFacet datasetFacet =
         datasetFacetsBuilder.build().getAdditionalProperties().get("customFacet");
@@ -144,7 +144,7 @@ class ExtesionDataSourceV2UtilsTest {
 
     properties.put("openlineage.dataset.facets.customFacet", facetJson);
 
-    ExtesionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
+    ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
 
     DatasetFacet datasetFacet =
         datasetFacetsBuilder.build().getAdditionalProperties().get("customFacet");

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/PlanUtils3Test.java
@@ -5,7 +5,6 @@
 
 package io.openlineage.spark3.agent.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -13,29 +12,17 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.DatasetFacet;
 import io.openlineage.client.utils.DatasetIdentifier;
-import io.openlineage.spark.agent.util.PlanUtils;
-import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.UnsupportedCatalogException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -45,14 +32,9 @@ class PlanUtils3Test {
 
   OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
   SparkSession sparkSession = mock(SparkSession.class);
-  DatasetFactory<OpenLineage.Dataset> datasetFactory = mock(DatasetFactory.class);
   DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
-  OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-      mock(OpenLineage.DatasetFacetsBuilder.class);
   TableCatalog tableCatalog = mock(TableCatalog.class);
   Identifier identifier = mock(Identifier.class);
-  StructType schema = mock(StructType.class);
-  Table table = mock(Table.class);
   Map<String, String> tableProperties;
   OpenLineage openLineage = mock(OpenLineage.class);
 
@@ -61,84 +43,8 @@ class PlanUtils3Test {
     tableProperties = new HashMap<>();
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(sparkSession));
     when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
-    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(dataSourceV2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
     when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(identifier));
-    when(dataSourceV2Relation.schema()).thenReturn(schema);
-    when(dataSourceV2Relation.table()).thenReturn(table);
-    when(table.properties()).thenReturn(tableProperties);
-  }
-
-  @Test
-  void testFromDataSourceV2Relation() {
-    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
-      try (MockedStatic<PlanUtils> mockedPlanUtils = mockStatic(PlanUtils.class)) {
-        DatasetIdentifier di = mock(DatasetIdentifier.class);
-        when(di.getNamespace()).thenReturn("file://tmp");
-        when(di.getName()).thenReturn("name");
-
-        OpenLineage.DatasetFacets datasetFacets = mock(OpenLineage.DatasetFacets.class);
-        OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
-        OpenLineage.SchemaDatasetFacet schemaDatasetFacet =
-            mock(OpenLineage.SchemaDatasetFacet.class);
-        OpenLineage.DatasourceDatasetFacet datasourceDatasetFacet =
-            mock(OpenLineage.DatasourceDatasetFacet.class);
-        when(PlanUtils.schemaFacet(openLineage, schema)).thenReturn(schemaDatasetFacet);
-        when(PlanUtils.datasourceFacet(openLineage, di.getNamespace()))
-            .thenReturn(datasourceDatasetFacet);
-        when(datasetFacetsBuilder.schema(schemaDatasetFacet)).thenReturn(datasetFacetsBuilder);
-        when(datasetFacetsBuilder.dataSource(datasourceDatasetFacet))
-            .thenReturn(datasetFacetsBuilder);
-        when(datasetFacetsBuilder.build()).thenReturn(datasetFacets);
-
-        when(CatalogUtils3.getDatasetIdentifier(
-                openLineageContext, tableCatalog, identifier, tableProperties))
-            .thenReturn(di);
-        when(datasetFactory.getDataset(di, datasetFacetsBuilder)).thenReturn(dataset);
-
-        assertEquals(
-            Collections.singletonList(dataset),
-            PlanUtils3.fromDataSourceV2Relation(
-                datasetFactory, openLineageContext, dataSourceV2Relation));
-      }
-    }
-  }
-
-  @Test
-  void testFromDataSourceV2RelationWhenDatasetIdentifierEmpty() {
-    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
-      DatasetIdentifier di = mock(DatasetIdentifier.class);
-      OpenLineage.Dataset dataset = mock(OpenLineage.Dataset.class);
-
-      when(CatalogUtils3.getDatasetIdentifier(
-              openLineageContext, tableCatalog, identifier, tableProperties))
-          .thenThrow(new UnsupportedCatalogException("exception"));
-      when(datasetFactory.getDataset(di, schema)).thenReturn(dataset);
-
-      assertEquals(
-          Collections.emptyList(),
-          PlanUtils3.fromDataSourceV2Relation(
-              datasetFactory, openLineageContext, dataSourceV2Relation));
-    }
-  }
-
-  @Test
-  void testFromDataSourceV2RelationWhenIdentifierEmpty() {
-    when(dataSourceV2Relation.identifier()).thenReturn(Option.empty());
-    final List<OpenLineage.Dataset> result =
-        PlanUtils3.fromDataSourceV2Relation(
-            datasetFactory, openLineageContext, dataSourceV2Relation);
-    assertEquals(0, result.size());
-  }
-
-  @Test
-  void testFromDataSourceV2RelationWhenCatalogEmpty() {
-    when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(mock(Identifier.class)));
-    when(dataSourceV2Relation.catalog()).thenReturn(Option.empty());
-    final List<OpenLineage.Dataset> result =
-        PlanUtils3.fromDataSourceV2Relation(
-            datasetFactory, openLineageContext, dataSourceV2Relation);
-    assertEquals(0, result.size());
   }
 
   @Test
@@ -179,87 +85,5 @@ class PlanUtils3Test {
         () ->
             PlanUtils3.getDatasetIdentifier(
                 openLineageContext, tableCatalog, identifier, tableProperties));
-  }
-
-  @Test
-  void testGetDatasetIdentifierFromV2Relation() {
-    DatasetIdentifier di = mock(DatasetIdentifier.class);
-    try (MockedStatic<CatalogUtils3> mocked = mockStatic(CatalogUtils3.class)) {
-      when(CatalogUtils3.getDatasetIdentifier(
-              openLineageContext, tableCatalog, identifier, tableProperties))
-          .thenReturn(di);
-      assertEquals(
-          di, PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation).get());
-    }
-  }
-
-  @Test
-  void testGetDatasetIdentifierFromV2RelationWithMissingIdentifier() {
-    when(dataSourceV2Relation.identifier()).thenReturn(null).thenReturn(Option.empty());
-    assertEquals(
-        Optional.empty(),
-        PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation));
-    assertEquals(
-        Optional.empty(),
-        PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation));
-  }
-
-  @Test
-  void testGetDatasetIdentifierFromV2RelationWithMissingCatalog() {
-    when(dataSourceV2Relation.catalog())
-        .thenReturn(null)
-        .thenReturn(Option.empty())
-        .thenReturn(Option.apply(mock(CatalogPlugin.class)));
-
-    assertEquals(
-        Optional.empty(),
-        PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation));
-    assertEquals(
-        Optional.empty(),
-        PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation));
-    assertEquals(
-        Optional.empty(),
-        PlanUtils3.getDatasetIdentifier(openLineageContext, dataSourceV2Relation));
-  }
-
-  @Test
-  void testFromDataSourceV2RelationForExtensionLineage() throws URISyntaxException {
-    Map<String, String> properties = new HashMap<>();
-    properties.put("openlineage.dataset.name", "some-name");
-    properties.put("openlineage.dataset.namespace", "some-namespace");
-    properties.put(
-        "openlineage.dataset.facets.customFacet",
-        "{"
-            + "\"property\": \"value\","
-            + "\"_producer\": \"https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client\""
-            + "}");
-
-    StructType schema =
-        new StructType(
-            new StructField[] {new StructField("key", IntegerType$.MODULE$, false, null)});
-
-    when(dataSourceV2Relation.schema()).thenReturn(schema);
-    when(table.properties()).thenReturn(properties);
-    when(openLineageContext.getOpenLineage())
-        .thenReturn(
-            new OpenLineage(
-                new URI("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client")));
-
-    DatasetFactory<OpenLineage.OutputDataset> datasetFactory =
-        DatasetFactory.output(openLineageContext);
-
-    final List<OpenLineage.OutputDataset> result =
-        PlanUtils3.fromDataSourceV2Relation(
-            datasetFactory, openLineageContext, dataSourceV2Relation);
-
-    assertEquals(1, result.size());
-    assertThat(result.get(0))
-        .hasFieldOrPropertyWithValue("name", "some-name")
-        .hasFieldOrPropertyWithValue("namespace", "some-namespace");
-
-    DatasetFacet datasetFacet =
-        result.get(0).getFacets().getAdditionalProperties().get("customFacet");
-    assertThat(datasetFacet.getAdditionalProperties())
-        .hasFieldOrPropertyWithValue("property", "value");
   }
 }

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
@@ -8,8 +8,8 @@ package io.openlineage.spark33.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +66,7 @@ public class ReplaceIcebergDataDatasetBuilder
       DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, table);
     }
 
-    return PlanUtils3.fromDataSourceV2Relation(
+    return DataSourceV2RelationDatasetExtractor.extract(
         outputDataset(), context, table, datasetFacetsBuilder);
   }
 

--- a/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
+++ b/integration/spark/spark33/src/test/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilderTest.java
@@ -23,8 +23,8 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
-import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -78,13 +78,13 @@ class ReplaceIcebergDataDatasetBuilderTest {
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
 
     when(plan.table()).thenReturn(table);
-    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+    try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
         when(DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
                 openLineageContext, table))
             .thenReturn(Optional.of("v2"));
 
-        when(PlanUtils3.fromDataSourceV2Relation(
+        when(DataSourceV2RelationDatasetExtractor.extract(
                 any(DatasetFactory.class),
                 eq(openLineageContext),
                 eq(table),


### PR DESCRIPTION
### Problem

Closes: #2853 

### Solution

Some minor code  changes  in [PlanUtils3.java](https://github.com/OpenLineage/OpenLineage/compare/main...ddebowczyk92:cll-datasetidentifier?expand=1#diff-e81cf22f0f4afef7ac0f3267936ca97fbbd8608b3326b83a7ef62a84a975b9b7)

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project