### PR TITLE
Add GCP Dataplex transport as separate module

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -478,6 +478,81 @@ jobs:
           paths:
             - ~/.m2
 
+  build-transports-dataplex:
+    working_directory: ~/openlineage/client/java/transports-dataplex
+    parameters:
+      release:
+        default: false
+        type: boolean
+    docker:
+      - image: cimg/openjdk:17.0
+    steps:
+      - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
+      - restore_cache:
+          keys:
+            - v1-client-java-{{ checksum "/tmp/checksum.txt" }}
+      - run: ../gradlew --no-daemon --console=plain --stacktrace build check jacocoTestReport
+      - run: bash <(curl -s https://codecov.io/bash)
+      - run: ../gradlew --console=plain javadoc sourceJar shadowJar
+      - run: |
+          # Get, then decode the GPG private key used to sign *.jar
+          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
+          export RELEASE_PASSWORD=$(echo $OSSRH_TOKEN_PASSWORD)
+          export RELEASE_USERNAME=$(echo $OSSRH_TOKEN_USERNAME)
+          
+          ../gradlew --console=plain publishToMavenLocal --info
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - .m2/repository/io/openlineage/transports-dataplex
+            - openlineage/client/java/transports-dataplex/build-cache
+            - openlineage/client/java/transports-dataplex/build
+      - store_test_results:
+          path: client/java/transports-dataplex/build/test-results/test
+      - store_artifacts:
+          path: build/reports/tests/test
+          destination: test-report
+      - store_artifacts:
+          path: build/reports/tests/pmd
+          destination: pmd-report
+      - store_artifacts:
+          path: build/libs
+          destination: libs
+      - save_cache:
+          key: v1-transports-dataplex-{{ checksum "/tmp/checksum.txt" }}
+          paths:
+            - ~/.gradle
+
+  release-transports-dataplex:
+    working_directory: ~/openlineage/client/java/transports-dataplex
+    docker:
+      - image: cimg/openjdk:17.0
+    steps:
+      - *checkout_project_root
+      - run:
+          name: Generate cache key
+          command: ./../../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
+      - attach_workspace:
+          at: ~/
+      - run: ../gradlew --console=plain javadoc sourceJar shadowJar
+      - run: |
+          # Get, then decode the GPG private key used to sign *.jar
+          export ORG_GRADLE_PROJECT_signingKey=$(echo $GPG_SIGNING_KEY | base64 -d)
+          export RELEASE_PASSWORD=$(echo $OSSRH_TOKEN_PASSWORD)
+          export RELEASE_USERNAME=$(echo $OSSRH_TOKEN_USERNAME)
+
+          ../gradlew --console=plain publishToSonatype closeAndReleaseSonatypeStagingRepository --info
+      - store_artifacts:
+          path: ./build/libs
+          destination: transports-dataplex-artifacts
+      - save_cache:
+          key: v1-release-transports-dataplex-{{ checksum "/tmp/checksum.txt" }}
+          paths:
+            - ~/.m2
+
   release-integration-spark:
     working_directory: ~/openlineage/integration/spark
     docker:

--- a/.circleci/workflows/openlineage-java.yml
+++ b/.circleci/workflows/openlineage-java.yml
@@ -6,6 +6,13 @@ workflows:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
           context: << pipeline.parameters.build-context >>
+      - build-transports-dataplex:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+          context: << pipeline.parameters.build-context >>
+          requires:
+            - build-client-java
       - compile-integration-sql-java-linux:
           filters:
             tags:
@@ -51,6 +58,15 @@ workflows:
           requires:
             - build-integration-sql-java
             - build-client-java
+      - release-transports-dataplex:
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
+            branches:
+              only: main
+          context: release
+          requires:
+            - build-transports-dataplex
       - release-integration-sql-java:
           filters:
             tags:
@@ -69,3 +85,4 @@ workflows:
           requires:
             - release-client-java
             - release-integration-sql-java
+            - release-transports-dataplex

--- a/client/java/settings.gradle
+++ b/client/java/settings.gradle
@@ -6,6 +6,7 @@
 rootProject.name = 'openlineage-java'
 
 include('generator')
+include('transports-dataplex')
 
 buildCache {
     local {

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -40,7 +40,7 @@ be emitted correctly.
   provided [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
   are used
 - `mode` - enum that specifies the type of client used for publishing OpenLineage events to Dataplex. Possible values:
-  `sync` (synchronous) or `async` (asynchronous). Optional, default: `sync`.
+  `sync` (synchronous) or `async` (asynchronous). Optional, default: `async`.
 
 ### Behavior
 

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -1,0 +1,45 @@
+# Google Cloud Platform Dataplex Transport
+
+This library provides a transport layer that integrates OpenLineage with Google Cloud Platform's Dataplex service.
+It wraps the `com.google.cloud.datalineage:producerclient-java8` library into an OpenLineage transport, allowing you to
+emit lineage events directly to Dataplex using `gRPC` channel.
+
+## Getting Started
+
+### Adding the Dependency
+
+To use this transport in your project, you need to include the following dependency in your build configuration. This is
+particularly important for environments like `Spark`, where this transport must be on the classpath for lineage events
+to
+be emitted correctly.
+
+**Maven:**
+
+```xml
+
+<dependency>
+    <groupId>io.openlineage</groupId>
+    <artifactId>transports-dataplex</artifactId>
+    <version>YOUR_VERSION_HERE</version>
+</dependency>
+```
+
+### Configuration
+
+- `type` - string, must be `"dataplex"`. Required.
+- `endpoint` - string, specifies the endpoint to which events are sent. Optional.
+- `projectId` - string, the project quota identifier. If not provided, it is determined based on user credentials. Optional.
+- `locations` - string, [Dataplex locations](https://cloud.google.com/dataplex/docs/locations). Optional, default:
+  `"us"`.
+- `credentialsFile` - string, path
+  to the [Service Account credentials JSON file](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).
+  Optional, if not
+  provided [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+  are used
+- `headers` - dictionary specifying request headers. Optional.
+
+### Behavior
+
+- Events are serialized to JSON, included as a part of `gRPC` request, and then dispatched to the `Dataplex` endpoint.
+- Two constructors are available: one accepting both `SyncLineageClient` and `DataplexConfig` and another solely accepting
+  `DataplexConfig`.

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -36,7 +36,6 @@ be emitted correctly.
   Optional, if not
   provided [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
   are used
-- `headers` - dictionary specifying request headers. Optional.
 
 ### Behavior
 

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -27,18 +27,22 @@ be emitted correctly.
 ### Configuration
 
 - `type` - string, must be `"dataplex"`. Required.
-- `endpoint` - string, specifies the endpoint to which events are sent, default value is `datalineage.googleapis.com:443`. Optional.
-- `projectId` - string, the project quota identifier. If not provided, it is determined based on user credentials. Optional.
+- `endpoint` - string, specifies the endpoint to which events are sent, default value is
+  `datalineage.googleapis.com:443`. Optional.
+- `projectId` - string, the project quota identifier. If not provided, it is determined based on user credentials.
+  Optional.
 - `location` - string, [Dataplex location](https://cloud.google.com/dataplex/docs/locations). Optional, default:
   `"us"`.
 - `credentialsFile` - string, path
-  to the [Service Account credentials JSON file](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).
+  to
+  the [Service Account credentials JSON file](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).
   Optional, if not
   provided [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
   are used
+- `mode` - enum that specifies the type of client used for publishing OpenLineage events to Dataplex. Possible values:
+  `sync` (synchronous) or `async` (asynchronous). Optional, default: `sync`.
 
 ### Behavior
 
 - Events are serialized to JSON, included as part of a `gRPC` request, and then dispatched to the `Dataplex` endpoint.
-- Two constructors are available: one accepting both `SyncLineageClient` and `DataplexConfig` and another solely accepting
-  `DataplexConfig`.
+- Depending on the `mode` chosen, requests are sent using either a synchronous or asynchronous client.

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -29,7 +29,7 @@ be emitted correctly.
 - `type` - string, must be `"dataplex"`. Required.
 - `endpoint` - string, specifies the endpoint to which events are sent, default value is `datalineage.googleapis.com:443`. Optional.
 - `projectId` - string, the project quota identifier. If not provided, it is determined based on user credentials. Optional.
-- `locations` - string, [Dataplex locations](https://cloud.google.com/dataplex/docs/locations). Optional, default:
+- `location` - string, [Dataplex location](https://cloud.google.com/dataplex/docs/locations). Optional, default:
   `"us"`.
 - `credentialsFile` - string, path
   to the [Service Account credentials JSON file](https://developers.google.com/workspace/guides/create-credentials#create_credentials_for_a_service_account).

--- a/client/java/transports-dataplex/README.md
+++ b/client/java/transports-dataplex/README.md
@@ -27,7 +27,7 @@ be emitted correctly.
 ### Configuration
 
 - `type` - string, must be `"dataplex"`. Required.
-- `endpoint` - string, specifies the endpoint to which events are sent. Optional.
+- `endpoint` - string, specifies the endpoint to which events are sent, default value is `datalineage.googleapis.com:443`. Optional.
 - `projectId` - string, the project quota identifier. If not provided, it is determined based on user credentials. Optional.
 - `locations` - string, [Dataplex locations](https://cloud.google.com/dataplex/docs/locations). Optional, default:
   `"us"`.
@@ -39,6 +39,6 @@ be emitted correctly.
 
 ### Behavior
 
-- Events are serialized to JSON, included as a part of `gRPC` request, and then dispatched to the `Dataplex` endpoint.
+- Events are serialized to JSON, included as part of a `gRPC` request, and then dispatched to the `Dataplex` endpoint.
 - Two constructors are available: one accepting both `SyncLineageClient` and `DataplexConfig` and another solely accepting
   `DataplexConfig`.

--- a/client/java/transports-dataplex/build.gradle
+++ b/client/java/transports-dataplex/build.gradle
@@ -1,0 +1,250 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+import org.apache.tools.ant.filters.*
+
+plugins {
+    id 'eclipse'
+    id 'jacoco'
+    id 'java'
+    id 'java-library'
+    id 'maven-publish'
+    id 'signing'
+    id "com.adarshr.test-logger" version "3.2.0"
+    // Don't bump above 6.13 - it requires Java 11 https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#changes-12
+    id 'com.diffplug.spotless' version '6.13.0'
+    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "pmd"
+    id "io.freefair.lombok" version "8.10"
+}
+
+group = "io.openlineage"
+
+pmd {
+    consoleOutput = true
+    toolVersion = "6.46.0"
+    rulesMinimumPriority = 5
+    ruleSetFiles = rootProject.files("pmd-openlineage.xml")
+    ruleSets = []
+    ignoreFailures = false
+}
+
+pmdMain {
+    reports {
+        html.required = true
+    }
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+ext {
+    assertjVersion = '3.26.3'
+    junit5Version = '5.10.3'
+    lombokVersion = '1.18.34'
+    mockitoVersion = '5.2.0'
+    micrometerVersion = '1.13.2'
+    isReleaseVersion = !version.endsWith('SNAPSHOT')
+    guavaVersion = '33.2.1-jre'
+}
+
+dependencies {
+    compileOnly(rootProject)
+    implementation("com.google.cloud.datalineage:producerclient-java8:1.0.0")
+    implementation("com.google.cloud:google-cloud-datalineage:0.32.0")
+    compileOnly("com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+    compileOnly("org.slf4j:slf4j-api:1.7.36")
+
+    annotationProcessor ("org.projectlombok:lombok:${lombokVersion}")
+
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${junit5Version}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+    testImplementation "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation "io.micrometer:micrometer-registry-statsd:${micrometerVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testImplementation "com.google.guava:guava:${guavaVersion}"
+}
+
+configurations {
+    testImplementation.extendsFrom compileOnly
+}
+
+compileJava {
+    options.incremental = true
+    options.compilerArgs << '-parameters'
+    options.encoding = "UTF-8"
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileTestJava {
+    options.incremental = true
+    options.compilerArgs << '-parameters'
+    options.encoding = "UTF-8"
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+
+task sourceJar(type: Jar) {
+    archiveClassifier='sources'
+    from sourceSets.main.allJava
+}
+
+javadoc {
+    dependsOn delombok
+    failOnError = true
+
+    options.addBooleanOption("Xdoclint:-missing", true)
+
+    def capturedOutput = []
+    def listener = { capturedOutput << it } as StandardOutputListener
+    doFirst {
+        logging.addStandardErrorListener(listener)
+        logging.addStandardOutputListener(listener)
+    }
+    doLast {
+        logging.removeStandardOutputListener(listener)
+        logging.removeStandardErrorListener(listener)
+        capturedOutput.each { e ->
+            if(e.toString() =~ " warning: ") {
+                throw new GradleException("You have some javadoc warnings, please fix them!");
+            }
+        }
+    }
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier='javadoc'
+    from javadoc.destinationDir
+}
+
+test {
+    useJUnitPlatform()
+}
+
+shadowJar {
+    dependsOn test
+
+    dependencies {
+        exclude 'android/**'
+        exclude 'javax/**'
+    }
+
+    mergeServiceFiles()
+
+    archiveClassifier = ''
+    // avoid conflict with any client version of that lib
+    manifest {
+        attributes(
+                'Created-By': "Gradle ${gradle.gradleVersion}",
+                'Built-By': System.getProperty('user.name'),
+                'Build-Jdk': System.getProperty('java.version'),
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version
+        )
+    }
+    zip64 true
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = 'io.openlineage'
+            artifactId = 'transports-dataplex'
+
+            from components.java
+
+            artifact sourceJar
+            artifact javadocJar
+
+            pom {
+                name = 'transports-dataplex'
+                description = 'GCP Dataplex OpenLineage transport library'
+                url = 'https://github.com/OpenLineage/OpenLineage'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'openlineage'
+                        name = 'OpenLineage Project'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/OpenLineage/OpenLineage.git'
+                    developerConnection = 'scm:git:ssh://github.com:OpenLineage/OpenLineage.git'
+                    url = 'https://github.com/OpenLineage/OpenLineage'
+                }
+            }
+        }
+    }
+
+    processResources {
+        filter ReplaceTokens, tokens: [
+                "version": project.property("version")
+        ]
+    }
+}
+
+signing {
+    required { isReleaseVersion }
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.mavenJava
+}
+
+jar {
+    manifest {
+        attributes(
+                'Created-By': "Gradle ${gradle.gradleVersion}",
+                'Built-By': System.getProperty('user.name'),
+                'Build-Jdk': System.getProperty('java.version'),
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version
+        )
+    }
+}
+
+spotless {
+    java {
+        target fileTree('.') {
+            include '**/*.java'
+            exclude '**/build/**'
+        }
+        googleJavaFormat()
+        removeUnusedImports()
+    }
+}
+
+def reportsDir = "${getLayout().getBuildDirectory()}/reports";
+def coverageDir = "${reportsDir}/coverage";
+
+jacoco {
+    toolVersion = '0.8.12'
+    reportsDir = file(coverageDir)
+}
+
+jacocoTestReport {
+    reports {
+        xml {
+            enabled true
+        }
+        html {
+            enabled true
+            destination = file(coverageDir)
+        }
+    }
+}

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
@@ -1,0 +1,45 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.transports.dataplex;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.MergeConfig;
+import io.openlineage.client.transports.TransportConfig;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConfig> {
+
+  @Getter @Setter private @Nullable String endpoint;
+
+  @Getter @Setter private @Nullable String projectId;
+
+  @Getter @Setter private @Nullable String credentialsFile;
+
+  @Getter @Setter private @Nullable String locations;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @Getter
+  @Setter
+  private @Nullable Map<String, String> headers;
+
+  @Override
+  public DataplexConfig mergeWithNonNull(DataplexConfig other) {
+    return new DataplexConfig(
+        mergePropertyWith(endpoint, other.endpoint),
+        mergePropertyWith(projectId, other.projectId),
+        mergePropertyWith(credentialsFile, other.credentialsFile),
+        mergePropertyWith(locations, other.locations),
+        mergePropertyWith(headers, other.headers));
+  }
+}

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
@@ -6,7 +6,6 @@ package io.openlineage.client.transports.dataplex;
 
 import io.openlineage.client.MergeConfig;
 import io.openlineage.client.transports.TransportConfig;
-
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,6 +18,11 @@ import lombok.ToString;
 @ToString
 public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConfig> {
 
+  enum Mode {
+    sync,
+    async
+  }
+
   @Getter @Setter private @Nullable String endpoint;
 
   @Getter @Setter private @Nullable String projectId;
@@ -27,6 +31,7 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
 
   @Getter @Setter private @Nullable String location;
 
+  @Getter @Setter private @Nullable Mode mode;
 
   @Override
   public DataplexConfig mergeWithNonNull(DataplexConfig other) {
@@ -34,6 +39,7 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
         mergePropertyWith(endpoint, other.endpoint),
         mergePropertyWith(projectId, other.projectId),
         mergePropertyWith(credentialsFile, other.credentialsFile),
-        mergePropertyWith(location, other.location));
+        mergePropertyWith(location, other.location),
+        mergePropertyWith(mode, other.mode));
   }
 }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
@@ -28,10 +28,6 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
 
   @Getter @Setter private @Nullable String locations;
 
-  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-  @Getter
-  @Setter
-  private @Nullable Map<String, String> headers;
 
   @Override
   public DataplexConfig mergeWithNonNull(DataplexConfig other) {
@@ -39,7 +35,6 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
         mergePropertyWith(endpoint, other.endpoint),
         mergePropertyWith(projectId, other.projectId),
         mergePropertyWith(credentialsFile, other.credentialsFile),
-        mergePropertyWith(locations, other.locations),
-        mergePropertyWith(headers, other.headers));
+        mergePropertyWith(locations, other.locations));
   }
 }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexConfig.java
@@ -4,10 +4,9 @@
 */
 package io.openlineage.client.transports.dataplex;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.MergeConfig;
 import io.openlineage.client.transports.TransportConfig;
-import java.util.Map;
+
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,7 +25,7 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
 
   @Getter @Setter private @Nullable String credentialsFile;
 
-  @Getter @Setter private @Nullable String locations;
+  @Getter @Setter private @Nullable String location;
 
 
   @Override
@@ -35,6 +34,6 @@ public class DataplexConfig implements TransportConfig, MergeConfig<DataplexConf
         mergePropertyWith(endpoint, other.endpoint),
         mergePropertyWith(projectId, other.projectId),
         mergePropertyWith(credentialsFile, other.credentialsFile),
-        mergePropertyWith(locations, other.locations));
+        mergePropertyWith(location, other.location));
   }
 }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -75,16 +75,16 @@ public class DataplexTransport extends Transport implements Closeable {
 
     protected ProducerClientWrapper(DataplexConfig config) throws IOException {
       LineageSettings settings;
-      if (DataplexConfig.Mode.async == config.getMode()) {
-        syncLineageClient = null;
-        settings = createAsyncSettings(config);
-        asyncLineageClient =
-            AsyncLineageProducerClient.create((AsyncLineageProducerClientSettings) settings);
-      } else {
+      if (DataplexConfig.Mode.sync == config.getMode()) {
         settings = createSyncSettings(config);
         syncLineageClient =
             SyncLineageProducerClient.create((SyncLineageProducerClientSettings) settings);
         asyncLineageClient = null;
+      } else {
+        syncLineageClient = null;
+        settings = createAsyncSettings(config);
+        asyncLineageClient =
+            AsyncLineageProducerClient.create((AsyncLineageProducerClientSettings) settings);
       }
       this.parent = getParent(config, settings);
     }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -1,0 +1,132 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.transports.dataplex;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.datacatalog.lineage.v1.LineageSettings;
+import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
+import com.google.cloud.datalineage.producerclient.helpers.OpenLineageHelper;
+import com.google.cloud.datalineage.producerclient.v1.SyncLineageClient;
+import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClient;
+import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClientSettings;
+import com.google.protobuf.Struct;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.transports.Transport;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DataplexTransport extends Transport implements Closeable {
+
+  private final SyncLineageClient producerClient;
+
+  private final String parent;
+
+  public DataplexTransport(@NonNull DataplexConfig config) throws IOException {
+    this(config, SyncLineageProducerClient.create(createSettings(config)));
+  }
+
+  protected DataplexTransport(@NonNull DataplexConfig config, @NonNull SyncLineageClient client)
+      throws IOException {
+    this.producerClient = client;
+    this.parent =
+        String.format(
+            "projects/%s/locations/%s",
+            getProjectId(config, createSettings(config)),
+            config.getLocations() != null ? config.getLocations() : "us");
+  }
+
+  @Override
+  public void emit(OpenLineage.@NonNull RunEvent runEvent) {
+    emitEvent(runEvent);
+  }
+
+  @Override
+  public void emit(OpenLineage.@NonNull DatasetEvent datasetEvent) {
+    emitEvent(datasetEvent);
+  }
+
+  @Override
+  public void emit(OpenLineage.@NonNull JobEvent jobEvent) {
+    emitEvent(jobEvent);
+  }
+
+  private <T extends OpenLineage.BaseEvent> void emitEvent(T event) {
+    try {
+      String eventJson = OpenLineageClientUtils.toJson(event);
+      Struct openLineageStruct = OpenLineageHelper.jsonToStruct(eventJson);
+      ProcessOpenLineageRunEventRequest request =
+          ProcessOpenLineageRunEventRequest.newBuilder()
+              .setParent(parent)
+              .setOpenLineage(openLineageStruct)
+              .build();
+      producerClient.processOpenLineageRunEvent(request);
+    } catch (Exception e) {
+      throw new OpenLineageClientException(e);
+    }
+  }
+
+  private static SyncLineageProducerClientSettings createSettings(DataplexConfig config)
+      throws IOException {
+    SyncLineageProducerClientSettings.Builder builder =
+        SyncLineageProducerClientSettings.newBuilder();
+
+    if (config.getEndpoint() != null) {
+      builder.setEndpoint(config.getEndpoint());
+    }
+    if (config.getProjectId() != null) {
+      builder.setQuotaProjectId(config.getProjectId());
+    }
+    if (config.getCredentialsFile() != null) {
+      File file = new File(config.getCredentialsFile());
+      try (InputStream credentialsStream = Files.newInputStream(file.toPath())) {
+        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(credentialsStream);
+        builder.setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials));
+      }
+    }
+    if (config.getHeaders() != null && !config.getHeaders().isEmpty()) {
+      builder.setHeaderProvider(FixedHeaderProvider.create(config.getHeaders()));
+    }
+
+    return builder.build();
+  }
+
+  private static <T extends LineageSettings> String getProjectId(DataplexConfig config, T settings)
+      throws IOException {
+    if (config.getProjectId() != null) {
+      return config.getProjectId();
+    }
+    Credentials credentials = settings.getCredentialsProvider().getCredentials();
+    if (credentials instanceof ServiceAccountCredentials) {
+      ServiceAccountCredentials serviceAccountCredentials = (ServiceAccountCredentials) credentials;
+      return serviceAccountCredentials.getProjectId();
+    }
+    if (credentials instanceof GoogleCredentials) {
+      GoogleCredentials googleCredentials = (GoogleCredentials) credentials;
+      return googleCredentials.getQuotaProjectId();
+    }
+    return settings.getQuotaProjectId();
+  }
+
+  @Override
+  public void close() {
+    try {
+      producerClient.close();
+    } catch (Exception e) {
+      throw new OpenLineageClientException("Exception while closing the resource", e);
+    }
+  }
+}

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -97,9 +97,6 @@ public class DataplexTransport extends Transport implements Closeable {
         builder.setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials));
       }
     }
-    if (config.getHeaders() != null && !config.getHeaders().isEmpty()) {
-      builder.setHeaderProvider(FixedHeaderProvider.create(config.getHeaders()));
-    }
 
     return builder.build();
   }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -4,16 +4,24 @@
 */
 package io.openlineage.client.transports.dataplex;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.datacatalog.lineage.v1.LineageSettings;
 import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
+import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventResponse;
 import com.google.cloud.datalineage.producerclient.helpers.OpenLineageHelper;
+import com.google.cloud.datalineage.producerclient.v1.AsyncLineageClient;
+import com.google.cloud.datalineage.producerclient.v1.AsyncLineageProducerClient;
+import com.google.cloud.datalineage.producerclient.v1.AsyncLineageProducerClientSettings;
 import com.google.cloud.datalineage.producerclient.v1.SyncLineageClient;
 import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClient;
 import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClientSettings;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Struct;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClientException;
@@ -30,99 +38,177 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DataplexTransport extends Transport implements Closeable {
 
-  private final SyncLineageClient producerClient;
-
-  private final String parent;
+  private final ProducerClientWrapper producerClientWrapper;
 
   public DataplexTransport(@NonNull DataplexConfig config) throws IOException {
-    this(config, SyncLineageProducerClient.create(createSettings(config)));
+    this(new ProducerClientWrapper(config));
   }
 
-  protected DataplexTransport(@NonNull DataplexConfig config, @NonNull SyncLineageClient client)
-      throws IOException {
-    this.producerClient = client;
-    this.parent =
-        String.format(
-            "projects/%s/locations/%s",
-            getProjectId(config, createSettings(config)),
-            config.getLocation() != null ? config.getLocation() : "us");
+  protected DataplexTransport(@NonNull ProducerClientWrapper client) throws IOException {
+    this.producerClientWrapper = client;
   }
 
   @Override
   public void emit(OpenLineage.@NonNull RunEvent runEvent) {
-    emitEvent(runEvent);
+    producerClientWrapper.emitEvent(runEvent);
   }
 
   @Override
   public void emit(OpenLineage.@NonNull DatasetEvent datasetEvent) {
-    emitEvent(datasetEvent);
+    producerClientWrapper.emitEvent(datasetEvent);
   }
 
   @Override
   public void emit(OpenLineage.@NonNull JobEvent jobEvent) {
-    emitEvent(jobEvent);
-  }
-
-  private <T extends OpenLineage.BaseEvent> void emitEvent(T event) {
-    try {
-      String eventJson = OpenLineageClientUtils.toJson(event);
-      Struct openLineageStruct = OpenLineageHelper.jsonToStruct(eventJson);
-      ProcessOpenLineageRunEventRequest request =
-          ProcessOpenLineageRunEventRequest.newBuilder()
-              .setParent(parent)
-              .setOpenLineage(openLineageStruct)
-              .build();
-      producerClient.processOpenLineageRunEvent(request);
-    } catch (Exception e) {
-      throw new OpenLineageClientException(e);
-    }
-  }
-
-  private static SyncLineageProducerClientSettings createSettings(DataplexConfig config)
-      throws IOException {
-    SyncLineageProducerClientSettings.Builder builder =
-        SyncLineageProducerClientSettings.newBuilder();
-
-    if (config.getEndpoint() != null) {
-      builder.setEndpoint(config.getEndpoint());
-    }
-    if (config.getProjectId() != null) {
-      builder.setQuotaProjectId(config.getProjectId());
-    }
-    if (config.getCredentialsFile() != null) {
-      File file = new File(config.getCredentialsFile());
-      try (InputStream credentialsStream = Files.newInputStream(file.toPath())) {
-        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(credentialsStream);
-        builder.setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials));
-      }
-    }
-
-    return builder.build();
-  }
-
-  private static <T extends LineageSettings> String getProjectId(DataplexConfig config, T settings)
-      throws IOException {
-    if (config.getProjectId() != null) {
-      return config.getProjectId();
-    }
-    Credentials credentials = settings.getCredentialsProvider().getCredentials();
-    if (credentials instanceof ServiceAccountCredentials) {
-      ServiceAccountCredentials serviceAccountCredentials = (ServiceAccountCredentials) credentials;
-      return serviceAccountCredentials.getProjectId();
-    }
-    if (credentials instanceof GoogleCredentials) {
-      GoogleCredentials googleCredentials = (GoogleCredentials) credentials;
-      return googleCredentials.getQuotaProjectId();
-    }
-    return settings.getQuotaProjectId();
+    producerClientWrapper.emitEvent(jobEvent);
   }
 
   @Override
   public void close() {
-    try {
-      producerClient.close();
-    } catch (Exception e) {
-      throw new OpenLineageClientException("Exception while closing the resource", e);
+    producerClientWrapper.close();
+  }
+
+  static class ProducerClientWrapper implements Closeable {
+    private final SyncLineageClient syncLineageClient;
+    private final AsyncLineageClient asyncLineageClient;
+    private final String parent;
+
+    protected ProducerClientWrapper(DataplexConfig config) throws IOException {
+      LineageSettings settings;
+      if (DataplexConfig.Mode.async == config.getMode()) {
+        syncLineageClient = null;
+        settings = createAsyncSettings(config);
+        asyncLineageClient =
+            AsyncLineageProducerClient.create((AsyncLineageProducerClientSettings) settings);
+      } else {
+        settings = createSyncSettings(config);
+        syncLineageClient =
+            SyncLineageProducerClient.create((SyncLineageProducerClientSettings) settings);
+        asyncLineageClient = null;
+      }
+      this.parent = getParent(config, settings);
+    }
+
+    protected ProducerClientWrapper(DataplexConfig config, SyncLineageClient client)
+        throws IOException {
+      this.syncLineageClient = client;
+      this.parent = getParent(config, createAsyncSettings(config));
+      this.asyncLineageClient = null;
+    }
+
+    protected ProducerClientWrapper(DataplexConfig config, AsyncLineageClient client)
+        throws IOException {
+      this.asyncLineageClient = client;
+      this.parent = getParent(config, createSyncSettings(config));
+      this.syncLineageClient = null;
+    }
+
+    public <T extends OpenLineage.BaseEvent> void emitEvent(T event) {
+      try {
+        String eventJson = OpenLineageClientUtils.toJson(event);
+        Struct openLineageStruct = OpenLineageHelper.jsonToStruct(eventJson);
+        ProcessOpenLineageRunEventRequest request =
+            ProcessOpenLineageRunEventRequest.newBuilder()
+                .setParent(parent)
+                .setOpenLineage(openLineageStruct)
+                .build();
+        if (syncLineageClient != null) {
+          syncLineageClient.processOpenLineageRunEvent(request);
+        } else {
+          handleRequestAsync(request);
+        }
+      } catch (Exception e) {
+        throw new OpenLineageClientException(e);
+      }
+    }
+
+    private void handleRequestAsync(ProcessOpenLineageRunEventRequest request) {
+      ApiFuture<ProcessOpenLineageRunEventResponse> future =
+          asyncLineageClient.processOpenLineageRunEvent(request);
+      ApiFutureCallback<ProcessOpenLineageRunEventResponse> callback =
+          new ApiFutureCallback<ProcessOpenLineageRunEventResponse>() {
+            @Override
+            public void onFailure(Throwable t) {
+              log.error("Failed to collect a lineage event: {}", request.getOpenLineage(), t);
+            }
+
+            @Override
+            public void onSuccess(ProcessOpenLineageRunEventResponse result) {
+              log.debug("Event sent successfully: {}", request.getOpenLineage());
+            }
+          };
+      ApiFutures.addCallback(future, callback, MoreExecutors.directExecutor());
+    }
+
+    private String getParent(DataplexConfig config, LineageSettings settings) throws IOException {
+      return String.format(
+          "projects/%s/locations/%s",
+          getProjectId(config, settings),
+          config.getLocation() != null ? config.getLocation() : "us");
+    }
+
+    private static SyncLineageProducerClientSettings createSyncSettings(DataplexConfig config)
+        throws IOException {
+      SyncLineageProducerClientSettings.Builder builder =
+          SyncLineageProducerClientSettings.newBuilder();
+      return createSettings(config, builder).build();
+    }
+
+    private static AsyncLineageProducerClientSettings createAsyncSettings(DataplexConfig config)
+        throws IOException {
+      AsyncLineageProducerClientSettings.Builder builder =
+          AsyncLineageProducerClientSettings.newBuilder();
+      return createSettings(config, builder).build();
+    }
+
+    private static <T extends LineageSettings.Builder> T createSettings(
+        DataplexConfig config, T builder) throws IOException {
+      if (config.getEndpoint() != null) {
+        builder.setEndpoint(config.getEndpoint());
+      }
+      if (config.getProjectId() != null) {
+        builder.setQuotaProjectId(config.getProjectId());
+      }
+      if (config.getCredentialsFile() != null) {
+        File file = new File(config.getCredentialsFile());
+        try (InputStream credentialsStream = Files.newInputStream(file.toPath())) {
+          GoogleCredentials googleCredentials = GoogleCredentials.fromStream(credentialsStream);
+          builder.setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials));
+        }
+      }
+      return builder;
+    }
+
+    private static String getProjectId(DataplexConfig config, LineageSettings settings)
+        throws IOException {
+      if (config.getProjectId() != null) {
+        return config.getProjectId();
+      }
+      Credentials credentials = settings.getCredentialsProvider().getCredentials();
+      if (credentials instanceof ServiceAccountCredentials) {
+        ServiceAccountCredentials serviceAccountCredentials =
+            (ServiceAccountCredentials) credentials;
+        return serviceAccountCredentials.getProjectId();
+      }
+      if (credentials instanceof GoogleCredentials) {
+        GoogleCredentials googleCredentials = (GoogleCredentials) credentials;
+        return googleCredentials.getQuotaProjectId();
+      }
+      return settings.getQuotaProjectId();
+    }
+
+    @Override
+    public void close() {
+      try {
+        if (syncLineageClient != null) {
+          syncLineageClient.close();
+        }
+        if (asyncLineageClient != null) {
+          asyncLineageClient.close();
+        }
+      } catch (Exception e) {
+        throw new OpenLineageClientException("Exception while closing the resource", e);
+      }
     }
   }
 }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -5,7 +5,6 @@
 package io.openlineage.client.transports.dataplex;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
