### PR TITLE
docs: fix edit this page link.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
                   pip install pyyaml==6.0.1
                   python dev/filter_approvals.py
       - run: |
-          export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.currentBranch.labels[]; .name == "full-tests")')
+          export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.labels[]; .name == "full-tests")')
           echo $IS_FULL_TESTS
           if [ -z "$IS_FULL_TESTS" ] || [ "$IS_FULL_TESTS" == "0" ]; then
             pip install pyyaml==6.0.1

--- a/dev/filter_matrix.py
+++ b/dev/filter_matrix.py
@@ -11,6 +11,9 @@ for _, workflow_definition in d["workflows"].items():
     if not jobs:
         continue
 
+    test_job = None
+    integration_test_job = None
+
     for job in jobs:
         if "test-integration-spark" in job:
             test_job = job["test-integration-spark"]

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           exclude: ['**/partials/**'],
           editUrl:
-            'https://github.com/OpenLineage/docs/tree/main/',
+            'https://github.com/OpenLineage/OpenLineage/tree/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
### Problem

`Edit this page` link got broken when migrating docs page to monorepo.

### Solution

Fix the link.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project