### PR TITLE
spark: Limit the Seq size in RddPathUtils::extract() to avoid OutOfMemoryError for large jobs

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent.util;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -116,6 +117,7 @@ public class RddPathUtils {
     @Override
     public Stream<Path> extract(ParallelCollectionRDD rdd) {
       int SEQ_LIMIT = 1000;
+      AtomicBoolean loggingDone = new AtomicBoolean(false);
       try {
         Object data = FieldUtils.readField(rdd, "data", true);
         log.debug("ParallelCollectionRDD data: {}", data);
@@ -130,8 +132,9 @@ public class RddPathUtils {
                       // we're able to extract path
                       path = parentOf(((Tuple2) el)._1.toString());
                       log.debug("Found input {}", path);
-                    } else {
+                    } else if (!loggingDone.get()) {
                       log.warn("unable to extract Path from {}", el.getClass().getCanonicalName());
+                      loggingDone.set(true);
                     }
                     return path;
                   })

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -115,11 +115,14 @@ public class RddPathUtils {
 
     @Override
     public Stream<Path> extract(ParallelCollectionRDD rdd) {
+      int SEQ_LIMIT = 1000;
       try {
         Object data = FieldUtils.readField(rdd, "data", true);
         log.debug("ParallelCollectionRDD data: {}", data);
-        if (data instanceof Seq) {
-          return ScalaConversionUtils.fromSeq((Seq) data).stream()
+        if ((data instanceof Seq) && ((Seq) data).head() instanceof Tuple2) {
+          // exit if the first element is invalid
+          Seq data_slice = (Seq) ((Seq) data).slice(0, SEQ_LIMIT);
+          return ScalaConversionUtils.fromSeq(data_slice).stream()
               .map(
                   el -> {
                     Path path = null;


### PR DESCRIPTION
### Problem

Closes: #3146

### Solution

As suggested in [#3146#issuecomment-2404985178](https://github.com/OpenLineage/OpenLineage/issues/3146#issuecomment-2404985178), first we validate just the first element, and later we take a slice of the first few (here, 1000) elements and process it.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary: Limit the data Seq size in RddPathUtils::extract() to avoid OutOfMemoryError for large SparkPi jobs

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project