### PR TITLE
Enable building input/output facets from the visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.24.0...HEAD)
 
+### Changed
+
+* **Spark: enables building input/output facets through `DatasetFactory`** [`#3207`](https://github.com/OpenLineage/OpenLineage/pull/3207) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+   *Adds extra capabilities into `DatasetFactory` class, marks some public developers' API methods as deprecated.*
+
 ## [1.24.0](https://github.com/OpenLineage/OpenLineage/compare/1.23.0...1.24.0) - 2024-11-05
 
 ### Added

--- a/client/java/src/main/java/io/openlineage/client/dataset/DatasetCompositeFacetsBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/DatasetCompositeFacetsBuilder.java
@@ -6,16 +6,16 @@
 package io.openlineage.client.dataset;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.Dataset;
 import io.openlineage.client.OpenLineage.InputDatasetInputFacetsBuilder;
 import io.openlineage.client.OpenLineage.OutputDatasetOutputFacetsBuilder;
 import lombok.Getter;
+import lombok.Setter;
 
 /** Builder class to include both dataset and input/output facets in a single class. */
-public class DatasetCompositeFacetsBuilder<D extends Dataset> {
+public class DatasetCompositeFacetsBuilder {
   private OpenLineage openLineage;
 
-  @Getter private OpenLineage.DatasetFacetsBuilder facets;
+  @Setter @Getter private OpenLineage.DatasetFacetsBuilder facets;
 
   @Getter private InputDatasetInputFacetsBuilder inputFacets;
 

--- a/client/java/src/main/java/io/openlineage/client/dataset/DatasetCompositeFacetsBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/DatasetCompositeFacetsBuilder.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.dataset;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.Dataset;
+import io.openlineage.client.OpenLineage.InputDatasetInputFacetsBuilder;
+import io.openlineage.client.OpenLineage.OutputDatasetOutputFacetsBuilder;
+import lombok.Getter;
+
+/** Builder class to include both dataset and input/output facets in a single class. */
+public class DatasetCompositeFacetsBuilder<D extends Dataset> {
+  private OpenLineage openLineage;
+
+  @Getter private OpenLineage.DatasetFacetsBuilder facets;
+
+  @Getter private InputDatasetInputFacetsBuilder inputFacets;
+
+  @Getter private OutputDatasetOutputFacetsBuilder outputFacets;
+
+  public DatasetCompositeFacetsBuilder(OpenLineage openLineage) {
+    this.openLineage = openLineage;
+
+    this.facets = this.openLineage.newDatasetFacetsBuilder();
+    this.inputFacets = this.openLineage.newInputDatasetInputFacetsBuilder();
+    this.outputFacets = this.openLineage.newOutputDatasetOutputFacetsBuilder();
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AlterTableRenameCommandVisitor.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -62,12 +63,14 @@ public class AlterTableRenameCommandVisitor
             .build();
 
     DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
-    return Collections.singletonList(
-        factory.getDataset(
-            di,
-            new OpenLineage.DatasetFacetsBuilder()
-                .schema(PlanUtils.schemaFacet(context.getOpenLineage(), table.schema()))
-                .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
-                .lifecycleStateChange(lifecycleStateChangeDatasetFacet)));
+
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
+    datasetFacetsBuilder
+        .getFacets()
+        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), table.schema()))
+        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), di.getNamespace()))
+        .lifecycleStateChange(lifecycleStateChangeDatasetFacet);
+
+    return Collections.singletonList(factory.getDataset(di, datasetFacetsBuilder));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitor.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -44,19 +45,17 @@ public class DropTableCommandVisitor
         PathUtils.fromCatalogTable(table.get(), context.getSparkSession().get());
 
     DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
-    return Collections.singletonList(
-        factory.getDataset(
-            datasetIdentifier,
-            new OpenLineage.DatasetFacetsBuilder()
-                .schema(null)
-                .dataSource(
-                    PlanUtils.datasourceFacet(
-                        context.getOpenLineage(), datasetIdentifier.getNamespace()))
-                .lifecycleStateChange(
-                    context
-                        .getOpenLineage()
-                        .newLifecycleStateChangeDatasetFacet(
-                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP,
-                            null))));
+    DatasetCompositeFacetsBuilder facetsBuilder = factory.createCompositeFacetBuilder();
+    facetsBuilder
+        .getFacets()
+        .schema(null)
+        .dataSource(
+            PlanUtils.datasourceFacet(context.getOpenLineage(), datasetIdentifier.getNamespace()))
+        .lifecycleStateChange(
+            context
+                .getOpenLineage()
+                .newLifecycleStateChangeDatasetFacet(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP, null));
+    return Collections.singletonList(factory.getDataset(datasetIdentifier, facetsBuilder));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/TruncateTableCommandVisitor.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
@@ -47,21 +48,19 @@ public class TruncateTableCommandVisitor
         PathUtils.fromCatalogTable(table, context.getSparkSession().get());
 
     DatasetFactory<OutputDataset> datasetFactory = outputDataset();
