### PR TITLE
ci: get labels from GitHub, filter jobs based on them 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ setup: true
 # the path of an updated fileset
 orbs:
   continuation: circleci/continuation@1.0.0
+  github-cli: circleci/github-cli@2.4.0
 
 # optional parameter when triggering to
 # only run a particular type of integration
@@ -51,6 +52,7 @@ jobs:
       - image: cimg/python:3.8
     steps:
       - checkout
+      - github-cli/setup
       - run:
           name: Install yq
           command: |
@@ -149,27 +151,14 @@ jobs:
             - run:
                 name: Remove approval steps if not pull from forks.
                 command: |
-                  pip install pyyaml==6.0.1
-                  python -c  "import yaml
-                  d = yaml.safe_load(open('complete_config.yml'))
-                  for workflow_name, workflow_definition in d['workflows'].items():
-                      jobs = workflow_definition.get('jobs') if isinstance(workflow_definition, dict) else None
-                      if not jobs: continue
-                  
-                      # find all approvals
-                      approvals = list(filter(lambda x: isinstance(x, dict) and list(x.values())[0].get('type') == 'approval', jobs))
-                      for approval in approvals:
-                          approval_name = next(iter(approval))
-                          approval_upstreams = approval[approval_name].get('requires')
-                          approval_downstream = list(filter(lambda x: isinstance(x, dict) and approval_name in list(x.values())[0].get('requires', ''), jobs))
-                          # replace approval with its upstream jobs
-                          for job in approval_downstream:
-                              requires = next(iter(job.values()))['requires']
-                              requires.remove(approval_name)
-                              requires.extend(approval_upstreams)
-                          jobs.remove(approval)
-                  with open('complete_config.yml', 'w') as f:
-                      f.write(yaml.dump(d, sort_keys=False))"
+                  pip install pyyaml==6.0.1                  
+                  python dev/filter_approvals.py
+      - run: |
+          export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.currentBranch.labels[]; .name == "full-tests")')
+          echo $IS_FULL_TESTS
+          if [ -z "$IS_FULL_TESTS" ] || [ "$IS_FULL_TESTS" == "0" ]; then
+            python dev/filter_matrix.py 
+          fi
       - when:
           condition:
             or:
@@ -194,6 +183,7 @@ workflows:
   schedule_workflow:
     jobs:
       - determine_changed_modules:
+          context: pr
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -75,7 +75,32 @@ commands:
             echo "Setting default Java to ${JAVA_BIN}"
             sudo update-alternatives --set java ${JAVA_BIN}
             sudo update-alternatives --set javac ${JAVAC_BIN}
-
+  set_java_spark_scala_version:
+    parameters:
+      env-variant:
+        type: string
+    description: "Set Java, Spark and Scala versions"
+    steps:
+      - run: |
+          set -eux
+          JAVA=$(echo << parameters.env-variant >> | cut -d '-' -f 1 | cut -d ':' -f 2)
+          SPARK=$(echo << parameters.env-variant >> | cut -d '-' -f 2 | cut -d ':' -f 2)
+          SCALA=$(echo << parameters.env-variant >> | cut -d '-' -f 3 | cut -d ':' -f 2)
+          echo spark=$SPARK java=$JAVA scala=$SCALA
+          JAVA8_HOME='/usr/lib/jvm/java-8-openjdk-amd64'
+          JAVA17_HOME='/usr/lib/jvm/java-17-openjdk-amd64'
+          JAVA_BIN=$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/java" || echo "$JAVA8_HOME/jre/bin/java")
+          JAVAC_BIN=$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/javac" || echo "$JAVA8_HOME/bin/javac")
+            
+          echo 'export JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"' >> "$BASH_ENV"
+          echo "export SPARK=\"${SPARK}\"" >> "$BASH_ENV"
+          echo "export JAVA=\"${JAVA}\"" >> "$BASH_ENV"
+          echo "export JAVA_BIN=\"${JAVA_BIN}\"" >> "$BASH_ENV"
+          echo "export JAVAC_BIN=\"${JAVAC_BIN}\"" >> "$BASH_ENV"
+          echo "export SCALA=\"${SCALA}\"" >> "$BASH_ENV"
+          echo "Setting default Java to ${JAVA_BIN}"
+          sudo update-alternatives --set java ${JAVA_BIN}
+          sudo update-alternatives --set javac ${JAVAC_BIN}
   store_submodule_tests:
     parameters:
       submodule:
