### PR TITLE
Add extra CLL tests

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLevelLineageTestUtils.java
@@ -131,4 +131,49 @@ public class ColumnLevelLineageTestUtils {
         expectedAmountOfInputs,
         facet.getFields().getAdditionalProperties().get(outputColumn).getInputFields().size());
   }
+
+  static int countColumnDependencies(OpenLineage.ColumnLineageDatasetFacet facet) {
+    return countColumnDependencies(facet, null);
+  }
+
+  static int countColumnDependencies(
+      OpenLineage.ColumnLineageDatasetFacet facet, String outputColumn) {
+    int count = 0;
+    for (String column : facet.getFields().getAdditionalProperties().keySet()) {
+      if (outputColumn == null || column.equals(outputColumn)) {
+        List<OpenLineage.InputField> inputFields =
+            facet.getFields().getAdditionalProperties().get(column).getInputFields();
+        for (OpenLineage.InputField inputField : inputFields) {
+          count += inputField.getTransformations().size();
+        }
+      }
+    }
+    return count;
+  }
+
+  static void assertCountColumnDependencies(
+      OpenLineage.ColumnLineageDatasetFacet facet, int expected) {
+    assertEquals(expected, countColumnDependencies(facet));
+  }
+
+  static void assertCountColumnDependencies(
+      OpenLineage.ColumnLineageDatasetFacet facet, String outputColumn, int expected) {
+    assertEquals(expected, countColumnDependencies(facet, outputColumn));
+  }
+
+  static int countDatasetDependencies(OpenLineage.ColumnLineageDatasetFacet facet) {
+    int count = 0;
+    List<OpenLineage.InputField> inputFields = facet.getDataset();
+    if (inputFields != null) {
+      for (OpenLineage.InputField inputField : inputFields) {
+        count += inputField.getTransformations().size();
+      }
+    }
+    return count;
+  }
+
+  static void assertCountDatasetDependencies(
+      OpenLineage.ColumnLineageDatasetFacet facet, int expected) {
+    assertEquals(expected, countDatasetDependencies(facet));
+  }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesOnlyFieldDependenciesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesOnlyFieldDependenciesTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 // TODO #3084: Remove when the column lineage has dataset dependencies flag removed
 @Slf4j
 @EnabledIfSystemProperty(named = "spark.version", matches = "([34].*)")
+@SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
 class ColumnLineageWithTransformationTypesOnlyFieldDependenciesTest {
 
   private static final String FILE = "file";
@@ -148,7 +149,6 @@ class ColumnLineageWithTransformationTypesOnlyFieldDependenciesTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void simpleQueryMasking() {
     createTable("t1", "a;int", "b;int");
     OpenLineage.ColumnLineageDatasetFacet facet =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @Slf4j
 @EnabledIfSystemProperty(named = "spark.version", matches = "([34].*)")
+@SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
 class ColumnLineageWithTransformationTypesTest {
 
   private static final String FILE = "file";


### PR DESCRIPTION
- Added a few extra tests for `UNION` and windowed transformations
- Added a count functionality to be sure that no spurious transformations are included in the event.