### PR TITLE
fix: Fix AWS Glue jobs naming for RDD events

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -16,7 +16,6 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.spark.agent.EventEmitter;
-import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -54,7 +53,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
   private final OpenLineageContext olContext;
   private final EventEmitter eventEmitter;
   private final OpenLineageRunEventBuilder runEventBuilder;
-  private final OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
 
   private boolean emittedOnSqlExecutionStart = false;
   private boolean emittedOnSqlExecutionEnd = false;
@@ -101,7 +99,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(startEvent)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(toZonedTime(startEvent.time()))
                         .eventType(eventType))
@@ -147,7 +146,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(endEvent)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(toZonedTime(endEvent.time()))
                         .eventType(eventType))
@@ -179,7 +179,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(stageSubmitted)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
                         .eventType(RUNNING))
@@ -208,7 +209,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(stageCompleted)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
                         .eventType(RUNNING))
@@ -260,7 +262,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(jobStart)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(toZonedTime(jobStart.time()))
                         .eventType(eventType))
@@ -308,7 +311,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .applicationParentRunFacet(buildApplicationParentFacet())
                 .event(jobEnd)
                 .runEventBuilder(
-                    openLineage
+                    olContext
+                        .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(toZonedTime(jobEnd.time()))
                         .eventType(eventType))
@@ -334,7 +338,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
   }
 
   protected OpenLineage.JobBuilder buildJob() {
-    return openLineage
+    return olContext
+        .getOpenLineage()
         .newJobBuilder()
         .name(JobNameBuilder.build(olContext))
         .namespace(this.eventEmitter.getJobNamespace());
@@ -357,7 +362,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
       processingType = SPARK_PROCESSING_TYPE_BATCH;
     }
 
-    return openLineage
+    return olContext
+        .getOpenLineage()
         .newJobTypeJobFacetBuilder()
         .jobType(SPARK_JOB_TYPE)
         .processingType(processingType)
@@ -368,7 +374,10 @@ class SparkSQLExecutionContext implements ExecutionContext {
   private OpenLineage.JobFacetsBuilder getJobFacetsBuilder(QueryExecution queryExecution) {
 
     OpenLineage.JobFacetsBuilder builder =
-        openLineage.newJobFacetsBuilder().jobType(getJobTypeJobFacet(queryExecution));
+        olContext
+            .getOpenLineage()
+            .newJobFacetsBuilder()
+            .jobType(getJobTypeJobFacet(queryExecution));
 
     Optional<OpenLineage.SQLJobFacet> sqlFacets = resolveSQLFacets(queryExecution);
 
@@ -421,6 +430,6 @@ class SparkSQLExecutionContext implements ExecutionContext {
       return Optional.empty();
     }
 
-    return Optional.of(openLineage.newSQLJobFacetBuilder().query(query).build());
+    return Optional.of(olContext.getOpenLineage().newSQLJobFacetBuilder().query(query).build());
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageHiveTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageHiveTest.java
@@ -30,10 +30,7 @@ import org.apache.spark.sql.SparkSession$;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @Slf4j
@@ -103,6 +100,13 @@ class ColumnLevelLineageHiveTest {
     spark.sql("DROP TABLE IF EXISTS t1");
     spark.sql("DROP TABLE IF EXISTS t2");
     spark.sql("DROP TABLE IF EXISTS t");
+  }
+
+  @AfterEach
+  @SneakyThrows
+  public void afterEach() {
+    FileSystem.get(spark.sparkContext().hadoopConfiguration())
+        .delete(new Path("/tmp/column_non_v2/"), true);
   }
 
   @Test

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/JobNameBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/JobNameBuilder.java
@@ -71,6 +71,11 @@ public class JobNameBuilder {
     return jobName;
   }
 
+  public static String build(OpenLineageContext context, String rddSuffix) {
+    return normalizeName(
+        applicationJobNameResolver.getJobName(context) + JOB_NAME_PARTS_SEPARATOR + rddSuffix);
+  }
+
   private static String replaceDots(OpenLineageContext context, String jobName) {
     return Optional.of(context.getOpenLineageConfig())
         .map(SparkOpenLineageConfig::getJobName)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilderTest.java
@@ -191,15 +191,12 @@ class AbstractQueryPlanDatasetBuilderTest {
                     }))
             .queryExecution();
 
-    OpenLineageContext context =
-        OpenLineageContext.builder()
-            .sparkContext(
-                SparkContext.getOrCreate(new SparkConf().setAppName("test").setMaster(LOCAL)))
-            .openLineage(openLineage)
-            .queryExecution(queryExecution)
-            .meterRegistry(new SimpleMeterRegistry())
-            .openLineageConfig(new SparkOpenLineageConfig())
-            .build();
-    return context;
+    return OpenLineageContext.builder()
+        .sparkContext(SparkContext.getOrCreate(new SparkConf().setAppName("test").setMaster(LOCAL)))
+        .openLineage(openLineage)
+        .queryExecution(queryExecution)
+        .meterRegistry(new SimpleMeterRegistry())
+        .openLineageConfig(new SparkOpenLineageConfig())
+        .build();
   }
 }


### PR DESCRIPTION
* RDD events in AWS Glue contain correct job names

### Problem

The names of RDD jobs in AWS glue are autogenerated and different with every execution.

### Solution

The naming for RDD jobs should use the same code as SQL and Application events.

This is the second part of the changes in naming. It is ugly and requires further refactoring but provides support for AWS Glue naming.

The most significant changes include:
- `ContextFactory` method `createRddExecutionContext` producing `RddExecutionContext` accepts `OpenLineageContext` with correct `SparkContext` (it is required to determine proper naming)
- All execution contexts (RDD, SQL, Application) access the `OpenLineage` object from the `OpenLineageContext` (so far they were unnecessarily recreated). The `OpenLineage` object is accessed through the method instead of the files so that the tests are not broken
- The `JobNameBuilder` has additional method for building job name for RDDs. It will be further refactored.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project