### PR TITLE
ci: automatically close sonatype staging repo

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -46,7 +46,7 @@ commands:
           export RELEASE_PASSWORD=$(echo $OSSRH_TOKEN_PASSWORD)
           export RELEASE_USERNAME=$(echo $OSSRH_TOKEN_USERNAME)
 
-          ./gradlew --console=plain publish --info
+          ./gradlew --console=plain publishToSonatype closeSonatypeStagingRepository --info
   set_java_17:
     description: Set Java to Java 17
     steps:

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "pmd"
     id "io.freefair.lombok" version "8.7.1"
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 pmd {
@@ -207,16 +208,13 @@ publishing {
                 "version": project.property("version")
         ]
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }

--- a/integration/flink/build.gradle
+++ b/integration/flink/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow'
     id 'io.franzbecker.gradle-lombok'
     id 'io.openlineage.common-config'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 archivesBaseName='openlineage-flink'
@@ -144,16 +145,13 @@ publishing {
                 "version": project.property("version")
         ]
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }

--- a/integration/spark-extension-entrypoint/build.gradle
+++ b/integration/spark-extension-entrypoint/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'signing'
     id 'com.diffplug.spotless' version '6.12.0'
     id "pmd"
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 ext {
@@ -159,19 +160,17 @@ publishing {
                 "version": project.property("version")
         ]
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }
+
 
 signing {
     required { release }

--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.12.0'
     id "com.github.johnrengelman.shadow" version "8.1.1"
     id "pmd"
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 ext {
@@ -177,16 +178,13 @@ publishing {
                 "version": project.property("version")
         ]
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id("maven-publish")
     id("signing")
     id("jacoco")
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 ext {
@@ -124,15 +125,14 @@ publishing {
                 "version": project.property("version")
         ]
     }
+}
+
+
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }

--- a/integration/sql/iface-java/build.gradle
+++ b/integration/sql/iface-java/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'maven-publish'
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id 'com.diffplug.spotless' version '6.11.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 repositories {
@@ -100,16 +101,13 @@ publishing {
             }
         }
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = System.getenv('RELEASE_USERNAME')
-                password = System.getenv('RELEASE_PASSWORD')
-            }
+        sonatype {
+            username = System.getenv('RELEASE_USERNAME')
+            password = System.getenv('RELEASE_PASSWORD')
         }
     }
 }


### PR DESCRIPTION
This should automate closing of repository.

Next step - after this succeeds - is using `closeAndReleaseSonatypeStagingRepository` instead of just closing it - the author plugins recommend running just close when adding it for the first time.