### PR TITLE
Fix version snapshot to not override versions

### DIFF
--- a/.github/workflows/website-snapshot.yml
+++ b/.github/workflows/website-snapshot.yml
@@ -83,9 +83,10 @@ jobs:
           popd
       - name: Push target repo
         run: |
-          rm -r target/* 
-          cp -r source/website/* target
           cd target
+          # remove all files and directories except those starting with version
+          find . ! -name 'version*' -exec rm -rf {} \;
+          cp -r ../source/website/* ./
           git config user.name "GitHub Action Website Snapshot"
           git config user.email "<>"
           git add .


### PR DESCRIPTION
Current version of the website snapshot GitHub action overwrites whole website directory.
In order to introduce documentation versioning, a change in the script is required so that it does not delete existing version directories. 