### PR TITLE
Add option in changes script to get new contributors only

### DIFF
--- a/dev/get_changes.py
+++ b/dev/get_changes.py
@@ -75,6 +75,13 @@ class GetChanges:
             if "Thanks for opening your" in comment.body:
                 self.new_contributors[pull.user.login] = pull.user.url
 
+    def check_new_contributors_only(self):
+        for pull in self.pulls:
+            comments = pull.get_issue_comments()
+            for comment in comments:
+                if "Thanks for opening your" in comment.body:
+                    self.new_contributors[pull.user.login] = pull.user.url
+
     def print_new_contributors(self):
         if self.new_contributors:
             print("New contributors:")
@@ -123,11 +130,17 @@ class GetChanges:
     default="../OpenLineage/CHANGELOG.md",
     help="path to changelog",
 )
+@click.option(
+    "--contributors",
+    is_flag=True,
+    help="get new contributors only",
+)
 def main(
     github_token: str,
     previous: str,
     current: str,
     path: str,
+    contributors: bool,
 ):
     c = GetChanges(
         github_token=github_token,
@@ -135,12 +148,18 @@ def main(
         current=current,
         path=path,
     )
-    c.get_pulls()
-    c.describe_changes()
-    c.write_title()
-    c.update_changelog()
-    c.print_new_contributors()
-    print("...done!")
+    if contributors:
+        c.get_pulls()
+        c.check_new_contributors_only()
+        c.print_new_contributors()
+        print("...done!")
+    else:
+        c.get_pulls()
+        c.describe_changes()
+        c.write_title()
+        c.update_changelog()
+        c.print_new_contributors()
+        print("...done!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

The changes script in dev has no option for getting new contributors only.

### Solution

This adds an option and function for returning only the new contributors in the specified range between tags.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project