### PR TITLE
use uv to manage maturin in python sqlparser interface

### DIFF
--- a/integration/sql/iface-py/script/build-macos.sh
+++ b/integration/sql/iface-py/script/build-macos.sh
@@ -7,19 +7,6 @@
 # It's assumed that it will be run on MacOS
 set -e
 
-if [ -x "$(command -v /usr/local/opt/python@3.8/bin/python3)" ]; then
-  /usr/local/opt/python@3.8/bin/python3 -m venv .env
-elif [ -x "$(command -v /usr/local/bin/python3.8)" ]; then
-  /usr/local/bin/python3.8 -m venv .env
-elif [ -x "$(command -v python3.8)" ]; then
-  python3.8 -m venv .env
-else
-  python -m venv .env
-fi
-
-source .env/bin/activate
-source $HOME/.cargo/env
-
 # Disable incremental compilation, since it causes issues.
 export CARGO_INCREMENTAL=0
 
@@ -35,7 +22,7 @@ if [[ -d "./iface-py" ]]
 then
   cd iface-py
 fi
-maturin build --target universal2-apple-darwin --out target/wheels --release --strip
+uv tool run maturin build --target universal2-apple-darwin --out target/wheels --release --strip
 
 echo "Package build, trying to import"
 echo "Platform:"

--- a/integration/sql/iface-py/script/setup-macos.sh
+++ b/integration/sql/iface-py/script/setup-macos.sh
@@ -13,25 +13,20 @@ echo "Installing homebrew"
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
-echo "Installing Python 3.8"
-brew install python@3.8
-
 echo "Installing Rust"
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
+echo "Installing uv"
+curl -LsSf https://astral.sh/uv/install.sh | sh
 source $HOME/.cargo/env
 
 rustup target add aarch64-apple-darwin
 rustup target add x86_64-apple-darwin
 
+echo "Installing Python 3.8"
+uv python install 3.8
+
 # Maturin is build tool that we're using. It can build python wheels based on standard Rust Cargo.toml.
 echo "Installing Maturin"
-if [ -x "$(command -v /usr/local/opt/python@3.8/bin/python3)" ]; then
-  /usr/local/opt/python@3.8/bin/python3 -m pip install maturin
-elif [ -x "$(command -v /usr/local/bin/python3.8)" ]; then
-  /usr/local/bin/python3.8 -m pip install maturin
-elif [ -x "$(command -v python3.8)" ]; then
-  python3.8 -m pip install maturin
-else
-  python -m pip install maturin
-fi
+echo "$PWD"
+(cd iface-py && uv sync --no-install-project)


### PR DESCRIPTION
Move from installing Python via brew because it forces our hand when it comes to Python version support.