### PR TITLE
fix: Support IDENTIFIER function instead of treating it like table name

### DIFF
--- a/integration/sql/impl/tests/table_lineage/tests_delete.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_delete.rs
@@ -51,3 +51,32 @@ fn delete_from_using() {
         }
     );
 }
+
+#[test]
+fn delete_identifier_function() {
+    let test_cases = vec![
+        ("target", vec![table("target")]),
+        ("$target", vec![]),
+        (":target", vec![]),
+        ("?", vec![]),
+        (":myschema || '.' || :mytab", vec![]),
+    ];
+
+    let dialects = vec!["snowflake", "databricks", "mssql"];
+
+    for (out_table_id, out_tables) in &test_cases {
+        for dialect in &dialects {
+            let sql = format!("DELETE FROM identifier({}) WHERE x = 1;", out_table_id,);
+            assert_eq!(
+                test_sql_dialect(&sql, dialect).unwrap().table_lineage,
+                TableLineage {
+                    in_tables: vec![],
+                    out_tables: out_tables.clone(),
+                },
+                "Failed for dialect: {} with SQL: {}",
+                dialect,
+                sql
+            );
+        }
+    }
+}

--- a/integration/sql/impl/tests/table_lineage/tests_merge.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_merge.rs
@@ -38,6 +38,54 @@ fn merge_subquery_when_not_matched() {
     );
 }
 
+#[test]
+fn merge_identifier_function() {
+    let test_cases = vec![
+        (
+            "target",
+            "source",
+            vec![table("source")],
+            vec![table("target")],
+        ),
+        ("$target", ":source", vec![], vec![]),
+        ("?", "$source", vec![], vec![]),
+        (
+            ":myschema || '.' || :mytab",
+            "source",
+            vec![table("source")],
+            vec![],
+        ),
+    ];
+
+    let dialects = vec!["snowflake", "databricks", "mssql"];
+
+    for (out_table_id, in_table_id, in_tables, out_tables) in &test_cases {
+        for dialect in &dialects {
+            let sql = format!(
+                "MERGE INTO \
+                IDENTIFIER({}) \
+                USING \
+                identifier({})\
+                ON target.id = source.id \
+                WHEN MATCHED THEN \
+                UPDATE \
+                SET target.description = source.description",
+                out_table_id, in_table_id
+            );
+            assert_eq!(
+                test_sql_dialect(&sql, dialect).unwrap().table_lineage,
+                TableLineage {
+                    in_tables: in_tables.clone(),
+                    out_tables: out_tables.clone(),
+                },
+                "Failed for dialect: {} with SQL: {}",
+                dialect,
+                sql
+            );
+        }
+    }
+}
+
 // QUALIFY expression is not yet supported
 #[ignore]
 #[test]

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -188,3 +188,32 @@ fn select_bq_array_function() {
         }
     )
 }
+
+#[test]
+fn select_identifier_function() {
+    let test_cases = vec![
+        ("target", vec![table("target")]),
+        ("$target", vec![]),
+        (":target", vec![]),
+        ("?", vec![]),
+        (":myschema || '.' || :mytab", vec![]),
+    ];
+
+    let dialects = vec!["snowflake", "databricks", "mssql"];
+
+    for (in_table_id, in_tables) in &test_cases {
+        for dialect in &dialects {
+            let sql = format!("SELECT col1 FROM identifier({}) WHERE x = 1;", in_table_id);
+            assert_eq!(
+                test_sql_dialect(&sql, dialect).unwrap().table_lineage,
+                TableLineage {
+                    in_tables: in_tables.clone(),
+                    out_tables: vec![],
+                },
+                "Failed for dialect: {} with SQL: {}",
+                dialect,
+                sql
+            );
+        }
+    }
+}

--- a/integration/sql/impl/tests/table_lineage/tests_update.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_update.rs
@@ -55,3 +55,88 @@ fn update_table_from_subquery() {
         }
     )
 }
+
+#[test]
+fn update_identifier_function() {
+    let test_cases = vec![
+        (
+            "target",
+            "source",
+            vec![table("source")],
+            vec![table("target")],
+        ),
+        ("$target", ":source", vec![], vec![]),
+        ("?", "$source", vec![], vec![]),
+        (
+            ":myschema || '.' || :mytab",
+            "source",
+            vec![table("source")],
+            vec![],
+        ),
+    ];
+
+    let dialects = vec!["snowflake", "mssql"]; // Databricks has different update syntax
+
+    for (out_table_id, in_table_id, in_tables, out_tables) in &test_cases {
+        for dialect in &dialects {
+            let sql = format!(
+                "UPDATE \
+                IDENTIFIER({}) \
+                SET v = src.v \
+                FROM \
+                identifier({}) as src \
+                WHERE target.k = src.k;",
+                out_table_id, in_table_id
+            );
+            assert_eq!(
+                test_sql_dialect(&sql, dialect).unwrap().table_lineage,
+                TableLineage {
+                    in_tables: in_tables.clone(),
+                    out_tables: out_tables.clone(),
+                },
+                "Failed for dialect: {} with SQL: {}",
+                dialect,
+                sql
+            );
+        }
+    }
+}
+
+#[test]
+fn update_identifier_function_databricks() {
+    let test_cases = vec![
+        (
+            "target",
+            "source",
+            vec![table("source")],
+            vec![table("target")],
+        ),
+        ("$target", ":source", vec![], vec![]),
+        ("?", "$source", vec![], vec![]),
+        (
+            ":myschema || '.' || :mytab",
+            "source",
+            vec![table("source")],
+            vec![],
+        ),
+    ];
+
+    for (out_table_id, in_table_id, in_tables, out_tables) in &test_cases {
+        let sql = format!(
+            "UPDATE \
+            IDENTIFIER({}) \
+            SET v = src.v \
+            WHERE EXISTS (SELECT x FROM identifier({}) WHERE t1.oid = oid);",
+            out_table_id, in_table_id
+        );
+        assert_eq!(
+            test_sql_dialect(&sql, "databricks").unwrap().table_lineage,
+            TableLineage {
+                in_tables: in_tables.clone(),
+                out_tables: out_tables.clone(),
+            },
+            "Failed for dialect: databricks with SQL: {}",
+            sql
+        );
+    }
+}


### PR DESCRIPTION
### Problem

IDENTIFIER keyword, valid in certain SQL dialects (snowflake, databricks, mssql), is misplaced as table name in some cases (e.g. `SELECT col1 FROM IDENTIFIER(table)` would produce table named `IDENTIFIER` and not `table`)

### Solution

Whenever we have full information about the Table, we can try to repair the lineage. This PR adds support for this identifier in SELECT, MERGE, UPDATE, DELETE statements. For now only static identifiers are supported (e.g. IDENTIFIER("table_name") => table_name), when variable is used, we remove this table from lineage to avoid wrong lineage (with IDENTIFIER table).

### Future work
1. We don't always (not in all statements) have the full information about the table, sometimes we just receive the already parsed ObjectName - I will raise a separate PR to the sqlparser-rs source repo and try to add this feature there.
2. IDENTIFIER also support variables, but we currently do not have Visitor for `Statement::SetVariable`. As a followup PR i may try to add support for variables and keep them in our context so that we can support them f.e. in `IDENTIFIER`.

#### One-line summary:
Support IDENTIFIER function in some statements instead of treating it like table name

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project