### PR TITLE
Add JobTypeJobFacets to dbt integration's model, test, snapshot events

### DIFF
--- a/integration/common/tests/dbt/build/result.json
+++ b/integration/common/tests/dbt/build/result.json
@@ -43,7 +43,13 @@
 			}
 		],
 		"job": {
-			"facets": {},
+			"facets": {
+				"jobType": {
+					"jobType": "MODEL",
+					"integration": "DBT",
+					"processingType": "BATCH"
+				}
+			},
 			"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.run",
 			"namespace": "job-namespace"
 		},
@@ -77,7 +83,13 @@
 			}
 		],
 		"job": {
-			"facets": {},
+			"facets": {
+				"jobType": {
+					"jobType": "SNAPSHOT",
+					"integration": "DBT",
+					"processingType": "BATCH"
+				}
+			},
 			"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.orders_snapshot.build.snapshot",
 			"namespace": "job-namespace"
 		},
@@ -154,7 +166,13 @@
 			}
 		],
 		"job": {
-			"facets": {},
+			"facets": {
+				"jobType": {
+					"jobType": "TEST",
+					"integration": "DBT",
+					"processingType": "BATCH"
+				}
+			},
 			"name": "random-gcp-project.dbt_test1.dbt_bigquery_test.test_first_dbt_model.build.test",
 			"namespace": "job-namespace"
 		},

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -358,6 +358,11 @@
 		"facets": {
 			"sql": {
 				"query": "with customers as (\n\n    select * from DEMO_DB.public.stg_customers\n\n),\n\norders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final"
+			},
+			"jobType": {
+				"jobType": "MODEL",
+				"integration": "DBT",
+				"processingType": "BATCH"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -37,6 +37,11 @@
 		"facets": {
 			"sql": {
 				"query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1"
+			},
+			"jobType": {
+				"jobType": "MODEL",
+				"integration": "DBT",
+				"processingType": "BATCH"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/snapshot/result.json
+++ b/integration/common/tests/dbt/snapshot/result.json
@@ -102,6 +102,11 @@
           "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
           "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SQLJobFacet.json#/$defs/SQLJobFacet",
           "query": "\n\n\n\nselect * from \"postgres\".\"postgres\".\"my_second_dbt_model\"\n"
+        },
+        "jobType": {
+          "jobType": "SNAPSHOT",
+          "integration": "DBT",
+          "processingType": "BATCH"
         }
       },
       "name": "postgres.postgres.snapshot_test.orders_snapshot.snapshot",


### PR DESCRIPTION
Currently, dbt events do not have JobTypeJobFacet added to them. This PR adds them, allowing consumers to correctly determine job type without need to look up the events for parent runs.