### PR TITLE
Make OpenLineageClient and Transports AutoCloseable

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /** HTTP client used to emit {@link OpenLineage.RunEvent}s to HTTP backend. */
 @Slf4j
-public final class OpenLineageClient {
+public final class OpenLineageClient implements AutoCloseable {
   final Transport transport;
   final Optional<CircuitBreaker> circuitBreaker;
   final MeterRegistry meterRegistry;
@@ -158,6 +158,12 @@ public final class OpenLineageClient {
    */
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public void close() throws Exception {
+    transport.close();
+    meterRegistry.close();
   }
 
   /**

--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
@@ -6,6 +6,7 @@
 package io.openlineage.client.transports;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.NonNull;
@@ -72,5 +73,18 @@ public class CompositeTransport extends Transport {
       throw new RuntimeException(
           "Transport " + transport.getClass().getSimpleName() + " failed to emit event", e);
     }
+  }
+
+  @Override
+  public void close() throws Exception {
+    transports.forEach(
+        t -> {
+          try {
+            t.close();
+          } catch (Exception e) {
+            log.error("Failed to close {} transport", t.getClass().getSimpleName(), e);
+            throw new OpenLineageClientException(e);
+          }
+        });
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -14,7 +14,6 @@ import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageClientUtils;
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -39,7 +38,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 @Slf4j
-public final class HttpTransport extends Transport implements Closeable {
+public final class HttpTransport extends Transport {
   private static final String API_V1 = "/api/v1";
 
   private final CloseableHttpClient http;

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -99,4 +99,9 @@ public final class KafkaTransport extends Transport {
       log.error("Failed to collect lineage event: {}", eventAsJson, e);
     }
   }
+
+  @Override
+  public void close() throws Exception {
+    producer.close();
+  }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @NoArgsConstructor
-public abstract class Transport {
+public abstract class Transport implements AutoCloseable {
   enum Type {
     CONSOLE,
     FILE,
@@ -28,4 +28,7 @@ public abstract class Transport {
   public abstract void emit(@NonNull OpenLineage.DatasetEvent datasetEvent);
 
   public abstract void emit(@NonNull OpenLineage.JobEvent jobEvent);
+
+  @Override
+  public void close() throws Exception {}
 }

--- a/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
+++ b/client/java/transports-dataplex/src/main/java/io/openlineage/client/transports/dataplex/DataplexTransport.java
@@ -36,7 +36,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class DataplexTransport extends Transport implements Closeable {
+public class DataplexTransport extends Transport {
 
   private final ProducerClientWrapper producerClientWrapper;
 

--- a/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransport.java
+++ b/client/java/transports-gcs/src/main/java/io/openlineage/client/transports/gcs/GcsTransport.java
@@ -97,4 +97,9 @@ public class GcsTransport extends Transport {
     Blob blob = storage.create(blobInfo, content);
     log.debug("Stored event: {}", blob.asBlobInfo().getBlobId().toGsUtilUri());
   }
+
+  @Override
+  public void close() throws Exception {
+    storage.close();
+  }
 }


### PR DESCRIPTION
### Problem

`OpenLineageClient` doesn't have semantics to close underlying `Transports`, let's change it!.

Closes: #ISSUE-NUMBER

### Solution

Implement `AutoCloseable` interfaces in `OpenLineageClient` and classes extending `Transport`.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project