### PR TITLE
docs: Inject OpenLineage version in documentation

### DIFF
--- a/website/blog/openlineage-spark/index.mdx
+++ b/website/blog/openlineage-spark/index.mdx
@@ -51,7 +51,7 @@ familiar with it and how it's used in Spark applications. OpenLineage integrates
 interface and collecting information about jobs that are executed inside a Spark application. To activate the
 listener, add the following properties to your Spark configuration:
 ```
-spark.jars.packages     io.openlineage:openlineage-spark:1.23.0
+spark.jars.packages     io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}}
 spark.extraListeners	io.openlineage.spark.agent.OpenLineageSparkListener
 ```
 This can be added to your cluster’s `spark-defaults.conf` file, in which case it will record lineage for every job executed on the cluster, or added to specific jobs on submission via the `spark-submit` command. Once the listener is activated, it needs to know where to report lineage events, as well as the namespace of your jobs. Add the following additional configuration lines to your `spark-defaults.conf` file or your Spark submission script:
@@ -122,7 +122,7 @@ spark = (SparkSession.builder.master('local').appName('openlineage_spark_test')
              .config('spark.jars', ",".join(files))
              
              # Install and set up the OpenLineage listener
-             .config('spark.jars.packages', 'io.openlineage:openlineage-spark:1.23.0)
+             .config('spark.jars.packages', 'io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}})
              .config('spark.extraListeners', 'io.openlineage.spark.agent.OpenLineageSparkListener')
              .config('spark.openlineage.transport.url', 'http://marquez-api:5000')
              .config('spark.openlineage.transport.type', 'http')

--- a/website/docs/client/java/java.md
+++ b/website/docs/client/java/java.md
@@ -24,14 +24,14 @@ Maven:
 <dependency>
     <groupId>io.openlineage</groupId>
     <artifactId>openlineage-java</artifactId>
-    <version>${OPENLINEAGE_VERSION}</version>
+    <version>{{PREPROCESSOR:OPENLINEAGE_VERSION}}</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```groovy
-implementation("io.openlineage:openlineage-java:${OPENLINEAGE_VERSION}")
+implementation("io.openlineage:openlineage-java:{{PREPROCESSOR:OPENLINEAGE_VERSION}}")
 ```
 
 For more information on the available versions of the `openlineage-java`, 

--- a/website/docs/client/java/partials/s3_transport.md
+++ b/website/docs/client/java/partials/s3_transport.md
@@ -15,7 +15,7 @@ to be emitted correctly.
 <dependency>
     <groupId>io.openlineage</groupId>
     <artifactId>transports-s3</artifactId>
-    <version>YOUR_VERSION_HERE</version>
+    <version>{{PREPROCESSOR:OPENLINEAGE_VERSION}}</version>
 </dependency>
 ```
 

--- a/website/docs/guides/spark.md
+++ b/website/docs/guides/spark.md
@@ -13,7 +13,7 @@ This guide was developed using an **earlier version** of this integration and ma
 Adding OpenLineage to Spark is refreshingly uncomplicated, and this is thanks to Spark's SparkListener interface. OpenLineage integrates with Spark by implementing SparkListener and collecting information about jobs executed inside a Spark application. To activate the listener, add the following properties to your Spark configuration in your cluster's `spark-defaults.conf` file or, alternatively, add them to specific jobs on submission via the `spark-submit` command:
 
 ```
-spark.jars.packages     io.openlineage:openlineage-spark:1.23.0
+spark.jars.packages     io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}}
 spark.extraListeners    io.openlineage.spark.agent.OpenLineageSparkListener
 ```
 
@@ -91,7 +91,7 @@ spark = (SparkSession.builder.master('local').appName('openlineage_spark_test')
         .config('spark.jars', ",".join(files))
         
         # Install and set up the OpenLineage listener
-        .config('spark.jars.packages', 'io.openlineage:openlineage-spark:1.23.0')
+        .config('spark.jars.packages', 'io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}}')
         .config('spark.extraListeners', 'io.openlineage.spark.agent.OpenLineageSparkListener')
         .config('spark.openlineage.transport.url', 'http://marquez-api:5000')
         .config('spark.openlineage.transport.type', 'http')

--- a/website/docs/integrations/spark/installation.md
+++ b/website/docs/integrations/spark/installation.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 The above necessitates a change in the artifact identifier for `io.openlineage:openlineage-spark`.
 After version `1.8.0`, the artifact identifier has been updated. For subsequent versions, utilize:
-`io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:${OPENLINEAGE_SPARK_VERSION}`.
+`io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:{{PREPROCESSOR:OPENLINEAGE_VERSION}}`.
 :::
 
 To integrate OpenLineage Spark with your application, you can:
@@ -39,7 +39,7 @@ For Maven, add the following to your `pom.xml`:
 <dependency>
   <groupId>io.openlineage</groupId>
   <artifactId>openlineage-spark_${SCALA_BINARY_VERSION}</artifactId>
-  <version>${OPENLINEAGE_SPARK_VERSION}</version>
+  <version>{{PREPROCESSOR:OPENLINEAGE_VERSION}}</version>
 </dependency>
 ```
 
@@ -63,14 +63,14 @@ For Gradle, add this to your `build.gradle`:
 <TabItem value="after-1.8.0" label="After 1.8.0">
 
 ```groovy
-implementation("io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:${OPENLINEAGE_SPARK_VERSION}")
+implementation("io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:{{PREPROCESSOR:OPENLINEAGE_VERSION}}")
 ```
 
 </TabItem>
 <TabItem value="1.8.0-and-earlier" label="1.8.0 and earlier">
 
 ```groovy
-implementation("io.openlineage:openlineage-spark:${OPENLINEAGE_SPARK_VERSION}")
+implementation("io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}}")
 ```
 
 </TabItem>
@@ -100,7 +100,7 @@ if [ -z "$SPARK_HOME" ]; then
     exit 1
 fi
 
-OPENLINEAGE_SPARK_VERSION='1.9.0'  # Example version
+OPENLINEAGE_SPARK_VERSION='{{PREPROCESSOR:OPENLINEAGE_VERSION}}'
 SCALA_BINARY_VERSION='2.13'        # Example Scala version
 ARTIFACT_ID="openlineage-spark_${SCALA_BINARY_VERSION}"
 JAR_NAME="${ARTIFACT_ID}-${OPENLINEAGE_SPARK_VERSION}.jar"
@@ -172,7 +172,7 @@ This script demonstrate this process:
 ```bash
 #!/usr/bin/env bash
 
-OPENLINEAGE_SPARK_VERSION='1.9.0'  # Example version
+OPENLINEAGE_SPARK_VERSION='{{PREPROCESSOR:OPENLINEAGE_VERSION}}'
 SCALA_BINARY_VERSION='2.13'        # Example Scala version
 ARTIFACT_ID="openlineage-spark_${SCALA_BINARY_VERSION}"
 JAR_NAME="${ARTIFACT_ID}-${OPENLINEAGE_SPARK_VERSION}.jar"
@@ -237,10 +237,10 @@ during runtime and adds it to the classpath of your Spark application.
 <TabItem value="after-1.8.0" label="After 1.8.0">
 
 ```bash
-OPENLINEAGE_SPARK_VERSION='1.9.0'  # Example version
+OPENLINEAGE_SPARK_VERSION='{{PREPROCESSOR:OPENLINEAGE_VERSION}}'
 SCALA_BINARY_VERSION='2.13'        # Example Scala version
 
-spark-submit --packages "io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:${OPENLINEAGE_SPARK_VERSION}" \
+spark-submit --packages "io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION}:{{PREPROCESSOR:OPENLINEAGE_VERSION}}" \
     # ... other options
 ```
 
@@ -250,7 +250,7 @@ spark-submit --packages "io.openlineage:openlineage-spark_${SCALA_BINARY_VERSION
 ```bash
 OPENLINEAGE_SPARK_VERSION='1.8.0'  # Example version
 
-spark-submit --packages "io.openlineage:openlineage-spark::${OPENLINEAGE_SPARK_VERSION}" \
+spark-submit --packages "io.openlineage:openlineage-spark::{{PREPROCESSOR:OPENLINEAGE_VERSION}}" \
     # ... other options
 ```
 

--- a/website/docs/integrations/spark/quickstart/quickstart_local.md
+++ b/website/docs/integrations/spark/quickstart/quickstart_local.md
@@ -44,7 +44,7 @@ from pyspark.sql import SparkSession
 spark = (SparkSession.builder.master('local')
          .appName('sample_spark')
          .config('spark.extraListeners', 'io.openlineage.spark.agent.OpenLineageSparkListener')
-         .config('spark.jars.packages', 'io.openlineage:openlineage-spark:1.7.0')
+         .config('spark.jars.packages', 'io.openlineage:openlineage-spark:{{PREPROCESSOR:OPENLINEAGE_VERSION}}')
          .config('spark.openlineage.transport.type', 'console')
          .getOrCreate())
 ```

--- a/website/docs/spec/producers.md
+++ b/website/docs/spec/producers.md
@@ -10,4 +10,4 @@ This page could use some extra detail! You're welcome to contribute using the Ed
 
 The `_producer` value is included in an OpenLineage request as a way to know how the metadata was generated. It is a URI that links to a source code SHA or the location where a package can be found.
 
-For example, this field is populated by many of the common integrations. For example, the dbt integration will set this value to `https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integration/dbt` and the Python client will set it to `https://github.com/OpenLineage/OpenLineage/tree/{__version__}/client/python`.
+For example, this field is populated by many of the common integrations. For example, the dbt integration will set this value to `https://github.com/OpenLineage/OpenLineage/tree/{{PREPROCESSOR:OPENLINEAGE_VERSION}}/integration/dbt` and the Python client will set it to `https://github.com/OpenLineage/OpenLineage/tree/{{PREPROCESSOR:OPENLINEAGE_VERSION}}/client/python`.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,151 +2,173 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 const prism = require('prism-react-renderer');
+const path = require('path');
+const fs = require('fs');
+
+const getCurrentVersion = () => {
+    // The file is created when "docusaurus docs:version <version>" is executed.
+    const versionsPath = path.resolve(__dirname, 'versions.json');
+    if (fs.existsSync(versionsPath)) {
+        return require(versionsPath)[0];
+    } else {
+        console.warn("The documentation is not versioned. Run \"docusaurus docs:version <current version>\"")
+        return "<OPENLINEAGE VERSION>";
+    }
+}
+
+// Replaces every occurrence of "{{PREPROCESSOR:OPENLINEAGE_VERSION}}" with the current version of the documentation.
+const openLineageVersionProvider = ({filePath, fileContent}) => {
+    return fileContent.replace(/{{PREPROCESSOR:OPENLINEAGE_VERSION}}/g, getCurrentVersion());
+};
 
 const links = [
-  { to: '/getting-started', label: 'Getting Started', position: 'left' },
-  { to: '/resources', label: 'Resources', position: 'left' },
-  { to: '/ecosystem', label: 'Ecosystem', position: 'left' },
-  { to: '/community', label: 'Community', position: 'left' },
-  { to: '/blog', label: 'Blog', position: 'left' },
-  { to: '/docs', label: 'Docs', position: 'left' },
-  { to: '/survey', label: 'Ecosystem Survey 2023', position: 'left' },
+    {to: '/getting-started', label: 'Getting Started', position: 'left'},
+    {to: '/resources', label: 'Resources', position: 'left'},
+    {to: '/ecosystem', label: 'Ecosystem', position: 'left'},
+    {to: '/community', label: 'Community', position: 'left'},
+    {to: '/blog', label: 'Blog', position: 'left'},
+    {to: '/docs', label: 'Docs', position: 'left'},
+    {to: '/survey', label: 'Ecosystem Survey 2023', position: 'left'},
 ]
 
 const linksSocial = [
-  { href: 'https://fosstodon.org/@openlineage', label: 'Mastodon', rel: 'me' },
-  { href: 'https://twitter.com/OpenLineage', label: 'Twitter' },
-  { href: 'https://www.linkedin.com/groups/13927795/', label: 'LinkedIn'},
-  { href: 'http://bit.ly/OpenLineageSlack', label: 'Slack' },
-  { href: 'https://github.com/OpenLineage/OpenLineage', label: 'GitHub' }
+    {href: 'https://fosstodon.org/@openlineage', label: 'Mastodon', rel: 'me'},
+    {href: 'https://twitter.com/OpenLineage', label: 'Twitter'},
+    {href: 'https://www.linkedin.com/groups/13927795/', label: 'LinkedIn'},
+    {href: 'http://bit.ly/OpenLineageSlack', label: 'Slack'},
+    {href: 'https://github.com/OpenLineage/OpenLineage', label: 'GitHub'}
 ]
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'OpenLineage',
-  tagline: 'OpenLineage',
-  url: 'https://openlineage.io',
-  baseUrl: '/',
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
-  favicon: 'img/favicon.ico',
-  customFields: {
-    links: links,
-    linksSocial: linksSocial
-  },
-
-  organizationName: 'openlineage',
-  projectName: 'docs',
-  i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
-  },
-
-  presets: [
-    [
-      'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          exclude: ['**/partials/**'],
-          editUrl:
-            'https://github.com/OpenLineage/OpenLineage/tree/main/website/',
-        },
-        theme: {
-          customCss: require.resolve('./src/css/custom.css'),
-        },
-        blog: {
-          blogTitle: 'Blog',
-          blogDescription: 'Data lineage is the foundation for a new generation of powerful, context-aware data tools and best practices. OpenLineage enables consistent collection of lineage metadata, creating a deeper understanding of how data is produced and used.',
-          showReadingTime: true,
-          blogSidebarCount: 5,
-          blogSidebarTitle: 'Recent posts',
-          feedOptions: {
-            type: ['json'],
-            copyright: `Copyright © ${new Date().getFullYear()} The Linux Foundation®. All rights reserved.`,
-          },
-        },
-        pages: {
-          path: 'src/pages',
-          include: ['**/*.{js,jsx,ts,tsx,md,mdx}'],
-          exclude: [
-            'home.tsx', // this page served from plugin
-            '**/_*.{js,jsx,ts,tsx,md,mdx}',
-            '**/_*.{js,jsx,ts,tsx,md,mdx}',
-            '**/_*/**',
-            '**/*.test.{js,jsx,ts,tsx}',
-            '**/__tests__/**',
-          ],
-          mdxPageComponent: '@theme/MDXPage',
-        },
-        gtag: {
-          trackingID: 'G-QMTWMLMX4M',
-          anonymizeIP: true,
-        },
-      }),
-    ],
-  ],
-
-  plugins: [
-    function tailwindcssPlugin(ctx, options) {
-      return {
-        name: "docusaurus-tailwindcss",
-        configurePostCss(postcssOptions) {
-          // Appends TailwindCSS and AutoPrefixer.
-          postcssOptions.plugins.push(require("tailwindcss"));
-          postcssOptions.plugins.push(require("autoprefixer"));
-          return postcssOptions;
-        },
-      };
+    title: 'OpenLineage',
+    tagline: 'OpenLineage',
+    url: 'https://openlineage.io',
+    baseUrl: '/',
+    onBrokenLinks: 'throw',
+    onBrokenMarkdownLinks: 'throw',
+    favicon: 'img/favicon.ico',
+    customFields: {
+        links: links,
+        linksSocial: linksSocial
     },
-    [
-      "./plugins/home-blog-plugin",
-      {
-        id: "blogs",
-        routeBasePath: "/",
-        path: "./blogs"
-      },
-    ],
-    require.resolve('docusaurus-lunr-search')
-  ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        logo: {
-          alt: 'OpenLineage',
-          src: 'img/ol-logo.svg',
-        },
-        items: [
-          ...links,
-          {
-            href: 'https://github.com/OpenLineage/openlineage',
-            label: 'GitHub',
-            position: 'right',
-          }
+    organizationName: 'openlineage',
+    projectName: 'docs',
+    i18n: {
+        defaultLocale: 'en',
+        locales: ['en'],
+    },
+
+    presets: [
+        [
+            'classic',
+            /** @type {import('@docusaurus/preset-classic').Options} */
+            ({
+                docs: {
+                    sidebarPath: require.resolve('./sidebars.js'),
+                    exclude: ['**/partials/**'],
+                    editUrl:
+                        'https://github.com/OpenLineage/OpenLineage/tree/main/website/',
+                },
+                theme: {
+                    customCss: require.resolve('./src/css/custom.css'),
+                },
+                blog: {
+                    blogTitle: 'Blog',
+                    blogDescription: 'Data lineage is the foundation for a new generation of powerful, context-aware data tools and best practices. OpenLineage enables consistent collection of lineage metadata, creating a deeper understanding of how data is produced and used.',
+                    showReadingTime: true,
+                    blogSidebarCount: 5,
+                    blogSidebarTitle: 'Recent posts',
+                    feedOptions: {
+                        type: ['json'],
+                        copyright: `Copyright © ${new Date().getFullYear()} The Linux Foundation®. All rights reserved.`,
+                    },
+                },
+                pages: {
+                    path: 'src/pages',
+                    include: ['**/*.{js,jsx,ts,tsx,md,mdx}'],
+                    exclude: [
+                        'home.tsx', // this page served from plugin
+                        '**/_*.{js,jsx,ts,tsx,md,mdx}',
+                        '**/_*.{js,jsx,ts,tsx,md,mdx}',
+                        '**/_*/**',
+                        '**/*.test.{js,jsx,ts,tsx}',
+                        '**/__tests__/**',
+                    ],
+                    mdxPageComponent: '@theme/MDXPage',
+                },
+                gtag: {
+                    trackingID: 'G-QMTWMLMX4M',
+                    anonymizeIP: true,
+                },
+            }),
         ],
-      },
-      prism: {
-        theme: prism.themes.github,
-        darkTheme: prism.themes.dracula,
-        additionalLanguages: ['java'],
-      },
-      colorMode: {
-        defaultMode: 'light',
-        disableSwitch: true,
-        respectPrefersColorScheme: false,
-      },
-    }),
+    ],
 
