### PR TITLE
fix, ci: remove usage of unnecessary build tag on python build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -24,12 +24,6 @@ checkout_project_root: &checkout_project_root
 install_python_client: &install_python_client
   run: (cd ~/openlineage/client/python && pip install . --user)
 
-param_build_tag: &param_build_tag
-  parameters:
-    build_tag:
-      default: ""
-      type: string
-
 commands:
   publish_shadow_jar_local:
     description: "Build shadow JAR and publish to maven local repo"
@@ -251,10 +245,6 @@ jobs:
     working_directory: ~/openlineage/client/python
     docker:
       - image: cimg/python:3.8
-    parameters:
-      build_tag:
-        default: ""
-        type: string
     steps:
       - *checkout_project_root
       - run: python -m pip install build
@@ -295,10 +285,9 @@ jobs:
     working_directory: ~/openlineage/integration/dbt
     docker:
       - image: cimg/python:3.8
-    <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -309,10 +298,9 @@ jobs:
     working_directory: ~/openlineage/integration/common
     docker:
       - image: cimg/python:3.8
-    <<: *param_build_tag
     steps:
       - *checkout_project_root
-      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -344,13 +332,12 @@ jobs:
     working_directory: ~/openlineage/integration/airflow
     docker:
       - image: cimg/python:3.8
-    <<: *param_build_tag
     steps:
       - *checkout_project_root
       - *install_python_client
       - install_integration_common:
           install_parser: true
-      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:
@@ -417,11 +404,10 @@ jobs:
     working_directory: ~/openlineage/integration/dagster
     docker:
       - image: cimg/python:3.8
-    <<: *param_build_tag
     steps:
       - *checkout_project_root
       - *install_python_client
-      - run: python setup.py egg_info -b "<< parameters.build_tag >>" sdist bdist_wheel
+      - run: python setup.py sdist bdist_wheel
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/workflows/openlineage-python.yml
+++ b/.circleci/workflows/openlineage-python.yml
@@ -37,7 +37,6 @@ workflows:
           filters:
             branches:
               only: main
-          build_tag: ".dev<< pipeline.number >>"
           requires:
             - unit-test-integration-common
       - unit-test-integration-airflow:
@@ -104,7 +103,6 @@ workflows:
               only: main
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          build_tag: ".dev<< pipeline.number >>"
           requires:
             - integration-test-integration-airflow
       - unit-test-client-python:
@@ -158,7 +156,6 @@ workflows:
               only: main
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          build_tag: ".dev<< pipeline.number >>"
           requires:
             - unit-tests-client-python
       - publish-client-python-reference:
@@ -177,7 +174,6 @@ workflows:
               only: main
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          build_tag: ".dev<< pipeline.number >>"
       - unit-test-integration-dagster:
           filters:
             tags:
@@ -190,7 +186,6 @@ workflows:
               only: main
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          build_tag: ".dev<< pipeline.number >>"
           requires:
             - unit-test-integration-dagster
       - workflow_complete:


### PR DESCRIPTION
Stop building nonsense packages `dist/openlineage_python-1.20.3.dev12141-py3-none-any.whl` on release.