### PR TITLE
fix: Update classes used in column lineage after schema update

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -184,7 +184,7 @@ public class ColumnLevelLineageBuilder {
     return fieldsBuilder.build();
   }
 
-  private List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetInputFields(
+  private List<OpenLineage.InputField> facetInputFields(
       List<TransformedInput> inputFields, List<TransformedInput> datasetDependencyInputs) {
     Map<Input, List<TransformedInput>> combinedInputs = new HashMap<>();
     inputFields.stream()
@@ -195,7 +195,7 @@ public class ColumnLevelLineageBuilder {
     return combinedInputs.entrySet().stream()
         .map(
             field ->
-                new OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFieldsBuilder()
+                new OpenLineage.InputFieldBuilder()
                     .namespace(field.getKey().getDatasetIdentifier().getNamespace())
                     .name(field.getKey().getDatasetIdentifier().getName())
                     .field(field.getKey().getFieldName())

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformationInfo.java
@@ -161,10 +161,8 @@ public class TransformationInfo {
         this.getMasking() || another.getMasking());
   }
 
-  public OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFieldsTransformations
-      toInputFieldsTransformations() {
-    return new OpenLineage
-            .ColumnLineageDatasetFacetFieldsAdditionalInputFieldsTransformationsBuilder()
+  public OpenLineage.InputFieldTransformations toInputFieldsTransformations() {
+    return new OpenLineage.InputFieldTransformationsBuilder()
         .type(type.name())
         .subtype(subType.name())
         .description(description)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilderTest.java
@@ -115,7 +115,7 @@ class ColumnLevelLineageBuilderTest {
     builder.addInput(rootExprId, diA, INPUT_A);
     builder.addInput(rootExprId, diB, "inputB");
 
-    List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetFields =
+    List<OpenLineage.InputField> facetFields =
         builder.build().getAdditionalProperties().get("a").getInputFields();
 
     assertEquals(2, facetFields.size());
@@ -147,7 +147,7 @@ class ColumnLevelLineageBuilderTest {
     builder.addInput(childExprId, di, INPUT_A); // the same input with different exprId
     builder.addDependency(rootExprId, childExprId);
 
-    List<OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalInputFields> facetFields =
+    List<OpenLineage.InputField> facetFields =
         builder.build().getAdditionalProperties().get("a").getInputFields();
 
     assertEquals(1, facetFields.size());


### PR DESCRIPTION
### Problem

After the schema update, the new classes have not been used.

### Solution

The updated classes should be used

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project