### PR TITLE
chore: Update SQL integration code to work with latest sqlparser-rs main

### DIFF
--- a/integration/airflow/tests/integration/requests/failed_sql_extraction.json
+++ b/integration/airflow/tests/integration/requests/failed_sql_extraction.json
@@ -15,7 +15,7 @@
           "totalTasks": 1,
           "failedTasks": 1,
           "errors": [{
-            "errorMessage": "Expected TABLE, VIEW, INDEX, ROLE, SCHEMA, FUNCTION, STAGE or SEQUENCE after DROP, found: POLICY at Line: 1, Column 6",
+            "errorMessage": "Expected: TABLE, VIEW, INDEX, ROLE, SCHEMA, FUNCTION, PROCEDURE, STAGE, TRIGGER, SECRET or SEQUENCE after DROP, found: POLICY at Line: 1, Column: 6",
             "task": "DROP POLICY IF EXISTS name ON table_name",
             "taskNumber": 0
           }]
@@ -38,7 +38,7 @@
           "totalTasks": 1,
           "failedTasks": 1,
           "errors": [{
-            "errorMessage": "Expected TABLE, VIEW, INDEX, ROLE, SCHEMA, FUNCTION, STAGE or SEQUENCE after DROP, found: POLICY at Line: 1, Column 6",
+            "errorMessage": "Expected: TABLE, VIEW, INDEX, ROLE, SCHEMA, FUNCTION, PROCEDURE, STAGE, TRIGGER, SECRET or SEQUENCE after DROP, found: POLICY at Line: 1, Column: 6",
             "task": "DROP POLICY IF EXISTS name ON table_name",
             "taskNumber": 0
           }]

--- a/integration/common/tests/sql/test_parser.py
+++ b/integration/common/tests/sql/test_parser.py
@@ -265,7 +265,9 @@ def test_parse_bugged_cte():
             FROM sum_trans
             WHERE count > 1000 OR balance > 100000;
     """
-    assert parse(sql).errors == [ExtractionError(0, "Expected ), found: user_id at Line: 3, Column 20", sql)]
+    assert parse(sql).errors == [
+        ExtractionError(0, "Expected: ), found: user_id at Line: 3, Column: 20", sql)
+    ]
 
 
 def test_parse_recursive_cte():

--- a/integration/sql/impl/Cargo.toml
+++ b/integration/sql/impl/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["rlib"]
 [dependencies]
 anyhow = {workspace = true}
 
-sqlparser = {git = "https://github.com/OpenLineage/sqlparser-rs/", branch = "fix_snowflake_stage_no_parens"}
+sqlparser = {git = "https://github.com/OpenLineage/sqlparser-rs/", branch = "main"}

--- a/integration/sql/impl/tests/table_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_cte.rs
@@ -50,7 +50,7 @@ fn parse_bugged_cte() {
         meta.errors.first().unwrap(),
         &ExtractionError {
             index: 0,
-            message: "Expected ), found: user_id at Line: 3, Column 20".to_string(),
+            message: "Expected: ), found: user_id at Line: 3, Column: 20".to_string(),
             origin_statement: sql.to_string(),
         }
     );

--- a/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_error_handling.rs
@@ -28,13 +28,13 @@ fn test_failing_statement_with_insert() {
             errors: vec![
                 ExtractionError {
                     index: 0,
-                    message: "Expected an SQL statement, found: FAILING at Line: 1, Column 1".to_string(),
+                    message: "Expected: an SQL statement, found: FAILING at Line: 1, Column: 1".to_string(),
                     origin_statement: "FAILING STATEMENT;".to_string(),
                 },
                 ExtractionError {
                     index: 2,
                     message:
-                        "Expected SELECT, VALUES, or a subquery in the query body, found: FAILING at Line: 1, Column 13"
+                        "Expected: SELECT, VALUES, or a subquery in the query body, found: FAILING at Line: 1, Column: 13"
                             .to_string(),
                     origin_statement: "INSERT ALSO FAILING".to_string(),
                 }
@@ -50,7 +50,7 @@ fn test_failing_statement_tokenizer_failes() {
         errors,
         vec![ExtractionError {
             index: 0,
-            message: "Unterminated dollar-quoted string at Line: 1, Column 4".to_string(),
+            message: "Unterminated dollar-quoted string at Line: 1, Column: 4".to_string(),
             origin_statement: "$$$".to_string()
         },],
     )

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -175,3 +175,16 @@ fn select_window_function() {
         }
     )
 }
+
+#[test]
+fn select_bq_array_function() {
+    assert_eq!(
+        test_sql("SELECT l.LOCATION[offset(0)] AS my_city FROM my_bq_dataset.my_table_2 AS l")
+            .unwrap()
+            .table_lineage,
+        TableLineage {
+            in_tables: vec![table("my_bq_dataset.my_table_2")],
+            out_tables: vec![],
+        }
+    )
+}


### PR DESCRIPTION
Building on Maciej's branch, updating sql integration so that we can update our sqlparser-rs fork to the latest main.

#### One-line summary:

Adjusting sql integration after our sqlparser-rs fork has been updated to the latest main.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project