-import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -46,7 +45,7 @@ public class DataplexTransport extends Transport implements Closeable {
         String.format(
             "projects/%s/locations/%s",
             getProjectId(config, createSettings(config)),
-            config.getLocations() != null ? config.getLocations() : "us");
+            config.getLocation() != null ? config.getLocation() : "us");
   }
 
   @Override

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransportBuilder.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransportBuilder.java
@@ -1,0 +1,33 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.transports.dataplex;
+
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.transports.Transport;
+import io.openlineage.client.transports.TransportBuilder;
+import io.openlineage.client.transports.TransportConfig;
+import java.io.IOException;
+
+public class DataplexTransportBuilder implements TransportBuilder {
+  @Override
+  public String getType() {
+    return "dataplex";
+  }
+
+  @Override
+  public TransportConfig getConfig() {
+    return new DataplexConfig();
+  }
+
+  @Override
+  public Transport build(TransportConfig config) {
+    try {
+      return new DataplexTransport((DataplexConfig) config);
+    } catch (IOException e) {
+      throw new OpenLineageClientException(
+          "An exception occurred while creating a DataplexTransport", e);
+    }
+  }
+}

--- a/client/java/transports-dataplex/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
+++ b/client/java/transports-dataplex/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
@@ -1,0 +1,1 @@
+io.openlineage.client.transports.dataplex.DataplexTransportBuilder