-    return Collections.singletonList(
-        datasetFactory.getDataset(
-            datasetIdentifier,
-            new OpenLineage.DatasetFacetsBuilder()
-                .schema(null)
-                .dataSource(
-                    PlanUtils.datasourceFacet(
-                        context.getOpenLineage(), datasetIdentifier.getNamespace()))
-                .lifecycleStateChange(
-                    context
-                        .getOpenLineage()
-                        .newLifecycleStateChangeDatasetFacet(
-                            OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange
-                                .TRUNCATE,
-                            null))));
+    DatasetCompositeFacetsBuilder facetsBuilder = datasetFactory.createCompositeFacetBuilder();
+    facetsBuilder
+        .getFacets()
+        .schema(null)
+        .dataSource(
+            PlanUtils.datasourceFacet(context.getOpenLineage(), datasetIdentifier.getNamespace()))
+        .lifecycleStateChange(
+            context
+                .getOpenLineage()
+                .newLifecycleStateChangeDatasetFacet(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.TRUNCATE,
+                    null));
+    return Collections.singletonList(datasetFactory.getDataset(datasetIdentifier, facetsBuilder));
   }
 
   @Override

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/handlers/ExtensionLineageRelationHandler.java
@@ -37,7 +37,7 @@ public class ExtensionLineageRelationHandler<D extends Dataset> {
       return Collections.singletonList(datasetFactory.getDataset(di, x.schema()));
     } else {
       return Collections.singletonList(
-          datasetFactory.getDataset(di, context.getOpenLineage().newDatasetFacetsBuilder()));
+          datasetFactory.getDataset(di, datasetFactory.createCompositeFacetBuilder()));
     }
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlUtils.java
@@ -41,7 +41,7 @@ public class SqlUtils {
                               new DatasetIdentifier(
                                   getName(defaultDatabase, defaultSchema, dbtm.qualifiedName()),
                                   namespace),
-                              new OpenLineage.DatasetFacetsBuilder());
+                              datasetFactory.createCompositeFacetBuilder());
                         })
                     .collect(Collectors.toList()))
         .orElse(Collections.emptyList());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -7,6 +7,7 @@ package io.openlineage.spark.api;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
@@ -42,7 +43,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
   }
 
   abstract OpenLineage.Builder<D> datasetBuilder(
-      String name, String namespace, OpenLineage.DatasetFacets datasetFacet);
+      String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder);
 
   /**
    * Create a {@link DatasetFactory} that constructs only {@link OpenLineage.InputDataset}s.
@@ -54,13 +55,14 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
     return new DatasetFactory<OpenLineage.InputDataset>(context) {
       @Override
       public OpenLineage.Builder<OpenLineage.InputDataset> datasetBuilder(
-          String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {
+          String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder) {
         return context
             .getOpenLineage()
             .newInputDatasetBuilder()
             .namespace(namespaceResolver.resolve(namespace))
             .name(name)
-            .facets(datasetFacet);
+            .inputFacets(facetsBuilder.getInputFacets().build())
+            .facets(facetsBuilder.getFacets().build());
       }
     };
   }
@@ -75,13 +77,14 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
     return new DatasetFactory<OpenLineage.OutputDataset>(context) {
       @Override
       public OpenLineage.Builder<OpenLineage.OutputDataset> datasetBuilder(
-          String name, String namespace, OpenLineage.DatasetFacets datasetFacet) {
+          String name, String namespace, DatasetCompositeFacetsBuilder facetsBuilder) {
         return context
             .getOpenLineage()
             .newOutputDatasetBuilder()
             .namespace(namespaceResolver.resolve(namespace))
             .name(name)
-            .facets(datasetFacet);
+            .outputFacets(facetsBuilder.getOutputFacets().build())
+            .facets(facetsBuilder.getFacets().build());
       }
     };
   }
@@ -96,7 +99,15 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @return
    */
   public D getDataset(String name, String namespace, StructType schema) {
-    return datasetBuilder(name, namespace, datasetFacetBuilder(schema, namespace).build()).build();
+    DatasetCompositeFacetsBuilder facetsBuilder = createCompositeFacetBuilder();
+    facetsBuilder
+        .getFacets()
+        .dataSource(
+            PlanUtils.datasourceFacet(
+                context.getOpenLineage(), namespaceResolver.resolve(namespace)))
+        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema));
+
+    return datasetBuilder(name, namespace, facetsBuilder).build();
   }
 
   /**
@@ -108,11 +119,14 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @return
    */
   public D getDataset(
-      URI outputPath, StructType schema, OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder) {
+      URI outputPath, StructType schema, DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
     String namespace = PlanUtils.namespaceUri(outputPath);
     datasetFacetsBuilder
+        .getFacets()
         .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
-        .dataSource(PlanUtils.datasourceFacet(context.getOpenLineage(), namespace));
+        .dataSource(
+            PlanUtils.datasourceFacet(
+                context.getOpenLineage(), namespaceResolver.resolve(namespace)));
 
     return getDataset(new DatasetIdentifier(outputPath.getPath(), namespace), datasetFacetsBuilder);
   }
