### PR TITLE
test: Exit early when the Databricks integration test has unexpected version of the Spark passed.

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksEnvironment.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksEnvironment.java
@@ -332,13 +332,18 @@ public class DatabricksEnvironment implements AutoCloseable {
   }
 
   private String getSparkPlatformVersion() {
-    String sparkVersion = properties.cluster.getSparkVersion();
+    String sparkVersion = properties.getCluster().getSparkVersion();
     if (!PLATFORM_VERSIONS_NAMES.containsKey(sparkVersion)) {
-      log.error("Unsupported [spark.version] for databricks test: [{}].", sparkVersion);
+      log.error(
+          "Unsupported [spark.version] for Databricks test: [{}]. Supported versions are {}",
+          sparkVersion,
+          PLATFORM_VERSIONS_NAMES.keySet());
+      throw new IllegalStateException("Unsupported [spark.version] for Databricks");
     }
 
-    log.info("Databricks version: [{}].", PLATFORM_VERSIONS_NAMES.get(sparkVersion));
-    return PLATFORM_VERSIONS_NAMES.get(sparkVersion);
+    String platformVersion = PLATFORM_VERSIONS_NAMES.get(sparkVersion);
+    log.info("Databricks version: [{}].", platformVersion);
+    return platformVersion;
   }
 
   /**


### PR DESCRIPTION

### Problem

When someone misconfigures integration tests they proceed giving the impression that something else is wrong.

### Solution

We should fail fast.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project