### PR TITLE
Fix docs versioning script

### DIFF
--- a/.github/workflows/website-new-version.yml
+++ b/.github/workflows/website-new-version.yml
@@ -36,16 +36,14 @@ jobs:
       - name: Generate new version
         run: |
           cd source
-          LATEST_VERSION=$(git tag --sort=taggerdate | tail -1)
-          echo latest version is $LATEST_VERSION
-          echo "LATEST_VERSION=${LATEST_VERSION}" >> "$GITHUB_ENV"
+          echo latest version is $GITHUB_REF_NAME
           cd ../target
-          if [ -d "versioned_docs/version-$LATEST_VERSION" ]
+          if [ -d "versioned_docs/version-$GITHUB_REF_NAME" ]
           then
             echo "Version already exists. skipping"
           else
-            echo "Generating version $LATEST_VERSION"
-            yarn run docusaurus docs:version $LATEST_VERSION
+            echo "Generating version $GITHUB_REF_NAME"
+            yarn run docusaurus docs:version $GITHUB_REF_NAME
           fi
       - name: Push target repo
         run: |
@@ -54,6 +52,6 @@ jobs:
           git config user.email "<>"
           git add .
           if ! git diff-index --quiet HEAD; then
-            git commit -m "Generating new version $LATEST_VERSION"
+            git commit -m "Generating new version $GITHUB_REF_NAME"
             git push
           fi


### PR DESCRIPTION
Currently, a docs releasing script gets incorrect tag version. 

Incorrect run: 
https://github.com/OpenLineage/OpenLineage/actions/runs/10717162991/job/29716276345

![Screenshot 2024-10-04 at 12 39 18](https://github.com/user-attachments/assets/fb08a4e1-99ff-4383-9893-09b5eeadac6f)

results in:
```
Run cd source
latest version is 1.21.1
Version already exists. skipping
```

This is because the way tag is extracted. 


New approach has been tested on private fork: 
https://github.com/pawel-big-lebowski/OpenLineage/actions/runs/11178434320


![Screenshot 2024-10-04 at 12 40 56](https://github.com/user-attachments/assets/b2be2927-4868-41d4-81b6-dbbcd3824909)
