### PR TITLE
[SPARK] Extract DatasetIdentifier from extension LineageNode

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -124,6 +124,12 @@ public class InputFieldsCollector {
       return extractDatasetIdentifier(context, relation);
     } else if (node instanceof LogicalRDD) {
       return extractDatasetIdentifier((LogicalRDD) node);
+    } else if (node instanceof LogicalRelation
+        && context
+            .getOlContext()
+            .getSparkExtensionVisitorWrapper()
+            .isDefinedAt(((LogicalRelation) node).relation())) {
+      return extractExtensionDatasetIdentifier(context, (LogicalRelation) node);
     } else if (node instanceof InMemoryRelation) {
       // implemented in
       // io.openlineage.spark3.agent.lifecycle.plan.column.ColumnLevelLineageUtils.collectInputsAndExpressionDependencies
@@ -200,5 +206,14 @@ public class InputFieldsCollector {
     }
 
     return inputDatasets;
+  }
+
+  private static List<DatasetIdentifier> extractExtensionDatasetIdentifier(
+      ColumnLevelLineageContext context, LogicalRelation node) {
+    return Collections.singletonList(
+        context
+            .getOlContext()
+            .getSparkExtensionVisitorWrapper()
+            .getLineageDatasetIdentifier(node.relation(), context.getEvent().getClass().getName()));
   }
 }


### PR DESCRIPTION
### Problem

When performing column-level lineage input field data collection, the `DatasetIdentifier` was not extracted from nodes implementing the `LineageRelation` interface. 

### Solution

Now, the case when `LogicalRelation` has a grandChild node which implements `LineageRelation` interface is supported

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project