### PR TITLE
[SPARK] Extract Dataset from underlying BaseRelation

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -81,7 +81,9 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
     return x instanceof LogicalRelation
         && (((LogicalRelation) x).relation() instanceof HadoopFsRelation
             || ((LogicalRelation) x).relation() instanceof JDBCRelation
-            || context.getSparkExtensionVisitorWrapper().isDefinedAt(x)
+            || context
+                .getSparkExtensionVisitorWrapper()
+                .isDefinedAt(((LogicalRelation) x).relation())
             || ((LogicalRelation) x).catalogTable().isDefined());
   }
 
@@ -102,7 +104,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
 
   @Override
   public List<D> apply(SparkListenerEvent event, LogicalRelation logRel) {
-    if (context.getSparkExtensionVisitorWrapper().isDefinedAt(logRel)) {
+    if (context.getSparkExtensionVisitorWrapper().isDefinedAt(logRel.relation())) {
       return new ExtensionLineageRelationHandler<>(context, datasetFactory)
           .handleRelation(event, logRel);
     } else if (logRel.catalogTable() != null && logRel.catalogTable().isDefined()) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
@@ -24,14 +24,14 @@ public class ExtensionLineageRelationHandler<D extends Dataset> {
   }
 
   public List<D> handleRelation(SparkListenerEvent event, LogicalRelation x) {
-    if (!context.getSparkExtensionVisitorWrapper().isDefinedAt(x)) {
+    if (!context.getSparkExtensionVisitorWrapper().isDefinedAt(x.relation())) {
       return Collections.emptyList();
     }
 
     DatasetIdentifier di =
         context
             .getSparkExtensionVisitorWrapper()
-            .getLineageDatasetIdentifier(x, event.getClass().getName());
+            .getLineageDatasetIdentifier(x.relation(), event.getClass().getName());
 
     if (x.schema() != null) {
       return Collections.singletonList(datasetFactory.getDataset(di, x.schema()));


### PR DESCRIPTION
### Problem

Instead of deriving Dataset from `BaseRelation` implementing `LineageRelation` interface we tried to get it from the parent `LogicalRelation`


### Solution

DatasetIdentifier is extracted from `LogicalRelation` underlying node

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project