### PR TITLE
Spark - improve test logging

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -76,6 +76,21 @@ commands:
             sudo update-alternatives --set java ${JAVA_BIN}
             sudo update-alternatives --set javac ${JAVAC_BIN}
 
+  store_submodule_tests:
+    parameters:
+      submodule:
+        type: string
+        description: submodule name
+    description: Store test results and test report of a given submodule
+    steps:
+      - store_test_results:
+          name: Upload test results of << parameters.submodule >>
+          path: << parameters.submodule >>/build/test-results/test
+      - store_artifacts:
+          name: Upload test reports of << parameters.submodule >>
+          path: << parameters.submodule >>/build/reports/tests/test
+          destination: test-report-<< parameters.submodule >>
+
   install_integration_common:
     description: "Install common integration"
     parameters:
@@ -609,11 +624,24 @@ jobs:
           when: on_fail
           command: cat build/test-results/test/TEST-*.xml
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME}
-      - store_test_results:
-          path: build/test-results/test
-      - store_artifacts:
-          path: build/reports/tests/test
-          destination: test-report
+      - store_submodule_tests:
+          submodule: app
+      - store_submodule_tests:
+          submodule: spark2
+      - store_submodule_tests:
+          submodule: spark3
+      - store_submodule_tests:
+          submodule: spark31
+      - store_submodule_tests:
+          submodule: spark32
+      - store_submodule_tests:
+          submodule: spark33
+      - store_submodule_tests:
+          submodule: spark34
+      - store_submodule_tests:
+          submodule: spark35
+      - store_submodule_tests:
+          submodule: spark40
       - store_artifacts:
           path: build/reports/tests/pmd
           destination: pmd-report

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -12,7 +12,6 @@ plugins {
     id("io.freefair.lombok")
     id("com.github.johnrengelman.shadow")
     id("io.openlineage.common-config")
-    id "com.adarshr.test-logger" version "4.0.0"
     id "org.gradle.test-retry" version "1.6.0"
 }
 
@@ -205,11 +204,6 @@ tasks.named("test", Test.class) {
         }
     }
     systemProperties = testSystemProperties(spark, scala)
-
-    testLogging {
-        events "passed", "skipped", "failed"
-        showStandardStreams = true
-    }
 }
 
 tasks.named("jar", Jar.class) {
@@ -263,10 +257,6 @@ tasks.named("shadowJar", ShadowJar.class) {
 }
 
 tasks.withType(Test).configureEach {
-    testLogging {
-        events("passed", "skipped", "failed")
-        showStandardStreams = true
-    }
     systemProperties = testSystemProperties(spark, scala)
     retry {
         boolean isCiServer = System.getenv().containsKey("CI")

--- a/integration/spark/app/src/test/resources/log4j2.properties
+++ b/integration/spark/app/src/test/resources/log4j2.properties
@@ -4,7 +4,7 @@ name = PropertiesConfig
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = debug
+filter.threshold.level = info
 
 appenders = console
 
@@ -17,12 +17,16 @@ rootLogger.level=info
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT
 loggers=openlineage, openlineage-shaded, spark-sql, shutdown-hook-manager, spark-sql-execution, \
+  openlineage-argparser, \
   spark-sql-catalyst, hive, spark-jetty, spark-storage, spark-scheduler, \
   spark-executor, spark-security-manager, spark-context, spark-resource, \
   spark-util, spark-env, parquet, hadoop, iceberg, spark-mapred, spark-network, iceberg-hadoop
 
 logger.openlineage.name = io.openlineage
 logger.openlineage.level = info
+
+logger.openlineage-argparser.name = io.openlineage.spark.agent.ArgumentParser
+logger.openlineage-argparser.level = warn
 
 logger.openlineage-shaded.name = io.openlineage.spark.shaded
 logger.openlineage-shaded.level = off

--- a/integration/spark/buildSrc/build.gradle.kts
+++ b/integration/spark/buildSrc/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2")
     implementation("org.javassist:javassist:3.30.2-GA")
+    implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
 }
 
 gradlePlugin {

--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -8,6 +8,8 @@ package io.openlineage.gradle.plugin
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.diffplug.gradle.spotless.SpotlessPlugin
 import com.diffplug.spotless.FormatterFunc
+import com.adarshr.gradle.testlogger.TestLoggerPlugin
+import com.adarshr.gradle.testlogger.TestLoggerExtension
 import io.freefair.gradle.plugins.lombok.LombokExtension
 import io.freefair.gradle.plugins.lombok.LombokPlugin
 import org.gradle.api.JavaVersion
@@ -49,6 +51,7 @@ class CommonConfigPlugin : Plugin<Project> {
         configureLombok(target)
         configureSpotless(target)
         configurePrintSourceSetTask(target)
+        configureTestLogger(target)
     }
 
     private fun getPluginExtension(target: Project): CommonConfigPluginExtension =
@@ -142,6 +145,14 @@ class CommonConfigPlugin : Plugin<Project> {
         val commonConfigExtension = getPluginExtension(target)
         with(target.extensions.getByType<LombokExtension>()) {
             version.set(commonConfigExtension.lombokVersion)
+        }
+    }
+
+    private fun configureTestLogger(target: Project) = target.plugins.withType<TestLoggerPlugin> {
+        target.extensions.configure<TestLoggerExtension> {
+            showExceptions = false
+            showStackTraces = false
+            showStandardStreams = true
         }
     }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/LogicalPlanSerializer.java
@@ -147,7 +147,8 @@ class LogicalPlanSerializer {
     "constraints",
     "data",
     "deltaLog",
-    "limitExpr"
+    "limitExpr",
+    "mockitoInterceptor" // don't serialize fields if plan is a mock
   })
   @SuppressWarnings("PMD")
   abstract class ChildMixIn {}


### PR DESCRIPTION
Logging improvements for building spark integration: 

* Limit the amount of logs for unit tests (get rid of exception stack trace which is a result of serialising mocked LogicalPlan)
   * Before:  https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12727/workflows/a67d4e90-0372-4599-8fbf-d5dcb427f21a/jobs/300014?invite=true#step-107-526203_87
   * After: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12739/workflows/5685b055-3367-4aab-8f7d-73134ef62923/jobs/300498
   
* Store submodule test results
   *  Before: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12727/workflows/a67d4e90-0372-4599-8fbf-d5dcb427f21a/jobs/300014/artifacts
  * After:  https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12739/workflows/5685b055-3367-4aab-8f7d-73134ef62923/jobs/300498/artifacts