### PR TITLE
Python client: support OPENLINEAGE_HTTP_HEADERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   *Spark integration is always compiled with Java 17, while tests are running on both Java 8 and Java 17 according to the configuration.*
 * **Spark: Support preview release of Spark 4.0 .** [`#2854`](https://github.com/OpenLineage/OpenLineage/pull/2854) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Include Spark 4.0 preview release in the integration tests.*
-
+* **Python client**: support custom http headers for http transport [`#2910`](https://github.com/OpenLineage/OpenLineage/pull/2910) [@kr-igor](https://github.com/kr-igor)
+`OPENLINEAGE_HTTP_HEADERS` environment variable can be used to set custom headers.
 
 ### Fixed
 * **Spark: fix issue with kafka source when saving with for each batch method** [`#2868`](https://github.com/OpenLineage/OpenLineage/pull/2868) [@imbruced](https://github.com/Imbruced)    

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -228,6 +228,13 @@ class OpenLineageClient:
         if endpoint is not None:
             config.endpoint = endpoint
 
+        headers_str = os.environ.get("OPENLINEAGE_HTTP_HEADERS")
+        if headers_str is not None:
+            for val in headers_str.split(","):
+                if "=" in val:
+                    key, value = val.split("=")
+                    config.headers[key] = value
+
         return HttpTransport(config)
 
     @staticmethod

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -230,7 +230,7 @@ class OpenLineageClient:
 
         headers_str = os.environ.get("OPENLINEAGE_HTTP_HEADERS")
         if headers_str is not None:
-            for val in headers_str.split(","):
+            for val in headers_str.split(";"):
                 if "=" in val:
                     key, value = val.split("=")
                     config.headers[key] = value

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -87,6 +87,8 @@ class HttpConfig(Config):
     session: Session | None = attr.ib(default=None)
     # not set by TransportFactory
     adapter: HTTPAdapter | None = attr.ib(default=None)
+    # extra http headers to use
+    headers: dict[str, str] = attr.ib(default={})
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> HttpConfig:
@@ -150,6 +152,8 @@ class HttpTransport(Transport):
             self.session.headers["Content-Type"] = "application/json"
             auth_headers = self._auth_headers(config.auth)
             self.session.headers.update(auth_headers)
+            if len(config.headers) > 0:
+                self.session.headers.update(config.headers)
         self.timeout = config.timeout
         self.verify = config.verify
         self.compression = config.compression
@@ -179,6 +183,7 @@ class HttpTransport(Transport):
         else:
             headers["Content-Type"] = "application/json"
             headers.update(self._auth_headers(self.config.auth))
+            headers.update(self.config.headers)
             with Session() as session:
                 resp = session.post(
                     url=urljoin(self.url, self.endpoint),

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -64,7 +64,7 @@ def test_client_with_http_transport_from_env_emits(mocker: MockerFixture) -> Non
         {
             "OPENLINEAGE_URL": "http://backend:5000",
             "OPENLINEAGE_API_KEY": "API_KEY",
-            "OPENLINEAGE_HTTP_HEADERS": "header1=val1,header2=val2",
+            "OPENLINEAGE_HTTP_HEADERS": "header1=val1;header2=val2",
         },
     )
 


### PR DESCRIPTION
### Motivation

OpenLineage support `Authorization` http header, but some destinations may require a custom header. Specifically, Datadog requires `DD_API_KEY` to be set. It's not currently possible to set custom headers for the Python client.

### Description

Proposal is to support `OPENLINEAGE_HTTP_HEADERS: key=value;key1=value1` environment variable to set custom headers.

https://github.com/OpenLineage/OpenLineage/issues/2907