### PR TITLE
Fix issue when column lineage was pointing to cte instead of origin table for complex cte's.

### DIFF
--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -348,27 +348,10 @@ impl<'a> Context<'a> {
             let mut expanded = ColumnAncestors::new();
             for ancestor in ancestors {
                 // here we need also look on other if they are connected
-                let mut result = Vec::new();
-                let mut stack = Vec::new();
+                let traversed = Context::expand_ancestors(ancestor.clone(), &old);
 
-                stack.push(ancestor.clone());
-
-                while let Some(current) = stack.pop() {
-                    let column_ancestors = old.column_ancestry.get(&current);
-                    if column_ancestors.is_none() {
-                        result.push(current.clone());
-                        continue;
-                    }
-
-                    if let Some(ancestors) = column_ancestors {
-                        for ancestor in ancestors {
-                            stack.push(ancestor.clone());
-                        }
-                    }
-                }
-
-                if !result.is_empty() {
-                    expanded.extend(result.iter().cloned());
+                if !traversed.is_empty() {
+                    expanded.extend(traversed.iter().cloned());
                 } else {
                     expanded.insert(ancestor.clone());
                 }
@@ -379,6 +362,29 @@ impl<'a> Context<'a> {
         frame.column_ancestry = result;
         frame.dependencies.extend(old.dependencies);
         frame.is_main_body = old.is_main_body;
+    }
+
+    fn expand_ancestors(ancestor: ColumnMeta, old: &ContextFrame) -> Vec<ColumnMeta> {
+        let mut result = Vec::new();
+        let mut stack = Vec::new();
+
+        stack.push(ancestor.clone());
+
+        while let Some(current) = stack.pop() {
+            let column_ancestors = old.column_ancestry.get(&current);
+            if column_ancestors.is_none() {
+                result.push(current.clone());
+                continue;
+            }
+
+            if let Some(ancestors) = column_ancestors {
+                for ancestor in ancestors {
+                    stack.push(ancestor.clone());
+                }
+            }
+        }
+
+        result
     }
 
     pub fn collect(&mut self, mut old: ContextFrame) {
@@ -423,22 +429,8 @@ impl<'a> Context<'a> {
                 })
                 .collect::<HashMap<ColumnMeta, ColumnAncestors>>();
 
-            let mut removed_circular_deps: HashMap<ColumnMeta, ColumnAncestors> = HashMap::new();
-
-            for (key_column_meta, column_ancestors) in old_ancestry.iter() {
-                for column_meta in column_ancestors {
-                    if let Some(origin) = column_meta.origin.clone() {
-                        if frame.aliases.is_table_alias(&origin) && origin == from_table {
-                            continue;
-                        }
-                    }
-
-                    removed_circular_deps
-                        .entry(key_column_meta.clone())
-                        .or_default()
-                        .insert(column_meta.clone());
-                }
-            }
+            let removed_circular_deps =
+                Context::remove_circular_deps(&old_ancestry, frame, from_table);
 
             if !removed_circular_deps.is_empty() {
                 frame.column_ancestry.extend(old_ancestry);
@@ -450,6 +442,31 @@ impl<'a> Context<'a> {
             frame.cte_dependencies.extend(old.cte_dependencies);
             frame.is_main_body = old.is_main_body;
         }
+    }
+
+    fn remove_circular_deps(
+        old_ancestry: &HashMap<ColumnMeta, ColumnAncestors>,
+        frame: &ContextFrame,
+        from_table: DbTableMeta,
+    ) -> HashMap<ColumnMeta, ColumnAncestors> {
+        let mut removed_circular_deps: HashMap<ColumnMeta, ColumnAncestors> = HashMap::new();
+
+        for (key_column_meta, column_ancestors) in old_ancestry.iter() {
+            for column_meta in column_ancestors {
+                if let Some(origin) = column_meta.origin.clone() {
+                    if frame.aliases.is_table_alias(&origin) && origin == from_table {
+                        continue;
+                    }
+                }
+
+                removed_circular_deps
+                    .entry(key_column_meta.clone())
+                    .or_default()
+                    .insert(column_meta.clone());
+            }
+        }
+
+        removed_circular_deps
     }
 
     pub fn collect_lower_nested_dependencies(&mut self, cte_name: String) {

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -423,7 +423,7 @@ impl<'a> Context<'a> {
                 })
                 .collect::<HashMap<ColumnMeta, ColumnAncestors>>();
 
-            let mut result: HashMap<ColumnMeta, ColumnAncestors> = HashMap::new();
+            let mut removed_circular_deps: HashMap<ColumnMeta, ColumnAncestors> = HashMap::new();
 
             for (key_column_meta, column_ancestors) in old_ancestry.iter() {
                 for column_meta in column_ancestors {
@@ -433,17 +433,17 @@ impl<'a> Context<'a> {
                         }
                     }
 
-                    result
+                    removed_circular_deps
                         .entry(key_column_meta.clone())
                         .or_default()
                         .insert(column_meta.clone());
                 }
             }
 
-            if !result.is_empty() {
+            if !removed_circular_deps.is_empty() {
                 frame.column_ancestry.extend(old_ancestry);
             } else {
-                frame.column_ancestry.extend(result);
+                frame.column_ancestry.extend(removed_circular_deps);
             }
 
             frame.dependencies.extend(old.dependencies);

--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -353,19 +353,18 @@ impl<'a> Context<'a> {
 
                 stack.push(ancestor.clone());
 
-                while !stack.is_empty() {
-                    let current = stack.pop().unwrap();
+                while let Some(current) = stack.pop() {
                     let column_ancestors = old.column_ancestry.get(&current);
                     if column_ancestors.is_none() {
                         result.push(current.clone());
-                        continue
+                        continue;
                     }
 
-                    column_ancestors.map(|ancestors| {
+                    if let Some(ancestors) = column_ancestors {
                         for ancestor in ancestors {
                             stack.push(ancestor.clone());
                         }
-                    });
+                    }
                 }
 
                 if !result.is_empty() {

--- a/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
+++ b/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 contributors to the OpenLineage project
 // SPDX-License-Identifier: Apache-2.0
 
-use openlineage_sql::{ColumnLineage, ColumnMeta};
 use crate::test_utils::*;
+use openlineage_sql::{ColumnLineage, ColumnMeta};
 
 #[test]
 fn table_reference_with_simple_ctes() {
@@ -330,59 +330,50 @@ fn test_complex_cte() {
                  SELECT col1, col2, col3, col4 from tab1
             )
             SELECT col1, col2, col3, col4 FROM tab2",
-    )
-        .unwrap();
+    );
 
     assert_eq!(
-        output.column_lineage,
+        output.unwrap().column_lineage,
         vec![
             ColumnLineage {
                 descendant: ColumnMeta {
                     origin: None,
                     name: "col1".to_string()
                 },
-                lineage: vec![
-                    ColumnMeta {
-                        origin: Some(table("stg")),
-                        name: "col1".to_string()
-                    },
-                ]
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("stg")),
+                    name: "col1".to_string()
+                },]
             },
             ColumnLineage {
                 descendant: ColumnMeta {
                     origin: None,
                     name: "col2".to_string()
                 },
-                lineage: vec![
-                    ColumnMeta {
-                        origin: Some(table("stg")),
-                        name: "col2".to_string()
-                    },
-                ]
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("stg")),
+                    name: "col2".to_string()
+                },]
             },
             ColumnLineage {
                 descendant: ColumnMeta {
                     origin: None,
                     name: "col3".to_string()
                 },
-                lineage: vec![
-                    ColumnMeta {
-                        origin: Some(table("stg2")),
-                        name: "col3".to_string()
-                    },
-                ]
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("stg2")),
+                    name: "col3".to_string()
+                },]
             },
             ColumnLineage {
                 descendant: ColumnMeta {
                     origin: None,
                     name: "col4".to_string()
                 },
-                lineage: vec![
-                    ColumnMeta {
-                        origin: Some(table("stg2")),
-                        name: "col4".to_string()
-                    },
-                ]
+                lineage: vec![ColumnMeta {
+                    origin: Some(table("stg2")),
+                    name: "col4".to_string()
+                },]
             }
         ]
     );

--- a/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
+++ b/integration/sql/impl/tests/table_lineage/test_alias_resolving.rs
@@ -333,7 +333,6 @@ fn test_complex_cte() {
     )
         .unwrap();
 
-    println!("sss");
     assert_eq!(
         output.column_lineage,
         vec![


### PR DESCRIPTION
### Problem

When we have complex cte like this one 
```sql
        "with tab1 as (
                 SELECT s.col1, s.col2, s2.col3, s2.col4
                 from stg as s, stg2 AS s2
            ),
            tab2 as (
                 SELECT col1, col2, col3, col4 from tab1
            )
            SELECT col1, col2, col3, col4 FROM tab2",
```

We produced events with column lineage referring tab2 instead of stg or stg2

Closes: #ISSUE-NUMBER

### Solution

traversing column lineage graph and going up to the beginning

#### One-line summary:
traversing column lineage graph and going up to the beginning

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project