### PR TITLE
bug fixed on error msgs descriptions

### DIFF
--- a/proxy/fluentd/lib/fluent/plugin/parser_openlineage.rb
+++ b/proxy/fluentd/lib/fluent/plugin/parser_openlineage.rb
@@ -63,7 +63,7 @@ module Fluent
       def enrich_oneOf_errors(json)
         errors = []
         @schema["oneOf"].each { |ref|
-          changed_schema = @schema
+          changed_schema = Marshal.load(Marshal.dump(@schema))
           changed_schema.delete("oneOf")
           changed_schema["$ref"] = ref["$ref"]
           validator = RustyJSONSchema.build(changed_schema)


### PR DESCRIPTION
During tests I found out that whenever I had more than one bad request returned, the error descriptions would be lost and the plugin would only return a "generical-like" return. This would always be the case even if the cause of the bad request returned was some other type of mistake. I noticed that this issue lied was in the way the changed_schema was being modified. Since changed_schema is assigned to @schema, it did not create a new object; instead, it pointed to the same object as @schema. This means that when changed_schema was modified (e.g., deleting "oneOf" and setting "$ref"), those changes were also made directly to @schema, affecting subsequent iterations.