### PR TITLE
[Fix][Integration/dbt] Parse dbt source tests

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -317,7 +317,8 @@ class DbtArtifactProcessor:
         assertions = self.parse_assertions(context, nodes)
 
         events = DbtEvents()
-        for name, node in context.manifest["nodes"].items():
+        manifest_nodes = {**context.manifest["nodes"], **context.manifest["sources"]}
+        for name, node in manifest_nodes.items():
             if not name.startswith("model.") and not name.startswith("source."):
                 continue
             if len(assertions[name]) == 0:

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -77,6 +77,25 @@
     },
     {
         "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "START",
+        "inputs": [
+            {
+                "name": "random-gcp-project.dbt_test2.source_table",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "name": "random-gcp-project.dbt_test2.source.dbt_bigquery_test.dbt_test2.source_table.test",
+            "namespace": "dbt-test-namespace"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
         "eventType": "COMPLETE",
         "inputs": [
             {
@@ -291,6 +310,48 @@
                 }
             },
             "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"
+        }
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "column": "id",
+                                "assertion": "not_null",
+                                "success": true
+                            }
+                        ]
+                    }
+                },
+                "name": "random-gcp-project.dbt_test2.source_table",
+                "namespace": "bigquery"
+            }
+        ],
+        "job": {
+            "facets": {},
+            "name": "random-gcp-project.dbt_test2.source.dbt_bigquery_test.dbt_test2.source_table.test",
+            "namespace": "dbt-test-namespace"
+        },
+        "outputs": [],
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "run": {
+            "facets": {
+                "parent": {
+                    "job": {"name": "dbt-job-name", "namespace": "dbt"},
+                    "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
+                },
+                "dbt_version": {
+                    "version": "0.21.0"
+                }
+            },
+            "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3"
         }
     }
 ]

--- a/integration/common/tests/dbt/test/target/manifest.json
+++ b/integration/common/tests/dbt/test/target/manifest.json
@@ -484,6 +484,96 @@
             "relation_name": "`random-gcp-project`.`dbt_test1_dbt_test__audit`.`not_null_test_first_dbt_model_id`",
             "column_name": "id"
         },
+        "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a": {
+            "raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+            "test_metadata": {
+                "name": "not_null",
+                "kwargs": {
+                    "column_name": "id",
+                    "model": "{% if config.get('where') %}(select * from {{ source('dbt_test2', 'source_table') }} where {{config.get('where')}}) test_dbt_test2_source_table {% else %}{{ source('dbt_test2', 'source_table') }}{% endif %}"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_not_null",
+                    "macro.dbt.should_store_failures",
+                    "macro.dbt.statement"
+                ],
+                "nodes": [
+                    "source.dbt_bigquery_test.dbt_test2.source_table"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "materialized": "test",
+                "persist_docs": {},
+                "vars": {},
+                "quoting": {},
+                "column_types": {},
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "full_refresh": null,
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null,
+                "fail_calc": "count(*)",
+                "warn_if": "!= 0",
+                "error_if": "!= 0",
+                "post-hook": [],
+                "pre-hook": []
+            },
+            "database": "random-gcp-project",
+            "schema": "dbt_test1_dbt_test__audit",
+            "fqn": [
+                "dbt_bigquery_test",
+                "schema_test",
+                "source_not_null_dbt_test2_source_table_id"
+            ],
+            "unique_id": "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "schema_test/source_not_null_dbt_test2_source_table_id.sql",
+            "original_file_path": "models/example/schema.yml",
+            "name": "source_not_null_dbt_test2_source_table_id",
+            "alias": "source_not_null_dbt_test2_source_table_id",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [
+                "schema"
+            ],
+            "refs": [],
+            "sources": [
+                [
+                    "dbt_test2",
+                    "source_table"
+                ]
+            ],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/dbt_bigquery_test/models/example/schema.yml/schema_test/source_not_null_dbt_test2_source_table_id.sql",
+            "build_path": "target/run/dbt_bigquery_test/models/example/schema.yml/schema_test/source_not_null_dbt_test2_source_table_id.sql",
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1629731179,
+            "compiled_sql": "\n    \n    \n\nselect *\nfrom `random-gcp-project`.`dbt_test2`.`source_table`\nwhere id is null\n\n\n",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": "`random-gcp-project`.`dbt_test1_dbt_test__audit`.`source_not_null_dbt_test2_source_table_id`",
+            "column_name": "id"
+        },
         "test.dbt_bigquery_test.dbt_expectations_expect_column_values_to_not_be_null_test_first_dbt_model_id.2da7e7b96e": {
             "raw_sql": "{{ dbt_expectations.test_expect_column_values_to_not_be_null(**_dbt_schema_test_kwargs) }}{{ config(alias=\"dbt_expectations_expect_column_177e5e4ed27ab51efa28f8ff7a38e5fb\") }}",
             "test_metadata": {
@@ -1526,6 +1616,52 @@
             "unrendered_config": {},
             "relation_name": "`random-gcp-project`.`dbt_test1`.`source_table`",
             "created_at": 1629731179
+        },
+        "source.dbt_bigquery_test.dbt_test2.source_table": {
+            "fqn": [
+                "dbt_bigquery_test",
+                "example",
+                "dbt_test2",
+                "source_table"
+            ],
+            "database": "random-gcp-project",
+            "schema": "dbt_test2",
+            "unique_id": "source.dbt_bigquery_test.dbt_test2.source_table",
+            "package_name": "dbt_bigquery_test",
+            "root_path": "/home/dbt/code/dbt-test",
+            "path": "models/example/schema.yml",
+            "original_file_path": "models/example/schema.yml",
+            "name": "source_table",
+            "source_name": "dbt_test2",
+            "source_description": "",
+            "loader": "",
+            "identifier": "source_table",
+            "resource_type": "source",
+            "quoting": {
+                "database": null,
+                "schema": null,
+                "identifier": null,
+                "column": null
+            },
+            "loaded_at_field": null,
+            "freshness": {
+                "warn_after": null,
+                "error_after": null,
+                "filter": null
+            },
+            "external": null,
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "source_meta": {},
+            "tags": [],
+            "config": {
+                "enabled": true
+            },
+            "patch_path": null,
+            "unrendered_config": {},
+            "relation_name": "`random-gcp-project`.`dbt_test2`.`source_table`",
+            "created_at": 1629731179
         }
     },
     "macros": {},
