### PR TITLE
Airflow: Add airflowDagRun facet

### DIFF
--- a/integration/airflow/facets/AirflowDagRunFacet.json
+++ b/integration/airflow/facets/AirflowDagRunFacet.json
@@ -1,0 +1,97 @@
+// TODO: that is Airflow specific facet that should be placed in new system-specific directory
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "AirflowDagRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dag": {
+              "$ref": "#/$defs/DAG"
+            },
+            "dagRun": {
+              "$ref": "#/$defs/DagRun"
+            }
+          },
+          "required": ["dag", "dagRun"]
+        }
+      ]
+    },
+    "DAG": {
+      "type": "object",
+      "properties": {
+        "dag_id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "schedule_interval": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tags": {
+          "type": "string"
+        },
+        "timetable": {
+          "description": "Describes timetable (successor of schedule_interval)",
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true,
+      "required": ["dag_id", "start_date"]
+    },
+    "DagRun": {
+      "type": "object",
+      "properties": {
+        "conf": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "dag_id": {
+          "type": "string"
+        },
+        "data_interval_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "data_interval_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "external_trigger": {
+          "type": "boolean"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "run_type": {
+          "type": "string"
+        },
+        "start_date": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": true,
+      "required": ["dag_id", "run_id"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "airflowDagRun": {
+      "$ref": "#/$defs/AirflowDagRunFacet"
+    }
+  }
+}

--- a/integration/airflow/facets/AirflowRunFacet.json
+++ b/integration/airflow/facets/AirflowRunFacet.json
@@ -6,7 +6,7 @@
     "AirflowRunFacet": {
       "allOf": [
         {
-          "$ref": "https://openlineage.io/spec/1-0-3/OpenLineage.json#/$defs/RunFacet"
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
         },
         {
           "type": "object",

--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from openlineage.airflow.extractors import TaskMetadata
-from openlineage.airflow.utils import DagUtils, redact_with_exclusions
+from openlineage.airflow.utils import DagUtils, get_airflow_dag_run_facet, redact_with_exclusions
 from openlineage.airflow.version import __version__ as OPENLINEAGE_AIRFLOW_VERSION
 from openlineage.client import OpenLineageClient, OpenLineageClientOptions, set_producer
 from openlineage.client.event_v2 import Job, Run, RunEvent, RunState
@@ -273,6 +273,7 @@ class OpenLineageAdapter:
                 ),
                 nominal_start_time=nominal_start_time,
                 nominal_end_time=nominal_end_time,
+                run_facets=get_airflow_dag_run_facet(dag_run, dag_run.dag),
             ),
             inputs=[],
             outputs=[],

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -62,9 +62,19 @@ class AirflowMappedTaskRunFacet(BaseFacet):
 
 
 @attr.s
+class AirflowDagRunFacet(BaseFacet):
+    """
+    Composite Airflow DAG run facet.
+    """
+
+    dag: Dict = attr.ib()
+    dagRun: Dict = attr.ib()
+
+
+@attr.s
 class AirflowRunFacet(BaseFacet):
     """
-    Composite Airflow run facet.
+    Composite Airflow Task run facet.
     """
 
     dag: Dict = attr.ib()

--- a/integration/airflow/openlineage/airflow/utils.py
+++ b/integration/airflow/openlineage/airflow/utils.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import attr
 from openlineage.airflow.facets import (
+    AirflowDagRunFacet,
     AirflowMappedTaskRunFacet,
     AirflowRunArgsRunFacet,
     AirflowRunFacet,
@@ -343,6 +344,20 @@ class TaskGroupInfo(InfoJsonEncodable):
         "upstream_group_ids",
         "upstream_task_ids",
     ]
+
+
+def get_airflow_dag_run_facet(
+    dag_run: "DagRun",
+    dag: "DAG",
+):
+    return {
+        "airflowDagRun": attr.asdict(
+            AirflowDagRunFacet(
+                dag=DagInfo(dag),
+                dagRun=DagRunInfo(dag_run),
+            )
+        )
+    }
 
 
 def get_airflow_run_facet(

--- a/integration/airflow/tests/integration/requests/airflow_dag_run_facet/mysql.json
+++ b/integration/airflow/tests/integration/requests/airflow_dag_run_facet/mysql.json
@@ -1,0 +1,26 @@
+[
+    {
+        "eventType": "START",
+        "job": {
+            "name": "mysql_orders_popular_day_of_week"
+        },
+        "run": {
+            "facets": {
+                "airflowDagRun": {
+                    "dag": {
+                        "dag_id": "mysql_orders_popular_day_of_week"
+                    },
+                    "dagRun": {
+                        "conf": {},
+                        "dag_id": "mysql_orders_popular_day_of_week",
+                        "run_type": "manual"
+                    }
+                },
+                "processing_engine": {
+                    "version": "{{ env_var('AIRFLOW_VERSION') }}",
+                    "name": "Airflow"
+                }
+            }
+        }
+    }
+]

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -444,6 +444,27 @@ def test_integration_ordered(dag_id, request_dir: str, skip_jobs: List[str], air
     [
         pytest.param(
             "mysql_orders_popular_day_of_week",
+            "requests/airflow_dag_run_facet/mysql.json",
+        )
+    ],
+)
+def test_airflow_dag_run_facet(dag_id, request_path, airflow_db_conn):
+    log.info(f"Checking dag {dag_id} for AirflowDagRunFacet")
+    result = wait_for_dag(dag_id, airflow_db_conn)
+    assert result is True
+
+    with open(request_path) as f:
+        expected_events = json.load(f)
+
+    actual_events = get_events()
+    assert check_matches(expected_events, actual_events) is True
+
+
+@pytest.mark.parametrize(
+    "dag_id, request_path",
+    [
+        pytest.param(
+            "mysql_orders_popular_day_of_week",
             "requests/airflow_run_facet/mysql.json",
         )
     ],

--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -78,6 +78,8 @@ x-airflow-base: &airflow-base
       condition: service_healthy
     pure-ftpd:
       condition: service_started
+    backend:
+      condition: service_healthy
 
 services:
   integration:


### PR DESCRIPTION
### Problem

Currently `AirflowRunFacet` is present only RunEvents produces by Airflow tasks (containing fields `dag`, `dag_run`, `task`, `task_instance`). But DAG can be started too, and it currently contains only `AirflowJobFacet` (fields like `taskTree`, `taskGroups` and so on).

Having `dag_run` field allows custom OpenLineage backend implementations to have URL for Airflow UI page of a particular DagRun, as well as have custom logic based on `run_type` field value.

See https://github.com/apache/airflow/issues/40798

### Solution

#### One-line summary:

Add `AirflowDagRunFacet` facet for DAG run events.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project