### PR TITLE
Configure Java client with environment variables.

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/Clients.java
+++ b/client/java/src/main/java/io/openlineage/client/Clients.java
@@ -29,9 +29,16 @@ public final class Clients {
     if (isDisabled()) {
       return OpenLineageClient.builder().transport(new NoopTransport()).build();
     }
-    final OpenLineageConfig openLineageConfig =
-        OpenLineageClientUtils.loadOpenLineageConfigYaml(
-            configPathProvider, new TypeReference<OpenLineageConfig>() {});
+    OpenLineageConfig openLineageConfig;
+    try {
+      openLineageConfig =
+          OpenLineageClientUtils.loadOpenLineageConfigYaml(
+              configPathProvider, new TypeReference<OpenLineageConfig>() {});
+    } catch (OpenLineageClientException e) {
+      openLineageConfig =
+          OpenLineageClientUtils.loadOpenLineageConfigFromEnvVars(
+              new TypeReference<OpenLineageConfig>() {});
+    }
     return newClient(openLineageConfig);
   }
 

--- a/client/java/src/main/java/io/openlineage/client/Environment.java
+++ b/client/java/src/main/java/io/openlineage/client/Environment.java
@@ -5,9 +5,16 @@
 
 package io.openlineage.client;
 
+import java.util.Map;
+
 // This class exists because it's not possible to mock System
 public class Environment {
   public static String getEnvironmentVariable(String key) {
     return System.getenv(key);
+  }
+
+  // get all envinroment variables
+  public static Map<String, String> getAllEnvironmentVariables() {
+    return System.getenv();
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.utils.OpenLineageEnvParser;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -274,6 +276,34 @@ public final class OpenLineageClientUtils {
     } catch (IOException e) {
       throw new OpenLineageClientException(e);
     }
+  }
+
+  /**
+   * This method reads the OpenLineage configuration from environment variables, converts it to a
+   * JSON string, and then parses the JSON string into an instance of the specified {@link
+   * OpenLineageConfig} subclass.
+   *
+   * @param valueTypeRef The type to convert the JSON string into.
+   * @return An instance of {@link OpenLineageConfig} containing the parsed JSON configuration.
+   * @throws OpenLineageClientException If an error occurs while reading or parsing the
+   *     configuration.
+   * @param <T> generic type of merged config
+   */
+  public static <T extends OpenLineageConfig> T loadOpenLineageConfigFromEnvVars(
+      TypeReference<T> valueTypeRef) throws OpenLineageClientException {
+    String result;
+    if (!OpenLineageEnvParser.OpenLineageEnvVarsExist()) {
+      throw new OpenLineageClientException("No OpenLineage environment variables found");
+    }
+    try {
+      result = OpenLineageEnvParser.parseAllOpenLineageEnvVars();
+    } catch (JsonProcessingException e) {
+      throw new OpenLineageClientException(e);
+    }
+
+    byte[] jsonBytes = result.getBytes();
+    InputStream inputStream = new ByteArrayInputStream(jsonBytes);
+    return loadOpenLineageConfigJson(inputStream, valueTypeRef);
   }
 
   /**

--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
@@ -30,6 +30,10 @@ public class CompositeTransport extends Transport {
     }
   }
 
+  public List<Transport> getTransports() {
+    return transports;
+  }
+
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     for (Transport transport : transports) {

--- a/client/java/src/main/java/io/openlineage/client/utils/OpenLineageEnvParser.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/OpenLineageEnvParser.java
@@ -1,0 +1,160 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openlineage.client.Environment;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OpenLineageEnvParser {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String PREFIX = "OPENLINEAGE__";
+
+  /**
+   * Parses all environment variables starting with OPENLINEAGE__ into a single nested JSON
+   * structure.
+   *
+   * @return A single nested JSON structure with all matching environment variables.
+   * @throws JsonProcessingException
+   */
+  public static String parseAllOpenLineageEnvVars() throws JsonProcessingException {
+    ObjectNode root = objectMapper.createObjectNode();
+
+    // Filter all environment variables starting with 'OPENLINEAGE__'
+    Map<String, String> env = Environment.getAllEnvironmentVariables();
+    env.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(PREFIX))
+        .sorted(Map.Entry.comparingByKey(Comparator.reverseOrder()))
+        .map(
+            entry -> {
+              String envKey = entry.getKey();
+              String envValue = entry.getValue();
+              try {
+                // Parse the individual environment variable into a nested structure
+                return parseEnvToNestedJson(envKey, envValue);
+              } catch (Exception e) {
+                log.warn("Failed to parse environment variable: {}", envKey);
+                return null;
+              }
+            })
+        .filter(Objects::nonNull) // Filter out any failed parsing attempts
+        .forEach(parsedJson -> merge(root, parsedJson));
+    return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(root);
+  }
+
+  /**
+   * Parses a single environment variable key and value into a nested JSON structure.
+   *
+   * @param envKey The environment variable key.
+   * @param envValue The environment variable value.
+   * @return A nested JSON structure based on the key.
+   */
+  private static ObjectNode parseEnvToNestedJson(String envKey, String envValue) throws Exception {
+    // Remove the 'OPENLINEAGE__' prefix
+    String strippedKey = envKey.substring(PREFIX.length());
+
+    // Split the remaining key on '__' into a List<String>
+    List<String> keyParts =
+        Stream.of(strippedKey.split("__"))
+            .map(String::toLowerCase) // Lowercase the keys if needed
+            .map(OpenLineageEnvParser::convertSnakeCaseToCamelCase)
+            .collect(Collectors.toList());
+
+    // Create the final value node. If it's valid JSON, parse it; otherwise, treat
+    // it as a string.
+    JsonNode valueNode;
+    try {
+      valueNode = objectMapper.readTree(envValue);
+    } catch (JsonProcessingException e) {
+      // If it's not valid JSON, treat it as a plain string
+      valueNode = objectMapper.convertValue(envValue, JsonNode.class);
+    }
+
+    // Create nested structure based on keyParts
+    ObjectNode root = objectMapper.createObjectNode();
+    ObjectNode currentNode = root;
+
+    // Create nested objects for each key part except the last
+    for (int i = 0; i < keyParts.size() - 1; i++) {
+      ObjectNode nextNode = objectMapper.createObjectNode();
+      currentNode.set(keyParts.get(i), nextNode); // Use List's get() method
+      currentNode = nextNode;
+    }
+
+    // Set the final value at the last part of the key
+    currentNode.set(keyParts.get(keyParts.size() - 1), valueNode);
+
+    return root;
+  }
+
+  /**
+   * Converts a string from snake_case to camelCase.
+   *
+   * @param value The input string in snake_case.
+   * @return The input string converted to camelCase.
+   */
+  private static String convertSnakeCaseToCamelCase(String value) {
+    if (value.indexOf('_') == -1) {
+      return value;
+    }
+
+    String initialPart = value.substring(0, value.indexOf('_'));
+
+    String secondPart =
+        Arrays.stream(value.substring(value.indexOf('_') + 1).split("_"))
+            .map(s -> Character.toUpperCase(s.charAt(0)) + s.substring(1))
+            .collect(Collectors.joining());
+
+    return initialPart + secondPart;
+  }
+
+  /**
+   * Merges two ObjectNodes into one.
+   *
+   * @param mainNode The main ObjectNode that will be merged into.
+   * @param updateNode The ObjectNode to merge.
+   */
+  private static void merge(ObjectNode mainNode, ObjectNode updateNode) {
+    updateNode
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              String fieldName = entry.getKey();
+              JsonNode value = entry.getValue();
+
+              if (!mainNode.has(fieldName)) {
+                mainNode.set(fieldName, value);
+                return;
+              }
+
+              // If the field already exists and both are objects, recursively merge
+              JsonNode existingValue = mainNode.get(fieldName);
+              if (existingValue.isObject() && value.isObject()) {
+                merge((ObjectNode) existingValue, (ObjectNode) value);
+                return;
+              }
+
+              mainNode.set(fieldName, value);
+            });
+  }
+
+  public static boolean OpenLineageEnvVarsExist() {
+    return Environment.getAllEnvironmentVariables().entrySet().stream()
+        .anyMatch(entry -> entry.getKey().startsWith(PREFIX));
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/OpenLineageEnvParserTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/OpenLineageEnvParserTest.java
@@ -1,0 +1,103 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.client.Environment;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+class OpenLineageEnvParserTest {
+
+  @ParameterizedTest
+  @MethodSource("generateArgs")
+  void testParseAllOpenLineageEnvVars(Map<String, String> mocks, String expectedJson)
+      throws Exception {
+    try (MockedStatic mocked = mockStatic(Environment.class)) {
+      when(Environment.getAllEnvironmentVariables()).thenReturn(mocks);
+
+      // Call the method to test
+      String result = OpenLineageEnvParser.parseAllOpenLineageEnvVars();
+
+      // Assert that the result matches the expected JSON
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode expectedNode = objectMapper.readTree(expectedJson);
+      JsonNode actualNode = objectMapper.readTree(result);
+      assertEquals(expectedNode, actualNode, "The parsed JSON structure is incorrect.");
+    }
+  }
+
+  private static Stream<Arguments> generateArgs() {
+    return Stream.of(
+        // Empty map
+        Arguments.of(Map.of(), "{}"),
+        // Variavle with valid JSON
+        Arguments.of(
+            Map.of(
+                "OPENLINEAGE__API__URL", "http://example.com/api",
+                "OPENLINEAGE__API__TIMEOUT", "30"),
+            "{"
+                + "  \"api\": {"
+                + "    \"timeout\": 30,"
+                + "    \"url\": \"http://example.com/api\""
+                + "  }"
+                + "}"),
+        // Variable with invalid JSON
+        Arguments.of(
+            Map.of(
+                "OPENLINEAGE__API__URL", "http://example.com/api",
+                "OPENLINEAGE__API__TIMEOUT", "invalid_json"),
+            "{"
+                + "  \"api\": {"
+                + "    \"url\": \"http://example.com/api\","
+                + "    \"timeout\": \"invalid_json\""
+                + "  }"
+                + "}"),
+        // Unmatching variable
+        Arguments.of(
+            Map.of(
+                "OPENLINEAGE__API__URL", "http://example.com/api",
+                "SOME_OTHER_ENV", "ignore_this"),
+            "{\"api\":{\"url\":\"http://example.com/api\"}}"),
+        // Precedence with overlapping variables
+        Arguments.of(
+            Map.of(
+                "OPENLINEAGE__TRANSPORT",
+                    "{\"type\": \"http\", \"endpoint\": \"http://example.com/api\"}",
+                "OPENLINEAGE__TRANSPORT__TYPE", "console"),
+            "{"
+                + "   \"transport\":{"
+                + "     \"type\":\"http\","
+                + "     \"endpoint\":\"http://example.com/api\""
+                + "   }"
+                + "}"),
+        Arguments.of(
+            Map.of(
+                "OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__TYPE", "hostList",
+                "OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__HOSTS",
+                    "[\"kafka-prod13.company.com\", \"kafka-prod15.company.com\"]",
+                "OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__SCHEMA", "kafka"),
+            "{\n"
+                + "  \"dataset\":{"
+                + "     \"namespaceResolvers\":{"
+                + "          \"resolvedName\":{"
+                + "             \"type\":\"hostList\","
+                + "             \"schema\":\"kafka\","
+                + "             \"hosts\":[\"kafka-prod13.company.com\",\"kafka-prod15.company.com\"]"
+                + "          }"
+                + "     }"
+                + "  }"
+                + "}"));
+  }
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/FlinkConfigParser.java
@@ -59,7 +59,7 @@ public class FlinkConfigParser {
               OpenLineageClientUtils.loadOpenLineageConfigYaml(
                   new DefaultConfigPathProvider(), new TypeReference<FlinkOpenLineageConfig>() {}));
     } catch (OpenLineageClientException e) {
-      log.info("Couldn't log config from file, will read it from SparkConf");
+      log.info("Couldn't log config from file, will read it from FlinkConf");
       configFromFile = Optional.empty();
     }
     return configFromFile;

--- a/website/docs/client/java/configuration.md
+++ b/website/docs/client/java/configuration.md
@@ -23,6 +23,12 @@ The following environment variables are available:
 | OPENLINEAGE_CONFIG   | The path to the YAML configuration file. Example: `path/to/openlineage.yml` |       |
 | OPENLINEAGE_DISABLED | When `true`, OpenLineage will not emit events.                              | 0.9.0 |
 
+You can also configure the client with dynamic environment variables.
+
+import DynamicEnvVars from './partials/java_dynamic_env_vars.md';
+
+<DynamicEnvVars/>
+
 ## Facets Configuration
 
 In YAML configuration file you can also disable facets to filter them out from the OpenLineage event.

--- a/website/docs/client/java/partials/java_dynamic_env_vars.md
+++ b/website/docs/client/java/partials/java_dynamic_env_vars.md
@@ -1,0 +1,164 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+
+The OpenLineage client supports configuration through dynamic environment variables.
+
+### Configuring OpenLineage Client via Dynamic Environment Variables
+
+These environment variables must begin with `OPENLINEAGE__`, followed by sections  of the configuration separated by a double underscore `__`.
+All values in the environment variables are automatically converted to lowercase, 
+and variable names using snake_case (single underscore) are converted into camelCase within the final configuration.
+
+#### Key Features
+
+1. Prefix Requirement: All environment variables must begin with `OPENLINEAGE__`.
+2. Sections Separation: Configuration sections are separated using double underscores `__` to form the hierarchy.
+3. Lowercase Conversion: Environment variable values are automatically converted to lowercase.
+4. CamelCase Conversion: Any environment variable name using single underscore `_` will be converted to camelCase in the final configuration.
+5. JSON String Support: You can pass a JSON string at any level of the configuration hierarchy, which will be merged into the final configuration structure.
+6. Hyphen Restriction: You cannot use `-` in environment variable names. If a name strictly requires a hyphen, use a JSON string as the value of the environment variable.
+7. Precedence Rules:
+* Top-level keys have precedence and will not be overwritten by more nested entries.
+* For example, `OPENLINEAGE__TRANSPORT='{..}'` will not have its keys overwritten by `OPENLINEAGE__TRANSPORT__AUTH__KEY='key'`.
+
+#### Examples
+
+<Tabs groupId="configs">
+<TabItem value="basic" label="Basic Example">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__TRANSPORT__TYPE=http
+OPENLINEAGE__TRANSPORT__URL=http://localhost:5050
+OPENLINEAGE__TRANSPORT__ENDPOINT=/api/v1/lineage
+OPENLINEAGE__TRANSPORT__AUTH__TYPE=api_key
+OPENLINEAGE__TRANSPORT__AUTH__API_KEY=random_token
+OPENLINEAGE__TRANSPORT__COMPRESSION=gzip
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+transport:
+  type: http
+  url: http://localhost:5050
+  endpoint: api/v1/lineage
+  auth:
+    type: api_key
+    apiKey: random_token
+  compression: gzip
+```
+</TabItem>
+
+<TabItem value="composite" label="Composite Example">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__TRANSPORT__TYPE=composite
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__TYPE=http
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__TYPE=http
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__URL=http://localhost:5050
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__ENDPOINT=/api/v1/lineage
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__AUTH__TYPE=api_key
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__AUTH__API_KEY=random_token
+OPENLINEAGE__TRANSPORT__TRANSPORTS__FIRST__AUTH__COMPRESSION=gzip
+OPENLINEAGE__TRANSPORT__TRANSPORTS__SECOND__TYPE=console
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+transport:
+  type: composite
+  transports:
+    first:
+      type: http
+      url: http://localhost:5050
+      endpoint: api/v1/lineage
+      auth:
+        type: api_key
+        apiKey: random_token
+      compression: gzip
+    second:
+      type: console
+```
+</TabItem>
+
+<TabItem value="precedence" label="Precedence Example">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__TRANSPORT='{"type":"console"}'
+OPENLINEAGE__TRANSPORT__TYPE=http
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+transport:
+  type: console
+```
+</TabItem>
+
+<TabItem value="spark-properties" label="Spark Example">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__TRANSPORT__TYPE=kafka
+OPENLINEAGE__TRANSPORT__TOPIC_NAME=test
+OPENLINEAGE__TRANSPORT__MESSAGE_KEY=explicit-key
+OPENLINEAGE__TRANSPORT__PROPERTIES='{"key.serializer": "org.apache.kafka.common.serialization.StringSerializer"}'
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+transport:
+  type: kafka
+  topicName: test
+  messageKey: explicit-key
+  properties:
+    key.serializer: org.apache.kafka.common.serialization.StringSerializer
+```
+
+Please note that you can't use environment variables to set Spark properties, as they are not part of the configuration hierarchy.
+Following environment variable:
+```sh
+OPENLINEAGE__TRANSPORT__PROPERTIES__KEY__SERIALIZER="org.apache.kafka.common.serialization.StringSerializer"
+```
+would be equivalent to below YAML structure:
+```yaml
+transport:
+  properties:
+    key:
+      serializer: org.apache.kafka.common.serialization.StringSerializer
+```
+which is not a valid configuration for Spark.
+
+</TabItem>
+
+<TabItem value="namespace-resolvers" label="Namespace Resolvers Example">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__TYPE=hostList
+OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__HOSTS='["kafka-prod13.company.com", "kafka-prod15.company.com"]'
+OPENLINEAGE__DATASET__NAMESPACE_RESOLVERS__RESOLVED_NAME__SCHEMA=kafka
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+dataset:
+  namespaceResolvers:
+    resolvedName:
+      type: hostList
+      hosts:
+        - kafka-prod13.company.com
+        - kafka-prod15.company.com
+       schema: kafka
+```
+</TabItem>
+
+</Tabs>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -132,6 +132,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['java'],
       },
       colorMode: {
         defaultMode: 'light',


### PR DESCRIPTION
### Problem

Partially closes: #2916 

### Solution

Add the option in Java client and adjust code in Spark. Seems Flink handles this without code changes.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project