### PR TITLE
[SQL-Parser] Filter input tables to only used.

### DIFF
--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -367,6 +367,29 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub fn collect_inputs(
+        &mut self,
+        cte_deps: HashMap<String, CteDependency>,
+        deps: HashSet<DbTableMeta>,
+    ) {
+        if cte_deps.is_empty() {
+            for table in deps {
+                self.inputs.insert(table.clone());
+            }
+            return;
+        }
+
+        for (_key, value) in cte_deps {
+            if !value.is_used {
+                continue;
+            }
+
+            for table in value.deps {
+                self.inputs.insert(table.clone());
+            }
+        }
+    }
+
     pub fn bump_cte_level(&mut self) {
         if let Some(frame) = self.frames.last_mut() {
             frame.cte_level += 1;

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -245,7 +245,12 @@ impl<'a> Context<'a> {
     }
 
     pub fn add_table_dependency(&mut self, table: Vec<Ident>) {
-        let name = DbTableMeta::new(table, self.dialect, self.default_schema.clone());
+        let name = DbTableMeta::new(
+            table,
+            self.dialect,
+            self.default_schema.clone(),
+            self.default_database.clone(),
+        );
 
         if let Some(frame) = self.frames.last_mut() {
             frame.dependencies.extend(vec![name]);
@@ -263,7 +268,12 @@ impl<'a> Context<'a> {
     }
 
     pub fn mark_table_as_used(&mut self, table: Vec<Ident>) {
-        let name = DbTableMeta::new(table, self.dialect, self.default_schema.clone());
+        let name = DbTableMeta::new(
+            table,
+            self.dialect,
+            self.default_schema.clone(),
+            self.default_database.clone(),
+        );
 
         for frame in self.frames.iter_mut().rev() {
             if frame.cte_dependencies.contains_key(&name.qualified_name()) {

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -77,7 +77,6 @@ impl Visit for TableFactor {
                 if let Some(alias) = alias {
                     context.add_table_alias(table, vec![alias.name.clone()]);
                 }
-                context.add_input(effective_name.clone().0);
 
                 if !context.is_main() {
                     context.add_table_dependency(effective_name.clone().0);

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -569,9 +569,7 @@ impl Visit for Query {
             context.unset_frame_to_main_body();
         }
 
-        // context.unset_frame_to_main_body();
         let frame = context.pop_frame().unwrap();
-
         context.collect(frame);
 
         // Resolve CTEs
@@ -785,24 +783,8 @@ impl Visit for Statement {
         let frame = context.pop_frame().unwrap();
         let cte_deps = frame.cte_dependencies.clone();
         let deps = frame.dependencies.clone();
+        context.collect_inputs(cte_deps, deps);
         context.collect(frame);
-
-        if cte_deps.is_empty() {
-            for table in deps {
-                context.inputs.insert(table.clone());
-            }
-            return Ok(());
-        }
-
-        for (_key, value) in cte_deps {
-            if !value.is_used {
-                continue;
-            }
-
-            for table in value.deps {
-                context.inputs.insert(table.clone());
-            }
-        }
 
         Ok(())
     }

--- a/integration/sql/impl/tests/table_lineage/mod.rs
+++ b/integration/sql/impl/tests/table_lineage/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
-
 mod test_use;
+pub mod test_alias_resolving;
 pub mod tests_alter;
 pub mod tests_copy;
 pub mod tests_create;

--- a/integration/sql/impl/tests/table_lineage/mod.rs
+++ b/integration/sql/impl/tests/table_lineage/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
-mod test_use;
 pub mod test_alias_resolving;
+mod test_use;
 pub mod tests_alter;
 pub mod tests_copy;
 pub mod tests_create;

--- a/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
+++ b/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
@@ -1,0 +1,319 @@
+// Copyright 2018-2024 contributors to the OpenLineage project
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::test_utils::*;
+
+#[test]
+fn table_reference_with_simple_ctes() {
+    let query_string = "
+        WITH tab1 AS (
+            SELECT * FROM users as u
+        ),
+        tab2 AS (
+            SELECT * FROM bots
+        )
+        SELECT r.id
+        FROM python AS r
+        UNION ALL
+        SELECT id
+        FROM tab2";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["bots", "python"]
+    )
+}
+
+#[test]
+fn table_reference_with_simple_q_ctes() {
+    let query_string = "
+        WITH tab1 AS (
+            SELECT * FROM users
+        )
+        SELECT id
+        FROM tab2";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["tab2"]
+    )
+}
+
+#[test]
+fn table_reference_with_passersby_ctes() {
+    let query_string = "
+        WITH tab1 AS (
+            SELECT * FROM users as u
+        ),
+        tab2 AS (
+            SELECT * FROM tab1
+        ),
+        tab3 AS (
+            SELECT * FROM users2
+        )
+        SELECT id
+        FROM tab2
+        UNION ALL
+        SELECT id
+        FROM users3";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["users", "users3"]
+    )
+}
+
+#[test]
+fn table_references_with_simple_query() {
+    let query_string = "
+        SELECT * FROM tab1
+        UNION ALL
+        SELECT * FROM tab2";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["tab1", "tab2"]
+    )
+}
+
+#[test]
+fn table_references_with_subquery() {
+    let query_string = "
+        SELECT * FROM tab1
+        UNION ALL
+        SELECT * FROM (SELECT * FROM tab2)";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["tab1", "tab2"]
+    )
+}
+
+#[test]
+fn table_references_with_subquery_and_alias() {
+    let query_string = "
+        SELECT * FROM tab1
+        UNION ALL
+        SELECT * FROM (SELECT * FROM tab2) AS t";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["tab1", "tab2"]
+    )
+}
+
+#[test]
+fn table_references_with_subquery_and_alias_and_cte() {
+    let query_string = "
+        WITH tab1 AS (
+            SELECT * FROM users as u
+        )
+        SELECT * FROM tab1
+        UNION ALL
+        SELECT * FROM (SELECT * FROM tab2) AS t";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["tab2", "users"]
+    )
+}
+
+#[test]
+fn table_references_complex_main_query_does_not_use_ctes() {
+    let query_string = "
+        WITH tab10 AS (
+            SELECT * FROM users as u
+        )
+        SELECT * FROM animals1
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals2) AS t
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals3) AS t";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["animals1", "animals2", "animals3"]
+    )
+}
+
+#[test]
+fn table_references_complex_main_query_uses_ctes() {
+    let query_string = "
+        WITH tab10 AS (
+            SELECT * FROM
+            (SELECT * FROM users2 as u
+            UNION
+            SELECT * FROM users as u) as t
+        )
+        SELECT * FROM tab10
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals2) AS t
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals3) AS t";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["animals2", "animals3", "users", "users2"]
+    )
+}
+
+#[test]
+fn table_references_with_many_union_all() {
+    let query_string = "
+        WITH tab10 AS (
+            SELECT * FROM
+            (SELECT * FROM users2 as u
+            UNION
+            SELECT * FROM users as u
+            UNION
+            SELECT * FROM users3 as u
+            UNION
+            SELECT * FROM users4 as u
+            ) as t
+        )
+        SELECT * FROM tab10
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals2) AS t
+        UNION ALL
+        SELECT * FROM (SELECT * FROM animals3) AS t";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["animals2", "animals3", "users", "users2", "users3", "users4"]
+    )
+}
+
+#[test]
+fn table_references_connected_ctes() {
+    let query_string = "
+        WITH tab1 AS (
+            WITH data3 AS (
+                WITH data8 AS (
+                    SELECT r.* FROM (
+                        SELECT * FROM users as u
+                    ) as r
+                ),
+                data5 AS (
+                    SELECT r.* FROM (
+                        SELECT * FROM owners as u
+                    ) as r
+                ),
+               data6 AS (
+                    SELECT * FROM data5
+                )
+               SELECT * FROM data6
+               UNION ALL
+               SELECT * FROM data5
+            ),
+            data2 AS (
+                SELECT * FROM data3
+            )
+            SELECT * FROM data2
+        ),
+        tab2 AS (
+            SELECT * FROM tab1
+        ),
+        tab3 AS (
+            SELECT * FROM tab2
+        ),
+        tab4 AS (
+            SELECT * FROM users2
+        ),
+        tab5 AS (
+            SELECT * FROM tab4
+        )
+        SELECT * FROM tab5";
+
+    let table_lineage = test_sql(query_string);
+
+    assert_eq!(
+        table_lineage
+            .unwrap()
+            .table_lineage
+            .in_tables
+            .iter()
+            .map(|x| x.name.clone())
+            .collect::<Vec<String>>(),
+        vec!["users2"]
+    )
+}


### PR DESCRIPTION
### Problem

When we have sql query with tables which are not used at the end we still push them as input in the result. 
Example query

```sql
        WITH tab1 AS (
            SELECT * FROM users as u
        ),
        tab2 AS (
            SELECT * FROM bots
        )
        SELECT r.id
        FROM python AS r
        UNION ALL
        SELECT id
        FROM tab2";
```

currently: ["bots", "users", "python"]
desired: ["bots", "python"]

Closes: #ISSUE-NUMBER

### Solution

While we traverse the ast we add information about cte body where we call the tables, also full path to the table to be able to properly match them for nested structures.

#### One-line summary:
Filter not used sources.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project