### PR TITLE
disable facets unrelated to the test

### DIFF
--- a/integration/spark/app/integrations/container/pysparkHiveOverwriteDirCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveOverwriteDirCompleteEvent.json
@@ -2,22 +2,6 @@
 	"eventType": "COMPLETE",
 	"run": {
 		"facets": {
-			"spark_unknown": {
-				"inputs": [{
-					"description": {},
-					"inputAttributes": [],
-					"outputAttributes": [{
-						"name": "col1",
-						"type": "integer",
-						"metadata": {}
-					}, {
-						"name": "col2",
-						"type": "string",
-						"metadata": {}
-					}]
-				}]
-			},
-			"spark.logicalPlan": {},
 			"processing_engine": {
         "version": "${json-unit.any-string}",
         "name": "spark",

--- a/integration/spark/app/integrations/container/pysparkHiveOverwriteDirStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkHiveOverwriteDirStartEvent.json
@@ -2,22 +2,6 @@
 	"eventType": "START",
 	"run": {
 		"facets": {
-			"spark_unknown": {
-				"inputs": [{
-					"description": {},
-					"inputAttributes": [],
-					"outputAttributes": [{
-						"name": "col1",
-						"type": "integer",
-						"metadata": {}
-					}, {
-						"name": "col2",
-						"type": "string",
-						"metadata": {}
-					}]
-				}]
-			},
-			"spark.logicalPlan": {},
 			"processing_engine": {
         "version": "${json-unit.any-string}",
         "name": "spark",

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_overwrite_hive.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_overwrite_hive.py
@@ -13,6 +13,7 @@ spark = (
     SparkSession.builder.master("local")
     .appName("Open Lineage Integration Overwrite Hive")
     .config("spark.sql.warehouse.dir", "/tmp/overwrite")
+    .config("spark.openlineage.facets.disabled", "spark_unknown;spark.logicalPlan")
     .enableHiveSupport()
     .getOrCreate()
 )
@@ -23,4 +24,4 @@ spark.sql("CREATE TABLE IF NOT EXISTS test (key INT, value STRING) USING hive")
 spark.sql("INSERT OVERWRITE DIRECTORY '/tmp/overwrite/table' USING hive VALUES (1, 'a'), (2, 'b'), (3, 'c')")
 result = spark.sql("SELECT count(*) from test")
 
-time.sleep(1)
+time.sleep(3)


### PR DESCRIPTION
Test `io.openlineage.spark.agent.SparkContainerIntegrationTest#testPysparkSQLOverwriteDirHiveTest` is flaky on Circle CI as [here](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/11676/workflows/54791ba8-9778-459a-ae69-87611fac770a/jobs/257742/parallel-runs/0/steps/0-112?invite=true#step-112-2826932_106).

It is hard to find the cause bcz this barely happens locally, the issue may be related to the fact that Docker environment closes before emitting all the events.  As a remedy to this, this fix disables spark_unkown and logicalPlan facets, as they are unrelated to the feature verified and adds extra timeout at the end of Spark job to make sure all the events get emitted.