### PR TITLE
java: migrate and bump httpclient version

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4'
     implementation 'commons-logging:commons-logging:1.3.4'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation "io.micrometer:micrometer-core:${micrometerVersion}"


### PR DESCRIPTION
### Problem & Solution

This is a security fix as the current `httpclient` is vulnerable. Moreover, the artifact that java client uses is now migrated from [org.apache.httpcomponents](https://mvnrepository.com/artifact/org.apache.httpcomponents) » [httpclient](https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient) to [org.apache.httpcomponents.client5](https://mvnrepository.com/artifact/org.apache.httpcomponents.client5) » [httpclient5](https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5)

Closes: https://github.com/OpenLineage/OpenLineage/issues/3182

#### One-line summary:
Migrate httpclient artifact to httpclient5 and update version.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project