### PR TITLE
Fix issue with column lineage when using delta merge into command.

### DIFF
--- a/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
+++ b/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
@@ -1,6 +1,4 @@
 {
-  "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
   "eventType": "COMPLETE",
   "inputs": [],
   "outputs": [

--- a/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
+++ b/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
@@ -1,0 +1,124 @@
+{
+  "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+  "eventType": "COMPLETE",
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/delta/events",
+      "facets": {
+        "dataSource": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet",
+          "name": "file",
+          "uri": "file"
+        },
+        "version": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DatasetVersionDatasetFacet.json#/$defs/DatasetVersionDatasetFacet",
+          "datasetVersion": "2"
+        },
+        "schema": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet",
+          "fields": [
+            {
+              "name": "event_id",
+              "type": "long"
+            },
+            {
+              "name": "last_updated_at",
+              "type": "long"
+            }
+          ]
+        },
+        "columnLineage": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet",
+          "fields": {
+            "event_id": {
+              "inputFields": [
+                {
+                  "namespace": "file",
+                  "name": "/tmp/delta/events",
+                  "field": "event_id",
+                  "transformations": [
+                    {
+                      "type": "DIRECT",
+                      "subtype": "IDENTITY",
+                      "description": "",
+                      "masking": false
+                    }
+                  ]
+                },
+                {
+                  "namespace": "file",
+                  "name": "/tmp/delta/updates",
+                  "field": "event_id",
+                  "transformations": [
+                    {
+                      "type": "DIRECT",
+                      "subtype": "IDENTITY",
+                      "description": "",
+                      "masking": false
+                    }
+                  ]
+                },
+                {
+                  "namespace": "file",
+                  "name": "/tmp/delta/updates2",
+                  "field": "event_id",
+                  "transformations": [
+                    {
+                      "type": "DIRECT",
+                      "subtype": "IDENTITY",
+                      "description": "",
+                      "masking": false
+                    }
+                  ]
+                }
+              ]
+            },
+            "last_updated_at": {
+              "inputFields": [
+                {
+                  "namespace": "file",
+                  "name": "/tmp/delta/updates2",
+                  "field": "updated_at",
+                  "transformations": [
+                    {
+                      "type": "DIRECT",
+                      "subtype": "IDENTITY",
+                      "description": "",
+                      "masking": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "symlinks": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/delta",
+              "name": "default.events",
+              "type": "TABLE"
+            }
+          ]
+        }
+      },
+      "outputFacets": {
+        "outputStatistics": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet",
+          "rowCount": 0,
+          "size": 0
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
+++ b/integration/spark/app/integrations/container/deltaMergeCommandVerification.json
@@ -9,19 +9,13 @@
       "name": "/tmp/delta/events",
       "facets": {
         "dataSource": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DatasourceDatasetFacet.json#/$defs/DatasourceDatasetFacet",
           "name": "file",
           "uri": "file"
         },
         "version": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DatasetVersionDatasetFacet.json#/$defs/DatasetVersionDatasetFacet",
           "datasetVersion": "2"
         },
         "schema": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet",
           "fields": [
             {
               "name": "event_id",
@@ -34,8 +28,6 @@
           ]
         },
         "columnLineage": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet",
           "fields": {
             "event_id": {
               "inputFields": [
@@ -100,8 +92,6 @@
           }
         },
         "symlinks": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
           "identifiers": [
             {
               "namespace": "file:/tmp/delta",
@@ -113,8 +103,6 @@
       },
       "outputFacets": {
         "outputStatistics": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.21.0-SNAPSHOT/integration/spark",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-0-2/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet",
           "rowCount": 0,
           "size": 0
         }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
 import org.apache.spark.sql.catalyst.plans.logical.UnaryNode;
+import org.apache.spark.sql.catalyst.plans.logical.View;
 import org.apache.spark.sql.execution.ExternalRDD;
 import org.apache.spark.sql.execution.LogicalRDD;
 import org.apache.spark.sql.execution.columnar.InMemoryRelation;
@@ -140,6 +141,16 @@ public class InputFieldsCollector {
       // skip without warning
     } else if (node instanceof LeafNode) {
       log.warn("Could not extract dataset identifier from {}", node.getClass().getCanonicalName());
+    } else if (node instanceof View) {
+      List<DatasetIdentifier> inputDatasets = new ArrayList<>();
+      View view = ((View) node);
+
+      context
+          .getOlContext()
+          .getSparkSession()
+          .ifPresent(spark -> inputDatasets.add(PathUtils.fromCatalogTable(view.desc(), spark)));
+
+      return inputDatasets;
     }
     return Collections.emptyList();
   }


### PR DESCRIPTION
### Problem
Delta merge command is not returning proper column lineage. Example is in the bug ticket.


Closes: #2895

### Solution

We need to include view instance of a node when we gathering datasources for input columns.

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project