### PR TITLE
Fix/emr implicit glue catalog

### DIFF
--- a/.github/workflows/integration-tests-spark-aws.yml
+++ b/.github/workflows/integration-tests-spark-aws.yml
@@ -1,0 +1,52 @@
+name: Integration tests for Spark AWS
+
+# Runs the AWS integration tests
+#
+# The workflow is triggered manually. To run, you have to install GitHub CLI, setup secrets and run:
+# gh workflow run "Integration tests for Spark AWS" --ref <name of your branch>
+#
+# The required secrets are:
+# - EMR_TESTS_AWS_ACCESS_KEY_ID
+# - EMR_TESTS_AWS_SECRET_ACCESS_KEY
+# - EMR_TESTS_AWS_REGION
+# - EMR_TESTS_BUCKET_NAME
+# - EMR_TESTS_EC2_SUBNET_ID
+#
+# For local development use the command as in the step "Run AWS integration tests" below. You can specify
+# more parameters. See class DynamicParameters and EmrIntegrationTest in Spark integration for details.
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: integration/spark
+
+jobs:
+  run-integration-tests-emr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.EMR_TESTS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EMR_TESTS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EMR_TESTS_AWS_REGION }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Build Spark integration dependencies
+        run: ./buildDependencies.sh
+      - name: Build Spark integration jar
+        run: ./gradlew shadowJar -x test -Pjava.compile.home=${JAVA_HOME}
+      - name: Run AWS integration tests
+        run: ./gradlew awsIntegrationTest --info -x test -Pjava.compile.home=${JAVA_HOME} -Dopenlineage.tests.bucketName=${{ secrets.EMR_TESTS_BUCKET_NAME }} -Dopenlineage.tests.ec2SubnetId=${{ secrets.EMR_TESTS_EC2_SUBNET_ID }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: integration/spark/app/build/test-results

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -427,6 +427,9 @@ tasks.register("awsIntegrationTest", Test) {
          */
         systemProperties = System.getProperties().findAll { key, value -> key.toString().startsWith("openlineage") }
     }
+    testLogging {
+        exceptionFormat "full"
+    }
 }
 
 tasks.register("configurableIntegrationTest", Test) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DynamicParameter.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DynamicParameter.java
