### PR TITLE
fix: add support for SingleQuotedString in Identifier()

### DIFF
--- a/integration/sql/impl/tests/table_lineage/tests_delete.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_delete.rs
@@ -56,6 +56,7 @@ fn delete_from_using() {
 fn delete_identifier_function() {
     let test_cases = vec![
         ("target", vec![table("target")]),
+        ("'target'", vec![table("target")]),
         ("$target", vec![]),
         (":target", vec![]),
         ("?", vec![]),

--- a/integration/sql/impl/tests/table_lineage/tests_merge.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_merge.rs
@@ -43,7 +43,7 @@ fn merge_identifier_function() {
     let test_cases = vec![
         (
             "target",
-            "source",
+            "'source'",
             vec![table("source")],
             vec![table("target")],
         ),

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -193,6 +193,7 @@ fn select_bq_array_function() {
 fn select_identifier_function() {
     let test_cases = vec![
         ("target", vec![table("target")]),
+        ("'target'", vec![table("target")]),
         ("$target", vec![]),
         (":target", vec![]),
         ("?", vec![]),

--- a/integration/sql/impl/tests/table_lineage/tests_update.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_update.rs
@@ -61,7 +61,7 @@ fn update_identifier_function() {
     let test_cases = vec![
         (
             "target",
-            "source",
+            "'source'",
             vec![table("source")],
             vec![table("target")],
         ),


### PR DESCRIPTION
### Problem

When fixing identifier in #2999 i missed the case with single quoted string that is treated differently than string with no quotes, double quotes or backticks.

### Solution

Adding support for single quoted string.

#### One-line summary:
fix: sqlparser - add support for SingleQuotedString in IDENTIFIER()

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project