--- a/client/java/transports-dataplex/src/test/java/io/openlineage/client/transports/dataplex/DataplexTransportTest.java
+++ b/client/java/transports-dataplex/src/test/java/io/openlineage/client/transports/dataplex/DataplexTransportTest.java
@@ -1,0 +1,89 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.transports.dataplex;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.rpc.AsyncTaskException;
+import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
+import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventResponse;
+import com.google.cloud.datalineage.producerclient.helpers.OpenLineageHelper;
+import com.google.cloud.datalineage.producerclient.v1.SyncLineageProducerClient;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.transports.Transport;
+import java.net.URI;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DataplexTransportTest {
+
+  @Test
+  void clientEmitsRunEventGCPTransport() throws Exception {
+    SyncLineageProducerClient producer = mock(SyncLineageProducerClient.class);
+    DataplexConfig config = new DataplexConfig();
+
+    config.setProjectId("my-project");
+    config.setLocations("us");
+
+    Transport transport = new DataplexTransport(config, producer);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    OpenLineage.RunEvent event = runEvent();
+    ProcessOpenLineageRunEventRequest request =
+        ProcessOpenLineageRunEventRequest.newBuilder()
+            .setParent("projects/my-project/locations/us")
+            .setOpenLineage(OpenLineageHelper.jsonToStruct(OpenLineageClientUtils.toJson(event)))
+            .build();
+    when(producer.processOpenLineageRunEvent(request))
+        .thenReturn(ProcessOpenLineageRunEventResponse.newBuilder().build());
+
+    client.emit(event);
+
+    verify(producer, times(1)).processOpenLineageRunEvent(request);
+  }
+
+  @Test
+  void gcpTransportRaisesOnException() throws Exception {
+    SyncLineageProducerClient producer = mock(SyncLineageProducerClient.class);
+    DataplexConfig config = new DataplexConfig();
+
+    config.setProjectId("my-project");
+    config.setLocations("us");
+
+    Transport transport = new DataplexTransport(config, producer);
+    OpenLineageClient client = new OpenLineageClient(transport);
+
+    OpenLineage.RunEvent event = runEvent();
+    ProcessOpenLineageRunEventRequest request =
+        ProcessOpenLineageRunEventRequest.newBuilder()
+            .setParent("projects/my-project/locations/us")
+            .setOpenLineage(OpenLineageHelper.jsonToStruct(OpenLineageClientUtils.toJson(event)))
+            .build();
+    when(producer.processOpenLineageRunEvent(request)).thenThrow(AsyncTaskException.class);
+
+    assertThrows(OpenLineageClientException.class, () -> client.emit(runEvent()));
+  }
+
+  public static OpenLineage.RunEvent runEvent() {
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    OpenLineage.Run run =
+        new OpenLineage.RunBuilder()
+            .runId(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54"))
+            .build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newRunEventBuilder()
+        .job(job)
+        .run(run)
+        .build();
+  }
+}

--- a/client/java/transports-dataplex/src/test/java/io/openlineage/client/transports/dataplex/DataplexTransportTest.java
+++ b/client/java/transports-dataplex/src/test/java/io/openlineage/client/transports/dataplex/DataplexTransportTest.java
@@ -32,7 +32,7 @@ class DataplexTransportTest {
     DataplexConfig config = new DataplexConfig();
 
     config.setProjectId("my-project");
-    config.setLocations("us");
+    config.setLocation("us");
 
     Transport transport = new DataplexTransport(config, producer);
     OpenLineageClient client = new OpenLineageClient(transport);
@@ -57,7 +57,7 @@ class DataplexTransportTest {
     DataplexConfig config = new DataplexConfig();
 
     config.setProjectId("my-project");
-    config.setLocations("us");
+    config.setLocation("us");
 
     Transport transport = new DataplexTransport(config, producer);
     OpenLineageClient client = new OpenLineageClient(transport);


### PR DESCRIPTION
This PR adds `GCP` transport as separate module.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project