### PR TITLE
Update visitors to be able to support table extended sources via extensions.

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanInputDatasetBuilder.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 
 /**
@@ -49,5 +51,14 @@ public abstract class AbstractQueryPlanInputDatasetBuilder<P extends LogicalPlan
             node, ScalaConversionUtils.toScalaFn((lp) -> Collections.<InputDataset>emptyList()))
         .stream()
         .collect(Collectors.toList());
+  }
+
+  protected List<InputDataset> getTableInputs(DataSourceV2ScanRelation plan) {
+    Table table = plan.relation().table();
+
+    return context
+        .getSparkExtensionVisitorWrapper()
+        .getInputs(table, table.getClass().getName())
+        .getLeft();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanOutputDatasetBuilder.java
@@ -17,6 +17,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 
 /**
@@ -88,5 +90,14 @@ public abstract class AbstractQueryPlanOutputDatasetBuilder<P extends LogicalPla
     suffix += identifier.name();
 
     return suffix;
+  }
+
+  protected List<OpenLineage.OutputDataset> getTableOutputs(DataSourceV2Relation plan) {
+    Table table = plan.table();
+
+    return context
+        .getSparkExtensionVisitorWrapper()
+        .getOutputs(table, table.getClass().getName())
+        .getLeft();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -46,6 +46,10 @@ public class DataSourceV2RelationOutputDatasetBuilder
   @Override
   protected List<OpenLineage.OutputDataset> apply(
       SparkListenerEvent event, DataSourceV2Relation relation) {
+    if (context.getSparkExtensionVisitorWrapper().isDefinedAt(relation.table())) {
+      return getTableOutputs(relation);
+    }
+
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         context.getOpenLineage().newDatasetFacetsBuilder();
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
@@ -43,6 +43,10 @@ public final class DataSourceV2ScanRelationOnEndInputDatasetBuilder
 
   @Override
   public List<InputDataset> apply(DataSourceV2ScanRelation plan) {
+    if (context.getSparkExtensionVisitorWrapper().isDefinedAt(plan.relation().table())) {
+      return getTableInputs(plan);
+    }
+
     DataSourceV2Relation relation = plan.relation();
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         context.getOpenLineage().newDatasetFacetsBuilder();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
@@ -44,6 +44,11 @@ public final class DataSourceV2ScanRelationOnStartInputDatasetBuilder
 
   @Override
   public List<InputDataset> apply(DataSourceV2ScanRelation plan) {
+    if (context.getSparkExtensionVisitorWrapper().isDefinedAt(plan.relation().table())) {
+      List<InputDataset> tableInputs = getTableInputs(plan);
+      return tableInputs;
+    }
+
     DataSourceV2Relation relation = plan.relation();
     OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
         context.getOpenLineage().newDatasetFacetsBuilder();

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.withSettings;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
@@ -48,6 +49,7 @@ class AppendDataDatasetBuilderTest {
           .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
           .meterRegistry(new SimpleMeterRegistry())
           .openLineageConfig(new SparkOpenLineageConfig())
+          .sparkExtensionVisitorWrapper(mock(SparkOpenLineageExtensionVisitorWrapper.class))
           .build();
   DatasetFactory<OpenLineage.OutputDataset> factory = mock(DatasetFactory.class);
   AppendDataDatasetBuilder builder = new AppendDataDatasetBuilder(context, factory);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
@@ -75,6 +76,8 @@ class DataSourceV2ScanRelationOnEndInputDatasetBuilderTest {
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(scanRelation.relation()).thenReturn(relation);
+    when(context.getSparkExtensionVisitorWrapper())
+        .thenReturn(mock(SparkOpenLineageExtensionVisitorWrapper.class));
 
     try (MockedStatic<DataSourceV2RelationDatasetExtractor> ignored =
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilderTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
@@ -74,6 +75,8 @@ class DataSourceV2ScanRelationOnStartInputDatasetBuilderTest {
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(scanRelation.relation()).thenReturn(relation);
+    when(context.getSparkExtensionVisitorWrapper())
+        .thenReturn(mock(SparkOpenLineageExtensionVisitorWrapper.class));
 
     try (MockedStatic<DataSourceV2RelationDatasetExtractor> ignored =
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {


### PR DESCRIPTION
### Problem

Add missing pieces for extensions mechanism when provider is implementing table interface and not relation.

Closes: #ISSUE-NUMBER

### Solution

in few visitors we need to look at isDefinedAt in the SparkExtensionWrapper

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project