### PR TITLE
Require Java 17 only for Spark 4.0

### DIFF
--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/CommonConfigPlugin.kt
@@ -87,10 +87,6 @@ class CommonConfigPlugin : Plugin<Project> {
                     // never run compile on CI without property being set
                     throw RuntimeException("java.compile.home should be always set on CI env")
                 }
-
-                if (!target.hasProperty("java.compile.home") && JavaVersion.current() < JavaVersion.VERSION_17) {
-                    throw RuntimeException("This project will not compile with Java version below 17.")
-                }
             }
         }
 

--- a/integration/spark/spark40/build.gradle
+++ b/integration/spark/spark40/build.gradle
@@ -13,6 +13,12 @@ scalaVariants {
     create("2.13")
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 idea {
     module {
         testSources.from(sourceSets.testScala213.java.srcDirs)


### PR DESCRIPTION
Without this change, I get this kind of error whenever I run any gradle task:

```
Execution failed for task ':shared:compileScala212Java'.
> This project will not compile with Java version below 17.
```

My understanding is that Java 17 is only required for Spark 4.0. Is that correct? If so, then this change should hopefully more appropriately scope this requirement.