### PR TITLE
Verify website build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
               check_change integration/dbt/ openlineage-python.yml
               check_change proxy/backend/ openlineage-proxy-backend.yml
               check_change proxy/fluentd/ openlineage-proxy-fluentd.yml
+              check_change website openlineage-website.yml
             fi
             touch workflow_files.txt
             FILES=$(sort workflow_files.txt | uniq | tr "\n" " ")

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1169,6 +1169,19 @@ jobs:
             SKIP= && [ -n "${CI}" ] && export SKIP="pmd"
             pre-commit run --show-diff-on-failure --all-files
 
+  build-website:
+    # Build Openlineage website to make sure npm packages match
+    working_directory: ~/openlineage/website
+    docker:
+      - image: cimg/node:22.7.0
+    steps:
+      - *checkout_project_root
+      - run:
+          name: Install Dependencies
+          command: |
+            yarn install --frozen-lockfile
+            yarn build
+
   always_run:
     machine:
       image: ubuntu-2404:current

--- a/.circleci/workflows/openlineage-website.yml
+++ b/.circleci/workflows/openlineage-website.yml
@@ -1,0 +1,13 @@
+workflows:
+  openlineage-website:
+    jobs:
+      - build-website:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+      - workflow_complete:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+          requires:
+            - build-website

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,7 +26,7 @@ const linksSocial = [
 const config = {
   title: 'OpenLineage',
   tagline: 'OpenLineage',
-  url: 'https://openlineage.io',
+  url: 'https://openlineage.github.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',


### PR DESCRIPTION
Add CI step to verify website build.

This PR can help merging dependabot upgrades that affect website by making sure the page gets built. 