### PR TITLE
fix nightly-run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,6 @@ jobs:
   determine_changed_modules:
     docker:
       - image: cimg/python:3.8
-    parameters:
-      nightly-run:
-        type: string
-        default: "inactive"
     steps:
       - checkout
       - run:
@@ -86,9 +82,10 @@ jobs:
             echo "$PWD/.circleci/workflows/openlineage-always.yml" >> workflow_files.txt
 
             # Nightly build - add workflows to be included
-            if [ "<< parameters.nightly-run >>" == "active" ]; then
+            if [ "<< pipeline.parameters.nightly-run >>" == "active" ]; then
               # run only Spark within nightly build
               echo "$PWD/.circleci/workflows/openlineage-spark.yml" >> workflow_files.txt
+              echo "$PWD/.circleci/workflows/openlineage-java.yml" >> workflow_files.txt
             elif [ "$CIRCLE_BRANCH" == "main" ]; then
               # If we are on the main branch, run all of the workflows
               # if integration type is not all, we specify only a single integration type in workflow files


### PR DESCRIPTION
Nighty runs are failing:
https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/11475/workflows/ce4f5cc1-712b-4b2f-a7ef-a0b5519c4648

The cause looks to be related to an incorrect parameter usage. 

Successful CI run after applying the change:
https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/11487/workflows/eef4a21a-6a02-47e8-b99b-d869d7bf8177 -> it only run spark + java CI steps.