@@ -24,6 +24,18 @@ public enum DynamicParameter {
   ClusterId("clusterId", ""),
   PreventS3Cleanup("preventS3Cleanup", "false"),
   PreventClusterTermination("preventClusterTermination", "false"),
+  /**
+   * Determines which port can be used to debug the application. For debugging to work, make sure
+   * the EC2 subnet has the firewall rule, allowing you to access the master node using this port.
+   * You have to edit the EC2 security group the cluster is attached to and add the TCP inbound
+   * rule. Then you can use remote debugging option in your IDE (with this port and the master
+   * node's IP address) to attach session. If attaching seems to keep forever, it means that the
+   * firewall rule is not correct. If the server rejects the debugger's connection it means the
+   * application is not running yet, and you should repeat the attempt or make sure it is still
+   * running. You should run the cluster beforehand, note the master IP address and have the
+   * debugging session prepared before you attach the
+   */
+  DebugPort("debugPort", "5005"),
 
   // CLUSTER
   EmrLabel("emrLabel", "emr-7.2.0"),
@@ -32,6 +44,10 @@ public enum DynamicParameter {
   ServiceRole("serviceRole", "EMR_DefaultRole"),
   MasterInstanceType("masterInstanceType", "m4.large"),
   SlaveInstanceType("slaveInstanceType", "m4.large"),
+  Ec2SubnetId("ec2SubnetId"),
+  /** The optional key pair which can be used to SSH to the cluster. Useful for troubleshooting. */
+  SshKeyPairName("sshKeyPairName", ""),
+  IdleClusterTerminationSeconds("clusterIdleTerminationSeconds", "300"),
 
   /** The bucket where the tests keep the dependency jars, scripts, produced events, logs, etc */
   BucketName("bucketName"),

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/EmrIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/EmrIntegrationTest.java
@@ -79,6 +79,7 @@ class EmrIntegrationTest {
   private static final EmrTestEnvironment.EmrTestEnvironmentProperties emrTestParameters;
 
   static {
+    String clusterId = DynamicParameter.ClusterId.resolve();
     // Tests prefix with the date mark to tell when they were run in UTC
     String testsPrefix =
         DynamicParameter.TestsKeyPrefix.resolve()

--- a/integration/spark/app/src/test/resources/emr_test_jobs/glue_symlink_implicit_account_id.py
+++ b/integration/spark/app/src/test/resources/emr_test_jobs/glue_symlink_implicit_account_id.py
@@ -1,0 +1,54 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from pyspark.sql import SparkSession
+
+from time import sleep
+
+# Parameter provisioned by the templating system
+BUCKET_NAME = "{{bucketName}}"
+OUTPUT_PREFIX = "{{outputPrefix}}"
+DATABASE_NAME = "{{databaseName}}"
+SOURCE_TABLE_NAME = "{{sourceTableName}}"
+DESTINATION_TABLE_NAME = "{{destinationTableName}}"
+
+spark = (
+    SparkSession.builder.appName("Glue symlink implicit account id")
+    .config(
+        "hive.metastore.client.factory.class",
+        "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+    )
+    .config("spark.sql.catalogImplementation", "hive")
+    .getOrCreate()
+)
+
+spark.sql(f"DROP DATABASE IF EXISTS {DATABASE_NAME} CASCADE")
+
+spark.sql(f"CREATE DATABASE {DATABASE_NAME} LOCATION 's3://{BUCKET_NAME}/{OUTPUT_PREFIX}/{DATABASE_NAME}/'")
+
+source_table = f"{DATABASE_NAME}.{SOURCE_TABLE_NAME}"
+people_df = spark.createDataFrame(
+    [
+        (1, "John", "Smith", 49),
+        (2, "Mary", "Brown", 12),
+        (3, "Tom", "White", 51),
+        (4, "Bruce", "Willis", 18),
+        (5, "Jason", "Mane", 22),
+    ],
+    ["id", "first_name", "last_name", "age"],
+)
+people_df.writeTo(source_table).create()
+
+destination_table = f"{DATABASE_NAME}.{DESTINATION_TABLE_NAME}"
+spark.sql(f"""CREATE TABLE {destination_table} AS (SELECT * FROM {source_table})""")
+
+(
+    spark.sql(f"SELECT * FROM {source_table}")
+    .write.mode("overwrite")
+    .format("parquet")
+    .saveAsTable(f"{DATABASE_NAME}.{DESTINATION_TABLE_NAME}")
+)
+
+spark.sql(f"DROP DATABASE IF EXISTS {DATABASE_NAME} CASCADE")
+
+sleep(3)

--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -182,6 +182,12 @@ shadowJar {
     relocate "com.fasterxml.jackson", "io.openlineage.spark.shaded.com.fasterxml.jackson"
     relocate "org.LatencyUtils", "io.openlineage.spark.shaded.org.latencyutils"
     relocate "org.HdrHistogram", "io.openlineage.spark.shaded.org.hdrhistogram"
+
+    // AWS SDK dependencies
+    relocate "software.amazon", "io.openlineage.spark.shaded.software.amazon"
+    relocate "org.reactivestreams", "io.openlineage.spark.shaded.org.reactivestreams"
+    relocate "io.netty", "io.openlineage.spark.shaded.io.netty"
+
     manifest {
         attributes(
                 "Created-By": "Gradle ${gradle.gradleVersion}",

--- a/integration/spark/shared/build.gradle
+++ b/integration/spark/shared/build.gradle
@@ -37,7 +37,7 @@ ext {
     postgresqlVersion = "42.7.4"
     sqlLiteVersion = "3.46.1.3"
     testcontainersVersion = "1.19.3"
-    micrometerVersion = '1.13.2'
+    awsSdkVersion = '2.28.11'
 
     sparkVersion = project.findProperty("shared.spark.version")
     sparkSeries = sparkVersion.substring(0, 3)
@@ -63,6 +63,16 @@ dependencies {
         exclude(group: "com.fasterxml.jackson.core")
         exclude(group: "com.fasterxml.jackson.module")
     }
+
+    implementation(platform("software.amazon.awssdk:bom:${awsSdkVersion}"))
+    implementation("software.amazon.awssdk:sts")
+    implementation("software.amazon.awssdk:url-connection-client")
+    scala212Implementation(platform("software.amazon.awssdk:bom:${awsSdkVersion}"))
+    scala212Implementation("software.amazon.awssdk:sts")
+    scala212Implementation("software.amazon.awssdk:url-connection-client")
+    scala213Implementation(platform("software.amazon.awssdk:bom:${awsSdkVersion}"))
+    scala213Implementation("software.amazon.awssdk:sts")
+    scala213Implementation("software.amazon.awssdk:url-connection-client")
 
     // TODO: Convert these to testImplementation
     testFixturesApi(platform("org.junit:junit-bom:${junit5Version}"))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsAccountIdFetcher.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsAccountIdFetcher.java
@@ -1,0 +1,40 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
+
+/**
+ * Obtains and caches the account ID using the AWS SDK. The returned value is cached between
+ * invocations. This could potentially cause problems when the application is using custom
+ * credentials provider, but we don't support dynamic credentials providers anyway.
+ */
+@Slf4j
+@UtilityClass
+public class AwsAccountIdFetcher {
+  private static String accountId;
+
+  public static String getAccountId() {
+    if (accountId == null) {
+      log.info("Building STS client.");
+      try (StsClient stsClient =
+          StsClient.builder().httpClient(UrlConnectionHttpClient.builder().build()).build()) {
+        GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+        GetCallerIdentityResponse response = stsClient.getCallerIdentity(request);
+        accountId = response.account();
+        log.info("Retrieved account ID [{}].", accountId);
+      }
+    } else {
+      log.debug("Using cached account ID [{}].", accountId);
+    }
+    return accountId;
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -1,0 +1,119 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.util.Optional;
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+@UtilityClass
+public class AwsUtils {
+
+  public static final String HIVE_METASTORE_CLIENT_FACTORY_CLASS =
+      "hive.metastore.client.factory.class";
+  public static final String AWS_GLUE_HIVE_FACTORY_CLASS =
+      "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory";
+  private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
+
+  @SneakyThrows
+  public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
+    if (isHiveUsingGlue(sparkConf, hadoopConf)) {
+      return awsRegion()
+          .flatMap(
+              region ->
+                  getGlueCatalogId(sparkConf, hadoopConf)
+                      .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Obtains the Glue catalog ID.
+   *
+   * <p>There is no single place where Glue catalog ID is located. It depends on the environment
+   * where the application is running and optional, extra configuration.
+   */
+  private static @NotNull Optional<String> getGlueCatalogId(
+      SparkConf sparkConf, Configuration hadoopConf) {
+    /*
+    The ID of the Glue catalog can be specified explicitly. If it is not, then the account ID of the current account
+    is used.
+
+    To specify the catalog ID directly, the property "hive.metastore.glue.catalogid" is used. This method is useful
+    in scenarios when the application should use the organization's Glue catalog instead of the current account catalog.
+
+    When the catalog ID is not specified, there are different ways to determine the account ID. In environments like
+    Glue jobs, it is conveniently available as a Spark property. In other environments (like EMR), we have to use
+    AWS SDK to determine the current account ID.
+     */
+
+    Optional<String> explicitGlueCatalogId = getExplicitGlueCatalogId(sparkConf, hadoopConf);
+    if (explicitGlueCatalogId.isPresent()) {
+      return explicitGlueCatalogId;
+    }
+
+    Optional<String> glueJobAccountId =
+        SparkConfUtils.findSparkConfigKey(sparkConf, "spark.glue.accountId");
+    if (glueJobAccountId.isPresent()) {
+      log.debug("Using [spark.glue.account] property [{}] as catalog ID.", glueJobAccountId.get());
+      return glueJobAccountId;
+    } else {
+      log.debug("Fetching current account ID to use as the catalog ID.");
+      return Optional.of(AwsAccountIdFetcher.getAccountId());
+    }
+  }
+
+  /** Obtains the Glue catalog id when it is specified explicitly. */
+  private static Optional<String> getExplicitGlueCatalogId(
+      SparkConf sparkConf, Configuration hadoopConf) {
+    /*
+    For environments like EMR the catalog ID is specified in Spark properties.
+    For other environments like Athena it is specified as Hadoop properties.
+
+     Note for Athena: Even though the catalog ID is specified with prefix "spark.hadoop", it is removed by SparkHadoopUtil
+     */
+    Optional<String> sparkPropertyCatalogId =
+        SparkConfUtils.findSparkConfigKey(sparkConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
+    if (sparkPropertyCatalogId.isPresent()) {
+      log.debug(
+          "There is an explicit catalog ID [{}} passed as [{}] Spark property.",
+          sparkPropertyCatalogId.get(),
+          HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
+      return sparkPropertyCatalogId;
+    }
+    Optional<String> hadoopPropertyCatalogId =
+        SparkConfUtils.findHadoopConfigKey(hadoopConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
+    hadoopPropertyCatalogId.ifPresent(
+        s ->
+            log.debug(
+                "There is an explicit catalog ID [{}} passed as [{}] Hadoop property.",
+                s,
+                HIVE_METASTORE_GLUE_CATALOG_ID_KEY));
+    return hadoopPropertyCatalogId;
+  }
+
+  private static @NotNull Optional<String> awsRegion() {
+    return Optional.ofNullable(System.getenv("AWS_DEFAULT_REGION"))
+        .filter(s -> !s.isEmpty())
+        .map(Optional::of)
+        .orElseGet(() -> Optional.ofNullable(System.getenv("AWS_REGION")));
+  }
+
+  private static boolean isHiveUsingGlue(SparkConf sparkConf, Configuration hadoopConf) {
+    Optional<String> hadoopFactoryClass =
+        SparkConfUtils.findHadoopConfigKey(hadoopConf, HIVE_METASTORE_CLIENT_FACTORY_CLASS);
+    Optional<String> sparkFactoryClass =
+        SparkConfUtils.findSparkConfigKey(sparkConf, HIVE_METASTORE_CLIENT_FACTORY_CLASS);
+    return AWS_GLUE_HIVE_FACTORY_CLASS.equals(
+        hadoopFactoryClass.orElse(sparkFactoryClass.orElse(null)));
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -9,7 +9,6 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import java.net.URI;
 import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -25,7 +24,6 @@ import org.apache.spark.sql.internal.StaticSQLConf;
 @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 public class PathUtils {
   private static final String DEFAULT_DB = "default";
-  private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
   public static final String GLUE_TABLE_PREFIX = "table/";
 
   public static DatasetIdentifier fromPath(Path path) {
@@ -60,7 +58,7 @@ public class PathUtils {
     Configuration hadoopConf = sparkContext.hadoopConfiguration();
 
     Optional<URI> metastoreUri = getMetastoreUri(sparkContext);
-    Optional<String> glueArn = getGlueArn(sparkConf, hadoopConf);
+    Optional<String> glueArn = AwsUtils.getGlueArn(sparkConf, hadoopConf);
 
     if (glueArn.isPresent()) {
       // Even if glue catalog is used, it will have a hive metastore URI
@@ -151,54 +149,6 @@ public class PathUtils {
       return Optional.empty();
     }
     return SparkConfUtils.getMetastoreUri(context);
-  }
-
-  @SneakyThrows
-  public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
-    Optional<String> clientFactory =
-        SparkConfUtils.findHadoopConfigKey(hadoopConf, "hive.metastore.client.factory.class");
-    // Fetch from spark config if set.
-    clientFactory =
-        clientFactory.isPresent()
-            ? clientFactory
-            : SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.client.factory.class");
-    if (!clientFactory.isPresent()
-        || !"com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
-            .equals(clientFactory.get())) {
-      return Optional.empty();
-    }
-
-    Optional<String> region =
-        Optional.ofNullable(System.getenv("AWS_DEFAULT_REGION"))
-            .filter(s -> !s.isEmpty())
-            .map(Optional::of)
-            .orElseGet(() -> Optional.ofNullable(System.getenv("AWS_REGION")));
-
-    Optional<String> accountId =
-        SparkConfUtils.findSparkConfigKey(sparkConf, "spark.glue.accountId");
-    // For AWS Glue catalog in EMR spark
-    // Glue catalog with EMR guide:
-    // https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-glue.html
-    Optional<String> glueCatalogIdForEMR =
-        SparkConfUtils.findSparkConfigKey(sparkConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
-    // For AWS Glue access in Athena for Spark
-    // Guide: https://docs.aws.amazon.com/athena/latest/ug/spark-notebooks-cross-account-glue.html
-    // spark config "spark.hadoop.hive.metastore.glue.catalogid" is copied to hadoop
-    // "hive.metastore.glue.catalogid" by SparkHadoopUtil (removing the prefix spark.hadoop)
-    Optional<String> glueCatalogIdForAthena =
-        SparkConfUtils.findHadoopConfigKey(hadoopConf, HIVE_METASTORE_GLUE_CATALOG_ID_KEY);
-
-    Optional<String> glueCatalogId =
-        Stream.of(glueCatalogIdForEMR, glueCatalogIdForAthena, accountId)
-            .filter(Optional::isPresent)
-            .findFirst()
-            .orElse(Optional.empty());
-
-    if (!region.isPresent() || !glueCatalogId.isPresent()) {
-      return Optional.empty();
-    }
-
-    return Optional.of("arn:aws:glue:" + region.get() + ":" + glueCatalogId.get());
   }
 
   /** Get DatasetIdentifier name in format database.table or table */

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
+import io.openlineage.spark.agent.util.AwsUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.agent.util.SparkConfUtils;
@@ -222,7 +223,7 @@ public class IcebergHandler implements CatalogHandler {
   private DatasetIdentifier getGlueIdentifier(String table, SparkSession sparkSession) {
     SparkContext sparkContext = sparkSession.sparkContext();
     String arn =
-        PathUtils.getGlueArn(sparkContext.getConf(), sparkContext.hadoopConfiguration()).get();
+        AwsUtils.getGlueArn(sparkContext.getConf(), sparkContext.hadoopConfiguration()).get();
     return new DatasetIdentifier(GLUE_TABLE_PREFIX + table.replace(".", "/"), arn);
   }
 


### PR DESCRIPTION
### Problem

The mechanism for determining Glue catalog ID is broken when we don't pass it explicitly.

Closes: #ISSUE-NUMBER

### Solution

We should use account id when the user doesn't pass the catalog ID explicitly.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project