### PR TITLE
fix: Properly set ARN in namespace for Iceberg Glue symlinks

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -152,7 +152,7 @@ public class PathUtils {
   }
 
   @SneakyThrows
-  private static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
+  public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
     Optional<String> clientFactory =
         SparkConfUtils.findHadoopConfigKey(hadoopConf, "hive.metastore.client.factory.class");
     // Fetch from spark config if set.

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     testFixturesApi("org.assertj:assertj-core:${assertjVersion}")
     testFixturesApi("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
     testFixturesApi("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testFixturesApi("org.junit-pioneer:junit-pioneer:1.9.1")
     testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
 
@@ -95,6 +96,7 @@ dependencies {
     testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
     testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
     testScala212Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala212Implementation("org.junit-pioneer:junit-pioneer:1.9.1")
     testScala212Implementation("org.mockito:mockito-core:${mockitoVersion}")
     testScala212Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 
@@ -126,6 +128,7 @@ dependencies {
     testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
     testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
     testScala213Implementation("org.junit.jupiter:junit-jupiter:${junit5Version}")
+    testScala213Implementation("org.junit-pioneer:junit-pioneer:1.9.1")
     testScala213Implementation("org.mockito:mockito-core:${mockitoVersion}")
     testScala213Implementation("org.mockito:mockito-inline:${mockitoVersion}")
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -19,8 +19,11 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -30,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import scala.collection.immutable.Map;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -38,6 +42,9 @@ class IcebergHandlerTest {
   private OpenLineageContext context = mock(OpenLineageContext.class);
   private IcebergHandler icebergHandler = new IcebergHandler(context);
   private SparkSession sparkSession = mock(SparkSession.class);
+  private SparkContext sparkContext = mock(SparkContext.class);
+  private SparkConf sparkConf = new SparkConf();
+  private Configuration hadoopConf = new Configuration();
   private RuntimeConfig runtimeConfig = mock(RuntimeConfig.class);
 
   @ParameterizedTest
@@ -162,8 +169,16 @@ class IcebergHandlerTest {
 
   @Test
   @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-west-2")
   void testGetDatasetIdentifierForGlue() {
     when(sparkSession.conf()).thenReturn(runtimeConfig);
+    sparkConf.set("spark.glue.accountId", "1122334455");
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    hadoopConf.set(
+        "hive.metastore.client.factory.class",
+        "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
     when(runtimeConfig.getAll())
         .thenReturn(
             new Map.Map2<>(
@@ -193,7 +208,7 @@ class IcebergHandlerTest {
 
     assertThat(datasetIdentifier.getSymlinks())
         .singleElement()
-        .hasFieldOrPropertyWithValue("namespace", "file:/tmp/warehouse")
+        .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-west-2:1122334455")
         .hasFieldOrPropertyWithValue("name", "database.table")
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }


### PR DESCRIPTION
### Problem

For Iceberg tables configured in Glue catalog, the symlinks have paths instead of ARNs in the `namespace` field. For example:

```json
"symlinks": {
  "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.20.0-SNAPSHOT/integration/spark",
  "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
  "identifiers": [
    {
      "namespace": "s3://aowczarek-glue-test/iceberg_warehouse",
      "name": "silver.silver_buyinggroup",
      "type": "TABLE"
    }
  ]
}
```

What we want instead is:

```json
"symlinks": {
  "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.20.0-SNAPSHOT/integration/spark",
  "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
  "identifiers": [
    {
      "namespace": "arn:aws:glue:eu-central-1:654654611584",
      "name": "silver.silver_buyinggroup",
      "type": "TABLE"
    }
  ]
}
```

The problem is in `io.openlineage.spark3.agent.lifecycle.plan.catalog.IcebergHandler#getDatasetIdentifier` method which doesn't support `glue` catalog type.

### Solution

The `IcebergHandler` should support `glue` catalog table and create the symlink using the code from `PathUtils`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project