@@ -127,7 +141,15 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    */
   public D getDataset(URI outputPath, StructType schema) {
     String namespace = PlanUtils.namespaceUri(outputPath);
-    return getDataset(PathUtils.fromURI(outputPath), datasetFacetBuilder(schema, namespace));
+    DatasetCompositeFacetsBuilder facetsBuilder = createCompositeFacetBuilder();
+    facetsBuilder
+        .getFacets()
+        .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
+        .dataSource(
+            PlanUtils.datasourceFacet(
+                context.getOpenLineage(), namespaceResolver.resolve(namespace)));
+
+    return getDataset(PathUtils.fromURI(outputPath), facetsBuilder);
   }
 
   /**
@@ -138,8 +160,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @return
    */
   public D getDataset(DatasetIdentifier ident, StructType schema) {
-    OpenLineage.DatasetFacetsBuilder facetsBuilder =
-        datasetFacetBuilder(schema, ident.getNamespace());
+    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
     includeSymlinksFacet(facetsBuilder, ident);
     return getDataset(ident, facetsBuilder);
   }
@@ -155,16 +176,18 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    */
   public D getDataset(
       DatasetIdentifier ident, StructType schema, LifecycleStateChange lifecycleStateChange) {
-    OpenLineage.DatasetFacetsBuilder facetsBuilder =
-        datasetFacetBuilder(schema, ident.getNamespace());
-    facetsBuilder.lifecycleStateChange(
-        context.getOpenLineage().newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null));
+    DatasetCompositeFacetsBuilder facetsBuilder = datasetFacetBuilder(schema, ident.getNamespace());
+    facetsBuilder
+        .getFacets()
+        .lifecycleStateChange(
+            context
+                .getOpenLineage()
+                .newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null));
     includeSymlinksFacet(facetsBuilder, ident);
     return getDataset(new DatasetIdentifier(ident.getName(), ident.getNamespace()), facetsBuilder);
   }
 
-  private void includeSymlinksFacet(
-      OpenLineage.DatasetFacetsBuilder builder, DatasetIdentifier di) {
+  private void includeSymlinksFacet(DatasetCompositeFacetsBuilder builder, DatasetIdentifier di) {
     if (!di.getSymlinks().isEmpty()) {
       List<OpenLineage.SymlinksDatasetFacetIdentifiers> symlinks =
           di.getSymlinks().stream()
@@ -179,7 +202,7 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
                           .build())
               .collect(Collectors.toList());
 
-      builder.symlinks(context.getOpenLineage().newSymlinksDatasetFacet(symlinks));
+      builder.getFacets().symlinks(context.getOpenLineage().newSymlinksDatasetFacet(symlinks));
     }
   }
 
@@ -191,13 +214,13 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @param facetsBuilder
    * @return
    */
