### PR TITLE
fix: Fix missing WEB_PORT variable where marquez-web container is used.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,12 +151,13 @@ jobs:
             - run:
                 name: Remove approval steps if not pull from forks.
                 command: |
-                  pip install pyyaml==6.0.1                  
+                  pip install pyyaml==6.0.1
                   python dev/filter_approvals.py
       - run: |
           export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.currentBranch.labels[]; .name == "full-tests")')
           echo $IS_FULL_TESTS
           if [ -z "$IS_FULL_TESTS" ] || [ "$IS_FULL_TESTS" == "0" ]; then
+            pip install pyyaml==6.0.1
             python dev/filter_matrix.py 
           fi
       - when:

--- a/integration/spark/docker-compose.yml
+++ b/integration/spark/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     environment:
       - MARQUEZ_HOST=marquez-api
       - MARQUEZ_PORT=5000
+      - WEB_PORT=3000
     ports:
       - "3000:3000"
     stdin_open: true

--- a/proxy/backend/docker-compose.yml
+++ b/proxy/backend/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     environment:
       - MARQUEZ_HOST=marquez-api
       - MARQUEZ_PORT=5000
+      - WEB_PORT=3000
     ports:
       - "3000:3000"
     stdin_open: true

--- a/proxy/fluentd/docker/docker-compose.yml
+++ b/proxy/fluentd/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       - MARQUEZ_HOST=marquez-api
       - MARQUEZ_PORT=5000
+      - WEB_PORT=3000
     ports:
       - "3000:3000"
     stdin_open: true

--- a/website/blog/openlineage-spark/index.mdx
+++ b/website/blog/openlineage-spark/index.mdx
@@ -211,7 +211,7 @@ For exploring visually, we’ll also want to start up the Marquez web project. W
 containers, run the following command in a new terminal:
 
 ```bash
-docker run --network spark_default -p 3000:3000 -e MARQUEZ_HOST=marquez-api -e MARQUEZ_PORT=5000 --link marquez-api:marquez-api marquezproject/marquez-web:0.19.1
+docker run --network spark_default -p 3000:3000 -e MARQUEZ_HOST=marquez-api -e MARQUEZ_PORT=5000 -e WEB_PORT=3000 --link marquez-api:marquez-api marquezproject/marquez-web:0.19.1
 ```
 
 Now open a new browser tab and navigate to `http://localhost:3000`. You should see a screen like the following:

--- a/website/docs/guides/airflow-quickstart.md
+++ b/website/docs/guides/airflow-quickstart.md
@@ -110,6 +110,7 @@ services:
     environment:
       - MARQUEZ_HOST=api
       - MARQUEZ_PORT=5000
+      - WEB_PORT=3000
     ports:
       - "3000:3000"
     depends_on:

--- a/website/docs/guides/spark.md
+++ b/website/docs/guides/spark.md
@@ -151,7 +151,7 @@ Now that the pipeline is operational it is available for lineage collection.
 The `docker-compose.yml` file that ships with the OpenLineage repo includes only the Jupyter notebook and the Marquez API. To explore the lineage visually, start up the Marquez web project. Without terminating the existing docker containers, run the following command in a new terminal:
 
 ```
-docker run --network spark_default -p 3000:3000 -e MARQUEZ_HOST=marquez-api -e MARQUEZ_PORT=5000 --link marquez-api:marquez-api marquezproject/marquez-web:0.19.1
+docker run --network spark_default -p 3000:3000 -e MARQUEZ_HOST=marquez-api -e MARQUEZ_PORT=5000 -e WEB_PORT=3000 --link marquez-api:marquez-api marquezproject/marquez-web:0.19.1
 ```
 
 Next, open a new browser tab and navigate to http://localhost:3000, which should look like this:


### PR DESCRIPTION
### Problem

Marquez web container is using proxy which since August is configured via environment variable WEB_PORT. Without it the application doesn't start.

Is related to, but probably not closes: https://github.com/OpenLineage/OpenLineage/issues/3185

### Solution

Every usage of marquez-web should pass this variable.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project