### PR TITLE
docs: Document CompositeTransport in Python.

### DIFF
--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -561,12 +561,12 @@ OpenLineageClient client = OpenLineageClient.builder()
 
 ## [Composite](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java)
 
-The `CompositeTransport` is designed to aggregate multiple transports, allowing event emission to several destinations sequentially. This is useful when events need to be sent to multiple targets, such as a logging system and an API endpoint, one after another in a defined order.
+The `CompositeTransport` is designed to combine multiple transports, allowing event emission to several destinations. This is useful when events need to be sent to multiple targets, such as a logging system and an API endpoint. The events are delivered sequentially - one after another in a defined order.
 
 #### Configuration
 
 - `type` - string, must be "composite". Required.
-- `transports` - may be a list or a map of transport configurations. Required.
+- `transports` - a list or a map of transport configurations. Required.
 - `continueOnFailure` - boolean flag, determines if the process should continue even when one of the transports fails. Default is `false`.
 
 #### Behavior
@@ -576,14 +576,17 @@ The `CompositeTransport` is designed to aggregate multiple transports, allowing 
 - If `continueOnFailure` is `true`, the failure will be logged, but the remaining transports will still attempt to send the event.
 
 #### Notes for Multiple Transports
-This transport can include a variety of other transport types (e.g., `HttpTransport`, `KafkaTransport`, etc.), allowing flexibility in event distribution.
+The composite transport can be used with any OpenLineage transport (e.g. `HttpTransport`, `KafkaTransport`, etc).
 Ideal for scenarios where OpenLineage events need to reach multiple destinations for redundancy or different types of processing.
 
 The `transports` configuration can be provided in two formats:
 
-1. A list of transport configurations, where each transport may optionally include a name field.
+1. A list of transport configurations, where each transport may optionally include a `name` field.
 2. A map of transport configurations, where the key acts as the name for each transport.
 The map format is particularly useful for configurations set via environment variables or Java properties, providing a more convenient and flexible setup.
+
+##### Why are transport names used?
+Transport names are not required for basic functionality. Their primary purpose is to enable configuration of composite transports via environment variables, which is only supported when names are defined.
 
 #### Examples
 


### PR DESCRIPTION
### Problem

Docs are missing CompositeTransport description in Python.

### Solution

Add documentation.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project