@@ -1594,7 +1730,11 @@
         "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604": [
             "model.dbt_bigquery_test.test_third_dbt_model"
         ],
-        "source.dbt_bigquery_test.dbt_test1.source_table": []
+        "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a": [
+            "source.dbt_bigquery_test.dbt_test2.source_table"
+        ],
+        "source.dbt_bigquery_test.dbt_test1.source_table": [],
+        "source.dbt_bigquery_test.dbt_test2.source_table": []
     },
     "child_map": {
         "model.dbt_bigquery_test.test_third_dbt_model": [
@@ -1634,8 +1774,12 @@
         "test.dbt_bigquery_test.not_null_test_third_dbt_model_id.ee37a1e1fb": [],
         "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89": [],
         "test.dbt_bigquery_test.not_null_test_third_dbt_model_second_id.808ed9e604": [],
+        "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a": [],
         "source.dbt_bigquery_test.dbt_test1.source_table": [
             "model.dbt_bigquery_test.test_second_parallel_dbt_model"
+        ],
+        "source.dbt_bigquery_test.dbt_test2.source_table": [
+            "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a"
         ]
     }
 }

--- a/integration/common/tests/dbt/test/target/run_results.json
+++ b/integration/common/tests/dbt/test/target/run_results.json
@@ -279,6 +279,27 @@
             "message": null,
             "failures": 0,
             "unique_id": "test.dbt_bigquery_test.unique_test_third_dbt_model_second_id.f3c38f3b89"
+        },
+        {
+            "status": "pass",
+            "timing": [
+                {
+                    "name": "compile",
+                    "started_at": "2021-08-23T15:06:24.008644Z",
+                    "completed_at": "2021-08-23T15:06:24.031682Z"
+                },
+                {
+                    "name": "execute",
+                    "started_at": "2021-08-23T15:06:24.034392Z",
+                    "completed_at": "2021-08-23T15:06:27.418481Z"
+                }
+            ],
+            "thread_id": "Thread-1",
+            "execution_time": 3.411060333251953,
+            "adapter_response": {},
+            "message": null,
+            "failures": 0,
+            "unique_id": "test.dbt_bigquery_test.source_not_null_dbt_test2_source_table_id.a44e73432a"
         }
     ],
     "elapsed_time": 25.34427523612976,

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -79,6 +79,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
         "f99310b4-339a-4381-ad3e-c1b95c24ff11",
         "c11f2efd-4415-45fc-8081-10d2aaa594d2",
+        "b901441a-7b4a-4a97-aa61-a200106b3ce3"
     ]
 
     processor = DbtLocalArtifactProcessor(

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -79,7 +79,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
         "f99310b4-339a-4381-ad3e-c1b95c24ff11",
         "c11f2efd-4415-45fc-8081-10d2aaa594d2",
-        "b901441a-7b4a-4a97-aa61-a200106b3ce3"
+        "b901441a-7b4a-4a97-aa61-a200106b3ce3",
     ]
 
     processor = DbtLocalArtifactProcessor(


### PR DESCRIPTION
Signed-off-by: Massy Bourennani <massy.bourennani@datadoghq.com>

### Problem

When parsing test results, the `dbt-ol` integration misses tests that are attached to sources. It only considers the `manifest["nodes"]` which doesn't contain sources. The source nodes are in `manifest["sources"]`

**To reproduce:**
Requirements
```
dbt-core==1.7.7
dbt-snowflake==1.7.1
openlineage-dbt==1.22.0
```
Add a test to a source 
```yaml
sources:
  - name: dbt_test2
    tables:
      - name: source_table
        tests:
         - not_null:
           column_name: id   
```
Run command
```
dbt-ol test source:dbt_test2.source_table
```

### Solution

I've added the `manifest["sources"]` to the nodes to look for when parsing tests.

#### One-line summary:

Parse dbt source tests

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project