### PR TITLE
[Spark] add handling for Generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.18.0...HEAD)
 
 ### Fixed
-* **Remove shaded dependency in `ColumnLevelLineageBuilder`** [`#2850`](https://github.com/OpenLineage/OpenLineage/pull/2850) [@tnazarew](https://github.com/tnazarew)  
+* **Spark: Remove shaded dependency in `ColumnLevelLineageBuilder`** [`#2850`](https://github.com/OpenLineage/OpenLineage/pull/2850) [@tnazarew](https://github.com/tnazarew)  
   *Remove shaded `Streams` dependency in `ColumnLevelLineageBuilder` causing `ClassNotFoundException`*
+* **Spark: add handling for `Generate`** [`#2856`](https://github.com/OpenLineage/OpenLineage/pull/2856) [@tnazarew](https://github.com/tnazarew)  
+  *Add handling for `Generate` type nodes of logical plan (e.g. explode operation)*
 
 ## [1.18.0](https://github.com/OpenLineage/OpenLineage/compare/1.17.1...1.18.0) - 2024-07-11
 ### Added

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -243,6 +243,18 @@ class ColumnLineageWithTransformationTypesTest {
   }
 
   @Test
+  void simpleQueryExplode() {
+    createTable("t1", "a;string");
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        getFacetForQuery(
+            getSchemaFacet("a;string"),
+            "SELECT a FROM (SELECT explode(split(a, ' ')) AS a FROM t1)");
+
+    assertColumnDependsOnType(
+        facet, "a", FILE, T1_EXPECTED_NAME, "a", TransformationInfo.transformation());
+  }
+
+  @Test
   void complexQueryCTEJoinsFilter() {
     createTable("t1", "a;int", "b;string");
     createTable("t2", "a;int", "c;int");


### PR DESCRIPTION
### Problem

Spark integration doesn't handle logical plan nodes of type `Generate` (e.g. explode) 

Closes: 

### Solution

Add handling for `Generate` type nodes.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project