@@ -620,24 +645,8 @@ jobs:
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
       - attach_workspace:
           at: ~/
-      - run:
-          name: Spark & Java version Variable
-          command: |
-            JAVA=$(echo << parameters.env-variant >> | cut -d '-' -f 1 | cut -d ':' -f 2)
-            SPARK=$(echo << parameters.env-variant >> | cut -d '-' -f 2 | cut -d ':' -f 2)
-            SCALA=$(echo << parameters.env-variant >> | cut -d '-' -f 3 | cut -d ':' -f 2)
-            echo spark=$SPARK java=$JAVA scala=$SCALA
-            JAVA8_HOME='/usr/lib/jvm/java-8-openjdk-amd64'
-            JAVA17_HOME='/usr/lib/jvm/java-17-openjdk-amd64'
-
-            echo 'export JAVA17_HOME=/usr/lib/jvm/java-17-openjdk-amd64' >> "$BASH_ENV"
-            echo 'export SPARK='${SPARK} >> "$BASH_ENV"
-            echo 'export JAVA_BIN='$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/java" || echo "$JAVA8_HOME/jre/bin/java") >> "$BASH_ENV"
-            echo 'export JAVAC_BIN='$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/javac" || echo "$JAVA8_HOME/bin/javac") >> "$BASH_ENV"
-            echo 'export SCALA='${SCALA} >> "$BASH_ENV"
-            echo "${JAVA}"
-            echo "${JAVA_BIN}"
-            echo "${JAVAC_BIN}"
+      - set_java_spark_scala_version:
+            env-variant: << parameters.env-variant >>
       - restore_cache:
           keys:
             - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
@@ -689,33 +698,15 @@ jobs:
       - run:
           name: Generate cache key
           command: ./../../.circleci/checksum.sh /tmp/checksum.txt $CIRCLE_BRANCH
-      - run:
-          name: Spark & Java version Variable
-          command: |
-            JAVA=$(echo << parameters.env-variant >> | cut -d '-' -f 1 | cut -d ':' -f 2)
-            SPARK=$(echo << parameters.env-variant >> | cut -d '-' -f 2 | cut -d ':' -f 2)
-            SCALA=$(echo << parameters.env-variant >> | cut -d '-' -f 3 | cut -d ':' -f 2)
-            echo spark=$SPARK java=$JAVA scala=$SCALA
-            JAVA8_HOME='/usr/lib/jvm/java-8-openjdk-amd64'
-            JAVA17_HOME='/usr/lib/jvm/java-17-openjdk-amd64'
-
-            echo 'export JAVA17_HOME=/usr/lib/jvm/java-17-openjdk-amd64' >> "$BASH_ENV"
-            echo 'export SPARK_VERSION_VAR='${SPARK} >> "$BASH_ENV"
-            echo 'export SCALA='${SCALA} >> "$BASH_ENV"
-            echo 'export JAVA_BIN='$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/java" || echo "$JAVA8_HOME/jre/bin/java") >> "$BASH_ENV"
-            echo 'export JAVAC_BIN='$([ "$JAVA" = "17" ] && echo "$JAVA17_HOME/bin/javac" || echo "$JAVA8_HOME/bin/javac") >> "$BASH_ENV"
-            echo $JAVA_BIN
+      - set_java_spark_scala_version:
+            env-variant: << parameters.env-variant >>
       - run: mkdir -p app/build/gcloud && echo $GCLOUD_SERVICE_KEY > app/build/gcloud/gcloud-service-key.json && chmod 644 app/build/gcloud/gcloud-service-key.json
       - restore_cache:
           keys:
             - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
       - attach_workspace:
           at: ~/
