### PR TITLE
Tweak the Maven signing config

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -244,7 +244,9 @@ signing {
     required { isReleaseVersion }
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKey, signingPassword)
+    if (signingKey && signingPassword) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
     sign publishing.publications.mavenJava
 }
 


### PR DESCRIPTION
This tweak allows Gradle to default to using the values set in `~/.gradle/gradle.properties`