### PR TITLE
add support for the athena-dbt adapter

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -40,6 +40,7 @@ class Adapter(Enum):
     DATABRICKS = "databricks"
     SQLSERVER = "sqlserver"
     DREMIO = "dremio"
+    ATHENA = "athena"
 
     @staticmethod
     def adapters() -> str:
@@ -583,6 +584,8 @@ class DbtArtifactProcessor:
             return f"mssql://{profile['server']}:{profile['port']}"
         elif self.adapter_type == Adapter.DREMIO:
             return f"dremio://{profile['software_host']}:{profile['port']}"
+        elif self.adapter_type == Adapter.ATHENA:
+            return "athena"
         elif self.adapter_type == Adapter.SPARK:
             port = ""
 


### PR DESCRIPTION
### Problem

I am using the [dbt-athena](https://github.com/dbt-labs/dbt-athena) adapter together with astronomer-cosmos to run a dbt
project within airflow. Cosmos supports emitting open lineage events automatically create airflow datasets which i want to use for scheduling. 


Closes: #2288

### Solution
I added athena as a possible value for the adapter and the namespace. Which solves the problem of astronomer-cosmos not emitting Datasets.

Here's an example of an emitted dataset uri:

`[Dataset(uri='athena/AwsDataCatalog.prod_general_prepared.data_glue_jobs_metadata', extra=None)]`
where `prod_general_prepared` is the database name and `data_glue_jobs_metadata` the table name.

I unsure if i configured the dataset namespace correctly and would appreciate input on this. Thanks

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:
add support for the dbt-athena adapter.
### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project