### PR TITLE
fix: Iceberg tables in AWS Glue have slashes instead of dots in symlinks

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.internal.StaticSQLConf;
 public class PathUtils {
   private static final String DEFAULT_DB = "default";
   private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
+  public static final String GLUE_TABLE_PREFIX = "table/";
 
   public static DatasetIdentifier fromPath(Path path) {
     return fromURI(path.toUri());
@@ -65,7 +66,8 @@ public class PathUtils {
       // Even if glue catalog is used, it will have a hive metastore URI
       // Use ARN format 'arn:aws:glue:{region}:{account_id}:table/{database}/{table}'
       String tableName = nameFromTableIdentifier(catalogTable.identifier(), "/");
-      symlinkDataset = Optional.of(new DatasetIdentifier("table/" + tableName, glueArn.get()));
+      symlinkDataset =
+          Optional.of(new DatasetIdentifier(GLUE_TABLE_PREFIX + tableName, glueArn.get()));
     } else if (metastoreUri.isPresent()) {
       // dealing with Hive tables
       URI hiveUri = prepareHiveUri(metastoreUri.get());

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import static io.openlineage.spark.agent.util.PathUtils.GLUE_TABLE_PREFIX;
+
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
@@ -221,7 +223,7 @@ public class IcebergHandler implements CatalogHandler {
     SparkContext sparkContext = sparkSession.sparkContext();
     String arn =
         PathUtils.getGlueArn(sparkContext.getConf(), sparkContext.hadoopConfiguration()).get();
-    return new DatasetIdentifier(table, arn);
+    return new DatasetIdentifier(GLUE_TABLE_PREFIX + table.replace(".", "/"), arn);
   }
 
   @SneakyThrows

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -209,7 +209,7 @@ class IcebergHandlerTest {
     assertThat(datasetIdentifier.getSymlinks())
         .singleElement()
         .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-west-2:1122334455")
-        .hasFieldOrPropertyWithValue("name", "database.table")
+        .hasFieldOrPropertyWithValue("name", "table/database/table")
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 


### PR DESCRIPTION
### Problem

Iceberg tables names contain dots instead of slashes and have no `table/` prefix.

### Solution

They should use slashes and the prefix `table/` as in documentation https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html

I've also updated the documentation: https://github.com/OpenLineage/docs/pull/365

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_) https://github.com/OpenLineage/docs/pull/365
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project