### PR TITLE
Extract legacy column lineage visitors loader

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/LegacyColumnLineageVisitorsLoader.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/LegacyColumnLineageVisitorsLoader.java
@@ -1,0 +1,63 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.column.CustomColumnLineageVisitor;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+
+/**
+ * Utility class responsible for loading deprecated `CustomColumnLineageVisitor` implementations and
+ * converting them to the new `ColumnLevelLineageVisitor` interface.
+ */
+public class LegacyColumnLineageVisitorsLoader {
+
+  /**
+   * Loads the deprecated `CustomColumnLineageVisitor` implementations using the ServiceLoader and
+   * converts them to `ColumnLevelLineageVisitor` instances.
+   *
+   * @return a list of `ColumnLevelLineageVisitor` instances converted from the deprecated visitors.
+   */
+  static List<ColumnLevelLineageVisitor> getVisitors() {
+    ServiceLoader<CustomColumnLineageVisitor> loader =
+        ServiceLoader.load(CustomColumnLineageVisitor.class);
+
+    return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(
+                loader.iterator(), Spliterator.IMMUTABLE & Spliterator.DISTINCT),
+            false)
+        .map(LegacyColumnLineageVisitorsLoader::fromLegacyInterface)
+        .collect(Collectors.toList());
+  }
+
+  /** Converts a deprecated `CustomColumnLineageVisitor` to a `ColumnLevelLineageVisitor`. */
+  private static ColumnLevelLineageVisitor fromLegacyInterface(
+      CustomColumnLineageVisitor customVisitor) {
+    return new ColumnLevelLineageVisitor() {
+      @Override
+      public void collectInputs(ColumnLevelLineageContext context, LogicalPlan node) {
+        customVisitor.collectInputs(node, context.getBuilder());
+      }
+
+      @Override
+      public void collectOutputs(ColumnLevelLineageContext context, LogicalPlan node) {
+        customVisitor.collectOutputs(node, context.getBuilder());
+      }
+
+      @Override
+      public void collectExpressionDependencies(
+          ColumnLevelLineageContext context, LogicalPlan node) {
+        customVisitor.collectExpressionDependencies(node, context.getBuilder());
+      }
+    };
+  }
+}


### PR DESCRIPTION
### Problem

`CustomCollectorUtils` is a little bit confusing. It is responsible for loading, concatenating and delegating calls.

### Solution

- I've extracted the loader for legacy visitors into a separate class.
- I've done some refactoring to expose what is the most important
  - I've changed the `loadCollectors` method into `getCollectors`, because the only ones that are being loaded at this point are the legacy ones which probably don't even exist. The remaining collectors are already loaded and present in the context. We only read them
  - I extracted `concatLists` method for better readability. There are already some method calls to read through. Adding extra streams and collecting can be hidden.
  - I passed the whole `ColumnLevelLineageContext` into the `getCollectors` and there extract the OpenLineage context. I'm not sure it is super better but we have only one place where it is extracted. Let me know if you think it is significantly worse in your opinion.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [X] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project