### PR TITLE
ci, fix: Don't add requires to openlineage-always.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,14 @@ jobs:
             #
             # This configuration is piped into yq along with the continue_config.yml file and the
             # union of the two files is output to complete_config.yml
-            yq eval-all '.workflows[].jobs |= map(select(.[].requires == null) |= .[].requires = ["always_run"])
-                | .workflows | . as $wf ireduce({}; . * $wf) |
-                (map(.jobs[] | select(has("workflow_complete") | not)) | . as $item ireduce ([]; (. *+ $item) ))
-                + [(map(.jobs[] | select(has("workflow_complete"))) | .[] as $item ireduce ({}; . *+ $item))] | {"workflows": {"build": {"jobs": .}}}' $FILES | \
+            yq eval-all '.workflows | . as $wf ireduce({}; . * $wf) | to_entries |
+                .[] |= (
+                  with(select(.key == "openlineage-always"); .) |
+                  with(select(.key != "openlineage-always"); .value.jobs |= map(select(.[].requires == null) |= .[].requires = ["always_run"]))
+                  ) | from_entries |
+                ((map(.jobs[] | select(has("workflow_complete") | not)) | . as $item ireduce ([]; (. *+ $item) ))
+                + [(map(.jobs[] | select(has("workflow_complete"))) | .[] as $item ireduce ({}; . *+ $item))])' $FILES | \
+            yq eval-all '{"workflows": {"build": {"jobs": .}}}' - | \
             yq eval-all '. as $wf ireduce({}; . * $wf)' .circleci/continue_config.yml - > complete_config.yml
             cat complete_config.yml  # to reproduce generated workflow
       - unless:
@@ -156,7 +160,7 @@ jobs:
                       for approval in approvals:
                           approval_name = next(iter(approval))
                           approval_upstreams = approval[approval_name].get('requires')
-                          approval_downstream = list(filter(lambda x: isinstance(x, dict) and approval_name in list(x.values())[0].get('requires'), jobs))
+                          approval_downstream = list(filter(lambda x: isinstance(x, dict) and approval_name in list(x.values())[0].get('requires', ''), jobs))
                           # replace approval with its upstream jobs
                           for job in approval_downstream:
                               requires = next(iter(job.values()))['requires']

--- a/.circleci/workflows/openlineage-always.yml
+++ b/.circleci/workflows/openlineage-always.yml
@@ -5,10 +5,12 @@ workflows:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-      - always_run
-      - workflow_complete:
+      - always_run:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
           requires:
             - run-pre-commit
+      - workflow_complete:
+          requires:
+            - always_run


### PR DESCRIPTION
### Problem

ci got broken after changes to single workflow build.

### Solution

Adjust yq code.

https://app.circleci.com/pipelines/github/JDarDagran/OpenLineage/43 and https://app.circleci.com/pipelines/github/JDarDagran/OpenLineage/44 show proper resolution of the workflows.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project