-  scripts: [
-    {
-      src: 'https://plausible.io/js/script.js',
-      defer: true,
-      'data-domain': 'openlineage.io',
-    },
-  ],
+    plugins: [
+        function tailwindcssPlugin(ctx, options) {
+            return {
+                name: "docusaurus-tailwindcss",
+                configurePostCss(postcssOptions) {
+                    // Appends TailwindCSS and AutoPrefixer.
+                    postcssOptions.plugins.push(require("tailwindcss"));
+                    postcssOptions.plugins.push(require("autoprefixer"));
+                    return postcssOptions;
+                },
+            };
+        },
+        [
+            "./plugins/home-blog-plugin",
+            {
+                id: "blogs",
+                routeBasePath: "/",
+                path: "./blogs"
+            },
+        ],
+        require.resolve('docusaurus-lunr-search')
+    ],
+
+    themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+        ({
+            navbar: {
+                logo: {
+                    alt: 'OpenLineage',
+                    src: 'img/ol-logo.svg',
+                },
+                items: [
+                    ...links,
+                    {
+                        href: 'https://github.com/OpenLineage/openlineage',
+                        label: 'GitHub',
+                        position: 'right',
+                    }
+                ],
+            },
+            prism: {
+                theme: prism.themes.github,
+                darkTheme: prism.themes.dracula,
+                additionalLanguages: ['java'],
+            },
+            colorMode: {
+                defaultMode: 'light',
+                disableSwitch: true,
+                respectPrefersColorScheme: false,
+            },
+        }),
+
+    scripts: [
+        {
+            src: 'https://plausible.io/js/script.js',
+            defer: true,
+            'data-domain': 'openlineage.io',
+        },
+    ],
+
+    markdown: {
+        preprocessor: openLineageVersionProvider
+    }
 };
 
 module.exports = config;


### PR DESCRIPTION
### Problem

With every new release the versions in our examples in documentation stay the same.

### Solution

We should have them updated with every new release

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project