### PR TITLE
[airflow] fix: replace datetime.now with airflow.utils.timezone.utcnow

### DIFF
--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import datetime
 import logging
 import threading
 from concurrent.futures import Executor, ThreadPoolExecutor
@@ -22,6 +21,7 @@ from openlineage.airflow.utils import (
 )
 
 from airflow.listeners import hookimpl
+from airflow.utils import timezone
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -140,7 +140,7 @@ def on_task_instance_running(previous_state, task_instance: "TaskInstance", sess
 
         task_metadata = extractor_manager.extract_metadata(dagrun, task, task_uuid=task_uuid)
 
-        ti_start_time = ti.start_date if ti.start_date else datetime.datetime.now()
+        ti_start_time = ti.start_date if ti.start_date else timezone.utcnow()
         start, end = get_dagrun_start_end(dagrun=dagrun, dag=dag)
 
         adapter.start_task(
@@ -221,7 +221,7 @@ def on_task_instance_failed(previous_state, task_instance: "TaskInstance", sessi
             dagrun, task, complete=True, task_instance=task_instance
         )
 
-        end_date = task_instance.end_date if task_instance.end_date else datetime.datetime.now()
+        end_date = task_instance.end_date if task_instance.end_date else timezone.utcnow()
 
         adapter.fail_task(
             run_id=task_uuid,


### PR DESCRIPTION
### Problem

Closes: #2858 

#### One-line summary:

Fix missing timezone information in task FAIL event.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project