### PR TITLE
Add missing javadocs for spark-extension-interfaces (causing warnings)

### DIFF
--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/DatasetWithDelegate.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/DatasetWithDelegate.java
@@ -4,7 +4,18 @@
 */
 package io.openlineage.spark.shade.extension.v1;
 
-/** Dataset with a node in LogicalPlan where a input dataset shall be extracted from */
+/**
+ * Represents a dataset associated with a node in a Spark LogicalPlan.
+ *
+ * <p>Implementing classes should provide a method to retrieve the node from which an input or
+ * output dataset can be extracted. This is used to capture lineage information by identifying the
+ * node in the Spark LogicalPlan that corresponds to the dataset.
+ */
 interface DatasetWithDelegate {
+  /**
+   * Returns the node in the LogicalPlan from which the dataset is extracted.
+   *
+   * @return the node object representing the location in the LogicalPlan
+   */
   Object getNode();
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/DatasetWithIdentifier.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/DatasetWithIdentifier.java
@@ -6,7 +6,19 @@ package io.openlineage.spark.shade.extension.v1;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 
-/** Dataset with an identifier containing namespace and name */
+/**
+ * Represents a dataset with an identifier that includes the dataset's namespace and name.
+ *
+ * <p>Implementing classes should provide a method to retrieve the {@link DatasetIdentifier}, which
+ * encapsulates the dataset's unique namespace and name. This identifier follows the naming
+ * conventions outlined in the <a href="https://openlineage.io/docs/spec/naming/">OpenLineage Naming
+ * Specification</a>, ensuring consistency across datasets for lineage tracking and data cataloging.
+ */
 interface DatasetWithIdentifier {
+  /**
+   * Returns the {@link DatasetIdentifier}, which contains the namespace and name of the dataset.
+   *
+   * @return the dataset identifier containing the namespace and name
+   */
   DatasetIdentifier getDatasetIdentifier();
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithDelegate.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithDelegate.java
@@ -8,13 +8,26 @@ import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.InputDatasetInputFacetsBuilder;
 import java.util.Objects;
 
-/** Input dataset with a node in LogicalPlan where a input dataset shall be extracted from */
+/**
+ * Represents an input dataset associated with a node in a LogicalPlan. This class allows the
+ * extraction of facets (metadata) from the input dataset.
+ *
+ * <p>It implements both {@link InputDatasetWithFacets} and {@link DatasetWithDelegate}, providing
+ * methods to retrieve dataset facets and the node from which the dataset is extracted.
+ */
 public class InputDatasetWithDelegate implements InputDatasetWithFacets, DatasetWithDelegate {
 
   private final Object node;
   private final DatasetFacetsBuilder datasetFacetsBuilder;
   private final InputDatasetInputFacetsBuilder inputFacetsBuilder;
 
+  /**
+   * Constructs a new {@code InputDatasetWithDelegate}.
+   *
+   * @param node the node in the LogicalPlan from which the input dataset is extracted
+   * @param datasetFacetsBuilder a builder for the dataset facets
+   * @param inputFacetsBuilder a builder for the input dataset input facets
+   */
   public InputDatasetWithDelegate(
       Object node,
       DatasetFacetsBuilder datasetFacetsBuilder,
@@ -24,16 +37,31 @@ public class InputDatasetWithDelegate implements InputDatasetWithFacets, Dataset
     this.inputFacetsBuilder = inputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * @return the dataset facets builder
+   */
   @Override
   public DatasetFacetsBuilder getDatasetFacetsBuilder() {
     return datasetFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link InputDatasetInputFacetsBuilder} for building input dataset facets.
+   *
+   * @return the input dataset input facets builder
+   */
   @Override
   public InputDatasetInputFacetsBuilder getInputFacetsBuilder() {
     return inputFacetsBuilder;
   }
 
+  /**
+   * Returns the node in the LogicalPlan from which the input dataset is extracted.
+   *
+   * @return the LogicalPlan node
+   */
   @Override
   public Object getNode() {
     return node;

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithFacets.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithFacets.java
@@ -7,8 +7,30 @@ package io.openlineage.spark.shade.extension.v1;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.InputDatasetInputFacetsBuilder;
 
+/**
+ * Interface representing an input dataset with associated facets (metadata).
+ *
+ * <p>Classes implementing this interface provide methods to retrieve builders for both dataset
+ * facets and input dataset input facets. These facets capture metadata associated with the input
+ * dataset.
+ */
 public interface InputDatasetWithFacets {
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * <p>Dataset facets include general metadata associated with the dataset.
+   *
+   * @return the dataset facets builder
+   */
   DatasetFacetsBuilder getDatasetFacetsBuilder();
 
+  /**
+   * Returns the {@link InputDatasetInputFacetsBuilder} for building input dataset facets.
+   *
+   * <p>Input dataset facets include specific metadata related to the input datasets that are being
+   * used.
+   *
+   * @return the input dataset input facets builder
+   */
   InputDatasetInputFacetsBuilder getInputFacetsBuilder();
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithIdentifier.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/InputDatasetWithIdentifier.java
@@ -9,13 +9,27 @@ import io.openlineage.client.OpenLineage.InputDatasetInputFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.util.Objects;
 
-/** Input dataset with an identifier containing namespace and name */
+/**
+ * Represents an input dataset with an associated {@link DatasetIdentifier} containing the dataset's
+ * namespace and name.
+ *
+ * <p>This class provides methods to retrieve the dataset's identifier, as well as builders for the
+ * dataset's facets and input dataset input facets. It implements both {@link
+ * InputDatasetWithFacets} and {@link DatasetWithIdentifier}.
+ */
 public class InputDatasetWithIdentifier implements InputDatasetWithFacets, DatasetWithIdentifier {
 
   private final DatasetIdentifier datasetIdentifier;
   private final DatasetFacetsBuilder facetsBuilder;
   private final InputDatasetInputFacetsBuilder inputFacetsBuilder;
 
+  /**
+   * Constructs a new {@code InputDatasetWithIdentifier}.
+   *
+   * @param datasetIdentifier the identifier of the dataset, containing its namespace and name
+   * @param facetsBuilder a builder for the dataset facets
+   * @param inputFacetsBuilder a builder for the input dataset input facets
+   */
   public InputDatasetWithIdentifier(
       DatasetIdentifier datasetIdentifier,
       DatasetFacetsBuilder facetsBuilder,
@@ -25,16 +39,36 @@ public class InputDatasetWithIdentifier implements InputDatasetWithFacets, Datas
     this.inputFacetsBuilder = inputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * <p>Dataset facets include general metadata associated with the dataset.
+   *
+   * @return the dataset facets builder
+   */
   @Override
   public DatasetFacetsBuilder getDatasetFacetsBuilder() {
     return facetsBuilder;
   }
 
+  /**
+   * Returns the {@link InputDatasetInputFacetsBuilder} for building input dataset input facets.
+   *
+   * <p>Input dataset facets include specific metadata related to the input datasets that are being
+   * used like data quality metrics.
+   *
+   * @return the input dataset input facets builder
+   */
   @Override
   public InputDatasetInputFacetsBuilder getInputFacetsBuilder() {
     return inputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetIdentifier} that contains the dataset's namespace and name.
+   *
+   * @return the dataset identifier
+   */
   @Override
   public DatasetIdentifier getDatasetIdentifier() {
     return datasetIdentifier;

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/LineageRelation.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/LineageRelation.java
@@ -8,11 +8,26 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 
 /**
- * Interface to be implemented for extension's classes extending
- * `org.apache.spark.sql.sources.BaseRelation`. Implementing it allows extracting lineage from such
- * objects. Implementing `getNamespace` and `getName` within the `DatasetIdentifier` is obligatory.
+ * Interface to be implemented by extension classes that extend {@code
+ * org.apache.spark.sql.sources.BaseRelation}.
+ *
+ * <p>Implementing this interface allows for the extraction of lineage information from {@code
+ * BaseRelation} objects. The methods {@code getNamespace} and {@code getName}, provided by {@link
+ * DatasetIdentifier}, must be implemented by the classes that implement this interface. This
+ * identifier must follow the naming conventions outlined in the <a
+ * href="https://openlineage.io/docs/spec/naming/">OpenLineage Naming Specification</a>, ensuring
+ * consistency across datasets for lineage tracking and data cataloging.
  */
 public interface LineageRelation {
+  /**
+   * Returns a {@link DatasetIdentifier} containing the namespace and name of the dataset for
+   * lineage tracking purposes.
+   *
+   * @param sparkListenerEventName the name of the Spark listener event triggering the lineage
+   *     extraction
+   * @param openLineage an instance of {@link OpenLineage} used for lineage-related operations
+   * @return a {@link DatasetIdentifier} representing the dataset associated with the event
+   */
   DatasetIdentifier getLineageDatasetIdentifier(
       String sparkListenerEventName, OpenLineage openLineage);
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/LineageRelationProvider.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/LineageRelationProvider.java
@@ -8,17 +8,32 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 
 /**
- * Interface for classes implementing `org.apache.spark.sql.sources.RelationProvider`.
- * `RelationProvider` implements `createRelation` with `SQLContext` and `parameters` as arguments.
- * We want this package to not depend on Spark's code which may be different across Spark versions.
+ * Interface for classes implementing {@code org.apache.spark.sql.sources.RelationProvider}.
  *
- * <p>We're aiming to have arguments of `getLineageDataset` the same as arguments of
- * `createRelation` within `RelationProvider`. When implementing this method, one can provide two
- * implementations: one with arguments exactly the same as with `RelationProvider`, and other
- * throwing an exception which should never be called.
+ * <p>The {@code RelationProvider} interface defines the {@code createRelation} method, which takes
+ * {@code SQLContext} and {@code parameters} as arguments. This interface enables lineage extraction
+ * from relation providers without directly depending on Spark's code, as the code may vary across
+ * different Spark versions.
+ *
+ * <p>To align with the {@code createRelation} method, the {@code getLineageDatasetIdentifier}
+ * method in this interface is designed to accept similar arguments. When implementing this method,
+ * classes can provide two versions: one that matches the arguments of {@code createRelation}, and
+ * another that throws an exception if it is ever called, ensuring compatibility across different
+ * implementations.
  */
 public interface LineageRelationProvider {
 
+  /**
+   * Returns a {@link DatasetIdentifier} containing the namespace and name of the dataset for
+   * lineage tracking purposes.
+   *
+   * @param sparkListenerEventName the name of the Spark listener event triggering the lineage
+   *     extraction
+   * @param openLineage an instance of {@link OpenLineage} used for lineage-related operations
+   * @param sqlContext the SQL context, typically used in Spark SQL queries
+   * @param parameters the parameters used by the relation provider to create the relation
+   * @return a {@link DatasetIdentifier} representing the dataset associated with the event
+   */
   DatasetIdentifier getLineageDatasetIdentifier(
       String sparkListenerEventName, OpenLineage openLineage, Object sqlContext, Object parameters);
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OlExprId.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OlExprId.java
@@ -7,7 +7,12 @@ package io.openlineage.spark.shade.extension.v1;
 import java.util.Objects;
 
 /**
- * Class to contain reference to Spark's ExprId without adding dependency to Spark library
+ * A class to hold a reference to Spark's {@code ExprId} without introducing a dependency on the
+ * Spark library.
+ *
+ * <p>This class serves as a lightweight alternative for storing {@code ExprId}, which is used in
+ * Spark's expression identifiers, while avoiding direct integration with Spark's internal
+ * libraries.
  *
  * @see <a
  *     href="https://github.com/apache/spark/blob/ce5ddad990373636e94071e7cef2f31021add07b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala#L48">namedExpressions.scala</a>
@@ -16,10 +21,20 @@ public final class OlExprId {
 
   private final Long exprId;
 
+  /**
+   * Constructs a new {@code OlExprId} with the specified expression identifier.
+   *
+   * @param exprId the expression identifier
+   */
   public OlExprId(Long exprId) {
     this.exprId = exprId;
   }
 
+  /**
+   * Returns the expression identifier.
+   *
+   * @return the expression identifier as a {@link Long}
+   */
   public Long getExprId() {
     return exprId;
   }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithDelegate.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithDelegate.java
@@ -8,13 +8,27 @@ import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.OutputDatasetOutputFacetsBuilder;
 import java.util.Objects;
 
-/** Output dataset with a node in LogicalPlan where a input dataset shall be extracted from */
+/**
+ * Represents an output dataset associated with a node in a LogicalPlan. This class allows for the
+ * extraction of metadata (facets) from output datasets.
+ *
+ * <p>It implements both {@link OutputDatasetWithFacets} and {@link DatasetWithDelegate}, providing
+ * methods to retrieve dataset facets, output dataset facets, and the node from which the dataset is
+ * extracted.
+ */
 public class OutputDatasetWithDelegate implements OutputDatasetWithFacets, DatasetWithDelegate {
 
   private final Object node;
   private final DatasetFacetsBuilder datasetFacetsBuilder;
   private final OutputDatasetOutputFacetsBuilder outputFacetsBuilder;
 
+  /**
+   * Constructs a new {@code OutputDatasetWithDelegate}.
+   *
+   * @param node the node in the LogicalPlan from which the output dataset is extracted
+   * @param datasetFacetsBuilder a builder for the dataset facets
+   * @param outputFacetsBuilder a builder for the output dataset output facets
+   */
   public OutputDatasetWithDelegate(
       Object node,
       DatasetFacetsBuilder datasetFacetsBuilder,
@@ -24,16 +38,35 @@ public class OutputDatasetWithDelegate implements OutputDatasetWithFacets, Datas
     this.outputFacetsBuilder = outputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * <p>Dataset facets include general metadata associated with the dataset.
+   *
+   * @return the dataset facets builder
+   */
   @Override
   public DatasetFacetsBuilder getDatasetFacetsBuilder() {
     return datasetFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link OutputDatasetOutputFacetsBuilder} for building output dataset facets.
+   *
+   * <p>Output dataset facets include specific metadata related to the output datasets.
+   *
+   * @return the output dataset facets builder
+   */
   @Override
   public OutputDatasetOutputFacetsBuilder getOutputFacetsBuilder() {
     return outputFacetsBuilder;
   }
 
+  /**
+   * Returns the node in the LogicalPlan from which the output dataset is extracted.
+   *
+   * @return the LogicalPlan node
+   */
   @Override
   public Object getNode() {
     return node;

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithFacets.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithFacets.java
@@ -7,8 +7,30 @@ package io.openlineage.spark.shade.extension.v1;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.OutputDatasetOutputFacetsBuilder;
 
+/**
+ * Interface representing an output dataset with associated facets (metadata).
+ *
+ * <p>Classes implementing this interface provide methods to retrieve builders for both dataset
+ * facets and output dataset facets. These facets capture metadata associated with the output
+ * dataset.
+ */
 public interface OutputDatasetWithFacets {
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * <p>Dataset facets include general metadata associated with the dataset.
+   *
+   * @return the dataset facets builder
+   */
   DatasetFacetsBuilder getDatasetFacetsBuilder();
 
+  /**
+   * Returns the {@link OutputDatasetOutputFacetsBuilder} for building output dataset facets.
+   *
+   * <p>Output dataset facets include specific metadata related to the output datasets being
+   * written.
+   *
+   * @return the output dataset facets builder
+   */
   OutputDatasetOutputFacetsBuilder getOutputFacetsBuilder();
 }

--- a/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithIdentifier.java
+++ b/integration/spark-extension-interfaces/src/main/java/io/openlineage/spark/shade/extension/v1/OutputDatasetWithIdentifier.java
@@ -9,13 +9,27 @@ import io.openlineage.client.OpenLineage.OutputDatasetOutputFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.util.Objects;
 
-/** Output dataset with an identifier containing namespace and name */
+/**
+ * Represents an output dataset associated with an identifier that includes the dataset's namespace
+ * and name.
+ *
+ * <p>This class provides methods to retrieve the dataset's identifier, as well as builders for the
+ * dataset's facets and output dataset facets. It implements both {@link OutputDatasetWithFacets}
+ * and {@link DatasetWithIdentifier}.
+ */
 public class OutputDatasetWithIdentifier implements OutputDatasetWithFacets, DatasetWithIdentifier {
 
   private final DatasetIdentifier datasetIdentifier;
   private final DatasetFacetsBuilder facetsBuilder;
   private final OutputDatasetOutputFacetsBuilder outputFacetsBuilder;
 
+  /**
+   * Constructs a new {@code OutputDatasetWithIdentifier}.
+   *
+   * @param datasetIdentifier the identifier of the dataset, containing its namespace and name
+   * @param facetsBuilder a builder for the dataset facets
+   * @param outputFacetsBuilder a builder for the output dataset facets
+   */
   public OutputDatasetWithIdentifier(
       DatasetIdentifier datasetIdentifier,
       DatasetFacetsBuilder facetsBuilder,
@@ -25,16 +39,36 @@ public class OutputDatasetWithIdentifier implements OutputDatasetWithFacets, Dat
     this.outputFacetsBuilder = outputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetFacetsBuilder} for building dataset facets.
+   *
+   * <p>Dataset facets include general metadata associated with the dataset.
+   *
+   * @return the dataset facets builder
+   */
   @Override
   public DatasetFacetsBuilder getDatasetFacetsBuilder() {
     return facetsBuilder;
   }
 
+  /**
+   * Returns the {@link OutputDatasetOutputFacetsBuilder} for building output dataset facets.
+   *
+   * <p>Output dataset facets include specific metadata related to the output datasets that are
+   * being written.
+   *
+   * @return the output dataset facets builder
+   */
   @Override
   public OutputDatasetOutputFacetsBuilder getOutputFacetsBuilder() {
     return outputFacetsBuilder;
   }
 
+  /**
+   * Returns the {@link DatasetIdentifier} that contains the dataset's namespace and name.
+   *
+   * @return the dataset identifier
+   */
   @Override
   public DatasetIdentifier getDatasetIdentifier() {
     return datasetIdentifier;


### PR DESCRIPTION
### Problem

While building process, there is a dozen of warnings complaining that the javadocs for spark-extension-interfaces are not present.

### Solution

We should have javadocs for public interfaces.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project