### PR TITLE
Python: allow custom headers in HTTP transport

### DIFF
--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -232,6 +232,7 @@ Allows sending events to HTTP endpoint, using [requests](https://requests.readth
   - `type` - string specifying the "api_key" or the fully qualified class name of your TokenProvider. Required if `auth` is provided.
   - `apiKey` - string setting the Authentication HTTP header as the Bearer. Required if `type` is `api_key`.
 - `compression` - string, name of algorithm used by HTTP client to compress request body. Optional, default value `null`, allowed values: `gzip`. Added in v1.13.0.
+- `custom_headers` - dictionary of additional headers to be sent with each request. Optional, default: `{}`.
 
 #### Behavior
 


### PR DESCRIPTION
### Problem

Needs #3114 so it works with env var configuration.

Closes: #2907

### Solution

Add `custom_headers` in HttpConfig.

**Note:** Env var configuration would work only if whole transport is set with dynamic env vars introduced in #3114. This means you can't e.g. set `OPENLINEAGE_URL` and `OPENLINEAGE__TRANSPORT__CUSTOM_HEADERS`. Instead of `OPENLINEAGE_URL` set `OPENLINEAGE__TRANSPORT__TYPE=http` and `OPENLINEAGE__TRANSPORT__URL=...`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project