### PR TITLE
Spark: Make Delta dataset symlink consistent with non-Delta tables

### DIFF
--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -5,52 +5,212 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.V1Table;
 import org.apache.spark.sql.delta.catalog.DeltaCatalog;
 import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import scala.Option;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class DeltaHandlerTest {
-
   DeltaCatalog deltaCatalog = mock(DeltaCatalog.class);
-  DeltaTableV2 deltaTable = Mockito.mock(DeltaTableV2.class, RETURNS_DEEP_STUBS);
-  Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
-
   DeltaHandler deltaHandler = new DeltaHandler(mock(OpenLineageContext.class));
+  SparkSession sparkSession = mock(SparkSession.class);
+  SparkContext sparkContext = mock(SparkContext.class);
+
+  @BeforeEach
+  void beforeEach() {
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.sql.warehouse.dir", "file:/tmp/warehouse");
+    Configuration hadoopConf = new Configuration();
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+  }
 
   @Test
   void testGetVersionString() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    DeltaTableV2 deltaTable = Mockito.mock(DeltaTableV2.class, RETURNS_DEEP_STUBS);
     when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
     when(deltaTable.snapshot().version()).thenReturn(2L);
 
     Optional<String> version =
         deltaHandler.getDatasetVersion(deltaCatalog, identifier, Collections.emptyMap());
 
-    assertTrue(version.isPresent());
-    assertEquals(version.get(), "2");
+    assertThat(version.isPresent()).isTrue();
+    assertThat(version.get()).isEqualTo("2");
   }
 
   @Test
-  void testGetIdentifierLoadsTablePath() {
-    when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
-    when(deltaTable.properties().get("location")).thenReturn("/some/location");
+  @SneakyThrows
+  void testGetIdentifierForPath() {
+    Identifier identifier = Identifier.of(new String[] {}, "/some/location");
+    when(deltaCatalog.isPathIdentifier(identifier)).thenReturn(true);
 
-    assertEquals(
-        "/some/location",
-        deltaHandler
-            .getDatasetIdentifier(
-                mock(SparkSession.class), deltaCatalog, identifier, Collections.emptyMap())
-            .getName());
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/location");
+
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetidentifierForDeltaTableWithDefaultLocation() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(tableIdentifier.database()).thenReturn(Option.apply("schema"));
+    when(tableIdentifier.table()).thenReturn("table");
+
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+
+    CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    when(catalogTable.provider()).thenReturn(Option.empty());
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(Option.apply(new URI("/tmp/warehouse/schema.db/table")));
+
+    DeltaTableV2 deltaTable = Mockito.mock(DeltaTableV2.class);
+    when(deltaTable.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
+        .hasFieldOrPropertyWithValue("name", "schema.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetidentifierForV1TableWithDefaultLocation() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(tableIdentifier.database()).thenReturn(Option.apply("schema"));
+    when(tableIdentifier.table()).thenReturn("table");
+
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+
+    CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    when(catalogTable.provider()).thenReturn(Option.empty());
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(Option.apply(new URI("/tmp/warehouse/schema.db/table")));
+
+    V1Table v1Table = Mockito.mock(V1Table.class);
+    when(v1Table.catalogTable()).thenReturn(catalogTable);
+    when(deltaCatalog.loadTable(identifier)).thenReturn(v1Table);
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/schema.db/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
+        .hasFieldOrPropertyWithValue("name", "schema.table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetidentifierForDeltaTableWithCustomLocation() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(tableIdentifier.database()).thenReturn(Option.apply("schema"));
+    when(tableIdentifier.table()).thenReturn("table");
+
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+
+    CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    when(catalogTable.provider()).thenReturn(Option.empty());
+    when(catalogStorageFormat.locationUri()).thenReturn(Option.apply(new URI("/some/location")));
+
+    DeltaTableV2 deltaTable = Mockito.mock(DeltaTableV2.class);
+    when(deltaTable.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(deltaCatalog.loadTable(identifier)).thenReturn(deltaTable);
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/location");
+
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
+  }
+
+  @Test
+  @SneakyThrows
+  void testGetidentifierForV1TableWithCustomLocation() {
+    Identifier identifier = Identifier.of(new String[] {"database", "schema"}, "table");
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(tableIdentifier.database()).thenReturn(Option.apply("schema"));
+    when(tableIdentifier.table()).thenReturn("table");
+
+    CatalogTable catalogTable = mock(CatalogTable.class);
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+
+    CatalogStorageFormat catalogStorageFormat = mock(CatalogStorageFormat.class);
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+    when(catalogTable.provider()).thenReturn(Option.empty());
+    when(catalogStorageFormat.locationUri()).thenReturn(Option.apply(new URI("/some/location")));
+
+    V1Table v1Table = Mockito.mock(V1Table.class);
+    when(v1Table.catalogTable()).thenReturn(catalogTable);
+    when(deltaCatalog.loadTable(identifier)).thenReturn(v1Table);
+
+    DatasetIdentifier datasetIdentifier =
+        deltaHandler.getDatasetIdentifier(
+            sparkSession, deltaCatalog, identifier, Collections.emptyMap());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/some/location");
+
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
 }


### PR DESCRIPTION
### Problem

Currently DeltaHandler has its own logic for generating Dataset symlink, and it does this by stripping the last component from table location. There are 2 issues with that:
* Table metadata can be stored in the metastore, like Hive, but symlink does not reflect that.
* Table could have custom location, which may produce symlink which has no meaning.

### Solution

Reuse existing logic from `PathUtils.fromCatalogTable`.

#### One-line summary:

Make dataset symlinks for Delta and non-Delta tables consistent.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project