### PR TITLE
[SPARK][JAR-VERIFIER] verify major java version of compiled classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.18.0...HEAD)
 
+### Added
+* **Spark: verify bytecode version of the built jar.** [`#2859`](https://github.com/OpenLineage/OpenLineage/pull/2859) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Extend `JarVerifier` plugin to assure all compiled classes have bytecode version of Java 8 or lower.*
+
 ### Fixed
 * **Spark: Remove shaded dependency in `ColumnLevelLineageBuilder`** [`#2850`](https://github.com/OpenLineage/OpenLineage/pull/2850) [@tnazarew](https://github.com/tnazarew)  
   *Remove shaded `Streams` dependency in `ColumnLevelLineageBuilder` causing `ClassNotFoundException`*

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("org.javassist:javassist:3.30.2-GA")
 }
 
 gradlePlugin {

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPlugin.kt
@@ -39,6 +39,7 @@ class JarVerificationPlugin : Plugin<Project> {
                     "io.micrometer.common",
                     "io.micrometer.observation"
                 ))
+                highestMajorClassVersionAllowed.set(52)
             }
     }
 

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginExtension.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/JarVerificationPluginExtension.kt
@@ -57,4 +57,9 @@ interface JarVerificationPluginExtension {
      * Exceptions to this rule can be defined in allowedUnshadedPackages
      */
     val assertJarDoesNotContainUnshadedClasses: Property<Boolean>
+
+    /**
+     * Highest major class version allowed within compiled classes.
+     */
+    val highestMajorClassVersionAllowed: Property<Int>
 }


### PR DESCRIPTION
In order to support Spark 4.0, we want to be able to run gradle tests with Java 17 and be able to compile `openlineage-spark` with Java 17 and target compatibility set to Java 8. It's reasonable to make sure and verify if all the classes compiled have bytecode version corresponding to Java 8. 

This PR extends JarVerifier plugin to check `majorJavaVersion` of each class from within a packed jar. It makes sure if all the versions are below a configured value. If no configured value found, then `52` is the default (which represents Java 8). 