### PR TITLE
fix: Fix Kotlin capitalized function deprecation warning

### DIFF
--- a/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
+++ b/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt
@@ -8,7 +8,6 @@ package io.openlineage.gradle.plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
@@ -48,6 +47,9 @@ class ScalaVariantDelegate(
         configureTasks()
         configureArtifacts()
     }
+
+    fun CharSequence.capitalized(): String =
+        toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 
     private fun getSourceSetContainer(target: Project) =
         target.extensions.getByType<SourceSetContainer>()


### PR DESCRIPTION
### Problem

W have the following warnings in the logs
```
> Task :buildSrc:compileKotlin
w: file:///Users/aowczarek/Documents/gid/OpenLineage/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt:43:58 'capitalized(): String' is deprecated. This was never intended as a public API.
w: file:///Users/aowczarek/Documents/gid/OpenLineage/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt:128:58 'capitalized(): String' is deprecated. This was never intended as a public API.
w: file:///Users/aowczarek/Documents/gid/OpenLineage/integration/spark/buildSrc/src/main/kotlin/io/openlineage/gradle/plugin/ScalaVariantDelegate.kt:148:63 'capitalized(): String' is deprecated. This was never intended as a public API.
```

### Solution

We should replace it with what is recommended: https://github.com/gradle/gradle/blob/master/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project