### PR TITLE
Feature/spark/support mongostream source

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -176,6 +176,7 @@ def testSystemProperties = { String spark, String scala ->
             "junit.platform.output.capture.stderr": "true",
             "junit.platform.output.capture.stdout": "true",
             "kafka.package.version"               : "org.apache.spark:spark-sql-kafka-0-10_${scala}:${spark}",
+            "mongo.package.version"               : "org.mongodb.spark:mongo-spark-connector_${scala}:10.3.0",
             "lib.dir"                             : libsShadowDir.get().asFile.absolutePath,
             "mockserver.logLevel"                 : "ERROR",
             "resources.dir"                       : testResourcesDir.get().asFile.absolutePath,

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -5,9 +5,6 @@
 
 package io.openlineage.spark.agent;
 
-import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineageClientUtils;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_CONF_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_HOME_DIR;
@@ -22,6 +19,16 @@ import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAI
 import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockserver.model.HttpRequest.request;
+import static org.testcontainers.containers.Network.newNetwork;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,26 +41,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.awaitility.Awaitility;
-import static org.awaitility.Awaitility.await;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.ClearType;
-import static org.mockserver.model.HttpRequest.request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
-import static org.testcontainers.containers.Network.newNetwork;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -5,6 +5,9 @@
 
 package io.openlineage.spark.agent;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_CONF_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_HOME_DIR;
@@ -19,16 +22,6 @@ import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAI
 import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockserver.model.HttpRequest.request;
-import static org.testcontainers.containers.Network.newNetwork;
-
-import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,20 +34,27 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.awaitility.Awaitility;
+import static org.awaitility.Awaitility.await;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.ClearType;
+import static org.mockserver.model.HttpRequest.request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
+import static org.testcontainers.containers.Network.newNetwork;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -5,9 +5,6 @@
 
 package io.openlineage.spark.agent;
 
-import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineageClientUtils;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_CONF_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_HOME_DIR;
@@ -22,6 +19,16 @@ import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAI
 import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockserver.model.HttpRequest.request;
+import static org.testcontainers.containers.Network.newNetwork;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,27 +41,21 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.awaitility.Awaitility;
-import static org.awaitility.Awaitility.await;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.ClearType;
-import static org.mockserver.model.HttpRequest.request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
-import static org.testcontainers.containers.Network.newNetwork;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -72,547 +73,547 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @Slf4j
 class SparkScalaContainerTest {
-    private static final Network network = newNetwork();
+  private static final Network network = newNetwork();
 
-    @Container
-    private static final MockServerContainer openLineageClientMockContainer =
-            SparkContainerUtils.makeMockServerContainer(network);
+  @Container
+  private static final MockServerContainer openLineageClientMockContainer =
+      SparkContainerUtils.makeMockServerContainer(network);
 
-    private static GenericContainer<?> spark;
-    private static MockServerClient mockServerClient;
-    private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
-    private static final String SPARK_3_OR_ABOVE = "^[3-9].*";
-    private static final String SPARK_3_ONLY = "^3.*";
-    private static final String SCALA_2_12 = "^2.12.*";
-    private static final String SCALA_VERSION = "scala.binary.version";
+  private static GenericContainer<?> spark;
+  private static MockServerClient mockServerClient;
+  private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
+  private static final String SPARK_3_OR_ABOVE = "^[3-9].*";
+  private static final String SPARK_3_ONLY = "^3.*";
+  private static final String SCALA_2_12 = "^2.12.*";
+  private static final String SCALA_VERSION = "scala.binary.version";
 
-    private static final String SPARK_VERSION = "spark.version";
+  private static final String SPARK_VERSION = "spark.version";
 
-    @BeforeAll
-    public static void setup() {
-        mockServerClient =
-                new MockServerClient(
-                        openLineageClientMockContainer.getHost(),
-                        openLineageClientMockContainer.getServerPort());
+  @BeforeAll
+  public static void setup() {
+    mockServerClient =
+        new MockServerClient(
+            openLineageClientMockContainer.getHost(),
+            openLineageClientMockContainer.getServerPort());
 
-        mockServerClient
-                .when(request("/api/v1/lineage"))
-                .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
+    mockServerClient
+        .when(request("/api/v1/lineage"))
+        .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
 
-        Awaitility.await().until(openLineageClientMockContainer::isRunning);
+    Awaitility.await().until(openLineageClientMockContainer::isRunning);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
+    try {
+      if (spark != null) spark.stop();
+    } catch (Exception e) {
+      logger.error("Unable to shut down pyspark container", e);
     }
+  }
 
-    @AfterEach
-    public void cleanup() {
-        mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
-        try {
-            if (spark != null) spark.stop();
-        } catch (Exception e) {
-            logger.error("Unable to shut down pyspark container", e);
-        }
+  @AfterAll
+  public static void tearDown() {
+    try {
+      openLineageClientMockContainer.stop();
+    } catch (Exception e) {
+      logger.error("Unable to shut down openlineage client container", e);
     }
-
-    @AfterAll
-    public static void tearDown() {
-        try {
-            openLineageClientMockContainer.stop();
-        } catch (Exception e) {
-            logger.error("Unable to shut down openlineage client container", e);
-        }
-        network.close();
-    }
-
-    @SneakyThrows
-    private GenericContainer createSparkContainer(final String className) {
-        List<String> commandParts = constructSparkSubmitCommand(className);
-        String command = String.join(" ", commandParts);
-        log.info("Container will be started with command: {}", command);
-
-        GenericContainer container =
-                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-                        .withNetwork(network)
-                        .withNetworkAliases("spark")
-                        .withLogConsumer(SparkContainerUtils::consumeOutput)
-                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-                        .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
-                        .dependsOn(openLineageClientMockContainer)
-                        .withCommand(command);
-
-        // mount the additional Jars
-        mountPath(container, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-        mountFiles(container, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(container, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(container, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
-
-        return container;
-    }
-
-    private List<String> constructSparkSubmitCommand(String className) {
-        List<String> sparkSubmitCommand = new ArrayList<>();
-        sparkSubmitCommand.add(Paths.get(System.getProperty("spark.home.dir")) + "/bin/spark-submit");
-        sparkSubmitCommand.add("--master");
-        sparkSubmitCommand.add("local");
-        sparkSubmitCommand.add("--class");
-        sparkSubmitCommand.add(className);
-
-        addSparkConfig(sparkSubmitCommand, "spark.openlineage.transport.type=http");
-        addSparkConfig(
-                sparkSubmitCommand,
-                "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
-        addSparkConfig(sparkSubmitCommand, "spark.openlineage.debugFacet=enabled");
-        addSparkConfig(
-                sparkSubmitCommand, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-        addSparkConfig(sparkSubmitCommand, "spark.sql.warehouse.dir=/tmp/warehouse");
-        addSparkConfig(sparkSubmitCommand, "spark.sql.shuffle.partitions=1");
-        addSparkConfig(
-                sparkSubmitCommand, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-        addSparkConfig(sparkSubmitCommand, "spark.jars.ivy=/tmp/.ivy2/");
-        addSparkConfig(sparkSubmitCommand, "spark.openlineage.facets.disabled=");
-        addSparkConfig(sparkSubmitCommand, "spark.ui.enabled=false");
-        // Last, but not least, we add the path to the JAR
-        sparkSubmitCommand.add(CONTAINER_FIXTURES_JAR_PATH.toString());
-
-        return sparkSubmitCommand;
-    }
-
-    @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    void testScalaUnionRddToParquet() {
-        spark = createSparkContainer("io.openlineage.spark.test.RddUnion");
-        spark.start();
-
-        await()
-                .atMost(Duration.ofSeconds(10))
-                .pollInterval(Duration.ofMillis(500))
-                .untilAsserted(
-                        () -> {
-                            List<OpenLineage.RunEvent> events =
-                                    Arrays.stream(
-                                                    mockServerClient.retrieveRecordedRequests(
-                                                            request().withPath("/api/v1/lineage")))
-                                            .map(r -> r.getBodyAsString())
-                                            .map(event -> OpenLineageClientUtils.runEventFromJson(event))
-                                            .collect(Collectors.toList());
-
-                            assertThat(events).isNotEmpty();
-
-                            RunEvent lastEvent = events.get(events.size() - 2);
-                            assertThat(lastEvent.getOutputs().get(0))
-                                    .hasFieldOrPropertyWithValue("namespace", "file")
-                                    .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");
-
-                            assertThat(lastEvent.getInputs().stream().map(d -> d.getName()))
-                                    .contains("/tmp/scala-test/rdd_input1", "/tmp/scala-test/rdd_input2");
-                        });
-    }
-
-    @Test
-    @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_OR_ABOVE)
-    void testKafka2KafkaStreamingProducesInputAndOutputDatasets() throws IOException {
-        final Network network = newNetwork();
-        final String className = "io.openlineage.spark.streaming.Kafka2KafkaJob";
-        final DockerImageName kafkaDockerImageName =
-                DockerImageName.parse("docker.io/bitnami/kafka:3.4.1");
-
-        GenericContainer zookeeperContainer =
-                new GenericContainer(DockerImageName.parse("docker.io/bitnami/zookeeper:3.7"))
-                        .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
-                        .withEnv("ZOO_AUTOPURGE_INTERVAL", "1")
-                        .withNetwork(network)
-                        .withNetworkAliases("zookeeper")
-                        .withExposedPorts(2181);
-
-        GenericContainer kafkaContainer =
-                new GenericContainer(kafkaDockerImageName)
-                        .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
-                        .withEnv(
-                                "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP", "CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT")
-                        .withEnv("KAFKA_CFG_LISTENERS", "CLIENT://:9092,EXTERNAL://:9093")
-                        .withEnv(
-                                "KAFKA_CFG_ADVERTISED_LISTENERS",
-                                "CLIENT://kafka.broker.zero:9092,EXTERNAL://localhost:9093")
-                        .withEnv("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "CLIENT")
-                        .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
-                        .withEnv("KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME", "false")
-                        .withEnv("KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE", "true")
-                        .withNetwork(network)
-                        .withNetworkAliases("kafka.broker.zero")
-                        .withExposedPorts(9092, 9093)
-                        .dependsOn(zookeeperContainer);
-
-        GenericContainer kafkaInitContainer =
-                new GenericContainer(kafkaDockerImageName)
-                        .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
-                        .withNetwork(network)
-                        .dependsOn(zookeeperContainer, kafkaContainer)
-                        .withCommand(
-                                "/bin/bash",
-                                "-c",
-                                "/opt/bitnami/kafka/bin/kafka-topics.sh --create --topic input-topic --bootstrap-server kafka.broker.zero:9092");
-
-        zookeeperContainer.start();
-        kafkaContainer.start();
-        kafkaInitContainer.start();
-
-        GenericContainer spark =
-                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-                        .dependsOn(kafkaContainer)
-                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-                        .withNetwork(network)
-                        .withLogConsumer(SparkContainerUtils::consumeOutput)
-                        .withStartupTimeout(Duration.ofMinutes(2));
-
-        List<String> command = new ArrayList<>();
-        command.add(CONTAINER_SPARK_HOME_DIR + "/bin/spark-submit");
-        command.add("--master");
-        command.add("local[*]");
-        command.add("--class");
-        command.add(className);
-        command.add("--packages");
-        command.add(System.getProperty("kafka.package.version"));
-
-        addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-        addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-        addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-        addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
-        addSparkConfig(
-                command, "spark.openlineage.facets.disabled=[schema;spark_unknown;spark.logicalPlan]");
-        addSparkConfig(command, "spark.openlineage.transport.type=file");
-        addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
-        addSparkConfig(command, "spark.sql.shuffle.partitions=1");
-        addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
-        addSparkConfig(command, "spark.ui.enabled=false");
-        command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
-
-        // mount the additional Jars
-        mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-        mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
-
-        final String commandStr = String.join(" ", command);
-        log.info("Command is {}", commandStr);
-
-        spark.withCommand(commandStr);
-
-        spark.start();
-
-        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
-
-        kafkaInitContainer.stop();
-        kafkaContainer.stop();
-        zookeeperContainer.stop();
-
-        File temporaryFile = File.createTempFile("events", ".log");
-
-        spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
-
-        temporaryFile.deleteOnExit();
-
-        List<RunEvent> events =
-                Files.readAllLines(temporaryFile.toPath()).stream()
-                        .map(OpenLineageClientUtils::runEventFromJson)
-                        .collect(Collectors.toList());
-
-        List<RunEvent> nonEmptyInputEvents =
-                events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
-
-        assertThat(nonEmptyInputEvents).isNotEmpty();
-
-        nonEmptyInputEvents.forEach(
-                event -> {
-                    assertEquals(1, event.getInputs().size());
-                    assertEquals("input-topic", event.getInputs().get(0).getName());
-                    assertEquals("kafka://kafka.broker.zero:9092", event.getInputs().get(0).getNamespace());
-
-                    assertEquals(1, event.getOutputs().size());
-                    assertEquals("output-topic", event.getOutputs().get(0).getName());
-                    assertEquals("kafka://kafka.broker.zero:9092", event.getOutputs().get(0).getNamespace());
-                });
-    }
-
-    @Test
-    @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
-    @EnabledIfSystemProperty(named = SCALA_VERSION, matches = SCALA_2_12)
-    void testReadingFromKinesis() throws IOException, InterruptedException {
-        final String className = "io.openlineage.spark.streaming.KinesisReadJob";
-        Network localstackNetwork = newNetwork();
-
-        // latest left only because of issue with 3.6 version as 3.5, its planned to be fixed in 3.7
-        // (end of august)
-        GenericContainer localStack =
-                new GenericContainer<>(DockerImageName.parse("localstack/localstack:latest"))
-                        .withNetwork(localstackNetwork)
-                        .withNetworkAliases("localstack")
-                        .withLogConsumer(SparkContainerUtils::consumeOutput)
-                        .withExposedPorts(4566)
-                        .withCommand();
-
-        localStack.start();
-
-        GenericContainer pythonContainer =
-                new GenericContainer<>(DockerImageName.parse("python:3.11"))
-                        .withNetwork(localstackNetwork)
-                        .withNetworkAliases("python")
-                        .withCommand("sh", "-c", "tail -f /dev/null")
-                        .dependsOn(localStack)
-                        .withLogConsumer(SparkContainerUtils::consumeOutput);
-
-        pythonContainer.start();
-
-        pythonContainer.execInContainer("pip", "install", "awscli-local", "awscli");
-        pythonContainer.execInContainer(
-                "awslocal",
-                "--endpoint-url=http://localstack:4566",
-                "kinesis",
-                "create-stream",
-                "--stream-name",
-                "events",
-                "--shard-count",
-                "1");
-        pythonContainer.execInContainer(
-                "awslocal",
-                "--endpoint-url=http://localstack:4566",
-                "kinesis",
-                "put-record",
-                "--stream-name",
-                "events",
-                "--partition-key",
-                "1",
-                "--data",
-                "XzxkYXRhPl8x");
-
-        pythonContainer.execInContainer(
-                "awslocal",
-                "--endpoint-url=http://localstack:4566",
-                "kinesis",
-                "put-record",
-                "--stream-name",
-                "events",
-                "--partition-key",
-                "1",
-                "--data",
-                "XzxkYXRhPl8x");
-
-        GenericContainer spark =
-                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-                        .dependsOn(localStack)
-                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-                        .withNetwork(localstackNetwork)
-                        .withLogConsumer(SparkContainerUtils::consumeOutput)
-                        .withEnv("AWS_ACCESS_KEY_ID", "test")
-                        .withEnv("AWS_SECRET_ACCESS_KEY=", "test")
-                        .withStartupTimeout(Duration.ofMinutes(2));
-
-        List<String> command = new ArrayList<>();
-        command.add("./bin/spark-submit");
-        command.add("--master");
-        command.add("local[*]");
-        command.add("--class");
-        command.add(className);
-        command.add("--jars");
-        command.add(
-                "https://awslabs-code-us-east-1.s3.amazonaws.com/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_"
-                        + SCALA_BINARY_VERSION
-                        + "-1.0.0.jar");
-
-        addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-        addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-        addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-        addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
-        addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
-        addSparkConfig(command, "spark.openlineage.transport.type=file");
-        addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
-        addSparkConfig(command, "spark.sql.shuffle.partitions=1");
-        addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
-        addSparkConfig(command, "spark.ui.enabled=false");
-        command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
-
-        // mount the additional Jars
-        mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-        mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
-
-        final String commandStr = String.join(" ", command);
-        log.info("Command is {}", commandStr);
-
-        spark.withCommand(commandStr);
-        spark.start();
-
-        File temporaryFile = File.createTempFile("events", ".log");
-
-        spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
-
-        List<RunEvent> events =
-                Files.readAllLines(temporaryFile.toPath()).stream()
-                        .map(OpenLineageClientUtils::runEventFromJson)
-                        .collect(Collectors.toList());
-
-        List<RunEvent> nonEmptyInputEvents =
-                events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
-
-        assertFalse(nonEmptyInputEvents.isEmpty());
-
-        List<SchemaUtils.SchemaRecord> expectedInputSchema =
-                Arrays.asList(
-                        new SchemaUtils.SchemaRecord("data", "binary"),
-                        new SchemaUtils.SchemaRecord("streamName", "string"),
-                        new SchemaUtils.SchemaRecord("partitionKey", "string"),
-                        new SchemaUtils.SchemaRecord("sequenceNumber", "string"),
-                        new SchemaUtils.SchemaRecord("approximateArrivalTimestamp", "timestamp"));
-
-        nonEmptyInputEvents.forEach(
-                event -> {
-                    assertEquals(1, event.getInputs().size());
-                    assertEquals("events", event.getInputs().get(0).getName());
-                    assertEquals("kinesis://localstack:4566", event.getInputs().get(0).getNamespace());
-                    assertEquals(
-                            expectedInputSchema,
-                            SchemaUtils.mapToSchemaRecord(event.getInputs().get(0).getFacets().getSchema()));
-                });
-    }
-
-    @Test
-    @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
-    void testSparkStreamingWithMongoReplicaSource() throws IOException, InterruptedException {
-        Network containersNetwork = newNetwork();
-        final String className = "io.openlineage.spark.streaming.MongoStreamingJob";
-
-        GenericContainer mongo1 = buildMongoContainer(containersNetwork, "m1");
-        GenericContainer mongo2 = buildMongoContainer(containersNetwork, "m2");
-        GenericContainer mongo3 = buildMongoContainer(containersNetwork, "m3");
-
-        // start mongo cluster
-        mongo1.start();
-        mongo2.start();
-        mongo3.start();
-
-        initializeMongoReplicas(mongo1);
-
-        GenericContainer spark =
-                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-                        .dependsOn(mongo1, mongo2, mongo3)
-                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-                        .withNetwork(containersNetwork)
-                        .withStartupTimeout(Duration.ofMinutes(2));
-
-        List<String> command = new ArrayList<>();
-        command.add("./bin/spark-submit");
-        command.add("--master");
-        command.add("local[*]");
-        command.add("--class");
-        command.add(className);
-        command.add("--packages");
-        command.add(System.getProperty("mongo.package.version"));
-
-        addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-        addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-        addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-        addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
-        addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
-        addSparkConfig(command, "spark.openlineage.transport.type=file");
-        addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
-        addSparkConfig(command, "spark.sql.shuffle.partitions=1");
-        addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
-        addSparkConfig(command, "spark.ui.enabled=false");
-        command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
-
-        // mount the additional Jars
-        mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-        mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-        mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
-
-        final String commandStr = String.join(" ", command);
-        log.info("Command is {}", commandStr);
-
-        spark.withCommand(commandStr);
-
-        spark.start();
-
-        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
-
-        File temporaryFile = File.createTempFile("events", ".log");
-
-        spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
-
-        temporaryFile.deleteOnExit();
-
-        List<RunEvent> runEvents =
-                Files.readAllLines(temporaryFile.toPath()).stream()
-                        .map(OpenLineageClientUtils::runEventFromJson)
-                        .collect(Collectors.toList());
-
-        List<RunEvent> nonEmptySourceEvents =
-                runEvents.stream()
-                        .filter(event -> !event.getInputs().isEmpty())
-                        .collect(Collectors.toList());
-
-        assertFalse(nonEmptySourceEvents.isEmpty());
-
-        List<SchemaUtils.SchemaRecord> expectedInputSchema =
-                Arrays.asList(
-                        new SchemaUtils.SchemaRecord("_id", "string"),
-                        new SchemaUtils.SchemaRecord("name", "string"),
-                        new SchemaUtils.SchemaRecord("date", "timestamp"),
-                        new SchemaUtils.SchemaRecord("location", "string"));
-
-        nonEmptySourceEvents.forEach(
-                nonEmptyInputEvent -> {
-                    assertEquals(1, nonEmptyInputEvent.getInputs().size());
-                    assertEquals("events", nonEmptyInputEvent.getInputs().get(0).getName());
-                    assertEquals(
-                            "mongodb://m1:27017" + "/events",
-                            nonEmptyInputEvent.getInputs().get(0).getNamespace());
-                    assertEquals(
-                            expectedInputSchema,
-                            SchemaUtils.mapToSchemaRecord(
-                                    nonEmptyInputEvent.getInputs().get(0).getFacets().getSchema()));
-                });
-
-        spark.stop();
-        mongo1.stop();
-        mongo2.stop();
-        mongo3.stop();
-    }
-
-    private void initializeMongoReplicas(GenericContainer mongo)
-            throws IOException, InterruptedException {
-        org.testcontainers.containers.Container.ExecResult commandResult =
-                mongo.execInContainer("/bin/bash", "-c", "mongosh < initializeReplica.js");
-        assertEquals("", commandResult.getStderr());
-
-        new Thread(
-                () -> {
-                    try {
-                        Thread.sleep(1000);
-                        org.testcontainers.containers.Container.ExecResult insertResults =
-                                mongo.execInContainer(
-                                        "/bin/bash",
-                                        "-c",
-                                        "mongosh mongodb://m1:27017,m2:27017,m3:27017/events < insertRecords.js");
-                        assertEquals("", insertResults.getStderr());
-                    } catch (InterruptedException | IOException e) {
-                        log.error("Failed to insert records", e);
-                    }
-                })
-                .start();
-    }
-
-    private GenericContainer buildMongoContainer(Network network, String name) {
-        return new GenericContainer("mongo:7.0")
-                .withNetwork(network)
-                .withNetworkAliases(name)
-                .withExposedPorts(27017)
-                .withFileSystemBind(
-                        "src/test/resources/mongoconf/initializeReplica.js",
-                        "/initializeReplica.js",
-                        BindMode.READ_ONLY)
-                .withFileSystemBind(
-                        "src/test/resources/mongoconf/insertRecords.js",
-                        "/insertRecords.js",
-                        BindMode.READ_ONLY)
-                .withCommand("--replSet rs0 --bind_ip localhost," + name);
-    }
+    network.close();
+  }
+
+  @SneakyThrows
+  private GenericContainer createSparkContainer(final String className) {
+    List<String> commandParts = constructSparkSubmitCommand(className);
+    String command = String.join(" ", commandParts);
+    log.info("Container will be started with command: {}", command);
+
+    GenericContainer container =
+        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+            .withNetwork(network)
+            .withNetworkAliases("spark")
+            .withLogConsumer(SparkContainerUtils::consumeOutput)
+            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
+            .dependsOn(openLineageClientMockContainer)
+            .withCommand(command);
+
+    // mount the additional Jars
+    mountPath(container, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+    mountFiles(container, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(container, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(container, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+    return container;
+  }
+
+  private List<String> constructSparkSubmitCommand(String className) {
+    List<String> sparkSubmitCommand = new ArrayList<>();
+    sparkSubmitCommand.add(Paths.get(System.getProperty("spark.home.dir")) + "/bin/spark-submit");
+    sparkSubmitCommand.add("--master");
+    sparkSubmitCommand.add("local");
+    sparkSubmitCommand.add("--class");
+    sparkSubmitCommand.add(className);
+
+    addSparkConfig(sparkSubmitCommand, "spark.openlineage.transport.type=http");
+    addSparkConfig(
+        sparkSubmitCommand,
+        "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
+    addSparkConfig(sparkSubmitCommand, "spark.openlineage.debugFacet=enabled");
+    addSparkConfig(
+        sparkSubmitCommand, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(sparkSubmitCommand, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(sparkSubmitCommand, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(
+        sparkSubmitCommand, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(sparkSubmitCommand, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(sparkSubmitCommand, "spark.openlineage.facets.disabled=");
+    addSparkConfig(sparkSubmitCommand, "spark.ui.enabled=false");
+    // Last, but not least, we add the path to the JAR
+    sparkSubmitCommand.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+    return sparkSubmitCommand;
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testScalaUnionRddToParquet() {
+    spark = createSparkContainer("io.openlineage.spark.test.RddUnion");
+    spark.start();
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              List<OpenLineage.RunEvent> events =
+                  Arrays.stream(
+                          mockServerClient.retrieveRecordedRequests(
+                              request().withPath("/api/v1/lineage")))
+                      .map(r -> r.getBodyAsString())
+                      .map(event -> OpenLineageClientUtils.runEventFromJson(event))
+                      .collect(Collectors.toList());
+
+              assertThat(events).isNotEmpty();
+
+              RunEvent lastEvent = events.get(events.size() - 2);
+              assertThat(lastEvent.getOutputs().get(0))
+                  .hasFieldOrPropertyWithValue("namespace", "file")
+                  .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");
+
+              assertThat(lastEvent.getInputs().stream().map(d -> d.getName()))
+                  .contains("/tmp/scala-test/rdd_input1", "/tmp/scala-test/rdd_input2");
+            });
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_OR_ABOVE)
+  void testKafka2KafkaStreamingProducesInputAndOutputDatasets() throws IOException {
+    final Network network = newNetwork();
+    final String className = "io.openlineage.spark.streaming.Kafka2KafkaJob";
+    final DockerImageName kafkaDockerImageName =
+        DockerImageName.parse("docker.io/bitnami/kafka:3.4.1");
+
+    GenericContainer zookeeperContainer =
+        new GenericContainer(DockerImageName.parse("docker.io/bitnami/zookeeper:3.7"))
+            .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
+            .withEnv("ZOO_AUTOPURGE_INTERVAL", "1")
+            .withNetwork(network)
+            .withNetworkAliases("zookeeper")
+            .withExposedPorts(2181);
+
+    GenericContainer kafkaContainer =
+        new GenericContainer(kafkaDockerImageName)
+            .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
+            .withEnv(
+                "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP", "CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT")
+            .withEnv("KAFKA_CFG_LISTENERS", "CLIENT://:9092,EXTERNAL://:9093")
+            .withEnv(
+                "KAFKA_CFG_ADVERTISED_LISTENERS",
+                "CLIENT://kafka.broker.zero:9092,EXTERNAL://localhost:9093")
+            .withEnv("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "CLIENT")
+            .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
+            .withEnv("KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME", "false")
+            .withEnv("KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE", "true")
+            .withNetwork(network)
+            .withNetworkAliases("kafka.broker.zero")
+            .withExposedPorts(9092, 9093)
+            .dependsOn(zookeeperContainer);
+
+    GenericContainer kafkaInitContainer =
+        new GenericContainer(kafkaDockerImageName)
+            .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
+            .withNetwork(network)
+            .dependsOn(zookeeperContainer, kafkaContainer)
+            .withCommand(
+                "/bin/bash",
+                "-c",
+                "/opt/bitnami/kafka/bin/kafka-topics.sh --create --topic input-topic --bootstrap-server kafka.broker.zero:9092");
+
+    zookeeperContainer.start();
+    kafkaContainer.start();
+    kafkaInitContainer.start();
+
+    GenericContainer spark =
+        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+            .dependsOn(kafkaContainer)
+            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withNetwork(network)
+            .withLogConsumer(SparkContainerUtils::consumeOutput)
+            .withStartupTimeout(Duration.ofMinutes(2));
+
+    List<String> command = new ArrayList<>();
+    command.add(CONTAINER_SPARK_HOME_DIR + "/bin/spark-submit");
+    command.add("--master");
+    command.add("local[*]");
+    command.add("--class");
+    command.add(className);
+    command.add("--packages");
+    command.add(System.getProperty("kafka.package.version"));
+
+    addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+    addSparkConfig(
+        command, "spark.openlineage.facets.disabled=[schema;spark_unknown;spark.logicalPlan]");
+    addSparkConfig(command, "spark.openlineage.transport.type=file");
+    addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
+    addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(command, "spark.ui.enabled=false");
+    command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+    // mount the additional Jars
+    mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+    mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+    final String commandStr = String.join(" ", command);
+    log.info("Command is {}", commandStr);
+
+    spark.withCommand(commandStr);
+
+    spark.start();
+
+    Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
+
+    kafkaInitContainer.stop();
+    kafkaContainer.stop();
+    zookeeperContainer.stop();
+
+    File temporaryFile = File.createTempFile("events", ".log");
+
+    spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
+
+    temporaryFile.deleteOnExit();
+
+    List<RunEvent> events =
+        Files.readAllLines(temporaryFile.toPath()).stream()
+            .map(OpenLineageClientUtils::runEventFromJson)
+            .collect(Collectors.toList());
+
+    List<RunEvent> nonEmptyInputEvents =
+        events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
+
+    assertThat(nonEmptyInputEvents).isNotEmpty();
+
+    nonEmptyInputEvents.forEach(
+        event -> {
+          assertEquals(1, event.getInputs().size());
+          assertEquals("input-topic", event.getInputs().get(0).getName());
+          assertEquals("kafka://kafka.broker.zero:9092", event.getInputs().get(0).getNamespace());
+
+          assertEquals(1, event.getOutputs().size());
+          assertEquals("output-topic", event.getOutputs().get(0).getName());
+          assertEquals("kafka://kafka.broker.zero:9092", event.getOutputs().get(0).getNamespace());
+        });
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
+  @EnabledIfSystemProperty(named = SCALA_VERSION, matches = SCALA_2_12)
+  void testReadingFromKinesis() throws IOException, InterruptedException {
+    final String className = "io.openlineage.spark.streaming.KinesisReadJob";
+    Network localstackNetwork = newNetwork();
+
+    // latest left only because of issue with 3.6 version as 3.5, its planned to be fixed in 3.7
+    // (end of august)
+    GenericContainer localStack =
+        new GenericContainer<>(DockerImageName.parse("localstack/localstack:latest"))
+            .withNetwork(localstackNetwork)
+            .withNetworkAliases("localstack")
+            .withLogConsumer(SparkContainerUtils::consumeOutput)
+            .withExposedPorts(4566)
+            .withCommand();
+
+    localStack.start();
+
+    GenericContainer pythonContainer =
+        new GenericContainer<>(DockerImageName.parse("python:3.11"))
+            .withNetwork(localstackNetwork)
+            .withNetworkAliases("python")
+            .withCommand("sh", "-c", "tail -f /dev/null")
+            .dependsOn(localStack)
+            .withLogConsumer(SparkContainerUtils::consumeOutput);
+
+    pythonContainer.start();
+
+    pythonContainer.execInContainer("pip", "install", "awscli-local", "awscli");
+    pythonContainer.execInContainer(
+        "awslocal",
+        "--endpoint-url=http://localstack:4566",
+        "kinesis",
+        "create-stream",
+        "--stream-name",
+        "events",
+        "--shard-count",
+        "1");
+    pythonContainer.execInContainer(
+        "awslocal",
+        "--endpoint-url=http://localstack:4566",
+        "kinesis",
+        "put-record",
+        "--stream-name",
+        "events",
+        "--partition-key",
+        "1",
+        "--data",
+        "XzxkYXRhPl8x");
+
+    pythonContainer.execInContainer(
+        "awslocal",
+        "--endpoint-url=http://localstack:4566",
+        "kinesis",
+        "put-record",
+        "--stream-name",
+        "events",
+        "--partition-key",
+        "1",
+        "--data",
+        "XzxkYXRhPl8x");
+
+    GenericContainer spark =
+        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+            .dependsOn(localStack)
+            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withNetwork(localstackNetwork)
+            .withLogConsumer(SparkContainerUtils::consumeOutput)
+            .withEnv("AWS_ACCESS_KEY_ID", "test")
+            .withEnv("AWS_SECRET_ACCESS_KEY=", "test")
+            .withStartupTimeout(Duration.ofMinutes(2));
+
+    List<String> command = new ArrayList<>();
+    command.add("./bin/spark-submit");
+    command.add("--master");
+    command.add("local[*]");
+    command.add("--class");
+    command.add(className);
+    command.add("--jars");
+    command.add(
+        "https://awslabs-code-us-east-1.s3.amazonaws.com/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_"
+            + SCALA_BINARY_VERSION
+            + "-1.0.0.jar");
+
+    addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+    addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
+    addSparkConfig(command, "spark.openlineage.transport.type=file");
+    addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
+    addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(command, "spark.ui.enabled=false");
+    command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+    // mount the additional Jars
+    mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+    mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+    final String commandStr = String.join(" ", command);
+    log.info("Command is {}", commandStr);
+
+    spark.withCommand(commandStr);
+    spark.start();
+
+    File temporaryFile = File.createTempFile("events", ".log");
+
+    spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
+
+    List<RunEvent> events =
+        Files.readAllLines(temporaryFile.toPath()).stream()
+            .map(OpenLineageClientUtils::runEventFromJson)
+            .collect(Collectors.toList());
+
+    List<RunEvent> nonEmptyInputEvents =
+        events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
+
+    assertFalse(nonEmptyInputEvents.isEmpty());
+
+    List<SchemaUtils.SchemaRecord> expectedInputSchema =
+        Arrays.asList(
+            new SchemaUtils.SchemaRecord("data", "binary"),
+            new SchemaUtils.SchemaRecord("streamName", "string"),
+            new SchemaUtils.SchemaRecord("partitionKey", "string"),
+            new SchemaUtils.SchemaRecord("sequenceNumber", "string"),
+            new SchemaUtils.SchemaRecord("approximateArrivalTimestamp", "timestamp"));
+
+    nonEmptyInputEvents.forEach(
+        event -> {
+          assertEquals(1, event.getInputs().size());
+          assertEquals("events", event.getInputs().get(0).getName());
+          assertEquals("kinesis://localstack:4566", event.getInputs().get(0).getNamespace());
+          assertEquals(
+              expectedInputSchema,
+              SchemaUtils.mapToSchemaRecord(event.getInputs().get(0).getFacets().getSchema()));
+        });
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
+  void testSparkStreamingWithMongoReplicaSource() throws IOException, InterruptedException {
+    Network containersNetwork = newNetwork();
+    final String className = "io.openlineage.spark.streaming.MongoStreamingJob";
+
+    GenericContainer mongo1 = buildMongoContainer(containersNetwork, "m1");
+    GenericContainer mongo2 = buildMongoContainer(containersNetwork, "m2");
+    GenericContainer mongo3 = buildMongoContainer(containersNetwork, "m3");
+
+    // start mongo cluster
+    mongo1.start();
+    mongo2.start();
+    mongo3.start();
+
+    initializeMongoReplicas(mongo1);
+
+    GenericContainer spark =
+        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+            .dependsOn(mongo1, mongo2, mongo3)
+            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .withNetwork(containersNetwork)
+            .withStartupTimeout(Duration.ofMinutes(2));
+
+    List<String> command = new ArrayList<>();
+    command.add("./bin/spark-submit");
+    command.add("--master");
+    command.add("local[*]");
+    command.add("--class");
+    command.add(className);
+    command.add("--packages");
+    command.add(System.getProperty("mongo.package.version"));
+
+    addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+    addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+    addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+    addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
+    addSparkConfig(command, "spark.openlineage.transport.type=file");
+    addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
+    addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+    addSparkConfig(command, "spark.ui.enabled=false");
+    command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+    // mount the additional Jars
+    mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+    mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+    final String commandStr = String.join(" ", command);
+    log.info("Command is {}", commandStr);
+
+    spark.withCommand(commandStr);
+
+    spark.start();
+
+    Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
+
+    File temporaryFile = File.createTempFile("events", ".log");
+
+    spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
+
+    temporaryFile.deleteOnExit();
+
+    List<RunEvent> runEvents =
+        Files.readAllLines(temporaryFile.toPath()).stream()
+            .map(OpenLineageClientUtils::runEventFromJson)
+            .collect(Collectors.toList());
+
+    List<RunEvent> nonEmptySourceEvents =
+        runEvents.stream()
+            .filter(event -> !event.getInputs().isEmpty())
+            .collect(Collectors.toList());
+
+    assertFalse(nonEmptySourceEvents.isEmpty());
+
+    List<SchemaUtils.SchemaRecord> expectedInputSchema =
+        Arrays.asList(
+            new SchemaUtils.SchemaRecord("_id", "string"),
+            new SchemaUtils.SchemaRecord("name", "string"),
+            new SchemaUtils.SchemaRecord("date", "timestamp"),
+            new SchemaUtils.SchemaRecord("location", "string"));
+
+    nonEmptySourceEvents.forEach(
+        nonEmptyInputEvent -> {
+          assertEquals(1, nonEmptyInputEvent.getInputs().size());
+          assertEquals("events", nonEmptyInputEvent.getInputs().get(0).getName());
+          assertEquals(
+              "mongodb://m1:27017" + "/events",
+              nonEmptyInputEvent.getInputs().get(0).getNamespace());
+          assertEquals(
+              expectedInputSchema,
+              SchemaUtils.mapToSchemaRecord(
+                  nonEmptyInputEvent.getInputs().get(0).getFacets().getSchema()));
+        });
+
+    spark.stop();
+    mongo1.stop();
+    mongo2.stop();
+    mongo3.stop();
+  }
+
+  private void initializeMongoReplicas(GenericContainer mongo)
+      throws IOException, InterruptedException {
+    org.testcontainers.containers.Container.ExecResult commandResult =
+        mongo.execInContainer("/bin/bash", "-c", "mongosh < initializeReplica.js");
+    assertEquals("", commandResult.getStderr());
+
+    new Thread(
+            () -> {
+              try {
+                Thread.sleep(1000);
+                org.testcontainers.containers.Container.ExecResult insertResults =
+                    mongo.execInContainer(
+                        "/bin/bash",
+                        "-c",
+                        "mongosh mongodb://m1:27017,m2:27017,m3:27017/events < insertRecords.js");
+                assertEquals("", insertResults.getStderr());
+              } catch (InterruptedException | IOException e) {
+                log.error("Failed to insert records", e);
+              }
+            })
+        .start();
+  }
+
+  private GenericContainer buildMongoContainer(Network network, String name) {
+    return new GenericContainer("mongo:7.0")
+        .withNetwork(network)
+        .withNetworkAliases(name)
+        .withExposedPorts(27017)
+        .withFileSystemBind(
+            "src/test/resources/mongoconf/initializeReplica.js",
+            "/initializeReplica.js",
+            BindMode.READ_ONLY)
+        .withFileSystemBind(
+            "src/test/resources/mongoconf/insertRecords.js",
+            "/insertRecords.js",
+            BindMode.READ_ONLY)
+        .withCommand("--replSet rs0 --bind_ip localhost," + name);
+  }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -5,6 +5,9 @@
 
 package io.openlineage.spark.agent;
 
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_FIXTURES_JAR_PATH;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_CONF_DIR;
 import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_HOME_DIR;
@@ -19,16 +22,6 @@ import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAI
 import static io.openlineage.spark.agent.SparkContainerUtils.addSparkConfig;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
 import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockserver.model.HttpRequest.request;
-import static org.testcontainers.containers.Network.newNetwork;
-
-import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.RunEvent;
-import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,20 +34,26 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.awaitility.Awaitility;
+import static org.awaitility.Awaitility.await;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.ClearType;
+import static org.mockserver.model.HttpRequest.request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
+import static org.testcontainers.containers.Network.newNetwork;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -72,336 +71,429 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 @Slf4j
 class SparkScalaContainerTest {
-  private static final Network network = newNetwork();
+    private static final Network network = newNetwork();
 
-  @Container
-  private static final MockServerContainer openLineageClientMockContainer =
-      SparkContainerUtils.makeMockServerContainer(network);
+    @Container
+    private static final MockServerContainer openLineageClientMockContainer =
+            SparkContainerUtils.makeMockServerContainer(network);
 
-  private static GenericContainer<?> spark;
-  private static MockServerClient mockServerClient;
-  private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
-  private static final String SPARK_3_OR_ABOVE = "^[3-9].*";
-  private static final String SPARK_3_ONLY = "^3.*";
-  private static final String SCALA_2_12 = "^2.12.*";
-  private static final String SCALA_VERSION = "scala.binary.version";
+    private static GenericContainer<?> spark;
+    private static MockServerClient mockServerClient;
+    private static final Logger logger = LoggerFactory.getLogger(SparkContainerIntegrationTest.class);
+    private static final String SPARK_3_OR_ABOVE = "^[3-9].*";
+    private static final String SPARK_3_ONLY = "^3.*";
+    private static final String SCALA_2_12 = "^2.12.*";
+    private static final String SCALA_VERSION = "scala.binary.version";
 
-  private static final String SPARK_VERSION = "spark.version";
+    private static final String SPARK_VERSION = "spark.version";
 
-  @BeforeAll
-  public static void setup() {
-    mockServerClient =
-        new MockServerClient(
-            openLineageClientMockContainer.getHost(),
-            openLineageClientMockContainer.getServerPort());
+    @BeforeAll
+    public static void setup() {
+        mockServerClient =
+                new MockServerClient(
+                        openLineageClientMockContainer.getHost(),
+                        openLineageClientMockContainer.getServerPort());
 
-    mockServerClient
-        .when(request("/api/v1/lineage"))
-        .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
+        mockServerClient
+                .when(request("/api/v1/lineage"))
+                .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
 
-    Awaitility.await().until(openLineageClientMockContainer::isRunning);
-  }
-
-  @AfterEach
-  public void cleanup() {
-    mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
-    try {
-      if (spark != null) spark.stop();
-    } catch (Exception e) {
-      logger.error("Unable to shut down pyspark container", e);
+        Awaitility.await().until(openLineageClientMockContainer::isRunning);
     }
-  }
 
-  @AfterAll
-  public static void tearDown() {
-    try {
-      openLineageClientMockContainer.stop();
-    } catch (Exception e) {
-      logger.error("Unable to shut down openlineage client container", e);
+    @AfterEach
+    public void cleanup() {
+        mockServerClient.clear(request("/api/v1/lineage"), ClearType.LOG);
+        try {
+            if (spark != null) spark.stop();
+        } catch (Exception e) {
+            logger.error("Unable to shut down pyspark container", e);
+        }
     }
-    network.close();
-  }
 
-  @SneakyThrows
-  private GenericContainer createSparkContainer(final String className) {
-    List<String> commandParts = constructSparkSubmitCommand(className);
-    String command = String.join(" ", commandParts);
-    log.info("Container will be started with command: {}", command);
+    @AfterAll
+    public static void tearDown() {
+        try {
+            openLineageClientMockContainer.stop();
+        } catch (Exception e) {
+            logger.error("Unable to shut down openlineage client container", e);
+        }
+        network.close();
+    }
 
-    GenericContainer container =
-        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-            .withNetwork(network)
-            .withNetworkAliases("spark")
-            .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
-            .dependsOn(openLineageClientMockContainer)
-            .withCommand(command);
+    @SneakyThrows
+    private GenericContainer createSparkContainer(final String className) {
+        List<String> commandParts = constructSparkSubmitCommand(className);
+        String command = String.join(" ", commandParts);
+        log.info("Container will be started with command: {}", command);
 
-    // mount the additional Jars
-    mountPath(container, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-    mountFiles(container, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-    mountFiles(container, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-    mountFiles(container, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+        GenericContainer container =
+                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+                        .withNetwork(network)
+                        .withNetworkAliases("spark")
+                        .withLogConsumer(SparkContainerUtils::consumeOutput)
+                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+                        .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))
+                        .dependsOn(openLineageClientMockContainer)
+                        .withCommand(command);
 
-    return container;
-  }
+        // mount the additional Jars
+        mountPath(container, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+        mountFiles(container, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(container, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(container, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
 
-  private List<String> constructSparkSubmitCommand(String className) {
-    List<String> sparkSubmitCommand = new ArrayList<>();
-    sparkSubmitCommand.add(Paths.get(System.getProperty("spark.home.dir")) + "/bin/spark-submit");
-    sparkSubmitCommand.add("--master");
-    sparkSubmitCommand.add("local");
-    sparkSubmitCommand.add("--class");
-    sparkSubmitCommand.add(className);
+        return container;
+    }
 
-    addSparkConfig(sparkSubmitCommand, "spark.openlineage.transport.type=http");
-    addSparkConfig(
-        sparkSubmitCommand,
-        "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
-    addSparkConfig(sparkSubmitCommand, "spark.openlineage.debugFacet=enabled");
-    addSparkConfig(
-        sparkSubmitCommand, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-    addSparkConfig(sparkSubmitCommand, "spark.sql.warehouse.dir=/tmp/warehouse");
-    addSparkConfig(sparkSubmitCommand, "spark.sql.shuffle.partitions=1");
-    addSparkConfig(
-        sparkSubmitCommand, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-    addSparkConfig(sparkSubmitCommand, "spark.jars.ivy=/tmp/.ivy2/");
-    addSparkConfig(sparkSubmitCommand, "spark.openlineage.facets.disabled=");
-    addSparkConfig(sparkSubmitCommand, "spark.ui.enabled=false");
-    // Last, but not least, we add the path to the JAR
-    sparkSubmitCommand.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+    private List<String> constructSparkSubmitCommand(String className) {
+        List<String> sparkSubmitCommand = new ArrayList<>();
+        sparkSubmitCommand.add(Paths.get(System.getProperty("spark.home.dir")) + "/bin/spark-submit");
+        sparkSubmitCommand.add("--master");
+        sparkSubmitCommand.add("local");
+        sparkSubmitCommand.add("--class");
+        sparkSubmitCommand.add(className);
 
-    return sparkSubmitCommand;
-  }
+        addSparkConfig(sparkSubmitCommand, "spark.openlineage.transport.type=http");
+        addSparkConfig(
+                sparkSubmitCommand,
+                "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
+        addSparkConfig(sparkSubmitCommand, "spark.openlineage.debugFacet=enabled");
+        addSparkConfig(
+                sparkSubmitCommand, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+        addSparkConfig(sparkSubmitCommand, "spark.sql.warehouse.dir=/tmp/warehouse");
+        addSparkConfig(sparkSubmitCommand, "spark.sql.shuffle.partitions=1");
+        addSparkConfig(
+                sparkSubmitCommand, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+        addSparkConfig(sparkSubmitCommand, "spark.jars.ivy=/tmp/.ivy2/");
+        addSparkConfig(sparkSubmitCommand, "spark.openlineage.facets.disabled=");
+        addSparkConfig(sparkSubmitCommand, "spark.ui.enabled=false");
+        // Last, but not least, we add the path to the JAR
+        sparkSubmitCommand.add(CONTAINER_FIXTURES_JAR_PATH.toString());
 
-  @Test
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  void testScalaUnionRddToParquet() {
-    spark = createSparkContainer("io.openlineage.spark.test.RddUnion");
-    spark.start();
+        return sparkSubmitCommand;
+    }
 
-    await()
-        .atMost(Duration.ofSeconds(10))
-        .pollInterval(Duration.ofMillis(500))
-        .untilAsserted(
-            () -> {
-              List<OpenLineage.RunEvent> events =
-                  Arrays.stream(
-                          mockServerClient.retrieveRecordedRequests(
-                              request().withPath("/api/v1/lineage")))
-                      .map(r -> r.getBodyAsString())
-                      .map(event -> OpenLineageClientUtils.runEventFromJson(event))
-                      .collect(Collectors.toList());
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void testScalaUnionRddToParquet() {
+        spark = createSparkContainer("io.openlineage.spark.test.RddUnion");
+        spark.start();
 
-              assertThat(events).isNotEmpty();
+        await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(
+                        () -> {
+                            List<OpenLineage.RunEvent> events =
+                                    Arrays.stream(
+                                                    mockServerClient.retrieveRecordedRequests(
+                                                            request().withPath("/api/v1/lineage")))
+                                            .map(r -> r.getBodyAsString())
+                                            .map(event -> OpenLineageClientUtils.runEventFromJson(event))
+                                            .collect(Collectors.toList());
 
-              RunEvent lastEvent = events.get(events.size() - 2);
-              assertThat(lastEvent.getOutputs().get(0))
-                  .hasFieldOrPropertyWithValue("namespace", "file")
-                  .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");
+                            assertThat(events).isNotEmpty();
 
-              assertThat(lastEvent.getInputs().stream().map(d -> d.getName()))
-                  .contains("/tmp/scala-test/rdd_input1", "/tmp/scala-test/rdd_input2");
-            });
-  }
+                            RunEvent lastEvent = events.get(events.size() - 2);
+                            assertThat(lastEvent.getOutputs().get(0))
+                                    .hasFieldOrPropertyWithValue("namespace", "file")
+                                    .hasFieldOrPropertyWithValue("name", "/tmp/scala-test/rdd_output");
+
+                            assertThat(lastEvent.getInputs().stream().map(d -> d.getName()))
+                                    .contains("/tmp/scala-test/rdd_input1", "/tmp/scala-test/rdd_input2");
+                        });
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_OR_ABOVE)
+    void testKafka2KafkaStreamingProducesInputAndOutputDatasets() throws IOException {
+        final Network network = newNetwork();
+        final String className = "io.openlineage.spark.streaming.Kafka2KafkaJob";
+        final DockerImageName kafkaDockerImageName =
+                DockerImageName.parse("docker.io/bitnami/kafka:3.4.1");
+
+        GenericContainer zookeeperContainer =
+                new GenericContainer(DockerImageName.parse("docker.io/bitnami/zookeeper:3.7"))
+                        .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
+                        .withEnv("ZOO_AUTOPURGE_INTERVAL", "1")
+                        .withNetwork(network)
+                        .withNetworkAliases("zookeeper")
+                        .withExposedPorts(2181);
+
+        GenericContainer kafkaContainer =
+                new GenericContainer(kafkaDockerImageName)
+                        .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
+                        .withEnv(
+                                "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP", "CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT")
+                        .withEnv("KAFKA_CFG_LISTENERS", "CLIENT://:9092,EXTERNAL://:9093")
+                        .withEnv(
+                                "KAFKA_CFG_ADVERTISED_LISTENERS",
+                                "CLIENT://kafka.broker.zero:9092,EXTERNAL://localhost:9093")
+                        .withEnv("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "CLIENT")
+                        .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
+                        .withEnv("KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME", "false")
+                        .withEnv("KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE", "true")
+                        .withNetwork(network)
+                        .withNetworkAliases("kafka.broker.zero")
+                        .withExposedPorts(9092, 9093)
+                        .dependsOn(zookeeperContainer);
+
+        GenericContainer kafkaInitContainer =
+                new GenericContainer(kafkaDockerImageName)
+                        .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
+                        .withNetwork(network)
+                        .dependsOn(zookeeperContainer, kafkaContainer)
+                        .withCommand(
+                                "/bin/bash",
+                                "-c",
+                                "/opt/bitnami/kafka/bin/kafka-topics.sh --create --topic input-topic --bootstrap-server kafka.broker.zero:9092");
+
+        zookeeperContainer.start();
+        kafkaContainer.start();
+        kafkaInitContainer.start();
+
+        GenericContainer spark =
+                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+                        .dependsOn(kafkaContainer)
+                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+                        .withNetwork(network)
+                        .withLogConsumer(SparkContainerUtils::consumeOutput)
+                        .withStartupTimeout(Duration.ofMinutes(2));
+
+        List<String> command = new ArrayList<>();
+        command.add(CONTAINER_SPARK_HOME_DIR + "/bin/spark-submit");
+        command.add("--master");
+        command.add("local[*]");
+        command.add("--class");
+        command.add(className);
+        command.add("--packages");
+        command.add(System.getProperty("kafka.package.version"));
+
+        addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+        addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+        addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+        addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+        addSparkConfig(
+                command, "spark.openlineage.facets.disabled=[schema;spark_unknown;spark.logicalPlan]");
+        addSparkConfig(command, "spark.openlineage.transport.type=file");
+        addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
+        addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+        addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+        addSparkConfig(command, "spark.ui.enabled=false");
+        command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+        // mount the additional Jars
+        mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+        mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+        final String commandStr = String.join(" ", command);
+        log.info("Command is {}", commandStr);
+
+        spark.withCommand(commandStr);
+
+        spark.start();
+
+        Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
+
+        kafkaInitContainer.stop();
+        kafkaContainer.stop();
+        zookeeperContainer.stop();
+
+        File temporaryFile = File.createTempFile("events", ".log");
+
+        spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
+
+        temporaryFile.deleteOnExit();
+
+        List<RunEvent> events =
+                Files.readAllLines(temporaryFile.toPath()).stream()
+                        .map(OpenLineageClientUtils::runEventFromJson)
+                        .collect(Collectors.toList());
+
+        List<RunEvent> nonEmptyInputEvents =
+                events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
+
+        assertThat(nonEmptyInputEvents).isNotEmpty();
+
+        nonEmptyInputEvents.forEach(
+                event -> {
+                    assertEquals(1, event.getInputs().size());
+                    assertEquals("input-topic", event.getInputs().get(0).getName());
+                    assertEquals("kafka://kafka.broker.zero:9092", event.getInputs().get(0).getNamespace());
+
+                    assertEquals(1, event.getOutputs().size());
+                    assertEquals("output-topic", event.getOutputs().get(0).getName());
+                    assertEquals("kafka://kafka.broker.zero:9092", event.getOutputs().get(0).getNamespace());
+                });
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
+    @EnabledIfSystemProperty(named = SCALA_VERSION, matches = SCALA_2_12)
+    void testReadingFromKinesis() throws IOException, InterruptedException {
+        final String className = "io.openlineage.spark.streaming.KinesisReadJob";
+        Network localstackNetwork = newNetwork();
+
+        // latest left only because of issue with 3.6 version as 3.5, its planned to be fixed in 3.7
+        // (end of august)
+        GenericContainer localStack =
+                new GenericContainer<>(DockerImageName.parse("localstack/localstack:latest"))
+                        .withNetwork(localstackNetwork)
+                        .withNetworkAliases("localstack")
+                        .withLogConsumer(SparkContainerUtils::consumeOutput)
+                        .withExposedPorts(4566)
+                        .withCommand();
+
+        localStack.start();
+
+        GenericContainer pythonContainer =
+                new GenericContainer<>(DockerImageName.parse("python:3.11"))
+                        .withNetwork(localstackNetwork)
+                        .withNetworkAliases("python")
+                        .withCommand("sh", "-c", "tail -f /dev/null")
+                        .dependsOn(localStack)
+                        .withLogConsumer(SparkContainerUtils::consumeOutput);
+
+        pythonContainer.start();
+
+        pythonContainer.execInContainer("pip", "install", "awscli-local", "awscli");
+        pythonContainer.execInContainer(
+                "awslocal",
+                "--endpoint-url=http://localstack:4566",
+                "kinesis",
+                "create-stream",
+                "--stream-name",
+                "events",
+                "--shard-count",
+                "1");
+        pythonContainer.execInContainer(
+                "awslocal",
+                "--endpoint-url=http://localstack:4566",
+                "kinesis",
+                "put-record",
+                "--stream-name",
+                "events",
+                "--partition-key",
+                "1",
+                "--data",
+                "XzxkYXRhPl8x");
+
+        pythonContainer.execInContainer(
+                "awslocal",
+                "--endpoint-url=http://localstack:4566",
+                "kinesis",
+                "put-record",
+                "--stream-name",
+                "events",
+                "--partition-key",
+                "1",
+                "--data",
+                "XzxkYXRhPl8x");
+
+        GenericContainer spark =
+                new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+                        .dependsOn(localStack)
+                        .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+                        .withNetwork(localstackNetwork)
+                        .withLogConsumer(SparkContainerUtils::consumeOutput)
+                        .withEnv("AWS_ACCESS_KEY_ID", "test")
+                        .withEnv("AWS_SECRET_ACCESS_KEY=", "test")
+                        .withStartupTimeout(Duration.ofMinutes(2));
+
+        List<String> command = new ArrayList<>();
+        command.add("./bin/spark-submit");
+        command.add("--master");
+        command.add("local[*]");
+        command.add("--class");
+        command.add(className);
+        command.add("--jars");
+        command.add(
+                "https://awslabs-code-us-east-1.s3.amazonaws.com/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_"
+                        + SCALA_BINARY_VERSION
+                        + "-1.0.0.jar");
+
+        addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
+        addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
+        addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
+        addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
+        addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
+        addSparkConfig(command, "spark.openlineage.transport.type=file");
+        addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
+        addSparkConfig(command, "spark.sql.shuffle.partitions=1");
+        addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
+        addSparkConfig(command, "spark.ui.enabled=false");
+        command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
+
+        // mount the additional Jars
+        mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
+        mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+        mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
+
+        final String commandStr = String.join(" ", command);
+        log.info("Command is {}", commandStr);
+
+        spark.withCommand(commandStr);
+        spark.start();
+
+        File temporaryFile = File.createTempFile("events", ".log");
+
+        spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
+
+        List<RunEvent> events =
+                Files.readAllLines(temporaryFile.toPath()).stream()
+                        .map(OpenLineageClientUtils::runEventFromJson)
+                        .collect(Collectors.toList());
+
+        List<RunEvent> nonEmptyInputEvents =
+                events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
+
+        assertFalse(nonEmptyInputEvents.isEmpty());
+
+        List<SchemaUtils.SchemaRecord> expectedInputSchema =
+                Arrays.asList(
+                        new SchemaUtils.SchemaRecord("data", "binary"),
+                        new SchemaUtils.SchemaRecord("streamName", "string"),
+                        new SchemaUtils.SchemaRecord("partitionKey", "string"),
+                        new SchemaUtils.SchemaRecord("sequenceNumber", "string"),
+                        new SchemaUtils.SchemaRecord("approximateArrivalTimestamp", "timestamp"));
+
+        nonEmptyInputEvents.forEach(
+                event -> {
+                    assertEquals(1, event.getInputs().size());
+                    assertEquals("events", event.getInputs().get(0).getName());
+                    assertEquals("kinesis://localstack:4566", event.getInputs().get(0).getNamespace());
+                    assertEquals(
+                            expectedInputSchema,
+                            SchemaUtils.mapToSchemaRecord(event.getInputs().get(0).getFacets().getSchema()));
+                });
+    }
 
   @Test
   @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_OR_ABOVE)
-  void testKafka2KafkaStreamingProducesInputAndOutputDatasets() throws IOException {
-    final Network network = newNetwork();
-    final String className = "io.openlineage.spark.streaming.Kafka2KafkaJob";
-    final DockerImageName kafkaDockerImageName =
-        DockerImageName.parse("docker.io/bitnami/kafka:3.4.1");
+  void testSparkStreamingWithMongoReplicaSource() throws IOException, InterruptedException {
+    Network containersNetwork = newNetwork();
+    final String className = "io.openlineage.spark.streaming.MongoStreamingJob";
 
-    GenericContainer zookeeperContainer =
-        new GenericContainer(DockerImageName.parse("docker.io/bitnami/zookeeper:3.7"))
-            .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
-            .withEnv("ZOO_AUTOPURGE_INTERVAL", "1")
-            .withNetwork(network)
-            .withNetworkAliases("zookeeper")
-            .withExposedPorts(2181);
+    GenericContainer mongo1 = buildMongoContainer(containersNetwork, "m1");
+    GenericContainer mongo2 = buildMongoContainer(containersNetwork, "m2");
+    GenericContainer mongo3 = buildMongoContainer(containersNetwork, "m3");
 
-    GenericContainer kafkaContainer =
-        new GenericContainer(kafkaDockerImageName)
-            .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
-            .withEnv(
-                "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP", "CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT")
-            .withEnv("KAFKA_CFG_LISTENERS", "CLIENT://:9092,EXTERNAL://:9093")
-            .withEnv(
-                "KAFKA_CFG_ADVERTISED_LISTENERS",
-                "CLIENT://kafka.broker.zero:9092,EXTERNAL://localhost:9093")
-            .withEnv("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "CLIENT")
-            .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
-            .withEnv("KAFKA_ZOOKEEPER_TLS_VERIFY_HOSTNAME", "false")
-            .withEnv("KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE", "true")
-            .withNetwork(network)
-            .withNetworkAliases("kafka.broker.zero")
-            .withExposedPorts(9092, 9093)
-            .dependsOn(zookeeperContainer);
+    // start mongo cluster
+    mongo1.start();
+    mongo2.start();
+    mongo3.start();
 
-    GenericContainer kafkaInitContainer =
-        new GenericContainer(kafkaDockerImageName)
-            .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
-            .withNetwork(network)
-            .dependsOn(zookeeperContainer, kafkaContainer)
-            .withCommand(
-                "/bin/bash",
-                "-c",
-                "/opt/bitnami/kafka/bin/kafka-topics.sh --create --topic input-topic --bootstrap-server kafka.broker.zero:9092");
-
-    zookeeperContainer.start();
-    kafkaContainer.start();
-    kafkaInitContainer.start();
+    initializeMongoReplicas(mongo1);
 
     GenericContainer spark =
         new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-            .dependsOn(kafkaContainer)
+            .dependsOn(mongo1, mongo2, mongo3)
             .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-            .withNetwork(network)
-            .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .withStartupTimeout(Duration.ofMinutes(2));
-
-    List<String> command = new ArrayList<>();
-    command.add(CONTAINER_SPARK_HOME_DIR + "/bin/spark-submit");
-    command.add("--master");
-    command.add("local[*]");
-    command.add("--class");
-    command.add(className);
-    command.add("--packages");
-    command.add(System.getProperty("kafka.package.version"));
-
-    addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
-    addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
-    addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
-    addSparkConfig(
-        command, "spark.openlineage.facets.disabled=[schema;spark_unknown;spark.logicalPlan]");
-    addSparkConfig(command, "spark.openlineage.transport.type=file");
-    addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
-    addSparkConfig(command, "spark.sql.shuffle.partitions=1");
-    addSparkConfig(command, "spark.sql.warehouse.dir=/tmp/warehouse");
-    addSparkConfig(command, "spark.ui.enabled=false");
-    command.add(CONTAINER_FIXTURES_JAR_PATH.toString());
-
-    // mount the additional Jars
-    mountPath(spark, HOST_SCALA_FIXTURES_JAR_PATH, CONTAINER_FIXTURES_JAR_PATH);
-    mountFiles(spark, HOST_LIB_DIR, CONTAINER_SPARK_JARS_DIR);
-    mountFiles(spark, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
-    mountFiles(spark, HOST_ADDITIONAL_CONF_DIR, CONTAINER_SPARK_CONF_DIR);
-
-    final String commandStr = String.join(" ", command);
-    log.info("Command is {}", commandStr);
-
-    spark.withCommand(commandStr);
-
-    spark.start();
-
-    Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
-
-    kafkaInitContainer.stop();
-    kafkaContainer.stop();
-    zookeeperContainer.stop();
-
-    File temporaryFile = File.createTempFile("events", ".log");
-
-    spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
-
-    temporaryFile.deleteOnExit();
-
-    List<RunEvent> events =
-        Files.readAllLines(temporaryFile.toPath()).stream()
-            .map(OpenLineageClientUtils::runEventFromJson)
-            .collect(Collectors.toList());
-
-    List<RunEvent> nonEmptyInputEvents =
-        events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
-
-    assertThat(nonEmptyInputEvents).isNotEmpty();
-
-    nonEmptyInputEvents.forEach(
-        event -> {
-          assertEquals(1, event.getInputs().size());
-          assertEquals("input-topic", event.getInputs().get(0).getName());
-          assertEquals("kafka://kafka.broker.zero:9092", event.getInputs().get(0).getNamespace());
-
-          assertEquals(1, event.getOutputs().size());
-          assertEquals("output-topic", event.getOutputs().get(0).getName());
-          assertEquals("kafka://kafka.broker.zero:9092", event.getOutputs().get(0).getNamespace());
-        });
-  }
-
-  @Test
-  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = SPARK_3_ONLY)
-  @EnabledIfSystemProperty(named = SCALA_VERSION, matches = SCALA_2_12)
-  void testReadingFromKinesis() throws IOException, InterruptedException {
-    final String className = "io.openlineage.spark.streaming.KinesisReadJob";
-    Network localstackNetwork = newNetwork();
-
-    // latest left only because of issue with 3.6 version as 3.5, its planned to be fixed in 3.7
-    // (end of august)
-    GenericContainer localStack =
-        new GenericContainer<>(DockerImageName.parse("localstack/localstack:latest"))
-            .withNetwork(localstackNetwork)
-            .withNetworkAliases("localstack")
-            .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .withExposedPorts(4566)
-            .withCommand();
-
-    localStack.start();
-
-    GenericContainer pythonContainer =
-        new GenericContainer<>(DockerImageName.parse("python:3.11"))
-            .withNetwork(localstackNetwork)
-            .withNetworkAliases("python")
-            .withCommand("sh", "-c", "tail -f /dev/null")
-            .dependsOn(localStack)
-            .withLogConsumer(SparkContainerUtils::consumeOutput);
-
-    pythonContainer.start();
-
-    pythonContainer.execInContainer("pip", "install", "awscli-local", "awscli");
-    pythonContainer.execInContainer(
-        "awslocal",
-        "--endpoint-url=http://localstack:4566",
-        "kinesis",
-        "create-stream",
-        "--stream-name",
-        "events",
-        "--shard-count",
-        "1");
-    pythonContainer.execInContainer(
-        "awslocal",
-        "--endpoint-url=http://localstack:4566",
-        "kinesis",
-        "put-record",
-        "--stream-name",
-        "events",
-        "--partition-key",
-        "1",
-        "--data",
-        "XzxkYXRhPl8x");
-
-    pythonContainer.execInContainer(
-        "awslocal",
-        "--endpoint-url=http://localstack:4566",
-        "kinesis",
-        "put-record",
-        "--stream-name",
-        "events",
-        "--partition-key",
-        "1",
-        "--data",
-        "XzxkYXRhPl8x");
-
-    GenericContainer spark =
-        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
-            .dependsOn(localStack)
-            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
-            .withNetwork(localstackNetwork)
-            .withLogConsumer(SparkContainerUtils::consumeOutput)
-            .withEnv("AWS_ACCESS_KEY_ID", "test")
-            .withEnv("AWS_SECRET_ACCESS_KEY=", "test")
+            .withNetwork(containersNetwork)
             .withStartupTimeout(Duration.ofMinutes(2));
 
     List<String> command = new ArrayList<>();
@@ -410,11 +502,8 @@ class SparkScalaContainerTest {
     command.add("local[*]");
     command.add("--class");
     command.add(className);
-    command.add("--jars");
-    command.add(
-        "https://awslabs-code-us-east-1.s3.amazonaws.com/spark-sql-kinesis-connector/spark-streaming-sql-kinesis-connector_"
-            + SCALA_BINARY_VERSION
-            + "-1.0.0.jar");
+    command.add("--packages");
+    command.add(System.getProperty("mongo.package.version"));
 
     addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
     addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
@@ -438,38 +527,91 @@ class SparkScalaContainerTest {
     log.info("Command is {}", commandStr);
 
     spark.withCommand(commandStr);
+
     spark.start();
+
+    Awaitility.await().atMost(Duration.ofSeconds(60)).until(() -> !spark.isRunning());
 
     File temporaryFile = File.createTempFile("events", ".log");
 
     spark.copyFileFromContainer("/tmp/events.log", temporaryFile.getPath());
 
-    List<RunEvent> events =
+    temporaryFile.deleteOnExit();
+
+    List<RunEvent> runEvents =
         Files.readAllLines(temporaryFile.toPath()).stream()
             .map(OpenLineageClientUtils::runEventFromJson)
             .collect(Collectors.toList());
 
-    List<RunEvent> nonEmptyInputEvents =
-        events.stream().filter(e -> !e.getInputs().isEmpty()).collect(Collectors.toList());
+    List<RunEvent> nonEmptySourceEvents =
+        runEvents.stream()
+            .filter(event -> !event.getInputs().isEmpty())
+            .collect(Collectors.toList());
 
-    assertFalse(nonEmptyInputEvents.isEmpty());
+    assertFalse(nonEmptySourceEvents.isEmpty());
 
     List<SchemaUtils.SchemaRecord> expectedInputSchema =
         Arrays.asList(
-            new SchemaUtils.SchemaRecord("data", "binary"),
-            new SchemaUtils.SchemaRecord("streamName", "string"),
-            new SchemaUtils.SchemaRecord("partitionKey", "string"),
-            new SchemaUtils.SchemaRecord("sequenceNumber", "string"),
-            new SchemaUtils.SchemaRecord("approximateArrivalTimestamp", "timestamp"));
+            new SchemaUtils.SchemaRecord("_id", "string"),
+            new SchemaUtils.SchemaRecord("name", "string"),
+            new SchemaUtils.SchemaRecord("date", "timestamp"),
+            new SchemaUtils.SchemaRecord("location", "string"));
 
-    nonEmptyInputEvents.forEach(
-        event -> {
-          assertEquals(1, event.getInputs().size());
-          assertEquals("events", event.getInputs().get(0).getName());
-          assertEquals("kinesis://localstack:4566", event.getInputs().get(0).getNamespace());
+    nonEmptySourceEvents.forEach(
+        nonEmptyInputEvent -> {
+          assertEquals(1, nonEmptyInputEvent.getInputs().size());
+          assertEquals("events", nonEmptyInputEvent.getInputs().get(0).getName());
+          assertEquals(
+              "mongodb://m1:27017" + "/events",
+              nonEmptyInputEvent.getInputs().get(0).getNamespace());
           assertEquals(
               expectedInputSchema,
-              SchemaUtils.mapToSchemaRecord(event.getInputs().get(0).getFacets().getSchema()));
+              SchemaUtils.mapToSchemaRecord(
+                  nonEmptyInputEvent.getInputs().get(0).getFacets().getSchema()));
         });
+
+    spark.stop();
+    mongo1.stop();
+    mongo2.stop();
+    mongo3.stop();
+  }
+
+  private void initializeMongoReplicas(GenericContainer mongo)
+      throws IOException, InterruptedException {
+    org.testcontainers.containers.Container.ExecResult commandResult =
+        mongo.execInContainer("/bin/bash", "-c", "mongosh < initializeReplica.js");
+    assertEquals("", commandResult.getStderr());
+
+    new Thread(
+            () -> {
+              try {
+                Thread.sleep(1000);
+                org.testcontainers.containers.Container.ExecResult insertResults =
+                    mongo.execInContainer(
+                        "/bin/bash",
+                        "-c",
+                        "mongosh mongodb://m1:27017,m2:27017,m3:27017/events < insertRecords.js");
+                assertEquals("", insertResults.getStderr());
+              } catch (InterruptedException | IOException e) {
+                log.error("Failed to insert records", e);
+              }
+            })
+        .start();
+  }
+
+  private GenericContainer buildMongoContainer(Network network, String name) {
+    return new GenericContainer("mongo:7.0")
+        .withNetwork(network)
+        .withNetworkAliases(name)
+        .withExposedPorts(27017)
+        .withFileSystemBind(
+            "src/test/resources/mongoconf/initializeReplica.js",
+            "/initializeReplica.js",
+            BindMode.READ_ONLY)
+        .withFileSystemBind(
+            "src/test/resources/mongoconf/insertRecords.js",
+            "/insertRecords.js",
+            BindMode.READ_ONLY)
+        .withCommand("--replSet rs0 --bind_ip localhost," + name);
   }
 }

--- a/integration/spark/app/src/test/resources/mongoconf/initializeReplica.js
+++ b/integration/spark/app/src/test/resources/mongoconf/initializeReplica.js
@@ -1,0 +1,6 @@
+use events;
+
+rs.initiate({_id: "rs0", members: [
+        {_id:0,host: "M1:27017"},
+        {_id:1,host:"M2:27017"},
+        {_id:2,host:"M3:27017"}]});

--- a/integration/spark/app/src/test/resources/mongoconf/insertRecords.js
+++ b/integration/spark/app/src/test/resources/mongoconf/insertRecords.js
@@ -1,0 +1,30 @@
+use events;
+
+db.createCollection("events", {
+    validator: {
+        $jsonSchema: {
+            bsonType: "object",
+            required: ["name", "date", "location"],
+            properties: {
+                name: {
+                    bsonType: "string",
+                    description: "must be a string and is required"
+                },
+                date: {
+                    bsonType: "date",
+                    description: "must be a date and is required"
+                },
+                location: {
+                    bsonType: "string",
+                    description: "must be a string and is required"
+                }
+            }
+        }
+    }
+});
+
+db.events.insertOne({
+    name: "name",
+    date: new Date(),
+    location: "location"
+});

--- a/integration/spark/scala-fixtures/src/main/scala/io/openlineage/spark/streaming/MongoStreamingJob.scala
+++ b/integration/spark/scala-fixtures/src/main/scala/io/openlineage/spark/streaming/MongoStreamingJob.scala
@@ -1,0 +1,53 @@
+package io.openlineage.spark.streaming
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.types.{DataTypes, StructType}
+import org.slf4j.LoggerFactory
+
+import java.time.Duration
+
+object MongoStreamingJob {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("MongoStreamingJob")
+      .getOrCreate()
+    runJob(spark)
+  }
+
+  private def runJob(spark: SparkSession): Unit = {
+    try {
+      val readSchema = new StructType().
+        add("_id", DataTypes.StringType).
+        add("name", DataTypes.StringType).
+        add("date", DataTypes.TimestampType).
+        add("location", DataTypes.StringType)
+
+      val sourceStream = spark.readStream.
+        format("mongodb").
+        option("spark.mongodb.change.stream.publish.full.document.only", "true").
+        option("spark.mongodb.connection.uri", "mongodb://m1:27017").
+        option("spark.mongodb.database", "events").
+        option("spark.mongodb.collection", "events").
+        option("forceDeleteTempCheckpointLocation", "true").
+        option("spark.mongodb.change.stream.change.stream.full.document", "updateLookup").
+        schema(readSchema).
+        load
+
+      sourceStream.
+        writeStream.
+        format("console").
+        option("truncate", "false").
+        trigger(Trigger.ProcessingTime(Duration.ofSeconds(4).toMillis)).
+        start.
+        awaitTermination(Duration.ofSeconds(30).toMillis)
+    } catch {
+      case e: Exception => log.error("Caught an exception", e)
+    } finally {
+      spark.stop()
+    }
+
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
@@ -1,0 +1,58 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.DatasetFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation;
+
+public class MongoMicroBatchStreamStrategy extends StreamStrategy {
+  public MongoMicroBatchStreamStrategy(
+      DatasetFactory<OpenLineage.InputDataset> inputDatasetDatasetFactory,
+      StreamingDataSourceV2Relation relation) {
+    super(inputDatasetDatasetFactory, relation);
+  }
+
+  @Override
+  List<OpenLineage.InputDataset> getInputDatasets() {
+    Optional<Object> readConfig = tryReadField(relation.stream(), "readConfig");
+
+    if (!readConfig.isPresent()) {
+      return new ArrayList<>();
+    }
+
+    Optional<Map<String, String>> options = tryReadField(readConfig.get(), "options");
+    Optional<OpenLineage.InputDataset> dataset =
+        options.map(
+            option -> {
+              String databaseName = option.get("spark.mongodb.database");
+              String connectionURL = option.get("spark.mongodb.connection.uri");
+              String collectionName = option.get("spark.mongodb.collection");
+
+              return datasetFactory.getDataset(
+                  collectionName, connectionURL + "/" + databaseName, relation.schema());
+            });
+
+    return dataset.map(Arrays::asList).orElseGet(ArrayList::new);
+  }
+
+  private <T> Optional<T> tryReadField(Object target, String fieldName) {
+    try {
+      T value = (T) FieldUtils.readField(target, fieldName, true);
+      return Optional.ofNullable(value);
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    } catch (IllegalAccessException e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/MongoMicroBatchStreamStrategy.java
@@ -19,12 +19,12 @@ public class MongoMicroBatchStreamStrategy extends StreamStrategy {
   public MongoMicroBatchStreamStrategy(
       DatasetFactory<OpenLineage.InputDataset> inputDatasetDatasetFactory,
       StreamingDataSourceV2Relation relation) {
-    super(inputDatasetDatasetFactory, relation);
+    super(inputDatasetDatasetFactory, relation.schema(), relation.stream(), Optional.empty());
   }
 
   @Override
-  List<OpenLineage.InputDataset> getInputDatasets() {
-    Optional<Object> readConfig = tryReadField(relation.stream(), "readConfig");
+  public List<OpenLineage.InputDataset> getInputDatasets() {
+    Optional<Object> readConfig = tryReadField(stream, "readConfig");
 
     if (!readConfig.isPresent()) {
       return new ArrayList<>();
@@ -39,7 +39,7 @@ public class MongoMicroBatchStreamStrategy extends StreamStrategy {
               String collectionName = option.get("spark.mongodb.collection");
 
               return datasetFactory.getDataset(
-                  collectionName, connectionURL + "/" + databaseName, relation.schema());
+                  collectionName, connectionURL + "/" + databaseName, schema);
             });
 
     return dataset.map(Arrays::asList).orElseGet(ArrayList::new);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
@@ -22,10 +22,10 @@ public class StreamingDataSourceV2RelationVisitor
       "org.apache.spark.sql.kafka010.KafkaMicroBatchStream";
   private static final String KINESIS_MICRO_BATCH_STREAM_CLASS_NAME =
       "org.apache.spark.sql.connector.kinesis.KinesisV2MicrobatchStream";
-    private static final String MONGO_MICRO_BATCH_STREAM_CLASS_NAME =
-            "com.mongodb.spark.sql.connector.read.MongoMicroBatchStream";
+  private static final String MONGO_MICRO_BATCH_STREAM_CLASS_NAME =
+      "com.mongodb.spark.sql.connector.read.MongoMicroBatchStream";
 
-    public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
+  public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
     super(context);
   }
 
@@ -66,11 +66,9 @@ public class StreamingDataSourceV2RelationVisitor
               ScalaConversionUtils.asJavaOptional(relation.startOffset()));
     } else if (KINESIS_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
       streamStrategy = new KinesisMicroBatchStreamStrategy(inputDataset(), relation);
-    }
-    else if (MONGO_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
+    } else if (MONGO_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
       streamStrategy = new MongoMicroBatchStreamStrategy(inputDataset(), relation);
-    }
-    else {
+    } else {
       log.warn(
           "The {} has been selected because no rules have matched for the stream class of {}",
           NoOpStreamStrategy.class,

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
@@ -20,11 +20,12 @@ public class StreamingDataSourceV2RelationVisitor
     extends QueryPlanVisitor<StreamingDataSourceV2Relation, InputDataset> {
   private static final String KAFKA_MICRO_BATCH_STREAM_CLASS_NAME =
       "org.apache.spark.sql.kafka010.KafkaMicroBatchStream";
-
   private static final String KINESIS_MICRO_BATCH_STREAM_CLASS_NAME =
       "org.apache.spark.sql.connector.kinesis.KinesisV2MicrobatchStream";
+    private static final String MONGO_MICRO_BATCH_STREAM_CLASS_NAME =
+            "com.mongodb.spark.sql.connector.read.MongoMicroBatchStream";
 
-  public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
+    public StreamingDataSourceV2RelationVisitor(@NonNull OpenLineageContext context) {
     super(context);
   }
 
@@ -65,7 +66,11 @@ public class StreamingDataSourceV2RelationVisitor
               ScalaConversionUtils.asJavaOptional(relation.startOffset()));
     } else if (KINESIS_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
       streamStrategy = new KinesisMicroBatchStreamStrategy(inputDataset(), relation);
-    } else {
+    }
+    else if (MONGO_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
+        streamStrategy = new MongoMicroBatchStreamStrategy(inputDataset(), relation);
+    }
+    else {
       log.warn(
           "The {} has been selected because no rules have matched for the stream class of {}",
           NoOpStreamStrategy.class,

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java
@@ -68,7 +68,7 @@ public class StreamingDataSourceV2RelationVisitor
       streamStrategy = new KinesisMicroBatchStreamStrategy(inputDataset(), relation);
     }
     else if (MONGO_MICRO_BATCH_STREAM_CLASS_NAME.equals(streamClassName)) {
-        streamStrategy = new MongoMicroBatchStreamStrategy(inputDataset(), relation);
+      streamStrategy = new MongoMicroBatchStreamStrategy(inputDataset(), relation);
     }
     else {
       log.warn(


### PR DESCRIPTION
### Problem

Add support for sending events when reading from mongo db using spark streaming.

Closes: #2886

### Solution
Mongo streaming visitor + tests.

#### One-line summary:
Mongo streaming visitor + tests.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project