### PR TITLE
fix nightly run

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -946,7 +946,7 @@ jobs:
       - run: ./gradlew --no-daemon --console=plain clean jarVerification -Pscala.binary.version=2.12 -Pjava.compile.home=${JAVA17_HOME}
       - run: ./gradlew --no-daemon --console=plain clean jarVerification -Pscala.binary.version=2.13 -Pjava.compile.home=${JAVA17_HOME}
 
-  slack-notify:
+  slack-notify-success:
     docker:
       - image: "cimg/base:stable"
     steps:
@@ -958,9 +958,6 @@ jobs:
             - slack/notify:
                 event: pass
                 template: basic_success_1
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
 
   # FLINK
 

--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -95,6 +95,14 @@ workflows:
               spark-version: [ '3.4.2', '3.5.2' ]
           requires:
             - approval-integration-spark
+          post-steps:
+            - when:
+                condition:
+                  equal: [ active, << pipeline.parameters.nightly-run >> ]
+                steps:
+                  - slack/notify:
+                      event: fail
+                      template: basic_fail_1
       - integration-test-integration-spark:
           filters:
             tags:
@@ -120,16 +128,32 @@ workflows:
               ]
           requires:
             - approval-integration-spark
+          post-steps:
+            - when:
+                condition:
+                  equal: [ active, << pipeline.parameters.nightly-run >> ]
+                steps:
+                  - slack/notify:
+                      event: fail
+                      template: basic_fail_1
       - configurable-integration-test-spark:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
           context: integration-tests
-      - slack-notify:
+          post-steps:
+            - when:
+                condition:
+                  equal: [ active, << pipeline.parameters.nightly-run >> ]
+                steps:
+                  - slack/notify:
+                      event: fail
+                      template: basic_fail_1
+      - slack-notify-success:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          context: slack-secrets
+          context: integration-tests
           requires:
             - integration-test-integration-spark
             - integration-test-databricks-integration-spark
@@ -140,7 +164,7 @@ workflows:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
           requires:
-            - slack-notify
+            - slack-notify-success
       - release-integration-spark:
           context: release
           requires:

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksUtils.java
@@ -52,12 +52,12 @@ public class DatabricksUtils {
   public static final Map<String, String> PLATFORM_VERSIONS_NAMES =
       Stream.of(
               new AbstractMap.SimpleEntry<>("3.4.2", "13.3.x-scala2.12"),
-              new AbstractMap.SimpleEntry<>("3.5.0", "14.2.x-scala2.12"))
+              new AbstractMap.SimpleEntry<>("3.5.2", "14.2.x-scala2.12"))
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   public static final Map<String, String> PLATFORM_VERSIONS =
       Stream.of(
               new AbstractMap.SimpleEntry<>("3.4.2", "13.3"),
-              new AbstractMap.SimpleEntry<>("3.5.0", "14.2"))
+              new AbstractMap.SimpleEntry<>("3.5.2", "14.2"))
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   public static final String NODE_TYPE = "Standard_DS3_v2";
   public static final String INIT_SCRIPT_FILE = "/Shared/open-lineage-init-script.sh";

--- a/integration/sql/iface-java/script/compile.sh
+++ b/integration/sql/iface-java/script/compile.sh
@@ -19,16 +19,16 @@ JAVA_SRC=$SRC/java/io/openlineage/sql
 RESOURCES=$ROOT/src/main/resources/io/openlineage/sql
 SCRIPTS=$ROOT/script
 
-if [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "x86_64" ]]; then
+if [[ "$OSTYPE" == "linux-"* && "$(uname -m)" == "x86_64" ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java_x86_64.so
-elif [[ "$OSTYPE" == "linux-gnu"* && "$(uname -m)" == "aarch64" ]]; then
+elif [[ "$OSTYPE" == "linux-"* && "$(uname -m)" == "aarch64" ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java_aarch64.so
 elif [[ "$OSTYPE" == "darwin"* && "$(uname -m)" == "arm64" ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java_arm64.dylib
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     NATIVE_LIB_NAME=libopenlineage_sql_java.dylib
 else
-    printf "\n${RED}Unsupported OS!\n${NC}"
+    printf "\n${RED}Unsupported OS ${OSTYPE}!\n${NC}\n"
 fi
 
 # Build the Rust bindings


### PR DESCRIPTION
* Fix configurable test to run on architecture other than `linux-gnu` (`amazoncorretto:17-alpine-jdk` image runs `linux-musl`)]
* Fix databricks integration test for Spark 3.5.2 to select proper runtime
* Modify slack notifications as post-step of spark integration tests

Successful run: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12630/workflows/b5138d8e-0f90-4f0d-9003-f7fa076c033a