### PR TITLE
Fix docker container for configurable test

### DIFF
--- a/integration/spark/cli/Dockerfile
+++ b/integration/spark/cli/Dockerfile
@@ -1,16 +1,17 @@
-FROM openjdk:11
+FROM amazoncorretto:17-alpine-jdk
 ADD integration/sql /usr/lib/openlineage/integration/sql
 ADD client/java /usr/lib/openlineage/client/java
 ADD integration/spark-extension-entrypoint /usr/lib/openlineage/integration/spark-extension-entrypoint
 ADD spec /usr/lib/openlineage/spec
 VOLUME "/root/.m2" "/root/.gradle" "/root/.cargo" "/var/run/docker.sock"
+RUN apk add --update alpine-sdk
+RUN apk --no-cache add curl cargo build-base bash
 RUN \
     cd /usr/lib/openlineage/client/java && \
-    ./gradlew --no-daemon shadowJar publishToMavenLocal &&  \
+    ./gradlew --no-daemon shadowJar publishToMavenLocal && \
     cd /usr/lib/openlineage/integration/spark-extension-entrypoint && \
-    ./gradlew --no-daemon build publishToMavenLocal &&  \
+    ./gradlew --no-daemon jar publishToMavenLocal &&  \
     cd /usr/lib/openlineage/integration/sql/iface-java && \
-    apt-get update && apt-get -y install build-essential && \
     ./script/compile.sh && \
     ./script/build.sh
 WORKDIR /usr/lib/openlineage/integration/spark


### PR DESCRIPTION
Fix the way docker container for configurable test is built.

Daily builds are failing -> https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12544/workflows/ca4cfb8b-315c-48b1-b218-b594df11f097

However slack notification are misconfigured. they don't notify about failure for configurable test and databricks integration test. 

To test this change, please run:
```
./integration/spark/cli/configurable-test.sh --spark ./integration/spark/cli/spark-conf.yml --test ./integration/spark/cli/tests
```

