### PR TITLE
common: Suspend Great Expectations tests.

### DIFF
--- a/integration/common/openlineage/common/provider/redshift_data.py
+++ b/integration/common/openlineage/common/provider/redshift_data.py
@@ -6,7 +6,6 @@ import traceback
 from typing import Any, Dict, List, Optional
 
 import attr
-import botocore
 from openlineage.client.facet_v2 import (
     BaseFacet,
     error_message_run,
@@ -27,7 +26,7 @@ class RedshiftFacets:
 class RedshiftDataDatasetsProvider:
     def __init__(
         self,
-        client: botocore.client,
+        client,
         connection_details: Dict[str, Any],
         logger: Optional[logging.Logger] = None,
     ):

--- a/integration/common/pyproject.toml
+++ b/integration/common/pyproject.toml
@@ -10,3 +10,7 @@ target-version = "py37"
 ignore-init-module-imports = true
 src = ["openlineage", "tests"]
 namespace-packages = ["openlineage/common"]
+
+[tool.pytest.ini_options]
+# suspending GreatExpectations from tests
+addopts = "-p no:warnings --ignore=tests/great_expectations"

--- a/integration/common/setup.cfg
+++ b/integration/common/setup.cfg
@@ -18,9 +18,6 @@ replace = __version__ = "{new_version}"
 [flake8]
 max-line-length = 99
 
-[tool:pytest]
-addopts = -p no:warnings
-
 [mypy]
 ignore_missing_imports = True
 
@@ -39,5 +36,5 @@ deps = openlineage-python@../../client/python
 	dbt-1.0: dbt-core>=1.0,<1.3
 	dbt-1.3: dbt-core>=1.3
 commands = python -m mypy --ignore-missing-imports --no-namespace-packages openlineage
-	pytest -vv --cov=openlineage --junitxml=test-results/junit.xml tests/
+	pytest -vv --cov=openlineage --junitxml=test-results/junit.xml
 	coverage xml


### PR DESCRIPTION
Remove type hint from redshift common provider as it did not make sense.

### Problem

GE tests started failing.

### Solution

As Great Expectations integration is not actively developed I propose to suspend its tests rather than attempt to fix them from time to time.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project