### PR TITLE
Detect incorrect java version when compiling

### DIFF
--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -84,6 +84,10 @@ class CommonConfigPlugin : Plugin<Project> {
                     // never run compile on CI without property being set
                     throw RuntimeException("java.compile.home should be always set on CI env")
                 }
+
+                if (!target.hasProperty("java.compile.home") && JavaVersion.current() < JavaVersion.VERSION_17) {
+                    throw RuntimeException("This project will not compile with Java version below 17.")
+                }
             }
         }
 


### PR DESCRIPTION
Provide user with meaningful error when compiling Spark integration with incorrect Java version. 