### PR TITLE
ci: exclude dependabot from static analysis

### DIFF
--- a/.github/workflows/datadog-sca.yml
+++ b/.github/workflows/datadog-sca.yml
@@ -5,7 +5,7 @@ name: Datadog Software Composition Analysis
 jobs:
   software-composition-analysis:
     runs-on: ubuntu-latest
-    if: github.repository == 'OpenLineage/OpenLineage'
+    if: github.repository == 'OpenLineage/OpenLineage' && github.actor != 'dependabot[bot]'
     name: Datadog SBOM Generation and Upload
     steps:
       - name: Checkout

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -5,7 +5,7 @@ name: Datadog Static Analysis
 jobs:
   static-analysis:
     runs-on: ubuntu-latest
-    if: github.repository == 'OpenLineage/OpenLineage'
+    if: github.repository == 'OpenLineage/OpenLineage' && github.actor != 'dependabot[bot]'
     name: Datadog Static Analyzer
     steps:
       - name: Checkout


### PR DESCRIPTION
Dependabot can't access secrets, so the workflow always fails.