### PR TITLE
dbt: add V6 run_result support

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/cloud.py
+++ b/integration/common/openlineage/common/provider/dbt/cloud.py
@@ -61,7 +61,7 @@ class DbtCloudArtifactProcessor(DbtArtifactProcessor):
 
     def get_dbt_metadata(self):
         self.check_metadata_version(self.manifest, list(range(2, 13)), self.logger)
-        self.check_metadata_version(self.run_result, [2, 3, 4, 5], self.logger)
+        self.check_metadata_version(self.run_result, [2, 3, 4, 5, 6], self.logger)
 
         return self.manifest, self.run_result, self.profile, self.catalog
 

--- a/integration/common/openlineage/common/provider/dbt/local.py
+++ b/integration/common/openlineage/common/provider/dbt/local.py
@@ -245,7 +245,7 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
     ) -> Tuple[Dict[Any, Any], Dict[Any, Any], Dict[Any, Any], Optional[Dict[Any, Any]]]:
         manifest = self.load_metadata(self.manifest_path, [2, 3, 4, 5, 6, 7], self.logger)
 
-        run_result = self.load_metadata(self.run_result_path, [2, 3, 4, 5], self.logger)
+        run_result = self.load_metadata(self.run_result_path, [2, 3, 4, 5, 6], self.logger)
 
         try:
             catalog: Optional[Dict[Any, Any]] = self.load_metadata(self.catalog_path, [1], self.logger)


### PR DESCRIPTION
### Problem
Running DBT dbt=1.8.4 shows an error `Artifact schema version: https://schemas.getdbt.com/dbt/run-results/v6.json is above dbt-ol supported version 5. This might cause errors.`
Closes: no open issue

### Solution
Add V6 to the list of supported versions. Checking https://schemas.getdbt.com/dbt/run-results/v5.json and https://schemas.getdbt.com/dbt/run-results/v6.json shows that they are identical so there is no issue in adding it.

#### One-line summary:
V5 and V6 are identical so lets add it to get rid of warning

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
-  [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project