### PR TITLE
fix, ci: explicitely run workflow on versioned tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,9 @@ jobs:
               # run only Spark within nightly build
               echo "$PWD/.circleci/workflows/openlineage-spark.yml" >> workflow_files.txt
               echo "$PWD/.circleci/workflows/openlineage-java.yml" >> workflow_files.txt
+            elif [ -n "$CIRCLE_TAG" ]; then
+              # If we are on tag, run all of the workflows
+              ls -d $PWD/.circleci/workflows/* > workflow_files.txt
             elif [ "$CIRCLE_BRANCH" == "main" ]; then
               # If we are on the main branch, run all of the workflows
               # if integration type is not all, we specify only a single integration type in workflow files
@@ -185,4 +188,7 @@ jobs:
 workflows:
   schedule_workflow:
     jobs:
-      - determine_changed_modules
+      - determine_changed_modules:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/


### PR DESCRIPTION
Branches allow filtering them out, but tags are turned off by default.