### PR TITLE
refactor: Minor Spark filters refactor

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/AdaptivePlanEventFilter.java
@@ -10,6 +10,7 @@ import static io.openlineage.spark.agent.filters.EventFilterUtils.isDeltaPlan;
 import io.openlineage.spark.api.OpenLineageContext;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.execution.QueryExecution;
 
 /** Removes events generated with Adaptive Plan Execution. Those events contain duplicate events. */
 @Slf4j
@@ -24,8 +25,6 @@ public class AdaptivePlanEventFilter implements EventFilter {
   /**
    * In case of Join queries spark plan may get optimized within Adaptive Query Execution engine,
    * which leads into multiple query plans and duplicated START/COMPLETE events.
-   *
-   * @return
    */
   @Override
   public boolean isDisabled(SparkListenerEvent event) {
@@ -35,9 +34,7 @@ public class AdaptivePlanEventFilter implements EventFilter {
 
     return context
         .getQueryExecution()
-        .filter(queryExecution -> queryExecution != null)
-        .map(queryExecution -> queryExecution.executedPlan())
-        .filter(sparkPlan -> sparkPlan != null)
+        .map(QueryExecution::executedPlan)
         .filter(sparkPlan -> sparkPlan.nodeName().contains("AdaptiveSparkPlan"))
         .isPresent();
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/DatabricksEventFilter.java
@@ -41,7 +41,7 @@ public class DatabricksEventFilter implements EventFilter {
     return isSerializeFromObject() || isWriteIntoDeltaCommand() || isDisabledDatabricksPlan(event);
   }
 
-  public boolean isDisabledDatabricksPlan(SparkListenerEvent event) {
+  public boolean isDisabledDatabricksPlan(SparkListenerEvent ignoredEvent) {
     if (!DatabricksUtils.isRunOnDatabricksPlatform(context)
         || !context.getQueryExecution().isPresent()) {
       return false;
@@ -58,9 +58,7 @@ public class DatabricksEventFilter implements EventFilter {
 
     return excludedNodes.stream()
         .map(n -> n.replace("_", ""))
-        .filter(n -> n.equalsIgnoreCase(nodeName))
-        .findAny()
-        .isPresent();
+        .anyMatch(n -> n.equalsIgnoreCase(nodeName));
   }
 
   private boolean isSerializeFromObject() {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
@@ -19,7 +19,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Project;
 import org.apache.spark.sql.catalyst.plans.logical.Repartition;
 import org.apache.spark.sql.execution.command.CreateDatabaseCommand;
 
-/** If a root node of an Spark action is one of defined nodes, we should filter it */
+/** If a root node of a Spark action is one of defined nodes, we should filter it */
 public class SparkNodesFilter implements EventFilter {
   private final OpenLineageContext context;
 
@@ -45,9 +45,9 @@ public class SparkNodesFilter implements EventFilter {
 
   private boolean filterNode(LogicalPlan plan) {
     if (plan.isStreaming()) {
-      // When spark is in the streaming mode, kafka input when saving with method forEach batch is
+      // When Spark is in the streaming mode, Kafka input when saving with method forEach batch is
       // in the different
-      // plan which starts from Project, hence we are losing information about the kafka input
+      // plan which starts from Project, hence we are losing information about the Kafka input
       // dataset.
       return filterNodes.stream()
           .filter(node -> !node.equals(Project.class.getCanonicalName()))


### PR DESCRIPTION
### Problem

My IDE has highlighted some minor problems with the code. They include:
- Filtering nulls in Optionals (they are always true)
- Skipping occasions to use method reference
- Using chains of methods that can be replace with one method
- Using lists where sets are better suited

### Solution

The suggestions should have been accepted.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project