### PR TITLE
Java: Add DerbyJdbcExtractor

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/DerbyJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/DerbyJdbcExtractor.java
@@ -1,0 +1,45 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DerbyJdbcExtractor implements JdbcExtractor {
+  private static final Pattern DATABASE_NAME_PATTERN =
+      Pattern.compile(".*databaseName=(?<databaseName>[^;]+).*");
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return jdbcUri.startsWith("derby:");
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    Matcher databaseNameMatcher = DATABASE_NAME_PATTERN.matcher(rawUri);
+
+    String databaseName = "metastore_db";
+    if (databaseNameMatcher.find()) {
+      databaseName = databaseNameMatcher.group("databaseName");
+    }
+
+    // get Derby location, e.g. /tmp or /current/dir
+    // https://db.apache.org/derby/docs/10.3/tuning/rtunproper32066.html
+    String derbyHome =
+        Optional.ofNullable(System.getProperty("derby.system.home"))
+            .orElse(System.getProperty("user.dir"));
+
+    // databaseName could be a relative location. Normalize '/some/path/../abc' to '/some/abc'
+    String derbyLocation = new URI(derbyHome + File.separator + databaseName).normalize().getPath();
+
+    return new JdbcLocation("file", Optional.empty(), Optional.of(derbyLocation), Optional.empty());
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/GenericJdbcExtractor.java
@@ -51,7 +51,7 @@ public class GenericJdbcExtractor implements JdbcExtractor {
             .map(db -> db.replaceFirst("/", ""))
             .filter(db -> !db.isEmpty());
 
-    return new JdbcLocation(scheme, authority, Optional.empty(), database);
+    return new JdbcLocation(scheme, Optional.of(authority), Optional.empty(), database);
   }
 
   private JdbcLocation extractMultipleHosts(String rawUri) throws URISyntaxException {
@@ -66,6 +66,7 @@ public class GenericJdbcExtractor implements JdbcExtractor {
     String scheme = matcher.group("scheme");
     String authority = matcher.group("authority");
     String database = matcher.group("database");
-    return new JdbcLocation(scheme, authority, Optional.empty(), Optional.ofNullable(database));
+    return new JdbcLocation(
+        scheme, Optional.ofNullable(authority), Optional.empty(), Optional.ofNullable(database));
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -22,6 +22,7 @@ public class JdbcDatasetUtils {
     new MySqlJdbcExtractor(),
     new SqlServerJdbcExtractor(),
     new TeradataJdbcExtractor(),
+    new DerbyJdbcExtractor(),
     new GenericJdbcExtractor()
   };
 

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcLocation.java
@@ -12,20 +12,22 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 @AllArgsConstructor
 public class JdbcLocation {
   @NonNull @Getter @Setter private String scheme;
-  @NonNull @Getter @Setter private String authority;
+  @Getter @Setter private Optional<String> authority;
   @Getter @Setter private Optional<String> instance;
   @Getter @Setter private Optional<String> database;
 
   public String toNamespace() {
-    String result =
-        String.format(
-            "%s://%s", scheme.toLowerCase(Locale.ROOT), authority.toLowerCase(Locale.ROOT));
+    String result = scheme.toLowerCase(Locale.ROOT) + ":";
+    if (authority.isPresent()) {
+      result = String.format("%s//%s", result, authority.get().toLowerCase(Locale.ROOT));
+    }
     if (instance.isPresent()) {
-      result = String.format("%s/%s", result, instance.get());
+      result = String.format("%s/%s", result, StringUtils.stripStart(instance.get(), "/"));
     }
     return result;
   }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OverridingJdbcExtractor.java
@@ -7,6 +7,7 @@ package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,9 +36,9 @@ public class OverridingJdbcExtractor extends GenericJdbcExtractor implements Jdb
   public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
     JdbcLocation result = super.extract(rawUri, properties);
 
-    String authority = result.getAuthority();
-    if (defaultPort != null) {
-      authority = appendDefaultPort(authority);
+    Optional<String> authority = result.getAuthority();
+    if (authority.isPresent() && defaultPort != null) {
+      authority = authority.map(this::appendDefaultPort);
     }
 
     return new JdbcLocation(overrideScheme, authority, result.getInstance(), result.getDatabase());

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/SqlServerJdbcExtractor.java
@@ -100,6 +100,6 @@ public class SqlServerJdbcExtractor implements JdbcExtractor {
             .map(Optional::of)
             .orElseGet(() -> Optional.ofNullable(finalProperties.getProperty(DATABASE_PROPERTY)));
 
-    return new JdbcLocation(SCHEME, authority, instance, database);
+    return new JdbcLocation(SCHEME, Optional.of(authority), instance, database);
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TeradataJdbcExtractor.java
@@ -56,8 +56,7 @@ public class TeradataJdbcExtractor implements JdbcExtractor {
     }
 
     String port = Optional.ofNullable(params.getProperty(PORT_PROPERTY)).orElse(DEFAULT_PORT);
-    String authority = host + ":" + port;
-
+    Optional<String> authority = Optional.of(host + ":" + port);
     Optional<String> database = Optional.ofNullable(params.getProperty(DATABASE_PROPERTY));
 
     return new JdbcLocation(SCHEME, authority, Optional.empty(), database);

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForDerby.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForDerby.java
@@ -1,0 +1,69 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForDerby {
+  private static final String CURRENT_DIR_PROPERTY = "user.dir";
+  private static final String DERBY_HOME_PROPERTY = "derby.system.home";
+
+  @AfterEach
+  void restoreDerbyHome() {
+    System.clearProperty(DERBY_HOME_PROPERTY);
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithDefaultDatabase() {
+    String currentDir = System.getProperty(CURRENT_DIR_PROPERTY);
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier("jdbc:derby:", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "file:" + currentDir + "/metastore_db")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCustomDatabaseName() {
+    String currentDir = System.getProperty(CURRENT_DIR_PROPERTY);
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:derby:;databaseName=somedb", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "file:" + currentDir + "/somedb")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCustomDerbyHome() {
+    System.setProperty(DERBY_HOME_PROPERTY, "/some/path");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier("jdbc:derby:", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "file:/some/path/metastore_db")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCustomDatabasePath() {
+    System.setProperty(DERBY_HOME_PROPERTY, "/some/path");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:derby:;databaseName=nested/path", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "file:/some/path/nested/path")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:derby:;databaseName=../parent/path", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "file:/some/parent/path")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}


### PR DESCRIPTION
### Problem

Required for #2796.

### Solution

#### One-line summary:

Add JdbcExtractor implementation for Derby database. As this is a file-based DBMS, it dataset namespace is `file` and name is absolute path to a database file.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project