### PR TITLE
avoid tests in configurable test

### DIFF
--- a/integration/spark/cli/Dockerfile
+++ b/integration/spark/cli/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update alpine-sdk
 RUN apk --no-cache add curl cargo build-base bash
 RUN \
     cd /usr/lib/openlineage/client/java && \
-    ./gradlew --no-daemon shadowJar publishToMavenLocal && \
+    ./gradlew --no-daemon -x test shadowJar publishToMavenLocal && \
     cd /usr/lib/openlineage/integration/spark-extension-entrypoint && \
     ./gradlew --no-daemon jar publishToMavenLocal &&  \
     cd /usr/lib/openlineage/integration/sql/iface-java && \


### PR DESCRIPTION
Nightly build gets failing because client java tests requiring docker environment. 
Turn off running client/java tests when building it for configurable test run. 

successful ci run: https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/12900/workflows/be8a7213-58a2-4e1e-a76a-d707666e2113