-  public D getDataset(DatasetIdentifier ident, OpenLineage.DatasetFacetsBuilder facetsBuilder) {
+  public D getDataset(DatasetIdentifier ident, DatasetCompositeFacetsBuilder facetsBuilder) {
     includeSymlinksFacet(facetsBuilder, ident);
-    return datasetBuilder(ident.getName(), ident.getNamespace(), facetsBuilder.build()).build();
+    return datasetBuilder(ident.getName(), ident.getNamespace(), facetsBuilder).build();
   }
 
   public D getDataset(String name, String namespace) {
-    return datasetBuilder(name, namespace, datasetFacetBuilder(namespace).build()).build();
+    return datasetBuilder(name, namespace, datasetFacetBuilder(namespace)).build();
   }
 
   /**
@@ -207,23 +230,30 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
    * @param namespaceUri
    * @return
    */
-  private OpenLineage.DatasetFacetsBuilder datasetFacetBuilder(
+  private DatasetCompositeFacetsBuilder datasetFacetBuilder(
       StructType schema, String namespaceUri) {
-    return context
-        .getOpenLineage()
-        .newDatasetFacetsBuilder()
+    DatasetCompositeFacetsBuilder builder = createCompositeFacetBuilder();
+    builder
+        .getFacets()
         .schema(PlanUtils.schemaFacet(context.getOpenLineage(), schema))
         .dataSource(
             PlanUtils.datasourceFacet(
                 context.getOpenLineage(), namespaceResolver.resolve(namespaceUri)));
+    return builder;
   }
 
-  private OpenLineage.DatasetFacetsBuilder datasetFacetBuilder(String namespaceUri) {
-    return context
-        .getOpenLineage()
-        .newDatasetFacetsBuilder()
+  private DatasetCompositeFacetsBuilder datasetFacetBuilder(String namespaceUri) {
+    DatasetCompositeFacetsBuilder builder = createCompositeFacetBuilder();
+    builder
+        .getFacets()
         .dataSource(
             PlanUtils.datasourceFacet(
                 context.getOpenLineage(), namespaceResolver.resolve(namespaceUri)));
+
+    return builder;
+  }
+
+  public DatasetCompositeFacetsBuilder createCompositeFacetBuilder() {
+    return new DatasetCompositeFacetsBuilder(context.getOpenLineage());
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetBuilder.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -43,10 +44,10 @@ public class DataSourceV2RelationInputDatasetBuilder
 
   @Override
   public List<OpenLineage.InputDataset> apply(DataSourceV2Relation relation) {
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        context.getOpenLineage().newDatasetFacetsBuilder();
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
 
-    DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, relation);
+    DatasetVersionDatasetFacetUtils.includeDatasetVersion(
+        context, datasetFacetsBuilder.getFacets(), relation);
     return DataSourceV2RelationDatasetExtractor.extract(
         factory, context, relation, datasetFacetsBuilder);
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -50,12 +51,10 @@ public class DataSourceV2RelationOutputDatasetBuilder
       return getTableOutputs(relation);
     }
 
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        context.getOpenLineage().newDatasetFacetsBuilder();
-
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
     if (includeDatasetVersion(event)) {
       DatasetVersionDatasetFacetUtils.includeDatasetVersion(
-          context, datasetFacetsBuilder, relation);
+          context, datasetFacetsBuilder.getFacets(), relation);
     }
     return DataSourceV2RelationDatasetExtractor.extract(
         factory, context, relation, datasetFacetsBuilder);

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -48,8 +48,8 @@ public final class DataSourceV2ScanRelationOnEndInputDatasetBuilder
     }
 
     DataSourceV2Relation relation = plan.relation();
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        context.getOpenLineage().newDatasetFacetsBuilder();
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder =
+        new DatasetCompositeFacetsBuilder(context.getOpenLineage());
     return DataSourceV2RelationDatasetExtractor.extract(
         factory, context, relation, datasetFacetsBuilder);
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
@@ -5,8 +5,8 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
-import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -50,10 +50,10 @@ public final class DataSourceV2ScanRelationOnStartInputDatasetBuilder
     }
 
     DataSourceV2Relation relation = plan.relation();
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        context.getOpenLineage().newDatasetFacetsBuilder();
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
 
-    DatasetVersionDatasetFacetUtils.includeDatasetVersion(context, datasetFacetsBuilder, relation);
+    DatasetVersionDatasetFacetUtils.includeDatasetVersion(
+        context, datasetFacetsBuilder.getFacets(), relation);
     return DataSourceV2RelationDatasetExtractor.extract(
         factory, context, relation, datasetFacetsBuilder);
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -62,7 +62,7 @@ public class TableContentChangeDatasetBuilder
     }
 
     final DatasetCompositeFacetsBuilder datasetFacetsBuilder =
-        new DatasetCompositeFacetsBuilder<>(context.getOpenLineage());
+        new DatasetCompositeFacetsBuilder(context.getOpenLineage());
     if (includeOverwriteFacet) {
       datasetFacetsBuilder
           .getFacets()

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.IcebergHandler;
@@ -60,15 +61,17 @@ public class TableContentChangeDatasetBuilder
       includeOverwriteFacet = true;
     }
 
