### PR TITLE
fix slack notification

### DIFF
--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -132,6 +132,8 @@ workflows:
           context: slack-secrets
           requires:
             - integration-test-integration-spark
+            - integration-test-databricks-integration-spark
+            - configurable-integration-test-spark
             - jar-verification-spark
       - workflow_complete:
           filters:


### PR DESCRIPTION
Fix slack notify to depend on all Spark integration tests including: databricks integration test and configurable integration test

Code can be tested with: 
```
./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf.yml --test ./integration/spark/cli/tests
```