### PR TITLE
Update docker image for Fluentd 1.17

### DIFF
--- a/proxy/fluentd/docker/Dockerfile
+++ b/proxy/fluentd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.16-debian-amd64-1
+FROM fluent/fluentd:v1.17.0-debian-amd64-1.0
 
 # Use root account to use apk
 USER root


### PR DESCRIPTION
Updating Docker image for Fluentd from version 1.16 to version 1.17 on Dockerfile. I performed many tests and everything is working well. 