### PR TITLE
CI: Group Dependabot MRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
     ignore:
       - dependency-name: "org.slf4j.slf4j-api"
       - dependency-name: "org.openapi.generator"
+    # https://til.simonwillison.net/github/dependabot-python-setup
+    groups:
+      client/java:
+        patterns:
+          - '*'
 
   - package-ecosystem: "gradle"
     directory: "integration/flink"
@@ -42,6 +47,10 @@ updates:
       - "dependabot"
     ignore:
       - dependency-name: "org.slf4j.slf4j-api"
+    groups:
+      integration/flink:
+        patterns:
+          - '*'
 
   - package-ecosystem: "gradle"
     directory: "integration/spark"
@@ -60,6 +69,10 @@ updates:
       - dependency-name: "jackson-datatype-jdk8"
       - dependency-name: "jackson-datatype-jsr310"
       - dependency-name: "com.google.guava*"
+    groups:
+      integration/spark:
+        patterns:
+          - '*'
 
   - package-ecosystem: "pip"
     directory: "client/python"
@@ -68,6 +81,10 @@ updates:
       day: "sunday"
     labels:
       - "dependabot"
+    groups:
+      client/python:
+        patterns:
+          - '*'
 
   - package-ecosystem: "pip"
     directory: "integration/common"
@@ -78,6 +95,10 @@ updates:
       - "dependabot"
     ignore:
       - dependency-name: "great-expectations"
+    groups:
+      integration/common:
+        patterns:
+          - '*'
 
 
   - package-ecosystem: "pip"
@@ -89,6 +110,10 @@ updates:
       - "dependabot"
     ignore:
       - dependency-name: "great-expectations"
+    groups:
+      integration/airflow:
+        patterns:
+          - '*'
 
   - package-ecosystem: "pip"
     directory: "integration/dbt"
@@ -97,6 +122,10 @@ updates:
       day: "sunday"
     labels:
       - "dependabot"
+    groups:
+      integration/dbt:
+        patterns:
+          - '*'
 
   - package-ecosystem: "cargo"
     directory: "integration/sql"
@@ -104,3 +133,7 @@ updates:
       interval: "weekly"
     labels:
       - "dependabot"
+    groups:
+      integration/sql:
+        patterns:
+          - '*'


### PR DESCRIPTION
### Problem

Currently Dependabot creates a new PR for each dependency it updates:
![изображение](https://github.com/user-attachments/assets/10638b8e-d07d-4e94-9c91-9dbc9e4624d1)

### Solution

My proposal is to create one PR for each dependency group, containing all the updates since previous week:
![изображение](https://github.com/user-attachments/assets/8f729de2-aa00-45ef-a431-908ff1260c07)

Here is an example:
https://github.com/MobileTeleSystems/horizon/blob/8b21b805254d1d0b118660f973d2f177e5368201/.github/dependabot.yml#L22-L26
https://github.com/MobileTeleSystems/horizon/pull/75
![изображение](https://github.com/user-attachments/assets/9e4dfee9-d3a2-4dc2-bbab-501d2ab649d4)

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project