-      - run: |
-          echo "Setting default Java to ${JAVA_BIN}"
-          sudo update-alternatives --set java ${JAVA_BIN}
-          sudo update-alternatives --set javac ${JAVAC_BIN}
-      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK_VERSION_VAR} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
+      - run: ./gradlew --no-daemon --console=plain integrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
       - store_test_results:
           path: app/build/test-results/integrationTest
@@ -846,7 +837,7 @@ jobs:
 
   integration-test-databricks-integration-spark:
     parameters:
-      spark-version:
+      env-variant:
         type: string
     working_directory: ~/openlineage/integration/spark
     machine:
@@ -871,12 +862,10 @@ jobs:
                   - v1-integration-spark-{{ checksum "/tmp/checksum.txt" }}
             - attach_workspace:
                 at: ~/
-            - set_java_version
-            - run: |
-                sudo update-alternatives --set java ${JAVA_BIN}
-                sudo update-alternatives --set javac ${JAVAC_BIN}
+            - set_java_spark_scala_version:
+                  env-variant: << parameters.env-variant >>
             - run: ./gradlew --console=plain shadowJar -x test -Pjava.compile.home=${JAVA17_HOME}
-            - run: ./gradlew --no-daemon --console=plain databricksIntegrationTest -x test -Pspark.version=<< parameters.spark-version >> -Dopenlineage.tests.databricks.host=$DATABRICKS_HOST -Dopenlineage.tests.databricks.token=$DATABRICKS_TOKEN -Pjava.compile.home=${JAVA17_HOME}
+            - run: ./gradlew --no-daemon --console=plain databricksIntegrationTest -x test   -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}  -PdatabricksHost=${DATABRICKS_HOST} -PdatabricksToken=${DATABRICKS_TOKEN}
             - store_test_results:
                 path: app/build/test-results/databricksIntegrationTest
             - store_artifacts:

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -23,17 +23,17 @@ workflows:
             parameters:
               env-variant: [
                 'java:8-spark:2.4.8-scala:2.12',
-                'java:8-spark:3.2.4-scala:2.12',
-                'java:8-spark:3.2.4-scala:2.13',
-                'java:8-spark:3.3.4-scala:2.12',
-                'java:8-spark:3.3.4-scala:2.13',
-                'java:17-spark:3.3.4-scala:2.12',
-                'java:17-spark:3.3.4-scala:2.13',
-                'java:8-spark:3.4.3-scala:2.12',
-                'java:8-spark:3.4.3-scala:2.13',
-                'java:8-spark:3.5.2-scala:2.12',
-                'java:8-spark:3.5.2-scala:2.13',
-                'java:17-spark:3.5.2-scala:2.12',
+                'java:8-spark:3.2.4-scala:2.12-full-tests',
+                'java:8-spark:3.2.4-scala:2.13-full-tests',
+                'java:8-spark:3.3.4-scala:2.12-full-tests',
+                'java:8-spark:3.3.4-scala:2.13-full-tests',
+                'java:17-spark:3.3.4-scala:2.12-full-tests',
+                'java:17-spark:3.3.4-scala:2.13-full-tests',
+                'java:8-spark:3.4.3-scala:2.12-full-tests',
+                'java:8-spark:3.4.3-scala:2.13-full-tests',
+                'java:8-spark:3.5.2-scala:2.12-full-tests',
+                'java:8-spark:3.5.2-scala:2.13-full-tests',
+                'java:17-spark:3.5.2-scala:2.12-full-tests',
                 'java:17-spark:3.5.2-scala:2.13',
                 'java:17-spark:4.0.0-scala:2.13'
               ]
@@ -92,7 +92,10 @@ workflows:
           context: integration-tests
           matrix:
             parameters:
-              spark-version: [ '3.4.2', '3.5.2' ]
+              env-variant: [
+                'java:8-spark:3.4.3-scala:2.12-full-tests',
+                'java:17-spark:3.5.2-scala:2.13-full-tests'
+              ]
           requires:
             - approval-integration-spark
           post-steps:
