### PR TITLE
fix: Accept any provider for AWS Glue storage format.

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/CreateTableCommandVisitorTest.java
@@ -15,6 +15,7 @@ import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.lifecycle.CatalogTableTestUtils;
 import java.net.URI;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -38,6 +39,7 @@ class CreateTableCommandVisitorTest {
   public void setup() {
     SparkContext sparkContext = mock(SparkContext.class);
     when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
     when(session.sparkContext()).thenReturn(sparkContext);
     command = new CreateTableCommand(CatalogTableTestUtils.getCatalogTable(table), true);
     visitor = new CreateTableCommandVisitor(SparkAgentTestExtension.newContext(session));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -59,7 +59,7 @@ public class PathUtils {
     Configuration hadoopConf = sparkContext.hadoopConfiguration();
 
     Optional<URI> metastoreUri = getMetastoreUri(sparkContext);
-    Optional<String> glueArn = getGlueArn(catalogTable, sparkConf, hadoopConf);
+    Optional<String> glueArn = getGlueArn(sparkConf, hadoopConf);
 
     if (glueArn.isPresent()) {
       // Even if glue catalog is used, it will have a hive metastore URI
@@ -152,12 +152,7 @@ public class PathUtils {
   }
 
   @SneakyThrows
-  private static Optional<String> getGlueArn(
-      CatalogTable catalogTable, SparkConf sparkConf, Configuration hadoopConf) {
-    if (!catalogTable.provider().isDefined() || !"hive".equals(catalogTable.provider().get())) {
-      return Optional.empty();
-    }
-
+  private static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
     Optional<String> clientFactory =
         SparkConfUtils.findHadoopConfigKey(hadoopConf, "hive.metastore.client.factory.class");
     // Fetch from spark config if set.

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableAsSelectCommandVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -50,6 +51,7 @@ class CreateDataSourceTableAsSelectCommandVisitorTest {
     SparkConf conf = new SparkConf();
     conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
     when(sparkContext.getConf()).thenReturn(conf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateDataSourceTableCommandVisitorTest.java
@@ -18,6 +18,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -46,6 +47,7 @@ class CreateDataSourceTableCommandVisitorTest {
     SparkConf conf = new SparkConf();
     conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
     when(sparkContext.getConf()).thenReturn(conf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/CreateHiveTableAsSelectCommandVisitorTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.Partition;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -62,6 +63,7 @@ class CreateHiveTableAsSelectCommandVisitorTest {
     SparkConf conf = new SparkConf();
     conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
     when(sparkContext.getConf()).thenReturn(conf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 

--- a/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
+++ b/integration/spark/spark2/src/test/java/io/openlineage/spark2/agent/lifecycle/plan/OptimizedCreateHiveTableAsSelectCommandVisitorTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.Partition;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -62,6 +63,7 @@ class OptimizedCreateHiveTableAsSelectCommandVisitorTest {
     SparkConf conf = new SparkConf();
     conf.set("spark.sql.warehouse.dir", "s3://bucket/warehouse/location");
     when(sparkContext.getConf()).thenReturn(conf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
     when(session.sparkContext()).thenReturn(sparkContext);
   }
 


### PR DESCRIPTION
* Missing AWS Glue symlinks are generated for every storage format.

### Problem

When you use AWS Glue catalog but specify the format for the table (for example "parquet"), the symlinks are missing (because no AWS Glue ARN was generated).

### Solution

AWS Glue ARN generating method should accept every format (including `parquet`), not only Hive SerDe (value `hive` as storage `provider` field)

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project