### PR TITLE
Spark/add parsing dynamic info from env var

### DIFF
--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:${junit5Version}"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")
     testImplementation("org.postgresql:postgresql:${postgresqlVersion}")
     testImplementation('org.hamcrest:hamcrest-library:2.2')
     testImplementation('org.xerial:sqlite-jdbc:3.45.0.0')


### PR DESCRIPTION
### Problem

Currently, there is a limitation when supplying parentJobName or parentRunId for jobs scheduled on Databricks clusters. These jobs, which can be Python jobs or notebook jobs, do not allow parameters to be supplied via Spark Submit configuration arguments. This limitation affects our ability to create new clusters for each job while passing the necessary parameters.

Closes: #ISSUE-NUMBER

### Solution

Inspired from [Issue 2916](https://github.com/OpenLineage/OpenLineage/issues/2916), I propose adding the capability to supply parentJobName and parentRunId (and any relevant argument) via environment variables. This solution ensures that the configuration can be overridden in the following order of precedence:

1- Yaml file
2- Environment Variables
3- Spark Configuration

Changes Proposal:

Introduce a method to extract configuration from environment variables.
Update the parse method to incorporate configuration from environment variables.

#### One-line summary:

Add support for supplying parent job details from environment variables in Databricks clusters.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ 
/] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project