### PR TITLE
local file system should not point to IP, added remote file system doc

### DIFF
--- a/spec/Naming.md
+++ b/spec/Naming.md
@@ -1,5 +1,7 @@
 # Naming
 
+## This document is obsolete, please look at the [OpenLineage Naming Conventions](https://openlineage.io/docs/spec/naming)
+
 We define the unique name strategy per resource to ensure it is followed uniformly independently of who is producing
 metadata, so we can connect lineage from various sources.
 
@@ -380,6 +382,19 @@ Identifier :
   - URI = kafka://{bootstrap server host}:{port}/{topic name}
 
 ### Local file system
+
+Naming hierarchy:
+
+- Path
+
+Identifier :
+
+- Namespace: file
+  - Scheme = file
+- Unique name: {path}
+  - URI = file://{path}
+
+### Remote file system
 
 Datasource hierarchy:
 

--- a/website/docs/spec/naming.md
+++ b/website/docs/spec/naming.md
@@ -33,7 +33,8 @@ A dataset, or `table`, is organized according to a producer, namespace, database
 | GCS                           | Blob storage                         | gs://{bucket name}                                           | {object key}                                             |
 | HDFS                          | Distributed file system              | hdfs://{namenode host}:{namenode port}                       | {path}                                                   |
 | Kafka                         | distributed event streaming platform | kafka://{bootstrap server host}:{port}                       | {topic}                                                  |
-| Local file system             | File system                          | file://{host}                                                | {path}                                                   |
+| Local file system             | File system                          | file                                                         | {path}                                                   |
+| Remote file system            | File system                          | file://{host}                                                | {path}                                                   |
 | S3                            | Blob Storage                         | s3://{bucket name}                                           | {object key}                                             |
 | WASBS (Azure Blob Storage)    | Blob Storage                         | wasbs://{container name}@{service name}.dfs.core.windows.net | {object key}                                             |
 


### PR DESCRIPTION
Namespace for a `local file system`: `file` dataset mentions `host`, or `IP` and `port` when still talking about "local file system". It seems clear that this is not "local" if we need to mention IP or port.

This also adds `remote file system` dataset - which is for example used by `ftp` and `sftp` assets.

Draft to facilitate discussion.