### PR TITLE
[CIRCLE-CI] Optimize CircleCI Cache Keys to Reduce Excessive Storage Use

### DIFF
--- a/.circleci/checksum.sh
+++ b/.circleci/checksum.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 RESULT_FILE=$1
+BRANCH_NAME=$2
 
 if [ -f $RESULT_FILE ]; then
   rm $RESULT_FILE
 fi
 touch $RESULT_FILE
+
+# For dependabot PRs, skip checksum generation to reuse the same cache and reduce storage usage.
+if [[ $BRANCH_NAME == dependabot* ]]; then
+  echo "CONSTANT_STRING" >> $RESULT_FILE
+  exit 0
+fi
 
 checksum_file() {
   echo `openssl md5 $1 | awk '{print $2}'`

--- a/.circleci/checksum.sh
+++ b/.circleci/checksum.sh
@@ -9,7 +9,7 @@ touch $RESULT_FILE
 
 # For dependabot PRs, skip checksum generation to reuse the same cache and reduce storage usage.
 if [[ $BRANCH_NAME == dependabot* ]]; then
-  echo "CONSTANT_STRING" >> $RESULT_FILE
+  echo "DEPENDABOT" >> $RESULT_FILE
   exit 0
 fi
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -209,7 +209,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
@@ -443,7 +443,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-client-java-{{ checksum "/tmp/checksum.txt" }}
@@ -480,7 +480,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - publish_shadow_jar
@@ -500,7 +500,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
@@ -536,7 +536,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - set_java_17
       - restore_cache:
           keys:
@@ -579,7 +579,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - run:
@@ -637,7 +637,7 @@ jobs:
       - gcp-cli/initialize
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - run:
           name: Spark & Java version Variable
           command: |
@@ -689,7 +689,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - restore_cache:
@@ -728,7 +728,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - restore_cache:
@@ -755,7 +755,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - publish_shadow_jar
@@ -775,7 +775,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
       - run: |
@@ -814,7 +814,7 @@ jobs:
           steps:
             - run:
                 name: Generate cache key
-                command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+                command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
             - restore_cache:
                 keys:
                   - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
@@ -886,7 +886,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
@@ -922,7 +922,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
@@ -947,7 +947,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
@@ -982,7 +982,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
@@ -1013,7 +1013,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
@@ -1080,7 +1080,7 @@ jobs:
       - *checkout_project_root
       - run:
           name: Generate cache key
-          command: ./../../.circleci/checksum.sh /tmp/checksum.txt
+          command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - restore_cache:
           keys:
             - v1-proxy-{{ checksum "/tmp/checksum.txt" }}

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -212,8 +212,7 @@ jobs:
           command: ./../../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-release-client-java-{{ .Branch }}
+            - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ../
       - publish_shadow_jar
@@ -447,8 +446,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-client-java-{{ .Branch }}
+            - v1-client-java-{{ checksum "/tmp/checksum.txt" }}
       - run: ./gradlew --no-daemon --console=plain --stacktrace build check jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
       - publish_shadow_jar_local
@@ -470,7 +468,7 @@ jobs:
           path: build/libs
           destination: libs
       - save_cache:
-          key: v1-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-client-java-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -490,7 +488,7 @@ jobs:
           path: ./build/libs
           destination: java-client-artifacts
       - save_cache:
-          key: v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.m2
 
@@ -505,8 +503,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-release-client-java-{{ .Branch }}
+            - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - run: |
@@ -543,8 +540,7 @@ jobs:
       - set_java_17
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-spark-{{ .Branch }}
+            - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - run: |
@@ -565,7 +561,7 @@ jobs:
           path: build/libs
           destination: libs
       - save_cache:
-          key: v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -606,8 +602,7 @@ jobs:
             echo "${JAVAC_BIN}"
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-spark-{{ .Branch }}
+            - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - run: |
           echo "Setting default Java to ${JAVA_BIN}"
           sudo update-alternatives --set java ${JAVA_BIN}
@@ -662,8 +657,7 @@ jobs:
       - run: mkdir -p app/build/gcloud && echo $GCLOUD_SERVICE_KEY > app/build/gcloud/gcloud-service-key.json && chmod 644 app/build/gcloud/gcloud-service-key.json
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-spark-{{ .Branch }}
+            - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - run: |
@@ -678,7 +672,7 @@ jobs:
           path: app/build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
-          key: v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -700,8 +694,7 @@ jobs:
           at: ~/
       - restore_cache:
           keys:
-            - v1-spark-extension-interfaces-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-spark-extension-interfaces-{{ .Branch }}
+            - v1-spark-extension-interfaces-{{ checksum "/tmp/checksum.txt" }}
       - run: ./gradlew --no-daemon --console=plain --stacktrace build
       - run: ./gradlew --no-daemon --console=plain --info check
       - run: |
@@ -718,7 +711,7 @@ jobs:
             - openlineage/integration/spark-extension-interfaces/build-cache
             - openlineage/integration/spark-extension-interfaces/build
       - save_cache:
-          key: v1-spark-extension-interfaces-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-spark-extension-interfaces-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -740,8 +733,7 @@ jobs:
           at: ~/
       - restore_cache:
           keys:
-            - v1-spark-extension-entrypoint-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-spark-extension-entrypoint-{{ .Branch }}
+            - v1-spark-extension-entrypoint-{{ checksum "/tmp/checksum.txt" }}
       - run: ./gradlew --no-daemon --console=plain --stacktrace build
       - run: ./gradlew --no-daemon --console=plain --info check
       - persist_to_workspace:
@@ -751,7 +743,7 @@ jobs:
             - openlineage/integration/spark-extension-entrypoint/build-cache
             - openlineage/integration/spark-extension-entrypoint/build
       - save_cache:
-          key: v1-spark-extension-entrypoint-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-spark-extension-entrypoint-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -771,7 +763,7 @@ jobs:
           path: ./build/libs
           destination: spark-extension-interfaces-artifacts
       - save_cache:
-          key: v1-release-spark-extension-interfaces-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-release-spark-extension-interfaces-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.m2
 
@@ -797,7 +789,7 @@ jobs:
           path: ./build/libs
           destination: spark-extension-entrypoint-artifacts
       - save_cache:
-          key: v1-release-spark-extension-spark-extension-entrypoint-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-release-spark-extension-spark-extension-entrypoint-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.m2
 
@@ -825,8 +817,7 @@ jobs:
                 command: ./../../.circleci/checksum.sh /tmp/checksum.txt
             - restore_cache:
                 keys:
-                  - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-                  - v1-integration-spark-{{ .Branch }}
+                  - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
             - run:
                 name: Java version Variable
                 command: |
@@ -855,7 +846,7 @@ jobs:
                 path: app/build/cluster-log4j.log
                 destination: cluster-log4j.log
             - save_cache:
-                key: v1-databricks-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+                key: v1-databricks-integration-spark-{{ checksum "/tmp/checksum.txt" }}
                 paths:
                   - ~/.gradle
 
@@ -898,8 +889,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-spark-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-spark-{{ .Branch }}
+            - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - set_java_17
       - attach_workspace:
           at: ~/
@@ -935,8 +925,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-release-client-java-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-release-client-java-{{ .Branch }}
+            - v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - publish_shadow_jar
@@ -961,8 +950,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-flink-{{ .Branch }}
+            - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - set_java_17
@@ -979,7 +967,7 @@ jobs:
           path: app/build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
-          key: v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -997,8 +985,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-flink-{{ .Branch }}
+            - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - publish_shadow_jar_local
@@ -1029,8 +1016,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-integration-flink-{{ .Branch }}
+            - v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
       - run: ./gradlew --no-daemon --console=plain --stacktrace build check -Pflink.version=<< parameters.flink-version >>
@@ -1045,7 +1031,7 @@ jobs:
           path: app/build/reports/tests/test
           destination: test-report
       - save_cache:
-          key: v1-integration-flink-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 
@@ -1097,8 +1083,7 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt
       - restore_cache:
           keys:
-            - v1-proxy-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
-            - v1-proxy-{{ .Branch }}
+            - v1-proxy-{{ checksum "/tmp/checksum.txt" }}
       - run: ./gradlew --no-daemon --console=plain --stacktrace build
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - run: bash <(curl -s https://codecov.io/bash)
@@ -1108,7 +1093,7 @@ jobs:
           path: build/reports/tests/test
           destination: test-report
       - save_cache:
-          key: v1-proxy-{{ .Branch }}-{{ checksum "/tmp/checksum.txt" }}
+          key: v1-proxy-{{ checksum "/tmp/checksum.txt" }}
           paths:
             - ~/.gradle
 


### PR DESCRIPTION
### Problem

This PR aims to address the issue of excessive storage use in our CircleCI builds by optimizing the cache key patterns. Previously, our cache keys included both the branch name and a checksum value, which led to the creation of numerous cache entries and increased storage consumption. By removing the branch name from the cache keys, we can significantly reduce the number of cache entries and improve cache hit rates, ultimately optimizing our storage usage.


### Solution

#### Cache Key Optimization:

- Removed Branch Name from Cache Keys: The branch name ({{ .Branch }}) has been removed from all cache key patterns. The new cache keys now rely solely on the checksum value ({{ checksum "/tmp/checksum.txt" }}).
- Affected Jobs: This change has been applied to all jobs that include restore_cache and save_cache steps in the .circleci/continue_config.yml file.

##### Checksum Script Update:
- Dependabot PR Handling: The checksum.sh script has been updated to handle Dependabot PRs specifically. For branches starting with "dependabot", a constant string "DEPENDABOT" is written to the result file instead of generating a checksum. This allows reuse of the same cache for Dependabot PRs, reducing storage usage.
```schell 
# For dependabot PRs, skip checksum generation to reuse the same cache and reduce storage usage.
if [[ $BRANCH_NAME == dependabot* ]]; then
  echo "DEPENDABOT" >> $RESULT_FILE
  exit 0
fi
```

#### One-line summary:
Optimize CircleCI cache keys by removing branch names to reduce excessive storage use and improve cache efficiency.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project