### PR TITLE
Make `from_dict` backwards compatible in Python client.

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -82,7 +82,7 @@ class OpenLineageClient:
         transport: Transport | None = None,
         factory: TransportFactory | None = None,
         *,
-        config: dict[str, str] | None = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
         # Set parent's logging level if environment variable is present
         custom_logging_level = os.getenv("OPENLINEAGE_CLIENT_LOGGING", None)
@@ -126,7 +126,15 @@ class OpenLineageClient:
 
     @classmethod
     def from_dict(cls: type[_T], config: dict[str, str]) -> _T:
-        return cls(config=config)
+        warnings.warn(
+            message=(
+                "Using `from_dict` to set transport is deprecated. "
+                "Use `config` parameter to fully configure OpenLineageClient."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls(transport=get_default_factory().create(config=config), config={"transport": config})
 
     def filter_event(
         self,


### PR DESCRIPTION
### Problem

1.24.0 release introduced backwards-incompatible change in `from_dict` method of Python client.

### Solution

Bring back `from_dict` to expect `transport` section extracted only and deprecate the method in favor of `config` argument.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project