### PR TITLE
Fix issues in AirflowRunFacet.json

### DIFF
--- a/integration/airflow/facets/AirflowRunFacet.json
+++ b/integration/airflow/facets/AirflowRunFacet.json
@@ -1,4 +1,3 @@
-// TODO: that is Airflow specific facet that should be placed in new system-specific directory
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://openlineage.io/spec/facets/1-0-0/AirflowRunFacet.json",
@@ -101,7 +100,7 @@
           "type": "string"
         },
         "tags": {
-          "type": "string"
+          "type": "array"
         },
         "start_date": {
           "type": "string",
@@ -134,7 +133,7 @@
         }
       },
       "additionalProperties": true,
-      "required": ["duration", "try_number"]
+      "required": ["try_number"]
     },
     "DagRun": {
       "type": "object",


### PR DESCRIPTION
### Problem
The provided [AirflowRunFacet.json](https://github.com/OpenLineage/OpenLineage/blob/main/integration/airflow/facets/AirflowRunFacet.json) currently isn't usable to validate OpenLineage logs that contain the AirflowRunFacet.
This is due to three issues:
1. TODO comment on first line makes a simple curl request of:
https://raw.githubusercontent.com/OpenLineage/OpenLineage/refs/heads/main/integration/airflow/facets/AirflowRunFacet.json 
unusable because it doesn't return valid json (the comment line makes it invalid).
2. The `tags` field in `DAG` should be of type array instead of string.
3. The `duration` field in `TaskInstance` shouldn't be mandatory. This field isn't always included in logs created by the Airflow extractor.

### Solution
To solve the issues described above the following was implemented:
1. Removed comment line so that AirflowRunFacet.json is usable as-is.
2. Changed type of `tags` to array instead of string.
3. Removed `duration` as a mandatory field in the `TaskInstance` field.

Closes #3203