@@ -112,17 +115,17 @@ workflows:
             parameters:
               env-variant: [
                 'java:8-spark:2.4.8-scala:2.12',
-                'java:8-spark:3.2.4-scala:2.12',
-                'java:8-spark:3.2.4-scala:2.13',
-                'java:8-spark:3.3.4-scala:2.12',
-                'java:8-spark:3.3.4-scala:2.13',
-                'java:17-spark:3.3.4-scala:2.12',
-                'java:17-spark:3.3.4-scala:2.13',
-                'java:8-spark:3.4.3-scala:2.12',
-                'java:8-spark:3.4.3-scala:2.13',
-                'java:8-spark:3.5.2-scala:2.12',
-                'java:8-spark:3.5.2-scala:2.13',
-                'java:17-spark:3.5.2-scala:2.12',
+                'java:8-spark:3.2.4-scala:2.12-full-tests',
+                'java:8-spark:3.2.4-scala:2.13-full-tests',
+                'java:8-spark:3.3.4-scala:2.12-full-tests',
+                'java:8-spark:3.3.4-scala:2.13-full-tests',
+                'java:17-spark:3.3.4-scala:2.12-full-tests',
+                'java:17-spark:3.3.4-scala:2.13-full-tests',
+                'java:8-spark:3.4.3-scala:2.12-full-tests',
+                'java:8-spark:3.4.3-scala:2.13-full-tests',
+                'java:8-spark:3.5.2-scala:2.12-full-tests',
+                'java:8-spark:3.5.2-scala:2.13-full-tests',
+                'java:17-spark:3.5.2-scala:2.12-full-tests',
                 'java:17-spark:3.5.2-scala:2.13',
                 'java:17-spark:4.0.0-scala:2.13'
               ]

--- a/dev/filter_approvals.py
+++ b/dev/filter_approvals.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+with open("complete_config.yml") as f:
+    d = yaml.safe_load(f)
+
+for _, workflow_definition in d["workflows"].items():
+    jobs = workflow_definition.get("jobs") if isinstance(workflow_definition, dict) else None
+    if not jobs:
+        continue
+
+    # find all approvals
+    approvals = list(
+        filter(lambda x: isinstance(x, dict) and next(iter(x.values())).get("type") == "approval", jobs)
+    )
+    for approval in approvals:
+        approval_name = next(iter(approval))
+        approval_upstreams = approval[approval_name].get("requires")
+        approval_downstream = list(
+            filter(
+                lambda x: isinstance(x, dict) and approval_name in next(iter(x.values())).get("requires", ""),
+                jobs,
+            )
+        )
+        # replace approval with its upstream jobs
+        for job in approval_downstream:
+            requires = next(iter(job.values()))["requires"]
+            requires.remove(approval_name)
+            requires.extend(approval_upstreams)
+        jobs.remove(approval)
+with open("complete_config.yml", "w") as f:
+    f.write(yaml.dump(d, sort_keys=False))

--- a/dev/filter_matrix.py
+++ b/dev/filter_matrix.py
@@ -1,0 +1,26 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+with open("complete_config.yml") as f:
+    d = yaml.safe_load(f)
+
+for _, workflow_definition in d["workflows"].items():
+    jobs = workflow_definition.get("jobs") if isinstance(workflow_definition, dict) else None
+    if not jobs:
+        continue
+
+    for job in jobs:
+        if "test-integration-spark" in job:
+            test_job = job["test-integration-spark"]
+        elif "integration-test-integration-spark" in job:
+            integration_test_job = job["integration-test-integration-spark"]
+
+    for job in filter(None, [test_job, integration_test_job]):
+        variants = [
+            x for x in test_job.get("matrix").get("parameters").get("env-variant") if "full-tests" not in x
+        ]
+        job["matrix"]["parameters"]["env-variant"] = variants
+with open("complete_config.yml", "w") as f:
+    f.write(yaml.dump(d, sort_keys=False))


### PR DESCRIPTION
We are running full tests on each PR. This causes our CI to be severly throttled. This reduces matrix of Spark tests on PRs to three chosen ones - Spark 2.4.8 with Java 8 and Scala 2.12 as lowest dependency, Spark 3.5.1 with Scala 2.13 as highest dependency, and Spark 4. If you want to run all tests, you need to add label `full-tests` and rerun the CI.

This is done by getting GH labels from inside the setup CircleCI job, and using it in Python filtering script.