### PR TITLE
ci: use nexusPublishing plugin for proxy backend

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1071,7 +1071,7 @@ jobs:
           ./gradlew --info --console=plain publishToMavenLocal
 
           # Publish *.jar
-          ./gradlew --info --console=plain publish
+          ./gradlew --info --console=plain publishToSonatype closeAndReleaseSonatypeStagingRepository
 
   release-docker-proxy-backend:
     working_directory: ~/openlineage/proxy/backend


### PR DESCRIPTION
Make the behavior consistent and automatic for proxy backend too.