### PR TITLE
sqlparser: fix subquery column lineage.

### DIFF
--- a/integration/sql/impl/src/context/mod.rs
+++ b/integration/sql/impl/src/context/mod.rs
@@ -352,8 +352,6 @@ impl<'a> Context<'a> {
 
                 if !traversed.is_empty() {
                     expanded.extend(traversed.iter().cloned());
-                } else {
-                    expanded.insert(ancestor.clone());
                 }
             }
             result.insert(col.clone(), expanded);
@@ -371,15 +369,31 @@ impl<'a> Context<'a> {
         stack.push(ancestor.clone());
 
         while let Some(current) = stack.pop() {
-            let column_ancestors = old.column_ancestry.get(&current);
+            let column_ancestors = old
+                .column_ancestry
+                .get(&current)
+                // try to find by name in case of column without origin
+                // this can happen when selecting from subqery without alias
+                .or_else(|| {
+                    old.column_ancestry.iter().find_map(|(col, anc)| {
+                        if col.name == current.name && current.origin.is_none() {
+                            Some(anc)
+                        } else {
+                            None
+                        }
+                    })
+                });
             if column_ancestors.is_none() {
                 result.push(current.clone());
                 continue;
             }
 
             if let Some(ancestors) = column_ancestors {
-                for ancestor in ancestors {
-                    stack.push(ancestor.clone());
+                for anc in ancestors {
+                    // avoid infinite loop
+                    if anc != &current {
+                        stack.push(anc.clone());
+                    }
                 }
             }
         }
@@ -434,8 +448,6 @@ impl<'a> Context<'a> {
 
             if !removed_circular_deps.is_empty() {
                 frame.column_ancestry.extend(old_ancestry);
-            } else {
-                frame.column_ancestry.extend(removed_circular_deps);
             }
 
             frame.dependencies.extend(old.dependencies);

--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -555,9 +555,8 @@ impl Visit for Query {
             context.unset_frame_to_main_body();
         }
 
-        match &self.with {
-            Some(with) => with.visit(context)?,
-            None => (),
+        if let Some(with) = &self.with {
+            with.visit(context)?
         }
         let with_frame = context.pop_frame().unwrap();
 


### PR DESCRIPTION
### Problem

Column lineage with unaliased queries cause infinite loop in `expand_ancestors` introduced in #3107. The logic considered subqueries as CTEs. However, subqueries may remain without alias.

cc: @Imbruced

### Solution

Adjust logic in `expand_ancestors`. Couple of related lines changed as small improvements.

#### One-line summary:

SQL Parser: Fixes column lineage for unaliased subqueries.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project