-    final OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        context.getOpenLineage().newDatasetFacetsBuilder();
+    final DatasetCompositeFacetsBuilder datasetFacetsBuilder =
+        new DatasetCompositeFacetsBuilder<>(context.getOpenLineage());
     if (includeOverwriteFacet) {
-      datasetFacetsBuilder.lifecycleStateChange(
-          context
-              .getOpenLineage()
-              .newLifecycleStateChangeDatasetFacet(
-                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE,
-                  null));
+      datasetFacetsBuilder
+          .getFacets()
+          .lifecycleStateChange(
+              context
+                  .getOpenLineage()
+                  .newLifecycleStateChangeDatasetFacet(
+                      OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE,
+                      null));
     }
 
     // FIXME: Use 'castToDataSourceV2Relation()' to safely cast 'DataSourceV2ScanRelation' to
@@ -81,7 +84,7 @@ public class TableContentChangeDatasetBuilder
             : (DataSourceV2Relation) table;
     if (includeDatasetVersion(event)) {
       DatasetVersionDatasetFacetUtils.includeDatasetVersion(
-          context, datasetFacetsBuilder, returnTable);
+          context, datasetFacetsBuilder.getFacets(), returnTable);
     }
 
     return DataSourceV2RelationDatasetExtractor.extract(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.utils;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
@@ -26,15 +27,14 @@ public class DataSourceV2RelationDatasetExtractor {
 
   public static <D extends OpenLineage.Dataset> List<D> extract(
       DatasetFactory<D> datasetFactory, OpenLineageContext context, DataSourceV2Relation relation) {
-    return extract(
-        datasetFactory, context, relation, context.getOpenLineage().newDatasetFacetsBuilder());
+    return extract(datasetFactory, context, relation, datasetFactory.createCompositeFacetBuilder());
   }
 
   public static <D extends OpenLineage.Dataset> List<D> extract(
       DatasetFactory<D> datasetFactory,
       OpenLineageContext context,
       DataSourceV2Relation relation,
-      OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder) {
+      DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
 
     OpenLineage openLineage = context.getOpenLineage();
     Optional<DatasetIdentifier> di = getDatasetIdentifierExtended(context, relation);
@@ -47,9 +47,12 @@ public class DataSourceV2RelationDatasetExtractor {
 
                 Map<String, String> tableProperties = relation.table().properties();
                 CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-                    .map(storageDatasetFacet -> datasetFacetsBuilder.storage(storageDatasetFacet));
+                    .map(
+                        storageDatasetFacet ->
+                            datasetFacetsBuilder.getFacets().storage(storageDatasetFacet));
               }
               datasetFacetsBuilder
+                  .getFacets()
                   .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
                   .dataSource(PlanUtils.datasourceFacet(openLineage, identifier.getNamespace()));
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
@@ -19,6 +19,7 @@ import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
 import io.openlineage.client.OpenLineage.StorageDatasetFacet;
 import io.openlineage.client.OpenLineage.SymlinksDatasetFacet;
 import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ class ExtensionDataSourceV2Utils {
    */
   public static void loadBuilder(
       OpenLineage openLineage,
-      OpenLineage.DatasetFacetsBuilder builder,
+      DatasetCompositeFacetsBuilder builder,
       DataSourceV2Relation relation) {
     Map<String, String> properties = relation.table().properties();
 
@@ -70,7 +71,7 @@ class ExtensionDataSourceV2Utils {
                     OpenLineageClientUtils.fromJson(
                         properties.get(OPENLINEAGE_DATASET_FACETS_PREFIX + field),
                         predefinedFacets.get(field));
-                FieldUtils.writeField(builder, field, o, true);
+                FieldUtils.writeField(builder.getFacets(), field, o, true);
               } catch (IllegalAccessException | RuntimeException e) {
                 log.warn("Couldn't serialize and assign facet", e);
               }
@@ -88,10 +89,12 @@ class ExtensionDataSourceV2Utils {
                     OpenLineageClientUtils.fromJson(
                         properties.get(OPENLINEAGE_DATASET_FACETS_PREFIX + key),
                         new TypeReference<DatasetFacet>() {});
-                builder.put(
-                    key,
-                    enrichWithProducerUrl(
-                        datasetFacet, openLineage.newDatasetFacet().get_producer()));
+                builder
+                    .getFacets()
+                    .put(
+                        key,
+                        enrichWithProducerUrl(
+                            datasetFacet, openLineage.newDatasetFacet().get_producer()));
               } catch (RuntimeException e) {
                 log.warn("Couldn't serialize and assign facet", e);
               }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/AppendDataDatasetBuilderTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.withSettings;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
@@ -66,6 +67,8 @@ class AppendDataDatasetBuilderTest {
     DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
     OpenLineage.OutputDataset dataset = mock(OpenLineage.OutputDataset.class);
     when(appendData.table()).thenReturn(relation);
+    when(factory.createCompositeFacetBuilder())
+        .thenReturn(mock(DatasetCompositeFacetsBuilder.class));
 
     try (MockedStatic mockedPlanUtils3 = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationDatasetBuilderTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
@@ -73,14 +74,13 @@ class DataSourceV2RelationDatasetBuilderTest {
       OpenLineageContext context,
       DatasetFactory factory,
       OpenLineage openLineage) {
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        mock(OpenLineage.DatasetFacetsBuilder.class);
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder = mock(DatasetCompositeFacetsBuilder.class);
     List<OpenLineage.InputDataset> datasets = mock(List.class);
 
-    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(context.getSparkExtensionVisitorWrapper())
         .thenReturn(mock(SparkOpenLineageExtensionVisitorWrapper.class));
+    when(factory.createCompositeFacetBuilder()).thenReturn(datasetFacetsBuilder);
 
     try (MockedStatic planUtils3MockedStatic =
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
@@ -102,7 +102,7 @@ class DataSourceV2RelationDatasetBuilderTest {
         facetUtilsMockedStatic.verify(
             () ->
                 DatasetVersionDatasetFacetUtils.includeDatasetVersion(
-                    context, datasetFacetsBuilder, relation),
+                    context, datasetFacetsBuilder.getFacets(), relation),
             times(1));
       }
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -84,7 +86,7 @@ class DataSourceV2ScanRelationOnEndInputDatasetBuilderTest {
       try (MockedStatic<DatasetVersionDatasetFacetUtils> facetUtilsMockedStatic =
           mockStatic(DatasetVersionDatasetFacetUtils.class)) {
         when(DataSourceV2RelationDatasetExtractor.extract(
-                factory, context, relation, datasetFacetsBuilder))
+                eq(factory), eq(context), eq(relation), any()))
             .thenReturn(datasets);
 
         Assertions.assertThat(builder.apply(scanRelation)).isEqualTo(datasets);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilderTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -66,13 +68,13 @@ class DataSourceV2ScanRelationOnStartInputDatasetBuilderTest {
 
   @Test
   void testApply() {
-    OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-        mock(OpenLineage.DatasetFacetsBuilder.class);
+    DatasetCompositeFacetsBuilder datasetFacetsBuilder =
+        new DatasetCompositeFacetsBuilder(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(factory.createCompositeFacetBuilder()).thenReturn(datasetFacetsBuilder);
     List<OpenLineage.InputDataset> datasets = mock(List.class);
     DataSourceV2ScanRelation scanRelation = mock(DataSourceV2ScanRelation.class);
     DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
 
-    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(context.getOpenLineage()).thenReturn(openLineage);
     when(scanRelation.relation()).thenReturn(relation);
     when(context.getSparkExtensionVisitorWrapper())
@@ -91,7 +93,7 @@ class DataSourceV2ScanRelationOnStartInputDatasetBuilderTest {
         facetUtilsMockedStatic.verify(
             () ->
                 DatasetVersionDatasetFacetUtils.includeDatasetVersion(
-                    context, datasetFacetsBuilder, relation),
+                    context, datasetFacetsBuilder.getFacets(), relation),
             times(1));
       }
     }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
@@ -140,8 +141,7 @@ class TableContentChangeDatasetBuilderTest {
     try (MockedStatic mockedPlanUtils3 = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic mockedVersions = mockStatic(CatalogUtils3.class)) {
         OpenLineage.Dataset dataset = mock(OpenLineage.OutputDataset.class);
-        OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-            mock(OpenLineage.DatasetFacetsBuilder.class);
+        DatasetFacetsBuilder datasetFacetsBuilder = mock(DatasetFacetsBuilder.class);
         mock(OpenLineage.DatasetFacetsBuilder.class);
         OpenLineage.LifecycleStateChangeDatasetFacet lifecycleStateChangeDatasetFacet =
             mock(OpenLineage.LifecycleStateChangeDatasetFacet.class);
@@ -153,14 +153,14 @@ class TableContentChangeDatasetBuilderTest {
         when(dataSourceV2Relation.table()).thenReturn(table);
         when(table.properties()).thenReturn(tableProperties);
 
-        when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
         when(openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
             .thenReturn(lifecycleStateChangeDatasetFacet);
         when(openLineage.newDatasetVersionDatasetFacet("v2"))
             .thenReturn(datasetVersionDatasetFacet);
+        when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
 
         when(DataSourceV2RelationDatasetExtractor.extract(
-                any(), eq(openLineageContext), eq(dataSourceV2Relation), eq(datasetFacetsBuilder)))
+                any(), eq(openLineageContext), eq(dataSourceV2Relation), any()))
             .thenReturn(Collections.singletonList(dataset));
         when(CatalogUtils3.getDatasetVersion(any(), any(), any(), any()))
             .thenReturn(Optional.of("v2"));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
@@ -44,8 +46,7 @@ class DataSourceV2RelationDatasetExtractorTest {
   SparkSession sparkSession = mock(SparkSession.class);
   DatasetFactory<OpenLineage.Dataset> datasetFactory = mock(DatasetFactory.class);
   DataSourceV2Relation dataSourceV2Relation = mock(DataSourceV2Relation.class);
-  OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder =
-      mock(OpenLineage.DatasetFacetsBuilder.class);
+  DatasetCompositeFacetsBuilder datasetFacetsBuilder = mock(DatasetCompositeFacetsBuilder.class);
   TableCatalog tableCatalog = mock(TableCatalog.class);
   Identifier identifier = mock(Identifier.class);
   StructType schema = mock(StructType.class);
@@ -58,12 +59,12 @@ class DataSourceV2RelationDatasetExtractorTest {
     tableProperties = new HashMap<>();
     when(openLineageContext.getSparkSession()).thenReturn(Optional.of(sparkSession));
     when(openLineageContext.getOpenLineage()).thenReturn(openLineage);
-    when(openLineage.newDatasetFacetsBuilder()).thenReturn(datasetFacetsBuilder);
     when(dataSourceV2Relation.catalog()).thenReturn(Option.apply(tableCatalog));
     when(dataSourceV2Relation.identifier()).thenReturn(Option.apply(identifier));
     when(dataSourceV2Relation.schema()).thenReturn(schema);
     when(dataSourceV2Relation.table()).thenReturn(table);
     when(table.properties()).thenReturn(tableProperties);
+    when(datasetFactory.createCompositeFacetBuilder()).thenReturn(datasetFacetsBuilder);
   }
 
   @Test
@@ -83,10 +84,13 @@ class DataSourceV2RelationDatasetExtractorTest {
         when(PlanUtils.schemaFacet(openLineage, schema)).thenReturn(schemaDatasetFacet);
         when(PlanUtils.datasourceFacet(openLineage, di.getNamespace()))
             .thenReturn(datasourceDatasetFacet);
-        when(datasetFacetsBuilder.schema(schemaDatasetFacet)).thenReturn(datasetFacetsBuilder);
-        when(datasetFacetsBuilder.dataSource(datasourceDatasetFacet))
-            .thenReturn(datasetFacetsBuilder);
-        when(datasetFacetsBuilder.build()).thenReturn(datasetFacets);
+
+        DatasetFacetsBuilder facetsBuilder = mock(DatasetFacetsBuilder.class);
+        when(datasetFacetsBuilder.getFacets()).thenReturn(facetsBuilder);
+
+        when(facetsBuilder.schema(schemaDatasetFacet)).thenReturn(facetsBuilder);
+        when(facetsBuilder.dataSource(datasourceDatasetFacet)).thenReturn(facetsBuilder);
+        when(facetsBuilder.build()).thenReturn(datasetFacets);
 
         when(CatalogUtils3.getDatasetIdentifier(
                 openLineageContext, tableCatalog, identifier, tableProperties))

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2UtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2UtilsTest.java
@@ -15,6 +15,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.DatasetFacet;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacet;
 import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -34,14 +35,14 @@ class ExtensionDataSourceV2UtilsTest {
   Table table = mock(Table.class);
   Map<String, String> properties = new HashMap<>();
   OpenLineage openLineage;
-  OpenLineage.DatasetFacetsBuilder datasetFacetsBuilder;
+  DatasetCompositeFacetsBuilder datasetFacetsBuilder;
   URI producer;
 
   @BeforeEach
   void setup() throws URISyntaxException {
     producer = new URI("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client");
     openLineage = new OpenLineage(producer);
-    datasetFacetsBuilder = openLineage.newDatasetFacetsBuilder();
+    datasetFacetsBuilder = new DatasetCompositeFacetsBuilder(openLineage);
 
     when(relation.table()).thenReturn(table);
     when(table.properties()).thenReturn(properties);
@@ -97,11 +98,11 @@ class ExtensionDataSourceV2UtilsTest {
                     .type("int64")
                     .build()));
 
-    assertThat(datasetFacetsBuilder.build().getSchema().get_producer().toString())
+    assertThat(datasetFacetsBuilder.getFacets().build().getSchema().get_producer().toString())
         .isEqualTo("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client");
-    assertThat(datasetFacetsBuilder.build().getSchema().get_schemaURL().toString())
+    assertThat(datasetFacetsBuilder.getFacets().build().getSchema().get_schemaURL().toString())
         .isEqualTo(schemaDatasetFacet.get_schemaURL().toString());
-    assertThat(datasetFacetsBuilder.build().getSchema().getFields().get(0))
+    assertThat(datasetFacetsBuilder.getFacets().build().getSchema().getFields().get(0))
         .hasFieldOrPropertyWithValue("name", "user_id")
         .hasFieldOrPropertyWithValue("type", "int64");
   }
@@ -124,7 +125,7 @@ class ExtensionDataSourceV2UtilsTest {
     ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
 
     DatasetFacet datasetFacet =
-        datasetFacetsBuilder.build().getAdditionalProperties().get("customFacet");
+        datasetFacetsBuilder.getFacets().build().getAdditionalProperties().get("customFacet");
 
     assertThat(datasetFacet.get_producer()).isEqualTo(producer);
     assertThat(datasetFacet.getAdditionalProperties().get("property4")).isEqualTo("value4");
@@ -147,7 +148,7 @@ class ExtensionDataSourceV2UtilsTest {
     ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
 
     DatasetFacet datasetFacet =
-        datasetFacetsBuilder.build().getAdditionalProperties().get("customFacet");
+        datasetFacetsBuilder.getFacets().build().getAdditionalProperties().get("customFacet");
 
     assertThat(datasetFacet.get_producer()).isEqualTo(producer);
   }

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -7,6 +7,7 @@ package io.openlineage.spark33.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -147,23 +148,24 @@ public class CreateReplaceDatasetBuilder
     }
 
     OpenLineage openLineage = context.getOpenLineage();
-    OpenLineage.DatasetFacetsBuilder builder =
-        openLineage
-            .newDatasetFacetsBuilder()
-            .schema(PlanUtils.schemaFacet(openLineage, schema))
-            .lifecycleStateChange(
-                openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-            .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
+    builder
+        .getFacets()
+        .schema(PlanUtils.schemaFacet(openLineage, schema))
+        .lifecycleStateChange(
+            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
+        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
 
     if (includeDatasetVersion(event)) {
       Optional<String> datasetVersion =
           CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties);
       datasetVersion.ifPresent(
-          version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
+          version ->
+              builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
     }
 
     CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
-        .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
+        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -7,6 +7,7 @@ package io.openlineage.spark35.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -155,23 +156,24 @@ public class CreateReplaceOutputDatasetBuilder
     }
 
     OpenLineage openLineage = context.getOpenLineage();
-    OpenLineage.DatasetFacetsBuilder builder =
-        openLineage
-            .newDatasetFacetsBuilder()
-            .schema(PlanUtils.schemaFacet(openLineage, schema))
-            .lifecycleStateChange(
-                openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
-            .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
+    builder
+        .getFacets()
+        .schema(PlanUtils.schemaFacet(openLineage, schema))
+        .lifecycleStateChange(
+            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
+        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
 
     if (includeDatasetVersion(event)) {
       Optional<String> datasetVersion =
           CatalogUtils3.getDatasetVersion(context, catalog, identifier, tableProperties);
       datasetVersion.ifPresent(
-          version -> builder.version(openLineage.newDatasetVersionDatasetFacet(version)));
+          version ->
+              builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
     }
 
     CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
-        .map(storageDatasetFacet -> builder.storage(storageDatasetFacet));
+        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 


### PR DESCRIPTION
Currently, visitors and dataset builders create dataset objects through the DatasetFactory. This concept does not allow providing input nor output facets.

This PR enables it by including `DatasetCompositeFacetsBuilder` to include already existing facets as well as `input`/`output` ones. Extending existing methods to allow it requires changes in several places of the codebase. 