### PR TITLE
[Integration][DBT] Fix compatibility with DBT v1.8

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -389,8 +389,8 @@ class DbtArtifactProcessor:
                 node_columns = test_node
 
             else:
-                name = test_node["test_manifest"]["name"]
-                node_columns = test_node["test_manifest"]
+                name = test_node["test_metadata"]["name"]
+                node_columns = test_node["test_metadata"]
 
             assertions[model_node].append(
                 data_quality_assertions_dataset.Assertion(

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -384,11 +384,19 @@ class DbtArtifactProcessor:
                 if node.startswith("model.") or node.startswith("source."):
                     model_node = node
 
+            if self.manifest_version >= 12:
+                name = test_node["name"]
+                node_columns = test_node
+
+            else:
+                name = test_node["test_manifest"]["name"]
+                node_columns = test_node["test_manifest"]
+
             assertions[model_node].append(
                 data_quality_assertions_dataset.Assertion(
-                    assertion=test_node["test_metadata"]["name"],
+                    assertion=name,
                     success=True if run["status"] == "pass" else False,
-                    column=get_from_nullable_chain(test_node["test_metadata"], ["kwargs", "column_name"]),
+                    column=get_from_nullable_chain(node_columns, ["kwargs", "column_name"]),
                 )
             )
 

--- a/integration/common/tests/dbt/no_test_metadata/dbt_project.yml
+++ b/integration/common/tests/dbt/no_test_metadata/dbt_project.yml
@@ -1,0 +1,38 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_large_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" 1t uses for this project.
+profile: 'snowflake'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the {% raw %} `{{ config(...) }}` {% endraw %} macro.
+models:
+  dbt_large_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/no_test_metadata/profiles.yml
+++ b/integration/common/tests/dbt/no_test_metadata/profiles.yml
@@ -1,0 +1,12 @@
+snowflake:
+    target: dev
+    outputs:
+        dev:
+            type: snowflake
+            account: ASDF1234.eu-central-1
+            user: test
+            password: password
+            role: sysadmin
+            database: DEMO_DB
+            warehouse: COMPUTE_WH
+            schema: public

--- a/integration/common/tests/dbt/no_test_metadata/result.json
+++ b/integration/common/tests/dbt/no_test_metadata/result.json
@@ -1,0 +1,1042 @@
+[
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.customers.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "START",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.customers",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.orders.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "START",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.orders",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "relationships_orders_customer_id__customer_id__ref_customers_",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_credit_card_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_coupon_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_bank_transfer_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_gift_card_amount",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "relationships_orders_customer_id__customer_id__ref_customers_",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_credit_card_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_coupon_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_bank_transfer_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_gift_card_amount",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_customers.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "START",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_customers",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_payments.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "START",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_payments",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_orders.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "START",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_orders",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.customers.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.customers",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.orders.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.orders",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "relationships_orders_customer_id__customer_id__ref_customers_",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_credit_card_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_coupon_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_bank_transfer_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_gift_card_amount",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "relationships_orders_customer_id__customer_id__ref_customers_",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_credit_card_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_coupon_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_bank_transfer_amount",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_orders_gift_card_amount",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_customers.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_customers",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_customers_customer_id",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_payments.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_payments",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_payments_payment_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.stg_orders.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "COMPLETE",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.stg_orders",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "not_null_stg_orders_order_id",
+                                "success": true,
+                                "column": null
+                            },
+                            {
+                                "assertion": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+                                "success": true,
+                                "column": null
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    }
+]

--- a/integration/common/tests/dbt/no_test_metadata/target/manifest.json
+++ b/integration/common/tests/dbt/no_test_metadata/target/manifest.json
@@ -1,0 +1,5319 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+		"dbt_version": "1.8.6",
+		"generated_at": "2021-07-05T11:43:09.384637Z",
+		"invocation_id": "ebb384bf-f2f3-4303-bb1b-98b1daa6d2d4",
+		"env": {},
+		"project_id": "06e5b98c2db46f8a72cc4f66410e9b3b",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "snowflake"
+	},
+	"nodes": {
+		"model.jaffle_shop.customers": {
+			"raw_sql": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt_snowflake.unset_query_tag"],
+				"nodes": ["model.jaffle_shop.stg_customers", "model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "table",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "customers"],
+			"unique_id": "model.jaffle_shop.customers",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "customers.sql",
+			"original_file_path": "models/customers.sql",
+			"name": "customers",
+			"alias": "customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "7f193a2c3af2faa53e0bb7b75d2663f39db8c6b3913e9cafd245dc62f98a8d09"
+			},
+			"tags": [],
+			"refs": [
+				["stg_customers"],
+				["stg_orders"],
+				["stg_payments"]
+			],
+			"sources": [],
+			"description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
+			"columns": {
+				"customer_id": {
+					"name": "customer_id",
+					"description": "This is a unique identifier for a customer",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"first_name": {
+					"name": "first_name",
+					"description": "Customer's first name. PII.",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"last_name": {
+					"name": "last_name",
+					"description": "Customer's last name. PII.",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"first_order": {
+					"name": "first_order",
+					"description": "Date (UTC) of a customer's first order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"most_recent_order": {
+					"name": "most_recent_order",
+					"description": "Date (UTC) of a customer's most recent order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"number_of_orders": {
+					"name": "number_of_orders",
+					"description": "Count of the number of orders a customer has placed",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"total_order_amount": {
+					"name": "total_order_amount",
+					"description": "Total value (AUD) of a customer's orders",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "jaffle_shop://models/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/customers.sql",
+			"build_path": "target/run/jaffle_shop/models/customers.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1625485389,
+			"compiled_sql": "with customers as (\n\n    select * from DEMO_DB.public.stg_customers\n\n),\n\norders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by 1\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders using (order_id)\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders using (customer_id)\n\n    left join customer_payments using (customer_id)\n\n)\n\nselect * from final",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "DEMO_DB.public.customers"
+		},
+		"model.jaffle_shop.orders": {
+			"raw_sql": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt_snowflake.unset_query_tag"],
+				"nodes": ["model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "table",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "orders"],
+			"unique_id": "model.jaffle_shop.orders",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "orders.sql",
+			"original_file_path": "models/orders.sql",
+			"name": "orders",
+			"alias": "orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "ec3e8884f18110dd6d9b1ababdd85a6c04bf665ee0f57cade273e442f90e9994"
+			},
+			"tags": [],
+			"refs": [
+				["stg_orders"],
+				["stg_payments"]
+			],
+			"sources": [],
+			"description": "This table has basic information about orders, as well as some derived facts based on payments",
+			"columns": {
+				"order_id": {
+					"name": "order_id",
+					"description": "This is a unique identifier for an order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"description": "Foreign key to the customers table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"order_date": {
+					"name": "order_date",
+					"description": "Date (UTC) that the order was placed",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"status": {
+					"name": "status",
+					"description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"amount": {
+					"name": "amount",
+					"description": "Total amount (AUD) of the order",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"credit_card_amount": {
+					"name": "credit_card_amount",
+					"description": "Amount of the order (AUD) paid for by credit card",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"coupon_amount": {
+					"name": "coupon_amount",
+					"description": "Amount of the order (AUD) paid for by coupon",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"bank_transfer_amount": {
+					"name": "bank_transfer_amount",
+					"description": "Amount of the order (AUD) paid for by bank transfer",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"gift_card_amount": {
+					"name": "gift_card_amount",
+					"description": "Amount of the order (AUD) paid for by gift card",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "jaffle_shop://models/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/orders.sql",
+			"build_path": "target/run/jaffle_shop/models/orders.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "table"
+			},
+			"created_at": 1625485389,
+			"compiled_sql": "\n\nwith orders as (\n\n    select * from DEMO_DB.public.stg_orders\n\n),\n\npayments as (\n\n    select * from DEMO_DB.public.stg_payments\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by 1\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n    left join order_payments using (order_id)\n\n)\n\nselect * from final",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "DEMO_DB.public.orders"
+		},
+		"model.jaffle_shop.stg_customers": {
+			"raw_sql": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["seed.jaffle_shop.raw_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_customers"],
+			"unique_id": "model.jaffle_shop.stg_customers",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "staging/stg_customers.sql",
+			"original_file_path": "models/staging/stg_customers.sql",
+			"name": "stg_customers",
+			"alias": "stg_customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "6f18a29204dad1de6dbb0c288144c4990742e0a1e065c3b2a67b5f98334c22ba"
+			},
+			"tags": [],
+			"refs": [
+				["raw_customers"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {
+				"customer_id": {
+					"name": "customer_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_customers.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_customers.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1625485389,
+			"compiled_sql": "with source as (\n    select * from DEMO_DB.public.raw_customers\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "DEMO_DB.public.stg_customers"
+		},
+		"model.jaffle_shop.stg_payments": {
+			"raw_sql": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["seed.jaffle_shop.raw_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_payments"],
+			"unique_id": "model.jaffle_shop.stg_payments",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "staging/stg_payments.sql",
+			"original_file_path": "models/staging/stg_payments.sql",
+			"name": "stg_payments",
+			"alias": "stg_payments",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "113502ed19f04efb2af0629ff139f57f7463347b6d5218f3b80a8d128cc96852"
+			},
+			"tags": [],
+			"refs": [
+				["raw_payments"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {
+				"payment_id": {
+					"name": "payment_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"payment_method": {
+					"name": "payment_method",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_payments.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_payments.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1625485389,
+			"compiled_sql": "with source as (\n    select * from DEMO_DB.public.raw_payments\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        --`amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "DEMO_DB.public.stg_payments"
+		},
+		"model.jaffle_shop.stg_orders": {
+			"raw_sql": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["seed.jaffle_shop.raw_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "staging", "stg_orders"],
+			"unique_id": "model.jaffle_shop.stg_orders",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "staging/stg_orders.sql",
+			"original_file_path": "models/staging/stg_orders.sql",
+			"name": "stg_orders",
+			"alias": "stg_orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "afffa9cbc57e5fd2cf5898ebf571d444a62c9d6d7929d8133d30567fb9a2ce97"
+			},
+			"tags": [],
+			"refs": [
+				["raw_orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {
+				"order_id": {
+					"name": "order_id",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				},
+				"status": {
+					"name": "status",
+					"description": "",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "jaffle_shop://models/staging/schema.yml",
+			"compiled_path": "target/compiled/jaffle_shop/models/staging/stg_orders.sql",
+			"build_path": "target/run/jaffle_shop/models/staging/stg_orders.sql",
+			"deferred": false,
+			"unrendered_config": {
+				"materialized": "view"
+			},
+			"created_at": 1625485389,
+			"compiled_sql": "with source as (\n    select * from DEMO_DB.public.raw_orders\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "DEMO_DB.public.stg_orders"
+		},
+		"seed.jaffle_shop.raw_customers": {
+			"raw_sql": "",
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "seed",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_customers"],
+			"unique_id": "seed.jaffle_shop.raw_customers",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "raw_customers.csv",
+			"original_file_path": "data/raw_customers.csv",
+			"name": "raw_customers",
+			"alias": "raw_customers",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "24579b4b26098d43265376f3c50be8b10faf8e8fd95f5508074f10f76a12671d"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389
+		},
+		"seed.jaffle_shop.raw_orders": {
+			"raw_sql": "",
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "seed",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_orders"],
+			"unique_id": "seed.jaffle_shop.raw_orders",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "raw_orders.csv",
+			"original_file_path": "data/raw_orders.csv",
+			"name": "raw_orders",
+			"alias": "raw_orders",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "ee6c68d1639ec2b23a4495ec12475e09b8ed4b61e23ab0411ea7ec76648356f7"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389
+		},
+		"seed.jaffle_shop.raw_payments": {
+			"raw_sql": "",
+			"resource_type": "seed",
+			"depends_on": {
+				"macros": [],
+				"nodes": []
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "seed",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"quote_columns": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public",
+			"fqn": ["jaffle_shop", "raw_payments"],
+			"unique_id": "seed.jaffle_shop.raw_payments",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "raw_payments.csv",
+			"original_file_path": "data/raw_payments.csv",
+			"name": "raw_payments",
+			"alias": "raw_payments",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "03fd407f3135f84456431a923f22fc185a2154079e210c20b690e3ab11687d11"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389
+		},
+		"test.jaffle_shop.unique_customers_customer_id.d48e126d80": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.customers"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "unique_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.unique_customers_customer_id.d48e126d80",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/unique_customers_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "unique_customers_customer_id",
+			"alias": "unique_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["customers"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.not_null_customers_customer_id.923d2d910a": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.customers"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_customers_customer_id.923d2d910a",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_customers_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_customers_customer_id",
+			"alias": "not_null_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["customers"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.unique_orders_order_id.0d77ddcf59": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "unique_orders_order_id"],
+			"unique_id": "test.jaffle_shop.unique_orders_order_id.0d77ddcf59",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/unique_orders_order_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "unique_orders_order_id",
+			"alias": "unique_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "order_id"
+		},
+		"test.jaffle_shop.not_null_orders_order_id.4daff5eed7": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_order_id"],
+			"unique_id": "test.jaffle_shop.not_null_orders_order_id.4daff5eed7",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_order_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_order_id",
+			"alias": "not_null_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "order_id"
+		},
+		"test.jaffle_shop.not_null_orders_customer_id.70722cc05f": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_orders_customer_id.70722cc05f",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_customer_id.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_customer_id",
+			"alias": "not_null_orders_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4": {
+			"raw_sql": "{{ test_relationships(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_relationships", "macro.dbt.default__test_relationships"],
+				"nodes": ["model.jaffle_shop.customers", "model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "relationships_orders_customer_id__customer_id__ref_customers_"],
+			"unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/relationships_orders_customer_id__customer_id__ref_customers_.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "relationships_orders_customer_id__customer_id__ref_customers_",
+			"alias": "relationships_orders_customer_id__customer_id__ref_customers_",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["customers"],
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93": {
+			"raw_sql": "{{ test_accepted_values(**_dbt_schema_test_kwargs) }}{{ config(alias=\"accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758\") }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.default__test_accepted_values"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "accepted_values_orders_status__placed__shipped__completed__return_pending__returned"],
+			"unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "accepted_values_orders_status__placed__shipped__completed__return_pending__returned",
+			"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758"
+			},
+			"created_at": 1625485389,
+			"column_name": "status"
+		},
+		"test.jaffle_shop.not_null_orders_amount.f7bae8de1b": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_amount.f7bae8de1b",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_amount",
+			"alias": "not_null_orders_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "amount"
+		},
+		"test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_credit_card_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_credit_card_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_credit_card_amount",
+			"alias": "not_null_orders_credit_card_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "credit_card_amount"
+		},
+		"test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_coupon_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_coupon_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_coupon_amount",
+			"alias": "not_null_orders_coupon_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "coupon_amount"
+		},
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_bank_transfer_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_bank_transfer_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_bank_transfer_amount",
+			"alias": "not_null_orders_bank_transfer_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "bank_transfer_amount"
+		},
+		"test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_orders_gift_card_amount"],
+			"unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_orders_gift_card_amount.sql",
+			"original_file_path": "models/schema.yml",
+			"name": "not_null_orders_gift_card_amount",
+			"alias": "not_null_orders_gift_card_amount",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "gift_card_amount"
+		},
+		"test.jaffle_shop.unique_stg_customers_customer_id.5530022331": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "unique_stg_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.5530022331",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/unique_stg_customers_customer_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_customers_customer_id",
+			"alias": "unique_stg_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_customers"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_customers"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_stg_customers_customer_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_stg_customers_customer_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_customers_customer_id",
+			"alias": "not_null_stg_customers_customer_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_customers"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "customer_id"
+		},
+		"test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "unique_stg_orders_order_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/unique_stg_orders_order_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_orders_order_id",
+			"alias": "unique_stg_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "order_id"
+		},
+		"test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_stg_orders_order_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_stg_orders_order_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_orders_order_id",
+			"alias": "not_null_stg_orders_order_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "order_id"
+		},
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f": {
+			"raw_sql": "{{ test_accepted_values(**_dbt_schema_test_kwargs) }}{{ config(alias=\"accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58\") }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.default__test_accepted_values"],
+				"nodes": ["model.jaffle_shop.stg_orders"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned"],
+			"unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+			"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_orders"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58"
+			},
+			"created_at": 1625485389,
+			"column_name": "status"
+		},
+		"test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6": {
+			"raw_sql": "{{ test_unique(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_unique"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "unique_stg_payments_payment_id"],
+			"unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/unique_stg_payments_payment_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "unique_stg_payments_payment_id",
+			"alias": "unique_stg_payments_payment_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "payment_id"
+		},
+		"test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012": {
+			"raw_sql": "{{ test_not_null(**_dbt_schema_test_kwargs) }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_not_null"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "not_null_stg_payments_payment_id"],
+			"unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/not_null_stg_payments_payment_id.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "not_null_stg_payments_payment_id",
+			"alias": "not_null_stg_payments_payment_id",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625485389,
+			"column_name": "payment_id"
+		},
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081": {
+			"raw_sql": "{{ test_accepted_values(**_dbt_schema_test_kwargs) }}{{ config(alias=\"accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef\") }}",
+			"resource_type": "test",
+			"depends_on": {
+				"macros": ["macro.dbt.test_accepted_values", "macro.dbt.default__test_accepted_values"],
+				"nodes": ["model.jaffle_shop.stg_payments"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "test",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+				"schema": "dbt_test__audit",
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"severity": "ERROR",
+				"store_failures": null,
+				"where": null,
+				"limit": null,
+				"fail_calc": "count(*)",
+				"warn_if": "!= 0",
+				"error_if": "!= 0",
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "DEMO_DB",
+			"schema": "public_dbt_test__audit",
+			"fqn": ["jaffle_shop", "schema_test", "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card"],
+			"unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "schema_test/accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef.sql",
+			"original_file_path": "models/staging/schema.yml",
+			"name": "accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+			"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
+			"checksum": {
+				"name": "none",
+				"checksum": ""
+			},
+			"tags": ["schema"],
+			"refs": [
+				["stg_payments"]
+			],
+			"sources": [],
+			"description": "",
+			"columns": {},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"compiled_path": null,
+			"build_path": null,
+			"deferred": false,
+			"unrendered_config": {
+				"alias": "accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef"
+			},
+			"created_at": 1625485389,
+			"column_name": "payment_method"
+		}
+	},
+	"sources": {},
+	"macros": {
+		"macro.dbt_snowflake.snowflake__get_catalog": {
+			"unique_id": "macro.dbt_snowflake.snowflake__get_catalog",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/catalog.sql",
+			"original_file_path": "macros/catalog.sql",
+			"name": "snowflake__get_catalog",
+			"macro_sql": "{% macro snowflake__get_catalog(information_schema, schemas) -%}\n  {% set query %}\n      with tables as (\n\n          select\n              table_catalog as \"table_database\",\n              table_schema as \"table_schema\",\n              table_name as \"table_name\",\n              table_type as \"table_type\",\n              comment as \"table_comment\",\n\n              -- note: this is the _role_ that owns the table\n              table_owner as \"table_owner\",\n\n              'Clustering Key' as \"stats:clustering_key:label\",\n              clustering_key as \"stats:clustering_key:value\",\n              'The key used to cluster this table' as \"stats:clustering_key:description\",\n              (clustering_key is not null) as \"stats:clustering_key:include\",\n\n              'Row Count' as \"stats:row_count:label\",\n              row_count as \"stats:row_count:value\",\n              'An approximate count of rows in this table' as \"stats:row_count:description\",\n              (row_count is not null) as \"stats:row_count:include\",\n\n              'Approximate Size' as \"stats:bytes:label\",\n              bytes as \"stats:bytes:value\",\n              'Approximate size of the table as reported by Snowflake' as \"stats:bytes:description\",\n              (bytes is not null) as \"stats:bytes:include\",\n\n              'Last Modified' as \"stats:last_modified:label\",\n              to_varchar(convert_timezone('UTC', last_altered), 'yyyy-mm-dd HH24:MI'||'UTC') as \"stats:last_modified:value\",\n              'The timestamp for last update/change' as \"stats:last_modified:description\",\n              (last_altered is not null and table_type='BASE TABLE') as \"stats:last_modified:include\"\n\n          from {{ information_schema }}.tables\n\n      ),\n\n      columns as (\n\n          select\n              table_catalog as \"table_database\",\n              table_schema as \"table_schema\",\n              table_name as \"table_name\",\n\n              column_name as \"column_name\",\n              ordinal_position as \"column_index\",\n              data_type as \"column_type\",\n              comment as \"column_comment\"\n\n          from {{ information_schema }}.columns\n      )\n\n      select *\n      from tables\n      join columns using (\"table_database\", \"table_schema\", \"table_name\")\n      where (\n        {%- for schema in schemas -%}\n          upper(\"table_schema\") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}\n        {%- endfor -%}\n      )\n      order by \"column_index\"\n    {%- endset -%}\n\n  {{ return(run_query(query)) }}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__create_table_as": {
+			"unique_id": "macro.dbt_snowflake.snowflake__create_table_as",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__create_table_as",
+			"macro_sql": "{% macro snowflake__create_table_as(temporary, relation, sql) -%}\n  {%- set transient = config.get('transient', default=true) -%}\n  {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}\n  {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}\n  {%- set copy_grants = config.get('copy_grants', default=false) -%}\n\n  {%- if cluster_by_keys is not none and cluster_by_keys is string -%}\n    {%- set cluster_by_keys = [cluster_by_keys] -%}\n  {%- endif -%}\n  {%- if cluster_by_keys is not none -%}\n    {%- set cluster_by_string = cluster_by_keys|join(\", \")-%}\n  {% else %}\n    {%- set cluster_by_string = none -%}\n  {%- endif -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n      create or replace {% if temporary -%}\n        temporary\n      {%- elif transient -%}\n        transient\n      {%- endif %} table {{ relation }} {% if copy_grants and not temporary -%} copy grants {%- endif %} as\n      (\n        {%- if cluster_by_string is not none -%}\n          select * from(\n            {{ sql }}\n            ) order by ({{ cluster_by_string }})\n        {%- else -%}\n          {{ sql }}\n        {%- endif %}\n      );\n    {% if cluster_by_string is not none and not temporary -%}\n      alter table {{relation}} cluster by ({{cluster_by_string}});\n    {%- endif -%}\n    {% if enable_automatic_clustering and cluster_by_string is not none and not temporary  -%}\n      alter table {{relation}} resume recluster;\n    {%- endif -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__create_view_as": {
+			"unique_id": "macro.dbt_snowflake.snowflake__create_view_as",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__create_view_as",
+			"macro_sql": "{% macro snowflake__create_view_as(relation, sql) -%}\n  {%- set secure = config.get('secure', default=false) -%}\n  {%- set copy_grants = config.get('copy_grants', default=false) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create or replace {% if secure -%}\n    secure\n  {%- endif %} view {{ relation }} {% if copy_grants -%} copy grants {%- endif %} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__get_columns_in_relation": {
+			"unique_id": "macro.dbt_snowflake.snowflake__get_columns_in_relation",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__get_columns_in_relation",
+			"macro_sql": "{% macro snowflake__get_columns_in_relation(relation) -%}\n  {%- set sql -%}\n    describe table {{ relation }}\n  {%- endset -%}\n  {%- set result = run_query(sql) -%}\n\n  {% set maximum = 10000 %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many columns in relation {{ relation }}! dbt can only get\n      information about relations with fewer than {{ maximum }} columns.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n\n  {% set columns = [] %}\n  {% for row in result %}\n    {% do columns.append(api.Column.from_description(row['name'], row['type'])) %}\n  {% endfor %}\n  {% do return(columns) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__list_schemas": {
+			"unique_id": "macro.dbt_snowflake.snowflake__list_schemas",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__list_schemas",
+			"macro_sql": "{% macro snowflake__list_schemas(database) -%}\n  {# 10k limit from here: https://docs.snowflake.net/manuals/sql-reference/sql/show-schemas.html#usage-notes #}\n  {% set maximum = 10000 %}\n  {% set sql -%}\n    show terse schemas in database {{ database }}\n    limit {{ maximum }}\n  {%- endset %}\n  {% set result = run_query(sql) %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many schemas in database {{ database }}! dbt can only get\n      information about databases with fewer than {{ maximum }} schemas.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n  {{ return(result) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__list_relations_without_caching": {
+			"unique_id": "macro.dbt_snowflake.snowflake__list_relations_without_caching",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__list_relations_without_caching",
+			"macro_sql": "{% macro snowflake__list_relations_without_caching(schema_relation) %}\n  {%- set sql -%}\n    show terse objects in {{ schema_relation }}\n  {%- endset -%}\n\n  {%- set result = run_query(sql) -%}\n  {% set maximum = 10000 %}\n  {% if (result | length) >= maximum %}\n    {% set msg %}\n      Too many schemas in schema  {{ schema_relation }}! dbt can only get\n      information about schemas with fewer than {{ maximum }} objects.\n    {% endset %}\n    {% do exceptions.raise_compiler_error(msg) %}\n  {% endif %}\n  {%- do return(result) -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__check_schema_exists": {
+			"unique_id": "macro.dbt_snowflake.snowflake__check_schema_exists",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__check_schema_exists",
+			"macro_sql": "{% macro snowflake__check_schema_exists(information_schema, schema) -%}\n  {% call statement('check_schema_exists', fetch_result=True) -%}\n        select count(*)\n        from {{ information_schema }}.schemata\n        where upper(schema_name) = upper('{{ schema }}')\n            and upper(catalog_name) = upper('{{ information_schema.database }}')\n  {%- endcall %}\n  {{ return(load_result('check_schema_exists').table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__current_timestamp": {
+			"unique_id": "macro.dbt_snowflake.snowflake__current_timestamp",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__current_timestamp",
+			"macro_sql": "{% macro snowflake__current_timestamp() -%}\n  convert_timezone('UTC', current_timestamp())\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__snapshot_string_as_time": {
+			"unique_id": "macro.dbt_snowflake.snowflake__snapshot_string_as_time",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__snapshot_string_as_time",
+			"macro_sql": "{% macro snowflake__snapshot_string_as_time(timestamp) -%}\n    {%- set result = \"to_timestamp_ntz('\" ~ timestamp ~ \"')\" -%}\n    {{ return(result) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__snapshot_get_time": {
+			"unique_id": "macro.dbt_snowflake.snowflake__snapshot_get_time",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__snapshot_get_time",
+			"macro_sql": "{% macro snowflake__snapshot_get_time() -%}\n  to_timestamp_ntz({{ current_timestamp() }})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__rename_relation": {
+			"unique_id": "macro.dbt_snowflake.snowflake__rename_relation",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__rename_relation",
+			"macro_sql": "{% macro snowflake__rename_relation(from_relation, to_relation) -%}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ to_relation }}\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__alter_column_type": {
+			"unique_id": "macro.dbt_snowflake.snowflake__alter_column_type",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__alter_column_type",
+			"macro_sql": "{% macro snowflake__alter_column_type(relation, column_name, new_column_type) -%}\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} alter {{ adapter.quote(column_name) }} set data type {{ new_column_type }};\n  {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__alter_relation_comment": {
+			"unique_id": "macro.dbt_snowflake.snowflake__alter_relation_comment",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__alter_relation_comment",
+			"macro_sql": "{% macro snowflake__alter_relation_comment(relation, relation_comment) -%}\n  comment on {{ relation.type }} {{ relation }} IS $${{ relation_comment | replace('$', '[$]') }}$$;\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__alter_column_comment": {
+			"unique_id": "macro.dbt_snowflake.snowflake__alter_column_comment",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "snowflake__alter_column_comment",
+			"macro_sql": "{% macro snowflake__alter_column_comment(relation, column_dict) -%}\n    {% for column_name in column_dict %}\n        comment if exists on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is $${{ column_dict[column_name]['description'] | replace('$', '[$]') }}$$;\n    {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.get_current_query_tag": {
+			"unique_id": "macro.dbt_snowflake.get_current_query_tag",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "get_current_query_tag",
+			"macro_sql": "{% macro get_current_query_tag() -%}\n  {{ return(run_query(\"show parameters like 'query_tag' in session\").rows[0]['value']) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.set_query_tag": {
+			"unique_id": "macro.dbt_snowflake.set_query_tag",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "set_query_tag",
+			"macro_sql": "{% macro set_query_tag() -%}\n  {% set new_query_tag = config.get('query_tag') %}\n  {% if new_query_tag %}\n    {% set original_query_tag = get_current_query_tag() %}\n    {{ log(\"Setting query_tag to '\" ~ new_query_tag ~ \"'. Will reset to '\" ~ original_query_tag ~ \"' after materialization.\") }}\n    {% do run_query(\"alter session set query_tag = '{}'\".format(new_query_tag)) %}\n    {{ return(original_query_tag)}}\n  {% endif %}\n  {{ return(none)}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.get_current_query_tag", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.unset_query_tag": {
+			"unique_id": "macro.dbt_snowflake.unset_query_tag",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/adapters.sql",
+			"original_file_path": "macros/adapters.sql",
+			"name": "unset_query_tag",
+			"macro_sql": "{% macro unset_query_tag(original_query_tag) -%}\n  {% set new_query_tag = config.get('query_tag') %}\n  {% if new_query_tag %}\n    {% if original_query_tag %}\n      {{ log(\"Resetting query_tag to '\" ~ original_query_tag ~ \"'.\") }}\n      {% do run_query(\"alter session set query_tag = '{}'\".format(original_query_tag)) %}\n    {% else %}\n      {{ log(\"No original query_tag, unsetting parameter.\") }}\n      {% do run_query(\"alter session unset query_tag\") %}\n    {% endif %}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy": {
+			"unique_id": "macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/incremental.sql",
+			"original_file_path": "macros/materializations/incremental.sql",
+			"name": "dbt_snowflake_validate_get_incremental_strategy",
+			"macro_sql": "{% macro dbt_snowflake_validate_get_incremental_strategy(config) %}\n  {#-- Find and validate the incremental strategy #}\n  {%- set strategy = config.get(\"incremental_strategy\", default=\"merge\") -%}\n\n  {% set invalid_strategy_msg -%}\n    Invalid incremental strategy provided: {{ strategy }}\n    Expected one of: 'merge', 'delete+insert'\n  {%- endset %}\n  {% if strategy not in ['merge', 'delete+insert'] %}\n    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}\n  {% endif %}\n\n  {% do return(strategy) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.dbt_snowflake_get_incremental_sql": {
+			"unique_id": "macro.dbt_snowflake.dbt_snowflake_get_incremental_sql",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/incremental.sql",
+			"original_file_path": "macros/materializations/incremental.sql",
+			"name": "dbt_snowflake_get_incremental_sql",
+			"macro_sql": "{% macro dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}\n  {% if strategy == 'merge' %}\n    {% do return(get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}\n  {% elif strategy == 'delete+insert' %}\n    {% do return(get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}\n  {% else %}\n    {% do exceptions.raise_compiler_error('invalid strategy: ' ~ strategy) %}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_merge_sql", "macro.dbt.get_delete_insert_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.materialization_incremental_snowflake": {
+			"unique_id": "macro.dbt_snowflake.materialization_incremental_snowflake",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/incremental.sql",
+			"original_file_path": "macros/materializations/incremental.sql",
+			"name": "materialization_incremental_snowflake",
+			"macro_sql": "{% materialization incremental, adapter='snowflake' -%}\n\n  {% set original_query_tag = set_query_tag() %}\n\n  {%- set unique_key = config.get('unique_key') -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {% set target_relation = this %}\n  {% set existing_relation = load_relation(this) %}\n  {% set tmp_relation = make_temp_relation(this) %}\n\n  {#-- Validate early so we don't run SQL if the strategy is invalid --#}\n  {% set strategy = dbt_snowflake_validate_get_incremental_strategy(config) -%}\n\n  -- setup\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% if existing_relation is none %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% elif existing_relation.is_view %}\n    {#-- Can't overwrite a view with a table - we must drop --#}\n    {{ log(\"Dropping relation \" ~ target_relation ~ \" because it is a view and this model is a table.\") }}\n    {% do adapter.drop_relation(existing_relation) %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% elif full_refresh_mode %}\n    {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% else %}\n    {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n    {% do adapter.expand_target_column_types(\n           from_relation=tmp_relation,\n           to_relation=target_relation) %}\n    {% set dest_columns = adapter.get_columns_in_relation(target_relation) %}\n    {% set build_sql = dbt_snowflake_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key, dest_columns) %}\n  {% endif %}\n\n  {%- call statement('main') -%}\n    {{ build_sql }}\n  {%- endcall -%}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {% set target_relation = target_relation.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {% do unset_query_tag(original_query_tag) %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.should_full_refresh", "macro.dbt.load_relation", "macro.dbt.make_temp_relation", "macro.dbt_snowflake.dbt_snowflake_validate_get_incremental_strategy", "macro.dbt.run_hooks", "macro.dbt.create_table_as", "macro.dbt.run_query", "macro.dbt_snowflake.dbt_snowflake_get_incremental_sql", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt_snowflake.unset_query_tag"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.materialization_table_snowflake": {
+			"unique_id": "macro.dbt_snowflake.materialization_table_snowflake",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/table.sql",
+			"original_file_path": "macros/materializations/table.sql",
+			"name": "materialization_table_snowflake",
+			"macro_sql": "{% materialization table, adapter='snowflake' %}\n\n  {% set original_query_tag = set_query_tag() %}\n\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database, type='table') -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {#-- Drop the relation if it was a view to \"convert\" it in a table. This may lead to\n    -- downtime, but it should be a relatively infrequent occurrence  #}\n  {% if old_relation is not none and not old_relation.is_table %}\n    {{ log(\"Dropping relation \" ~ old_relation ~ \" because it is of type \" ~ old_relation.type) }}\n    {{ drop_relation_if_exists(old_relation) }}\n  {% endif %}\n\n  --build model\n  {% call statement('main') -%}\n    {{ create_table_as(false, target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% do unset_query_tag(original_query_tag) %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.run_hooks", "macro.dbt.drop_relation_if_exists", "macro.dbt.statement", "macro.dbt.create_table_as", "macro.dbt.persist_docs", "macro.dbt_snowflake.unset_query_tag"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.materialization_view_snowflake": {
+			"unique_id": "macro.dbt_snowflake.materialization_view_snowflake",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/view.sql",
+			"original_file_path": "macros/materializations/view.sql",
+			"name": "materialization_view_snowflake",
+			"macro_sql": "{% materialization view, adapter='snowflake' -%}\n\n    {% set original_query_tag = set_query_tag() %}\n    {% set to_return = create_or_replace_view() %}\n\n    {% set target_relation = this.incorporate(type='view') %}\n    {% do persist_docs(target_relation, model, for_columns=false) %}\n\n    {% do return(to_return) %}\n\n    {% do unset_query_tag(original_query_tag) %}\n\n{%- endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.set_query_tag", "macro.dbt.create_or_replace_view", "macro.dbt.persist_docs", "macro.dbt_snowflake.unset_query_tag"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt_snowflake.snowflake__get_merge_sql": {
+			"unique_id": "macro.dbt_snowflake.snowflake__get_merge_sql",
+			"package_name": "dbt_snowflake",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/snowflake",
+			"path": "macros/materializations/merge.sql",
+			"original_file_path": "macros/materializations/merge.sql",
+			"name": "snowflake__get_merge_sql",
+			"macro_sql": "{% macro snowflake__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) -%}\n\n    {#\n       Workaround for Snowflake not being happy with a merge on a constant-false predicate.\n       When no unique_key is provided, this macro will do a regular insert. If a unique_key\n       is provided, then this macro will do a proper merge instead.\n    #}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute='name')) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {%- if unique_key is none -%}\n\n        {{ sql_header if sql_header is not none }}\n\n        insert into {{ target }} ({{ dest_cols_csv }})\n        (\n            select {{ dest_cols_csv }}\n            from {{ source_sql }}\n        );\n\n    {%- else -%}\n\n        {{ default__get_merge_sql(target, source_sql, unique_key, dest_columns, predicates) }}\n\n    {%- endif -%}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv", "macro.dbt.default__get_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.statement": {
+			"unique_id": "macro.dbt.statement",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/core.sql",
+			"original_file_path": "macros/core.sql",
+			"name": "statement",
+			"macro_sql": "{% macro statement(name=None, fetch_result=False, auto_begin=True) -%}\n  {%- if execute: -%}\n    {%- set sql = caller() -%}\n\n    {%- if name == 'main' -%}\n      {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n      {{ write(sql) }}\n    {%- endif -%}\n\n    {%- set res, table = adapter.execute(sql, auto_begin=auto_begin, fetch=fetch_result) -%}\n    {%- if name is not none -%}\n      {{ store_result(name, response=res, agate_table=table) }}\n    {%- endif -%}\n\n  {%- endif -%}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.noop_statement": {
+			"unique_id": "macro.dbt.noop_statement",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/core.sql",
+			"original_file_path": "macros/core.sql",
+			"name": "noop_statement",
+			"macro_sql": "{% macro noop_statement(name=None, message=None, code=None, rows_affected=None, res=None) -%}\n  {%- set sql = caller() -%}\n\n  {%- if name == 'main' -%}\n    {{ log('Writing runtime SQL for node \"{}\"'.format(model['unique_id'])) }}\n    {{ write(sql) }}\n  {%- endif -%}\n\n  {%- if name is not none -%}\n    {{ store_raw_result(name, message=message, code=code, rows_affected=rows_affected, agate_table=res) }}\n  {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_test_sql": {
+			"unique_id": "macro.dbt.get_test_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/test.sql",
+			"original_file_path": "macros/materializations/test.sql",
+			"name": "get_test_sql",
+			"macro_sql": "{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n  {{ adapter.dispatch('get_test_sql')(main_sql, fail_calc, warn_if, error_if, limit) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_test_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_test_sql": {
+			"unique_id": "macro.dbt.default__get_test_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/test.sql",
+			"original_file_path": "macros/materializations/test.sql",
+			"name": "default__get_test_sql",
+			"macro_sql": "{% macro default__get_test_sql(main_sql, fail_calc, warn_if, error_if, limit) -%}\n    select\n      {{ fail_calc }} as failures,\n      {{ fail_calc }} {{ warn_if }} as should_warn,\n      {{ fail_calc }} {{ error_if }} as should_error\n    from (\n      {{ main_sql }}\n      {{ \"limit \" ~ limit if limit != none }}\n    ) dbt_internal_test\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_test_default": {
+			"unique_id": "macro.dbt.materialization_test_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/test.sql",
+			"original_file_path": "macros/materializations/test.sql",
+			"name": "materialization_test_default",
+			"macro_sql": "\n\n{%- materialization test, default -%}\n\n  {% set relations = [] %}\n\n  {% if should_store_failures() %}\n\n    {% set identifier = model['alias'] %}\n    {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n    {% set target_relation = api.Relation.create(\n        identifier=identifier, schema=schema, database=database, type='table') -%} %}\n    \n    {% if old_relation %}\n        {% do adapter.drop_relation(old_relation) %}\n    {% endif %}\n    \n    {% call statement(auto_begin=True) %}\n        {{ create_table_as(False, target_relation, sql) }}\n    {% endcall %}\n    \n    {% do relations.append(target_relation) %}\n  \n    {% set main_sql %}\n        select *\n        from {{ target_relation }}\n    {% endset %}\n    \n    {{ adapter.commit() }}\n  \n  {% else %}\n\n      {% set main_sql = sql %}\n  \n  {% endif %}\n\n  {% set limit = config.get('limit') %}\n  {% set fail_calc = config.get('fail_calc') %}\n  {% set warn_if = config.get('warn_if') %}\n  {% set error_if = config.get('error_if') %}\n\n  {% call statement('main', fetch_result=True) -%}\n\n    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}\n\n  {%- endcall %}\n  \n  {{ return({'relations': relations}) }}\n\n{%- endmaterialization -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_store_failures", "macro.dbt.statement", "macro.dbt.create_table_as", "macro.dbt.get_test_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.run_hooks": {
+			"unique_id": "macro.dbt.run_hooks",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "run_hooks",
+			"macro_sql": "{% macro run_hooks(hooks, inside_transaction=True) %}\n  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}\n    {% if not inside_transaction and loop.first %}\n      {% call statement(auto_begin=inside_transaction) %}\n        commit;\n      {% endcall %}\n    {% endif %}\n    {% set rendered = render(hook.get('sql')) | trim %}\n    {% if (rendered | length) > 0 %}\n      {% call statement(auto_begin=inside_transaction) %}\n        {{ rendered }}\n      {% endcall %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.column_list": {
+			"unique_id": "macro.dbt.column_list",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "column_list",
+			"macro_sql": "{% macro column_list(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {% if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.column_list_for_create_table": {
+			"unique_id": "macro.dbt.column_list_for_create_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "column_list_for_create_table",
+			"macro_sql": "{% macro column_list_for_create_table(columns) %}\n  {%- for col in columns %}\n    {{ col.name }} {{ col.data_type }} {%- if not loop.last %},{% endif %}\n  {% endfor -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.make_hook_config": {
+			"unique_id": "macro.dbt.make_hook_config",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "make_hook_config",
+			"macro_sql": "{% macro make_hook_config(sql, inside_transaction) %}\n    {{ tojson({\"sql\": sql, \"transaction\": inside_transaction}) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.before_begin": {
+			"unique_id": "macro.dbt.before_begin",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "before_begin",
+			"macro_sql": "{% macro before_begin(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.in_transaction": {
+			"unique_id": "macro.dbt.in_transaction",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "in_transaction",
+			"macro_sql": "{% macro in_transaction(sql) %}\n    {{ make_hook_config(sql, inside_transaction=True) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.after_commit": {
+			"unique_id": "macro.dbt.after_commit",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "after_commit",
+			"macro_sql": "{% macro after_commit(sql) %}\n    {{ make_hook_config(sql, inside_transaction=False) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_hook_config"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.drop_relation_if_exists": {
+			"unique_id": "macro.dbt.drop_relation_if_exists",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "drop_relation_if_exists",
+			"macro_sql": "{% macro drop_relation_if_exists(relation) %}\n  {% if relation is not none %}\n    {{ adapter.drop_relation(relation) }}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.load_relation": {
+			"unique_id": "macro.dbt.load_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "load_relation",
+			"macro_sql": "{% macro load_relation(relation) %}\n  {% do return(adapter.get_relation(\n    database=relation.database,\n    schema=relation.schema,\n    identifier=relation.identifier\n  )) -%}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.should_full_refresh": {
+			"unique_id": "macro.dbt.should_full_refresh",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "should_full_refresh",
+			"macro_sql": "{% macro should_full_refresh() %}\n  {% set config_full_refresh = config.get('full_refresh') %}\n  {% if config_full_refresh is none %}\n    {% set config_full_refresh = flags.FULL_REFRESH %}\n  {% endif %}\n  {% do return(config_full_refresh) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.should_store_failures": {
+			"unique_id": "macro.dbt.should_store_failures",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/helpers.sql",
+			"original_file_path": "macros/materializations/helpers.sql",
+			"name": "should_store_failures",
+			"macro_sql": "{% macro should_store_failures() %}\n  {% set config_store_failures = config.get('store_failures') %}\n  {% if config_store_failures is none %}\n    {% set config_store_failures = flags.STORE_FAILURES %}\n  {% endif %}\n  {% do return(config_store_failures) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_merge_sql": {
+			"unique_id": "macro.dbt.snapshot_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot_merge.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot_merge.sql",
+			"name": "snapshot_merge_sql",
+			"macro_sql": "{% macro snapshot_merge_sql(target, source, insert_cols) -%}\n  {{ adapter.dispatch('snapshot_merge_sql')(target, source, insert_cols) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__snapshot_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__snapshot_merge_sql": {
+			"unique_id": "macro.dbt.default__snapshot_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot_merge.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot_merge.sql",
+			"name": "default__snapshot_merge_sql",
+			"macro_sql": "{% macro default__snapshot_merge_sql(target, source, insert_cols) -%}\n    {%- set insert_cols_csv = insert_cols | join(', ') -%}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n    using {{ source }} as DBT_INTERNAL_SOURCE\n    on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id\n\n    when matched\n     and DBT_INTERNAL_DEST.dbt_valid_to is null\n     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')\n        then update\n        set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to\n\n    when not matched\n     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'\n        then insert ({{ insert_cols_csv }})\n        values ({{ insert_cols_csv }})\n    ;\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_columns": {
+			"unique_id": "macro.dbt.create_columns",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "create_columns",
+			"macro_sql": "{% macro create_columns(relation, columns) %}\n  {{ adapter.dispatch('create_columns')(relation, columns) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_columns"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_columns": {
+			"unique_id": "macro.dbt.default__create_columns",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "default__create_columns",
+			"macro_sql": "{% macro default__create_columns(relation, columns) %}\n  {% for column in columns %}\n    {% call statement() %}\n      alter table {{ relation }} add column \"{{ column.name }}\" {{ column.data_type }};\n    {% endcall %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.post_snapshot": {
+			"unique_id": "macro.dbt.post_snapshot",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "post_snapshot",
+			"macro_sql": "{% macro post_snapshot(staging_relation) %}\n  {{ adapter.dispatch('post_snapshot')(staging_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__post_snapshot"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__post_snapshot": {
+			"unique_id": "macro.dbt.default__post_snapshot",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "default__post_snapshot",
+			"macro_sql": "{% macro default__post_snapshot(staging_relation) %}\n    {# no-op #}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_staging_table": {
+			"unique_id": "macro.dbt.snapshot_staging_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "snapshot_staging_table",
+			"macro_sql": "{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}\n\n    with snapshot_query as (\n\n        {{ source_sql }}\n\n    ),\n\n    snapshotted_data as (\n\n        select *,\n            {{ strategy.unique_key }} as dbt_unique_key\n\n        from {{ target_relation }}\n        where dbt_valid_to is null\n\n    ),\n\n    insertions_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,\n            {{ strategy.scd_id }} as dbt_scd_id\n\n        from snapshot_query\n    ),\n\n    updates_source_data as (\n\n        select\n            *,\n            {{ strategy.unique_key }} as dbt_unique_key,\n            {{ strategy.updated_at }} as dbt_updated_at,\n            {{ strategy.updated_at }} as dbt_valid_from,\n            {{ strategy.updated_at }} as dbt_valid_to\n\n        from snapshot_query\n    ),\n\n    {%- if strategy.invalidate_hard_deletes %}\n\n    deletes_source_data as (\n\n        select \n            *,\n            {{ strategy.unique_key }} as dbt_unique_key\n        from snapshot_query\n    ),\n    {% endif %}\n\n    insertions as (\n\n        select\n            'insert' as dbt_change_type,\n            source_data.*\n\n        from insertions_source_data as source_data\n        left outer join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where snapshotted_data.dbt_unique_key is null\n           or (\n                snapshotted_data.dbt_unique_key is not null\n            and (\n                {{ strategy.row_changed }}\n            )\n        )\n\n    ),\n\n    updates as (\n\n        select\n            'update' as dbt_change_type,\n            source_data.*,\n            snapshotted_data.dbt_scd_id\n\n        from updates_source_data as source_data\n        join snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where (\n            {{ strategy.row_changed }}\n        )\n    )\n\n    {%- if strategy.invalidate_hard_deletes -%}\n    ,\n\n    deletes as (\n    \n        select\n            'delete' as dbt_change_type,\n            source_data.*,\n            {{ snapshot_get_time() }} as dbt_valid_from,\n            {{ snapshot_get_time() }} as dbt_updated_at,\n            {{ snapshot_get_time() }} as dbt_valid_to,\n            snapshotted_data.dbt_scd_id\n    \n        from snapshotted_data\n        left join deletes_source_data as source_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key\n        where source_data.dbt_unique_key is null\n    )\n    {%- endif %}\n\n    select * from insertions\n    union all\n    select * from updates\n    {%- if strategy.invalidate_hard_deletes %}\n    union all\n    select * from deletes\n    {%- endif %}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_get_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.build_snapshot_table": {
+			"unique_id": "macro.dbt.build_snapshot_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "build_snapshot_table",
+			"macro_sql": "{% macro build_snapshot_table(strategy, sql) %}\n\n    select *,\n        {{ strategy.scd_id }} as dbt_scd_id,\n        {{ strategy.updated_at }} as dbt_updated_at,\n        {{ strategy.updated_at }} as dbt_valid_from,\n        nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to\n    from (\n        {{ sql }}\n    ) sbq\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_or_create_relation": {
+			"unique_id": "macro.dbt.get_or_create_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "get_or_create_relation",
+			"macro_sql": "{% macro get_or_create_relation(database, schema, identifier, type) %}\n  {%- set target_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}\n\n  {% if target_relation %}\n    {% do return([true, target_relation]) %}\n  {% endif %}\n\n  {%- set new_relation = api.Relation.create(\n      database=database,\n      schema=schema,\n      identifier=identifier,\n      type=type\n  ) -%}\n  {% do return([false, new_relation]) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.build_snapshot_staging_table": {
+			"unique_id": "macro.dbt.build_snapshot_staging_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "build_snapshot_staging_table",
+			"macro_sql": "{% macro build_snapshot_staging_table(strategy, sql, target_relation) %}\n    {% set tmp_relation = make_temp_relation(target_relation) %}\n\n    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}\n\n    {% call statement('build_snapshot_staging_relation') %}\n        {{ create_table_as(True, tmp_relation, select) }}\n    {% endcall %}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.make_temp_relation", "macro.dbt.snapshot_staging_table", "macro.dbt.statement", "macro.dbt.create_table_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_snapshot_default": {
+			"unique_id": "macro.dbt.materialization_snapshot_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/snapshot.sql",
+			"original_file_path": "macros/materializations/snapshot/snapshot.sql",
+			"name": "materialization_snapshot_default",
+			"macro_sql": "{% materialization snapshot, default %}\n  {%- set config = model['config'] -%}\n\n  {%- set target_table = model.get('alias', model.get('name')) -%}\n\n  {%- set strategy_name = config.get('strategy') -%}\n  {%- set unique_key = config.get('unique_key') %}\n\n  {% if not adapter.check_schema_exists(model.database, model.schema) %}\n    {% do create_schema(model.database, model.schema) %}\n  {% endif %}\n\n  {% set target_relation_exists, target_relation = get_or_create_relation(\n          database=model.database,\n          schema=model.schema,\n          identifier=target_table,\n          type='table') -%}\n\n  {%- if not target_relation.is_table -%}\n    {% do exceptions.relation_wrong_type(target_relation, 'table') %}\n  {%- endif -%}\n\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set strategy_macro = strategy_dispatch(strategy_name) %}\n  {% set strategy = strategy_macro(model, \"snapshotted_data\", \"source_data\", config, target_relation_exists) %}\n\n  {% if not target_relation_exists %}\n\n      {% set build_sql = build_snapshot_table(strategy, model['compiled_sql']) %}\n      {% set final_sql = create_table_as(False, target_relation, build_sql) %}\n\n  {% else %}\n\n      {{ adapter.valid_snapshot_target(target_relation) }}\n\n      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}\n\n      -- this may no-op if the database does not require column expansion\n      {% do adapter.expand_target_column_types(from_relation=staging_table,\n                                               to_relation=target_relation) %}\n\n      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% do create_columns(target_relation, missing_columns) %}\n\n      {% set source_columns = adapter.get_columns_in_relation(staging_table)\n                                   | rejectattr('name', 'equalto', 'dbt_change_type')\n                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')\n                                   | rejectattr('name', 'equalto', 'dbt_unique_key')\n                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')\n                                   | list %}\n\n      {% set quoted_source_columns = [] %}\n      {% for column in source_columns %}\n        {% do quoted_source_columns.append(adapter.quote(column.name)) %}\n      {% endfor %}\n\n      {% set final_sql = snapshot_merge_sql(\n            target = target_relation,\n            source = staging_table,\n            insert_cols = quoted_source_columns\n         )\n      %}\n\n  {% endif %}\n\n  {% call statement('main') %}\n      {{ final_sql }}\n  {% endcall %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if not target_relation_exists %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if staging_table is defined %}\n      {% do post_snapshot(staging_table) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.create_schema", "macro.dbt.get_or_create_relation", "macro.dbt.run_hooks", "macro.dbt.strategy_dispatch", "macro.dbt.build_snapshot_table", "macro.dbt.create_table_as", "macro.dbt.build_snapshot_staging_table", "macro.dbt.create_columns", "macro.dbt.snapshot_merge_sql", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt.create_indexes", "macro.dbt.post_snapshot"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.strategy_dispatch": {
+			"unique_id": "macro.dbt.strategy_dispatch",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "strategy_dispatch",
+			"macro_sql": "{% macro strategy_dispatch(name) -%}\n{% set original_name = name %}\n  {% if '.' in name %}\n    {% set package_name, name = name.split(\".\", 1) %}\n  {% else %}\n    {% set package_name = none %}\n  {% endif %}\n\n  {% if package_name is none %}\n    {% set package_context = context %}\n  {% elif package_name in context %}\n    {% set package_context = context[package_name] %}\n  {% else %}\n    {% set error_msg %}\n        Could not find package '{{package_name}}', called with '{{original_name}}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n\n  {%- set search_name = 'snapshot_' ~ name ~ '_strategy' -%}\n\n  {% if search_name not in package_context %}\n    {% set error_msg %}\n        The specified strategy macro '{{name}}' was not found in package '{{ package_name }}'\n    {% endset %}\n    {{ exceptions.raise_compiler_error(error_msg | trim) }}\n  {% endif %}\n  {{ return(package_context[search_name]) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_hash_arguments": {
+			"unique_id": "macro.dbt.snapshot_hash_arguments",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_hash_arguments",
+			"macro_sql": "{% macro snapshot_hash_arguments(args) -%}\n  {{ adapter.dispatch('snapshot_hash_arguments')(args) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__snapshot_hash_arguments": {
+			"unique_id": "macro.dbt.default__snapshot_hash_arguments",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "default__snapshot_hash_arguments",
+			"macro_sql": "{% macro default__snapshot_hash_arguments(args) -%}\n    md5({%- for arg in args -%}\n        coalesce(cast({{ arg }} as varchar ), '')\n        {% if not loop.last %} || '|' || {% endif %}\n    {%- endfor -%})\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_get_time": {
+			"unique_id": "macro.dbt.snapshot_get_time",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_get_time",
+			"macro_sql": "{% macro snapshot_get_time() -%}\n  {{ adapter.dispatch('snapshot_get_time')() }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__snapshot_get_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__snapshot_get_time": {
+			"unique_id": "macro.dbt.default__snapshot_get_time",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "default__snapshot_get_time",
+			"macro_sql": "{% macro default__snapshot_get_time() -%}\n  {{ current_timestamp() }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_timestamp_strategy": {
+			"unique_id": "macro.dbt.snapshot_timestamp_strategy",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_timestamp_strategy",
+			"macro_sql": "{% macro snapshot_timestamp_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set primary_key = config['unique_key'] %}\n    {% set updated_at = config['updated_at'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n\n    {#/*\n        The snapshot relation might not have an {{ updated_at }} value if the\n        snapshot strategy is changed from `check` to `timestamp`. We\n        should use a dbt-created column for the comparison in the snapshot\n        table instead of assuming that the user-supplied {{ updated_at }}\n        will be present in the historical data.\n\n        See https://github.com/fishtown-analytics/dbt/issues/2350\n    */ #}\n    {% set row_changed_expr -%}\n        ({{ snapshotted_rel }}.dbt_valid_from < {{ current_rel }}.{{ updated_at }})\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_string_as_time": {
+			"unique_id": "macro.dbt.snapshot_string_as_time",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_string_as_time",
+			"macro_sql": "{% macro snapshot_string_as_time(timestamp) -%}\n    {{ adapter.dispatch('snapshot_string_as_time')(timestamp) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__snapshot_string_as_time"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__snapshot_string_as_time": {
+			"unique_id": "macro.dbt.default__snapshot_string_as_time",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "default__snapshot_string_as_time",
+			"macro_sql": "{% macro default__snapshot_string_as_time(timestamp) %}\n    {% do exceptions.raise_not_implemented(\n        'snapshot_string_as_time macro not implemented for adapter '+adapter.type()\n    ) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_check_all_get_existing_columns": {
+			"unique_id": "macro.dbt.snapshot_check_all_get_existing_columns",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_check_all_get_existing_columns",
+			"macro_sql": "{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}\n    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}\n    {%- if not target_exists -%}\n        {# no table yet -> return whatever the query does #}\n        {{ return([false, query_columns]) }}\n    {%- endif -%}\n    {# handle any schema changes #}\n    {%- set target_table = node.get('alias', node.get('name')) -%}\n    {%- set target_relation = adapter.get_relation(database=node.database, schema=node.schema, identifier=target_table) -%}\n    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}\n    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}\n    {%- set ns.column_added = false -%}\n\n    {%- set intersection = [] -%}\n    {%- for col in query_columns -%}\n        {%- if col in existing_cols -%}\n            {%- do intersection.append(col) -%}\n        {%- else -%}\n            {% set ns.column_added = true %}\n        {%- endif -%}\n    {%- endfor -%}\n    {{ return([ns.column_added, intersection]) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_columns_in_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.snapshot_check_strategy": {
+			"unique_id": "macro.dbt.snapshot_check_strategy",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/snapshot/strategies.sql",
+			"original_file_path": "macros/materializations/snapshot/strategies.sql",
+			"name": "snapshot_check_strategy",
+			"macro_sql": "{% macro snapshot_check_strategy(node, snapshotted_rel, current_rel, config, target_exists) %}\n    {% set check_cols_config = config['check_cols'] %}\n    {% set primary_key = config['unique_key'] %}\n    {% set invalidate_hard_deletes = config.get('invalidate_hard_deletes', false) %}\n    \n    {% set select_current_time -%}\n        select {{ snapshot_get_time() }} as snapshot_start\n    {%- endset %}\n\n    {#-- don't access the column by name, to avoid dealing with casing issues on snowflake #}\n    {%- set now = run_query(select_current_time)[0][0] -%}\n    {% if now is none or now is undefined -%}\n        {%- do exceptions.raise_compiler_error('Could not get a snapshot start time from the database') -%}\n    {%- endif %}\n    {% set updated_at = config.get('updated_at', snapshot_string_as_time(now)) %}\n\n    {% set column_added = false %}\n\n    {% if check_cols_config == 'all' %}\n        {% set column_added, check_cols = snapshot_check_all_get_existing_columns(node, target_exists) %}\n    {% elif check_cols_config is iterable and (check_cols_config | length) > 0 %}\n        {% set check_cols = check_cols_config %}\n    {% else %}\n        {% do exceptions.raise_compiler_error(\"Invalid value for 'check_cols': \" ~ check_cols_config) %}\n    {% endif %}\n\n    {%- set row_changed_expr -%}\n    (\n    {%- if column_added -%}\n        TRUE\n    {%- else -%}\n    {%- for col in check_cols -%}\n        {{ snapshotted_rel }}.{{ col }} != {{ current_rel }}.{{ col }}\n        or\n        (\n            (({{ snapshotted_rel }}.{{ col }} is null) and not ({{ current_rel }}.{{ col }} is null))\n            or\n            ((not {{ snapshotted_rel }}.{{ col }} is null) and ({{ current_rel }}.{{ col }} is null))\n        )\n        {%- if not loop.last %} or {% endif -%}\n    {%- endfor -%}\n    {%- endif -%}\n    )\n    {%- endset %}\n\n    {% set scd_id_expr = snapshot_hash_arguments([primary_key, updated_at]) %}\n\n    {% do return({\n        \"unique_key\": primary_key,\n        \"updated_at\": updated_at,\n        \"row_changed\": row_changed_expr,\n        \"scd_id\": scd_id_expr,\n        \"invalidate_hard_deletes\": invalidate_hard_deletes\n    }) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.snapshot_get_time", "macro.dbt.run_query", "macro.dbt.snapshot_string_as_time", "macro.dbt.snapshot_check_all_get_existing_columns", "macro.dbt.snapshot_hash_arguments"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_incremental_default": {
+			"unique_id": "macro.dbt.materialization_incremental_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/incremental/incremental.sql",
+			"original_file_path": "macros/materializations/incremental/incremental.sql",
+			"name": "materialization_incremental_default",
+			"macro_sql": "{% materialization incremental, default -%}\n\n  {% set unique_key = config.get('unique_key') %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% set existing_relation = load_relation(this) %}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  {% set to_drop = [] %}\n  {% if existing_relation is none %}\n      {% set build_sql = create_table_as(False, target_relation, sql) %}\n  {% elif existing_relation.is_view or should_full_refresh() %}\n      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}\n      {% set tmp_identifier = model['name'] + '__dbt_tmp' %}\n      {% set backup_identifier = model['name'] + \"__dbt_backup\" %}\n\n      {% set intermediate_relation = existing_relation.incorporate(path={\"identifier\": tmp_identifier}) %}\n      {% set backup_relation = existing_relation.incorporate(path={\"identifier\": backup_identifier}) %}\n\n      {% do adapter.drop_relation(intermediate_relation) %}\n      {% do adapter.drop_relation(backup_relation) %}\n\n      {% set build_sql = create_table_as(False, intermediate_relation, sql) %}\n      {% set need_swap = true %}\n      {% do to_drop.append(backup_relation) %}\n  {% else %}\n      {% set tmp_relation = make_temp_relation(target_relation) %}\n      {% do run_query(create_table_as(True, tmp_relation, sql)) %}\n      {% do adapter.expand_target_column_types(\n             from_relation=tmp_relation,\n             to_relation=target_relation) %}\n      {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}\n  {% endif %}\n\n  {% call statement(\"main\") %}\n      {{ build_sql }}\n  {% endcall %}\n\n  {% if need_swap %} \n      {% do adapter.rename_relation(target_relation, backup_relation) %} \n      {% do adapter.rename_relation(intermediate_relation, target_relation) %} \n  {% endif %}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {% do adapter.commit() %}\n\n  {% for rel in to_drop %}\n      {% do adapter.drop_relation(rel) %}\n  {% endfor %}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.load_relation", "macro.dbt.run_hooks", "macro.dbt.create_table_as", "macro.dbt.should_full_refresh", "macro.dbt.make_temp_relation", "macro.dbt.run_query", "macro.dbt.incremental_upsert", "macro.dbt.statement", "macro.dbt.persist_docs", "macro.dbt.create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.incremental_upsert": {
+			"unique_id": "macro.dbt.incremental_upsert",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/incremental/helpers.sql",
+			"original_file_path": "macros/materializations/incremental/helpers.sql",
+			"name": "incremental_upsert",
+			"macro_sql": "{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name=\"main\") %}\n    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}\n    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}\n\n    {%- if unique_key is not none -%}\n    delete\n    from {{ target_relation }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ tmp_relation }}\n    );\n    {%- endif %}\n\n    insert into {{ target_relation }} ({{ dest_cols_csv }})\n    (\n       select {{ dest_cols_csv }}\n       from {{ tmp_relation }}\n    );\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_csv_table": {
+			"unique_id": "macro.dbt.create_csv_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "create_csv_table",
+			"macro_sql": "{% macro create_csv_table(model, agate_table) -%}\n  {{ adapter.dispatch('create_csv_table')(model, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.reset_csv_table": {
+			"unique_id": "macro.dbt.reset_csv_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "reset_csv_table",
+			"macro_sql": "{% macro reset_csv_table(model, full_refresh, old_relation, agate_table) -%}\n  {{ adapter.dispatch('reset_csv_table')(model, full_refresh, old_relation, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__reset_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.load_csv_rows": {
+			"unique_id": "macro.dbt.load_csv_rows",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "load_csv_rows",
+			"macro_sql": "{% macro load_csv_rows(model, agate_table) -%}\n  {{ adapter.dispatch('load_csv_rows')(model, agate_table) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__load_csv_rows"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_csv_table": {
+			"unique_id": "macro.dbt.default__create_csv_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "default__create_csv_table",
+			"macro_sql": "{% macro default__create_csv_table(model, agate_table) %}\n  {%- set column_override = model['config'].get('column_types', {}) -%}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n\n  {% set sql %}\n    create table {{ this.render() }} (\n        {%- for col_name in agate_table.column_names -%}\n            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}\n            {%- set type = column_override.get(col_name, inferred_type) -%}\n            {%- set column_name = (col_name | string) -%}\n            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}\n        {%- endfor -%}\n    )\n  {% endset %}\n\n  {% call statement('_') -%}\n    {{ sql }}\n  {%- endcall %}\n\n  {{ return(sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__reset_csv_table": {
+			"unique_id": "macro.dbt.default__reset_csv_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "default__reset_csv_table",
+			"macro_sql": "{% macro default__reset_csv_table(model, full_refresh, old_relation, agate_table) %}\n    {% set sql = \"\" %}\n    {% if full_refresh %}\n        {{ adapter.drop_relation(old_relation) }}\n        {% set sql = create_csv_table(model, agate_table) %}\n    {% else %}\n        {{ adapter.truncate_relation(old_relation) }}\n        {% set sql = \"truncate table \" ~ old_relation %}\n    {% endif %}\n\n    {{ return(sql) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.create_csv_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_seed_column_quoted_csv": {
+			"unique_id": "macro.dbt.get_seed_column_quoted_csv",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "get_seed_column_quoted_csv",
+			"macro_sql": "{% macro get_seed_column_quoted_csv(model, column_names) %}\n  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote_seed_column(col, quote_seed_column)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.basic_load_csv_rows": {
+			"unique_id": "macro.dbt.basic_load_csv_rows",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "basic_load_csv_rows",
+			"macro_sql": "{% macro basic_load_csv_rows(model, batch_size, agate_table) %}\n    {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}\n    {% set bindings = [] %}\n\n    {% set statements = [] %}\n\n    {% for chunk in agate_table.rows | batch(batch_size) %}\n        {% set bindings = [] %}\n\n        {% for row in chunk %}\n            {% do bindings.extend(row) %}\n        {% endfor %}\n\n        {% set sql %}\n            insert into {{ this.render() }} ({{ cols_sql }}) values\n            {% for row in chunk -%}\n                ({%- for column in agate_table.column_names -%}\n                    %s\n                    {%- if not loop.last%},{%- endif %}\n                {%- endfor -%})\n                {%- if not loop.last%},{%- endif %}\n            {%- endfor %}\n        {% endset %}\n\n        {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True) %}\n\n        {% if loop.index0 == 0 %}\n            {% do statements.append(sql) %}\n        {% endif %}\n    {% endfor %}\n\n    {# Return SQL so we can render it out into the compiled files #}\n    {{ return(statements[0]) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_seed_column_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__load_csv_rows": {
+			"unique_id": "macro.dbt.default__load_csv_rows",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "default__load_csv_rows",
+			"macro_sql": "{% macro default__load_csv_rows(model, agate_table) %}\n  {{ return(basic_load_csv_rows(model, 10000, agate_table) )}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.basic_load_csv_rows"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_seed_default": {
+			"unique_id": "macro.dbt.materialization_seed_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/seed/seed.sql",
+			"original_file_path": "macros/materializations/seed/seed.sql",
+			"name": "materialization_seed_default",
+			"macro_sql": "{% materialization seed, default %}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set full_refresh_mode = (should_full_refresh()) -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set agate_table = load_agate_table() -%}\n  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% set create_table_sql = \"\" %}\n  {% if exists_as_view %}\n    {{ exceptions.raise_compiler_error(\"Cannot seed to '{}', it is a view\".format(old_relation)) }}\n  {% elif exists_as_table %}\n    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}\n  {% else %}\n    {% set create_table_sql = create_csv_table(model, agate_table) %}\n  {% endif %}\n\n  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}\n  {% set rows_affected = (agate_table.rows | length) %}\n  {% set sql = load_csv_rows(model, agate_table) %}\n\n  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}\n    {{ create_table_sql }};\n    -- dbt seed --\n    {{ sql }}\n  {% endcall %}\n\n  {% set target_relation = this.incorporate(type='table') %}\n  {% do persist_docs(target_relation, model) %}\n\n  {% if full_refresh_mode or not exists_as_table %}\n    {% do create_indexes(target_relation) %}\n  {% endif %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_full_refresh", "macro.dbt.run_hooks", "macro.dbt.reset_csv_table", "macro.dbt.create_csv_table", "macro.dbt.load_csv_rows", "macro.dbt.noop_statement", "macro.dbt.persist_docs", "macro.dbt.create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_table_default": {
+			"unique_id": "macro.dbt.materialization_table_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/table/table.sql",
+			"original_file_path": "macros/materializations/table/table.sql",
+			"name": "materialization_table_default",
+			"macro_sql": "{% materialization table, default %}\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type='table') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema,\n                                                      database=database,\n                                                      type='table') -%}\n\n  /*\n      See ../view/view.sql for more information about this relation.\n  */\n  {%- set backup_relation_type = 'table' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema,\n                                                database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_table_as(False, intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  {% if old_relation is not none %}\n      {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do create_indexes(target_relation) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  -- `COMMIT` happens here\n  {{ adapter.commit() }}\n\n  -- finally, drop the existing/backup relation after the commit\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n{% endmaterialization %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.create_table_as", "macro.dbt.create_indexes", "macro.dbt.persist_docs", "macro.dbt.drop_relation_if_exists"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_merge_sql": {
+			"unique_id": "macro.dbt.get_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "get_merge_sql",
+			"macro_sql": "{% macro get_merge_sql(target, source, unique_key, dest_columns, predicates=none) -%}\n  {{ adapter.dispatch('get_merge_sql')(target, source, unique_key, dest_columns, predicates) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__get_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_delete_insert_merge_sql": {
+			"unique_id": "macro.dbt.get_delete_insert_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "get_delete_insert_merge_sql",
+			"macro_sql": "{% macro get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n  {{ adapter.dispatch('get_delete_insert_merge_sql')(target, source, unique_key, dest_columns) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_delete_insert_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_insert_overwrite_merge_sql": {
+			"unique_id": "macro.dbt.get_insert_overwrite_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "get_insert_overwrite_merge_sql",
+			"macro_sql": "{% macro get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header=false) -%}\n  {{ adapter.dispatch('get_insert_overwrite_merge_sql')(target, source, dest_columns, predicates, include_sql_header) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_insert_overwrite_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_merge_sql": {
+			"unique_id": "macro.dbt.default__get_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "default__get_merge_sql",
+			"macro_sql": "{% macro default__get_merge_sql(target, source, unique_key, dest_columns, predicates) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set update_columns = config.get('merge_update_columns', default = dest_columns | map(attribute=\"quoted\") | list) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {% if unique_key %}\n        {% set unique_key_match %}\n            DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}\n        {% endset %}\n        {% do predicates.append(unique_key_match) %}\n    {% else %}\n        {% do predicates.append('FALSE') %}\n    {% endif %}\n\n    {{ sql_header if sql_header is not none }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on {{ predicates | join(' and ') }}\n\n    {% if unique_key %}\n    when matched then update set\n        {% for column_name in update_columns -%}\n            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}\n            {%- if not loop.last %}, {%- endif %}\n        {%- endfor %}\n    {% endif %}\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_quoted_csv": {
+			"unique_id": "macro.dbt.get_quoted_csv",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "get_quoted_csv",
+			"macro_sql": "{% macro get_quoted_csv(column_names) %}\n    {% set quoted = [] %}\n    {% for col in column_names -%}\n        {%- do quoted.append(adapter.quote(col)) -%}\n    {%- endfor %}\n\n    {%- set dest_cols_csv = quoted | join(', ') -%}\n    {{ return(dest_cols_csv) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.common_get_delete_insert_merge_sql": {
+			"unique_id": "macro.dbt.common_get_delete_insert_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "common_get_delete_insert_merge_sql",
+			"macro_sql": "{% macro common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n\n    {% if unique_key is not none %}\n    delete from {{ target }}\n    where ({{ unique_key }}) in (\n        select ({{ unique_key }})\n        from {{ source }}\n    );\n    {% endif %}\n\n    insert into {{ target }} ({{ dest_cols_csv }})\n    (\n        select {{ dest_cols_csv }}\n        from {{ source }}\n    );\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_delete_insert_merge_sql": {
+			"unique_id": "macro.dbt.default__get_delete_insert_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "default__get_delete_insert_merge_sql",
+			"macro_sql": "{% macro default__get_delete_insert_merge_sql(target, source, unique_key, dest_columns) -%}\n    {{ common_get_delete_insert_merge_sql(target, source, unique_key, dest_columns) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.common_get_delete_insert_merge_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_insert_overwrite_merge_sql": {
+			"unique_id": "macro.dbt.default__get_insert_overwrite_merge_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/common/merge.sql",
+			"original_file_path": "macros/materializations/common/merge.sql",
+			"name": "default__get_insert_overwrite_merge_sql",
+			"macro_sql": "{% macro default__get_insert_overwrite_merge_sql(target, source, dest_columns, predicates, include_sql_header) -%}\n    {%- set predicates = [] if predicates is none else [] + predicates -%}\n    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute=\"name\")) -%}\n    {%- set sql_header = config.get('sql_header', none) -%}\n\n    {{ sql_header if sql_header is not none and include_sql_header }}\n\n    merge into {{ target }} as DBT_INTERNAL_DEST\n        using {{ source }} as DBT_INTERNAL_SOURCE\n        on FALSE\n\n    when not matched by source\n        {% if predicates %} and {{ predicates | join(' and ') }} {% endif %}\n        then delete\n\n    when not matched then insert\n        ({{ dest_cols_csv }})\n    values\n        ({{ dest_cols_csv }})\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_quoted_csv"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.materialization_view_default": {
+			"unique_id": "macro.dbt.materialization_view_default",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/view/view.sql",
+			"original_file_path": "macros/materializations/view/view.sql",
+			"name": "materialization_view_default",
+			"macro_sql": "{%- materialization view, default -%}\n\n  {%- set identifier = model['alias'] -%}\n  {%- set tmp_identifier = model['name'] + '__dbt_tmp' -%}\n  {%- set backup_identifier = model['name'] + '__dbt_backup' -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,\n                                                type='view') -%}\n  {%- set intermediate_relation = api.Relation.create(identifier=tmp_identifier,\n                                                      schema=schema, database=database, type='view') -%}\n\n  /*\n     This relation (probably) doesn't exist yet. If it does exist, it's a leftover from\n     a previous run, and we're going to try to drop it immediately. At the end of this\n     materialization, we're going to rename the \"old_relation\" to this identifier,\n     and then we're going to drop it. In order to make sure we run the correct one of:\n       - drop view ...\n       - drop table ...\n\n     We need to set the type of this relation to be the type of the old_relation, if it exists,\n     or else \"view\" as a sane default if it does not. Note that if the old_relation does not\n     exist, then there is nothing to move out of the way and subsequentally drop. In that case,\n     this relation will be effectively unused.\n  */\n  {%- set backup_relation_type = 'view' if old_relation is none else old_relation.type -%}\n  {%- set backup_relation = api.Relation.create(identifier=backup_identifier,\n                                                schema=schema, database=database,\n                                                type=backup_relation_type) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {{ run_hooks(pre_hooks, inside_transaction=False) }}\n\n  -- drop the temp relations if they exists for some reason\n  {{ adapter.drop_relation(intermediate_relation) }}\n  {{ adapter.drop_relation(backup_relation) }}\n\n  -- `BEGIN` happens here:\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(intermediate_relation, sql) }}\n  {%- endcall %}\n\n  -- cleanup\n  -- move the existing view out of the way\n  {% if old_relation is not none %}\n    {{ adapter.rename_relation(target_relation, backup_relation) }}\n  {% endif %}\n  {{ adapter.rename_relation(intermediate_relation, target_relation) }}\n\n  {% do persist_docs(target_relation, model) %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {{ drop_relation_if_exists(backup_relation) }}\n\n  {{ run_hooks(post_hooks, inside_transaction=False) }}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{%- endmaterialization -%}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.statement", "macro.dbt.create_view_as", "macro.dbt.persist_docs", "macro.dbt.drop_relation_if_exists"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.handle_existing_table": {
+			"unique_id": "macro.dbt.handle_existing_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/view/create_or_replace_view.sql",
+			"original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+			"name": "handle_existing_table",
+			"macro_sql": "{% macro handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.dispatch('handle_existing_table', macro_namespace = 'dbt')(full_refresh, old_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__handle_existing_table"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__handle_existing_table": {
+			"unique_id": "macro.dbt.default__handle_existing_table",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/view/create_or_replace_view.sql",
+			"original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+			"name": "default__handle_existing_table",
+			"macro_sql": "{% macro default__handle_existing_table(full_refresh, old_relation) %}\n    {{ adapter.drop_relation(old_relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_or_replace_view": {
+			"unique_id": "macro.dbt.create_or_replace_view",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/materializations/view/create_or_replace_view.sql",
+			"original_file_path": "macros/materializations/view/create_or_replace_view.sql",
+			"name": "create_or_replace_view",
+			"macro_sql": "{% macro create_or_replace_view(run_outside_transaction_hooks=True) %}\n  {%- set identifier = model['alias'] -%}\n\n  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}\n\n  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}\n\n  {%- set target_relation = api.Relation.create(\n      identifier=identifier, schema=schema, database=database,\n      type='view') -%}\n\n  {% if run_outside_transaction_hooks %}\n      -- no transactions on BigQuery\n      {{ run_hooks(pre_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  -- `BEGIN` happens here on Snowflake\n  {{ run_hooks(pre_hooks, inside_transaction=True) }}\n\n  -- If there's a table with the same name and we weren't told to full refresh,\n  -- that's an error. If we were told to full refresh, drop it. This behavior differs\n  -- for Snowflake and BigQuery, so multiple dispatch is used.\n  {%- if old_relation is not none and old_relation.is_table -%}\n    {{ handle_existing_table(should_full_refresh(), old_relation) }}\n  {%- endif -%}\n\n  -- build model\n  {% call statement('main') -%}\n    {{ create_view_as(target_relation, sql) }}\n  {%- endcall %}\n\n  {{ run_hooks(post_hooks, inside_transaction=True) }}\n\n  {{ adapter.commit() }}\n\n  {% if run_outside_transaction_hooks %}\n      -- No transactions on BigQuery\n      {{ run_hooks(post_hooks, inside_transaction=False) }}\n  {% endif %}\n\n  {{ return({'relations': [target_relation]}) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_hooks", "macro.dbt.handle_existing_table", "macro.dbt.should_full_refresh", "macro.dbt.statement", "macro.dbt.create_view_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_columns_in_query": {
+			"unique_id": "macro.dbt.get_columns_in_query",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "get_columns_in_query",
+			"macro_sql": "{% macro get_columns_in_query(select_sql) -%}\n  {{ return(adapter.dispatch('get_columns_in_query')(select_sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_columns_in_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_columns_in_query": {
+			"unique_id": "macro.dbt.default__get_columns_in_query",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__get_columns_in_query",
+			"macro_sql": "{% macro default__get_columns_in_query(select_sql) %}\n    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}\n        select * from (\n            {{ select_sql }}\n        ) as __dbt_sbq\n        where false\n        limit 0\n    {% endcall %}\n\n    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_schema": {
+			"unique_id": "macro.dbt.create_schema",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "create_schema",
+			"macro_sql": "{% macro create_schema(relation) -%}\n  {{ adapter.dispatch('create_schema')(relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_schema"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_schema": {
+			"unique_id": "macro.dbt.default__create_schema",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__create_schema",
+			"macro_sql": "{% macro default__create_schema(relation) -%}\n  {%- call statement('create_schema') -%}\n    create schema if not exists {{ relation.without_identifier() }}\n  {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.drop_schema": {
+			"unique_id": "macro.dbt.drop_schema",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "drop_schema",
+			"macro_sql": "{% macro drop_schema(relation) -%}\n  {{ adapter.dispatch('drop_schema')(relation) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__drop_schema"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__drop_schema": {
+			"unique_id": "macro.dbt.default__drop_schema",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__drop_schema",
+			"macro_sql": "{% macro default__drop_schema(relation) -%}\n  {%- call statement('drop_schema') -%}\n    drop schema if exists {{ relation.without_identifier() }} cascade\n  {% endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_table_as": {
+			"unique_id": "macro.dbt.create_table_as",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "create_table_as",
+			"macro_sql": "{% macro create_table_as(temporary, relation, sql) -%}\n  {{ adapter.dispatch('create_table_as')(temporary, relation, sql) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__create_table_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_table_as": {
+			"unique_id": "macro.dbt.default__create_table_as",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__create_table_as",
+			"macro_sql": "{% macro default__create_table_as(temporary, relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n\n  create {% if temporary: -%}temporary{%- endif %} table\n    {{ relation.include(database=(not temporary), schema=(not temporary)) }}\n  as (\n    {{ sql }}\n  );\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_create_index_sql": {
+			"unique_id": "macro.dbt.get_create_index_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "get_create_index_sql",
+			"macro_sql": "{% macro get_create_index_sql(relation, index_dict) -%}\n  {{ return(adapter.dispatch('get_create_index_sql')(relation, index_dict)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__get_create_index_sql"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_create_index_sql": {
+			"unique_id": "macro.dbt.default__get_create_index_sql",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__get_create_index_sql",
+			"macro_sql": "{% macro default__get_create_index_sql(relation, index_dict) -%}\n  {% do return(None) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_indexes": {
+			"unique_id": "macro.dbt.create_indexes",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "create_indexes",
+			"macro_sql": "{% macro create_indexes(relation) -%}\n  {{ adapter.dispatch('create_indexes')(relation) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__create_indexes"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_indexes": {
+			"unique_id": "macro.dbt.default__create_indexes",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__create_indexes",
+			"macro_sql": "{% macro default__create_indexes(relation) -%}\n  {%- set _indexes = config.get('indexes', default=[]) -%}\n\n  {% for _index_dict in _indexes %}\n    {% set create_index_sql = get_create_index_sql(relation, _index_dict) %}\n    {% if create_index_sql %}\n      {% do run_query(create_index_sql) %}\n    {% endif %}\n  {% endfor %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.get_create_index_sql", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.create_view_as": {
+			"unique_id": "macro.dbt.create_view_as",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "create_view_as",
+			"macro_sql": "{% macro create_view_as(relation, sql) -%}\n  {{ adapter.dispatch('create_view_as')(relation, sql) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__create_view_as"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__create_view_as": {
+			"unique_id": "macro.dbt.default__create_view_as",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__create_view_as",
+			"macro_sql": "{% macro default__create_view_as(relation, sql) -%}\n  {%- set sql_header = config.get('sql_header', none) -%}\n\n  {{ sql_header if sql_header is not none }}\n  create view {{ relation }} as (\n    {{ sql }}\n  );\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_catalog": {
+			"unique_id": "macro.dbt.get_catalog",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "get_catalog",
+			"macro_sql": "{% macro get_catalog(information_schema, schemas) -%}\n  {{ return(adapter.dispatch('get_catalog')(information_schema, schemas)) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__get_catalog"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_catalog": {
+			"unique_id": "macro.dbt.default__get_catalog",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__get_catalog",
+			"macro_sql": "{% macro default__get_catalog(information_schema, schemas) -%}\n\n  {% set typename = adapter.type() %}\n  {% set msg -%}\n    get_catalog not implemented for {{ typename }}\n  {%- endset %}\n\n  {{ exceptions.raise_compiler_error(msg) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.get_columns_in_relation": {
+			"unique_id": "macro.dbt.get_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "get_columns_in_relation",
+			"macro_sql": "{% macro get_columns_in_relation(relation) -%}\n  {{ return(adapter.dispatch('get_columns_in_relation')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__get_columns_in_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.sql_convert_columns_in_relation": {
+			"unique_id": "macro.dbt.sql_convert_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "sql_convert_columns_in_relation",
+			"macro_sql": "{% macro sql_convert_columns_in_relation(table) -%}\n  {% set columns = [] %}\n  {% for row in table %}\n    {% do columns.append(api.Column(*row)) %}\n  {% endfor %}\n  {{ return(columns) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__get_columns_in_relation": {
+			"unique_id": "macro.dbt.default__get_columns_in_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__get_columns_in_relation",
+			"macro_sql": "{% macro default__get_columns_in_relation(relation) -%}\n  {{ exceptions.raise_not_implemented(\n    'get_columns_in_relation macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.alter_column_type": {
+			"unique_id": "macro.dbt.alter_column_type",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "alter_column_type",
+			"macro_sql": "{% macro alter_column_type(relation, column_name, new_column_type) -%}\n  {{ return(adapter.dispatch('alter_column_type')(relation, column_name, new_column_type)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__alter_column_type"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.alter_column_comment": {
+			"unique_id": "macro.dbt.alter_column_comment",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "alter_column_comment",
+			"macro_sql": "{% macro alter_column_comment(relation, column_dict) -%}\n  {{ return(adapter.dispatch('alter_column_comment')(relation, column_dict)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__alter_column_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__alter_column_comment": {
+			"unique_id": "macro.dbt.default__alter_column_comment",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__alter_column_comment",
+			"macro_sql": "{% macro default__alter_column_comment(relation, column_dict) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_column_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.alter_relation_comment": {
+			"unique_id": "macro.dbt.alter_relation_comment",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "alter_relation_comment",
+			"macro_sql": "{% macro alter_relation_comment(relation, relation_comment) -%}\n  {{ return(adapter.dispatch('alter_relation_comment')(relation, relation_comment)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__alter_relation_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__alter_relation_comment": {
+			"unique_id": "macro.dbt.default__alter_relation_comment",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__alter_relation_comment",
+			"macro_sql": "{% macro default__alter_relation_comment(relation, relation_comment) -%}\n  {{ exceptions.raise_not_implemented(\n    'alter_relation_comment macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.persist_docs": {
+			"unique_id": "macro.dbt.persist_docs",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "persist_docs",
+			"macro_sql": "{% macro persist_docs(relation, model, for_relation=true, for_columns=true) -%}\n  {{ return(adapter.dispatch('persist_docs')(relation, model, for_relation, for_columns)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__persist_docs"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__persist_docs": {
+			"unique_id": "macro.dbt.default__persist_docs",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__persist_docs",
+			"macro_sql": "{% macro default__persist_docs(relation, model, for_relation, for_columns) -%}\n  {% if for_relation and config.persist_relation_docs() and model.description %}\n    {% do run_query(alter_relation_comment(relation, model.description)) %}\n  {% endif %}\n\n  {% if for_columns and config.persist_column_docs() and model.columns %}\n    {% do run_query(alter_column_comment(relation, model.columns)) %}\n  {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query", "macro.dbt.alter_relation_comment", "macro.dbt.alter_column_comment"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__alter_column_type": {
+			"unique_id": "macro.dbt.default__alter_column_type",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__alter_column_type",
+			"macro_sql": "{% macro default__alter_column_type(relation, column_name, new_column_type) -%}\n  {#\n    1. Create a new column (w/ temp name and correct type)\n    2. Copy data over to it\n    3. Drop the existing column (cascade!)\n    4. Rename the new column to existing column\n  #}\n  {%- set tmp_column = column_name + \"__dbt_alter\" -%}\n\n  {% call statement('alter_column_type') %}\n    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }};\n    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};\n    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;\n    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}\n  {% endcall %}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.drop_relation": {
+			"unique_id": "macro.dbt.drop_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "drop_relation",
+			"macro_sql": "{% macro drop_relation(relation) -%}\n  {{ return(adapter.dispatch('drop_relation')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__drop_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__drop_relation": {
+			"unique_id": "macro.dbt.default__drop_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__drop_relation",
+			"macro_sql": "{% macro default__drop_relation(relation) -%}\n  {% call statement('drop_relation', auto_begin=False) -%}\n    drop {{ relation.type }} if exists {{ relation }} cascade\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.truncate_relation": {
+			"unique_id": "macro.dbt.truncate_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "truncate_relation",
+			"macro_sql": "{% macro truncate_relation(relation) -%}\n  {{ return(adapter.dispatch('truncate_relation')(relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__truncate_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__truncate_relation": {
+			"unique_id": "macro.dbt.default__truncate_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__truncate_relation",
+			"macro_sql": "{% macro default__truncate_relation(relation) -%}\n  {% call statement('truncate_relation') -%}\n    truncate table {{ relation }}\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.rename_relation": {
+			"unique_id": "macro.dbt.rename_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "rename_relation",
+			"macro_sql": "{% macro rename_relation(from_relation, to_relation) -%}\n  {{ return(adapter.dispatch('rename_relation')(from_relation, to_relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__rename_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__rename_relation": {
+			"unique_id": "macro.dbt.default__rename_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__rename_relation",
+			"macro_sql": "{% macro default__rename_relation(from_relation, to_relation) -%}\n  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}\n  {% call statement('rename_relation') -%}\n    alter table {{ from_relation }} rename to {{ target_name }}\n  {%- endcall %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.information_schema_name": {
+			"unique_id": "macro.dbt.information_schema_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "information_schema_name",
+			"macro_sql": "{% macro information_schema_name(database) %}\n  {{ return(adapter.dispatch('information_schema_name')(database)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__information_schema_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__information_schema_name": {
+			"unique_id": "macro.dbt.default__information_schema_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__information_schema_name",
+			"macro_sql": "{% macro default__information_schema_name(database) -%}\n  {%- if database -%}\n    {{ database }}.INFORMATION_SCHEMA\n  {%- else -%}\n    INFORMATION_SCHEMA\n  {%- endif -%}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.list_schemas": {
+			"unique_id": "macro.dbt.list_schemas",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "list_schemas",
+			"macro_sql": "{% macro list_schemas(database) -%}\n  {{ return(adapter.dispatch('list_schemas')(database)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__list_schemas"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__list_schemas": {
+			"unique_id": "macro.dbt.default__list_schemas",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__list_schemas",
+			"macro_sql": "{% macro default__list_schemas(database) -%}\n  {% set sql %}\n    select distinct schema_name\n    from {{ information_schema_name(database) }}.SCHEMATA\n    where catalog_name ilike '{{ database }}'\n  {% endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.information_schema_name", "macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.check_schema_exists": {
+			"unique_id": "macro.dbt.check_schema_exists",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "check_schema_exists",
+			"macro_sql": "{% macro check_schema_exists(information_schema, schema) -%}\n  {{ return(adapter.dispatch('check_schema_exists')(information_schema, schema)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__check_schema_exists"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__check_schema_exists": {
+			"unique_id": "macro.dbt.default__check_schema_exists",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__check_schema_exists",
+			"macro_sql": "{% macro default__check_schema_exists(information_schema, schema) -%}\n  {% set sql -%}\n        select count(*)\n        from {{ information_schema.replace(information_schema_view='SCHEMATA') }}\n        where catalog_name='{{ information_schema.database }}'\n          and schema_name='{{ schema }}'\n  {%- endset %}\n  {{ return(run_query(sql)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.run_query"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.list_relations_without_caching": {
+			"unique_id": "macro.dbt.list_relations_without_caching",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "list_relations_without_caching",
+			"macro_sql": "{% macro list_relations_without_caching(schema_relation) %}\n  {{ return(adapter.dispatch('list_relations_without_caching')(schema_relation)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__list_relations_without_caching"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__list_relations_without_caching": {
+			"unique_id": "macro.dbt.default__list_relations_without_caching",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__list_relations_without_caching",
+			"macro_sql": "{% macro default__list_relations_without_caching(schema_relation) %}\n  {{ exceptions.raise_not_implemented(\n    'list_relations_without_caching macro not implemented for adapter '+adapter.type()) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.current_timestamp": {
+			"unique_id": "macro.dbt.current_timestamp",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "current_timestamp",
+			"macro_sql": "{% macro current_timestamp() -%}\n  {{ adapter.dispatch('current_timestamp')() }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt_snowflake.snowflake__current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__current_timestamp": {
+			"unique_id": "macro.dbt.default__current_timestamp",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__current_timestamp",
+			"macro_sql": "{% macro default__current_timestamp() -%}\n  {{ exceptions.raise_not_implemented(\n    'current_timestamp macro not implemented for adapter '+adapter.type()) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.collect_freshness": {
+			"unique_id": "macro.dbt.collect_freshness",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "collect_freshness",
+			"macro_sql": "{% macro collect_freshness(source, loaded_at_field, filter) %}\n  {{ return(adapter.dispatch('collect_freshness')(source, loaded_at_field, filter))}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__collect_freshness"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__collect_freshness": {
+			"unique_id": "macro.dbt.default__collect_freshness",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__collect_freshness",
+			"macro_sql": "{% macro default__collect_freshness(source, loaded_at_field, filter) %}\n  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}\n    select\n      max({{ loaded_at_field }}) as max_loaded_at,\n      {{ current_timestamp() }} as snapshotted_at\n    from {{ source }}\n    {% if filter %}\n    where {{ filter }}\n    {% endif %}\n  {% endcall %}\n  {{ return(load_result('collect_freshness').table) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement", "macro.dbt.current_timestamp"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.make_temp_relation": {
+			"unique_id": "macro.dbt.make_temp_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "make_temp_relation",
+			"macro_sql": "{% macro make_temp_relation(base_relation, suffix='__dbt_tmp') %}\n  {{ return(adapter.dispatch('make_temp_relation')(base_relation, suffix))}}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__make_temp_relation"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__make_temp_relation": {
+			"unique_id": "macro.dbt.default__make_temp_relation",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "default__make_temp_relation",
+			"macro_sql": "{% macro default__make_temp_relation(base_relation, suffix) %}\n    {% set tmp_identifier = base_relation.identifier ~ suffix %}\n    {% set tmp_relation = base_relation.incorporate(\n                                path={\"identifier\": tmp_identifier}) -%}\n\n    {% do return(tmp_relation) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.set_sql_header": {
+			"unique_id": "macro.dbt.set_sql_header",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/adapters/common.sql",
+			"original_file_path": "macros/adapters/common.sql",
+			"name": "set_sql_header",
+			"macro_sql": "{% macro set_sql_header(config) -%}\n  {{ config.set('sql_header', caller()) }}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.convert_datetime": {
+			"unique_id": "macro.dbt.convert_datetime",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "convert_datetime",
+			"macro_sql": "{% macro convert_datetime(date_str, date_fmt) %}\n\n  {% set error_msg -%}\n      The provided partition date '{{ date_str }}' does not match the expected format '{{ date_fmt }}'\n  {%- endset %}\n\n  {% set res = try_or_compiler_error(error_msg, modules.datetime.datetime.strptime, date_str.strip(), date_fmt) %}\n  {{ return(res) }}\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.dates_in_range": {
+			"unique_id": "macro.dbt.dates_in_range",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "dates_in_range",
+			"macro_sql": "{% macro dates_in_range(start_date_str, end_date_str=none, in_fmt=\"%Y%m%d\", out_fmt=\"%Y%m%d\") %}\n    {% set end_date_str = start_date_str if end_date_str is none else end_date_str %}\n\n    {% set start_date = convert_datetime(start_date_str, in_fmt) %}\n    {% set end_date = convert_datetime(end_date_str, in_fmt) %}\n\n    {% set day_count = (end_date - start_date).days %}\n    {% if day_count < 0 %}\n        {% set msg -%}\n            Partiton start date is after the end date ({{ start_date }}, {{ end_date }})\n        {%- endset %}\n\n        {{ exceptions.raise_compiler_error(msg, model) }}\n    {% endif %}\n\n    {% set date_list = [] %}\n    {% for i in range(0, day_count + 1) %}\n        {% set the_date = (modules.datetime.timedelta(days=i) + start_date) %}\n        {% if not out_fmt %}\n            {% set _ = date_list.append(the_date) %}\n        {% else %}\n            {% set _ = date_list.append(the_date.strftime(out_fmt)) %}\n        {% endif %}\n    {% endfor %}\n\n    {{ return(date_list) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.convert_datetime"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.partition_range": {
+			"unique_id": "macro.dbt.partition_range",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "partition_range",
+			"macro_sql": "{% macro partition_range(raw_partition_date, date_fmt='%Y%m%d') %}\n    {% set partition_range = (raw_partition_date | string).split(\",\") %}\n\n    {% if (partition_range | length) == 1 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = none %}\n    {% elif (partition_range | length) == 2 %}\n      {% set start_date = partition_range[0] %}\n      {% set end_date = partition_range[1] %}\n    {% else %}\n      {{ exceptions.raise_compiler_error(\"Invalid partition time. Expected format: {Start Date}[,{End Date}]. Got: \" ~ raw_partition_date) }}\n    {% endif %}\n\n    {{ return(dates_in_range(start_date, end_date, in_fmt=date_fmt)) }}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.dates_in_range"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.py_current_timestring": {
+			"unique_id": "macro.dbt.py_current_timestring",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/datetime.sql",
+			"original_file_path": "macros/etc/datetime.sql",
+			"name": "py_current_timestring",
+			"macro_sql": "{% macro py_current_timestring() %}\n    {% set dt = modules.datetime.datetime.now() %}\n    {% do return(dt.strftime(\"%Y%m%d%H%M%S%f\")) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.generate_schema_name": {
+			"unique_id": "macro.dbt.generate_schema_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/get_custom_schema.sql",
+			"original_file_path": "macros/etc/get_custom_schema.sql",
+			"name": "generate_schema_name",
+			"macro_sql": "{% macro generate_schema_name(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if custom_schema_name is none -%}\n\n        {{ default_schema }}\n\n    {%- else -%}\n\n        {{ default_schema }}_{{ custom_schema_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.generate_schema_name_for_env": {
+			"unique_id": "macro.dbt.generate_schema_name_for_env",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/get_custom_schema.sql",
+			"original_file_path": "macros/etc/get_custom_schema.sql",
+			"name": "generate_schema_name_for_env",
+			"macro_sql": "{% macro generate_schema_name_for_env(custom_schema_name, node) -%}\n\n    {%- set default_schema = target.schema -%}\n    {%- if target.name == 'prod' and custom_schema_name is not none -%}\n\n        {{ custom_schema_name | trim }}\n\n    {%- else -%}\n\n        {{ default_schema }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.run_query": {
+			"unique_id": "macro.dbt.run_query",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/query.sql",
+			"original_file_path": "macros/etc/query.sql",
+			"name": "run_query",
+			"macro_sql": "{% macro run_query(sql) %}\n  {% call statement(\"run_query_statement\", fetch_result=true, auto_begin=false) %}\n    {{ sql }}\n  {% endcall %}\n\n  {% do return(load_result(\"run_query_statement\").table) %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.statement"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.is_incremental": {
+			"unique_id": "macro.dbt.is_incremental",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/is_incremental.sql",
+			"original_file_path": "macros/etc/is_incremental.sql",
+			"name": "is_incremental",
+			"macro_sql": "{% macro is_incremental() %}\n    {#-- do not run introspective queries in parsing #}\n    {% if not execute %}\n        {{ return(False) }}\n    {% else %}\n        {% set relation = adapter.get_relation(this.database, this.schema, this.table) %}\n        {{ return(relation is not none\n                  and relation.type == 'table'\n                  and model.config.materialized == 'incremental'\n                  and not should_full_refresh()) }}\n    {% endif %}\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.should_full_refresh"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.generate_database_name": {
+			"unique_id": "macro.dbt.generate_database_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/get_custom_database.sql",
+			"original_file_path": "macros/etc/get_custom_database.sql",
+			"name": "generate_database_name",
+			"macro_sql": "{% macro generate_database_name(custom_database_name=none, node=none) -%}\n    {% do return(adapter.dispatch('generate_database_name')(custom_database_name, node)) %}\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__generate_database_name"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__generate_database_name": {
+			"unique_id": "macro.dbt.default__generate_database_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/get_custom_database.sql",
+			"original_file_path": "macros/etc/get_custom_database.sql",
+			"name": "default__generate_database_name",
+			"macro_sql": "{% macro default__generate_database_name(custom_database_name=none, node=none) -%}\n    {%- set default_database = target.database -%}\n    {%- if custom_database_name is none -%}\n\n        {{ default_database }}\n\n    {%- else -%}\n\n        {{ custom_database_name }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.generate_alias_name": {
+			"unique_id": "macro.dbt.generate_alias_name",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/etc/get_custom_alias.sql",
+			"original_file_path": "macros/etc/get_custom_alias.sql",
+			"name": "generate_alias_name",
+			"macro_sql": "{% macro generate_alias_name(custom_alias_name=none, node=none) -%}\n\n    {%- if custom_alias_name is none -%}\n\n        {{ node.name }}\n\n    {%- else -%}\n\n        {{ custom_alias_name | trim }}\n\n    {%- endif -%}\n\n{%- endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__test_accepted_values": {
+			"unique_id": "macro.dbt.default__test_accepted_values",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/accepted_values.sql",
+			"original_file_path": "macros/schema_tests/accepted_values.sql",
+			"name": "default__test_accepted_values",
+			"macro_sql": "{% macro default__test_accepted_values(model, column_name, values, quote=True) %}\n\nwith all_values as (\n\n    select\n        {{ column_name }} as value_field,\n        count(*) as n_records\n\n    from {{ model }}\n    group by 1\n\n)\n\nselect *\nfrom all_values\nwhere value_field not in (\n    {% for value in values -%}\n        {% if quote -%}\n        '{{ value }}'\n        {%- else -%}\n        {{ value }}\n        {%- endif -%}\n        {%- if not loop.last -%},{%- endif %}\n    {%- endfor %}\n)\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.test_accepted_values": {
+			"unique_id": "macro.dbt.test_accepted_values",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/accepted_values.sql",
+			"original_file_path": "macros/schema_tests/accepted_values.sql",
+			"name": "test_accepted_values",
+			"macro_sql": "{% test accepted_values(model, column_name, values, quote=True) %}\n    {% set macro = adapter.dispatch('test_accepted_values') %}\n    {{ macro(model, column_name, values, quote) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_accepted_values"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__test_relationships": {
+			"unique_id": "macro.dbt.default__test_relationships",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/relationships.sql",
+			"original_file_path": "macros/schema_tests/relationships.sql",
+			"name": "default__test_relationships",
+			"macro_sql": "{% macro default__test_relationships(model, column_name, to, field) %}\n\nselect\n    child.{{ column_name }}\n\nfrom {{ model }} as child\n\nleft join {{ to }} as parent\n    on child.{{ column_name }} = parent.{{ field }}\n\nwhere child.{{ column_name }} is not null\n  and parent.{{ field }} is null\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.test_relationships": {
+			"unique_id": "macro.dbt.test_relationships",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/relationships.sql",
+			"original_file_path": "macros/schema_tests/relationships.sql",
+			"name": "test_relationships",
+			"macro_sql": "{% test relationships(model, column_name, to, field) %}\n    {% set macro = adapter.dispatch('test_relationships') %}\n    {{ macro(model, column_name, to, field) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_relationships"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__test_not_null": {
+			"unique_id": "macro.dbt.default__test_not_null",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/not_null.sql",
+			"original_file_path": "macros/schema_tests/not_null.sql",
+			"name": "default__test_not_null",
+			"macro_sql": "{% macro default__test_not_null(model, column_name) %}\n\nselect *\nfrom {{ model }}\nwhere {{ column_name }} is null\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.test_not_null": {
+			"unique_id": "macro.dbt.test_not_null",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/not_null.sql",
+			"original_file_path": "macros/schema_tests/not_null.sql",
+			"name": "test_not_null",
+			"macro_sql": "{% test not_null(model, column_name) %}\n    {% set macro = adapter.dispatch('test_not_null') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_not_null"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.default__test_unique": {
+			"unique_id": "macro.dbt.default__test_unique",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/unique.sql",
+			"original_file_path": "macros/schema_tests/unique.sql",
+			"name": "default__test_unique",
+			"macro_sql": "{% macro default__test_unique(model, column_name) %}\n\nselect\n    {{ column_name }},\n    count(*) as n_records\n\nfrom {{ model }}\nwhere {{ column_name }} is not null\ngroup by {{ column_name }}\nhaving count(*) > 1\n\n{% endmacro %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": []
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		},
+		"macro.dbt.test_unique": {
+			"unique_id": "macro.dbt.test_unique",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "macros/schema_tests/unique.sql",
+			"original_file_path": "macros/schema_tests/unique.sql",
+			"name": "test_unique",
+			"macro_sql": "{% test unique(model, column_name) %}\n    {% set macro = adapter.dispatch('test_unique') %}\n    {{ macro(model, column_name) }}\n{% endtest %}",
+			"resource_type": "macro",
+			"tags": [],
+			"depends_on": {
+				"macros": ["macro.dbt.default__test_unique"]
+			},
+			"description": "",
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": null,
+			"arguments": [],
+			"created_at": 1625485389
+		}
+	},
+	"docs": {
+		"jaffle_shop.__overview__": {
+			"unique_id": "jaffle_shop.__overview__",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "overview.md",
+			"original_file_path": "models/overview.md",
+			"name": "__overview__",
+			"block_contents": "## Data Documentation for Jaffle Shop\n\n`jaffle_shop` is a fictional ecommerce store.\n\nThis [dbt](https://www.getdbt.com/) project is for testing out code.\n\nThe source code can be found [here](https://github.com/clrcrl/jaffle_shop)."
+		},
+		"jaffle_shop.orders_status": {
+			"unique_id": "jaffle_shop.orders_status",
+			"package_name": "jaffle_shop",
+			"root_path": "/home/example/code/jaffle-shop",
+			"path": "docs.md",
+			"original_file_path": "models/docs.md",
+			"name": "orders_status",
+			"block_contents": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |"
+		},
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.jaffle_shop.customers": ["model.jaffle_shop.stg_customers", "model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"],
+		"model.jaffle_shop.orders": ["model.jaffle_shop.stg_orders", "model.jaffle_shop.stg_payments"],
+		"model.jaffle_shop.stg_customers": ["seed.jaffle_shop.raw_customers"],
+		"model.jaffle_shop.stg_payments": ["seed.jaffle_shop.raw_payments"],
+		"model.jaffle_shop.stg_orders": ["seed.jaffle_shop.raw_orders"],
+		"seed.jaffle_shop.raw_customers": [],
+		"seed.jaffle_shop.raw_orders": [],
+		"seed.jaffle_shop.raw_payments": [],
+		"test.jaffle_shop.unique_customers_customer_id.d48e126d80": ["model.jaffle_shop.customers"],
+		"test.jaffle_shop.not_null_customers_customer_id.923d2d910a": ["model.jaffle_shop.customers"],
+		"test.jaffle_shop.unique_orders_order_id.0d77ddcf59": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_order_id.4daff5eed7": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_customer_id.70722cc05f": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4": ["model.jaffle_shop.customers", "model.jaffle_shop.orders"],
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_amount.f7bae8de1b": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88": ["model.jaffle_shop.orders"],
+		"test.jaffle_shop.unique_stg_customers_customer_id.5530022331": ["model.jaffle_shop.stg_customers"],
+		"test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1": ["model.jaffle_shop.stg_customers"],
+		"test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f": ["model.jaffle_shop.stg_orders"],
+		"test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081": ["model.jaffle_shop.stg_payments"]
+	},
+	"child_map": {
+		"model.jaffle_shop.customers": ["test.jaffle_shop.not_null_customers_customer_id.923d2d910a", "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4", "test.jaffle_shop.unique_customers_customer_id.d48e126d80"],
+		"model.jaffle_shop.orders": ["test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93", "test.jaffle_shop.not_null_orders_amount.f7bae8de1b", "test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa", "test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47", "test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042", "test.jaffle_shop.not_null_orders_customer_id.70722cc05f", "test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88", "test.jaffle_shop.not_null_orders_order_id.4daff5eed7", "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4", "test.jaffle_shop.unique_orders_order_id.0d77ddcf59"],
+		"model.jaffle_shop.stg_customers": ["model.jaffle_shop.customers", "test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1", "test.jaffle_shop.unique_stg_customers_customer_id.5530022331"],
+		"model.jaffle_shop.stg_payments": ["model.jaffle_shop.customers", "model.jaffle_shop.orders", "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081", "test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012", "test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6"],
+		"model.jaffle_shop.stg_orders": ["model.jaffle_shop.customers", "model.jaffle_shop.orders", "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f", "test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90", "test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48"],
+		"seed.jaffle_shop.raw_customers": ["model.jaffle_shop.stg_customers"],
+		"seed.jaffle_shop.raw_orders": ["model.jaffle_shop.stg_orders"],
+		"seed.jaffle_shop.raw_payments": ["model.jaffle_shop.stg_payments"],
+		"test.jaffle_shop.unique_customers_customer_id.d48e126d80": [],
+		"test.jaffle_shop.not_null_customers_customer_id.923d2d910a": [],
+		"test.jaffle_shop.unique_orders_order_id.0d77ddcf59": [],
+		"test.jaffle_shop.not_null_orders_order_id.4daff5eed7": [],
+		"test.jaffle_shop.not_null_orders_customer_id.70722cc05f": [],
+		"test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4": [],
+		"test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93": [],
+		"test.jaffle_shop.not_null_orders_amount.f7bae8de1b": [],
+		"test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042": [],
+		"test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47": [],
+		"test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa": [],
+		"test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88": [],
+		"test.jaffle_shop.unique_stg_customers_customer_id.5530022331": [],
+		"test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1": [],
+		"test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48": [],
+		"test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90": [],
+		"test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f": [],
+		"test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6": [],
+		"test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012": [],
+		"test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081": []
+	}
+}

--- a/integration/common/tests/dbt/no_test_metadata/target/run_results.json
+++ b/integration/common/tests/dbt/no_test_metadata/target/run_results.json
@@ -1,0 +1,378 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v12.json",
+		"dbt_version": "1.8.5",
+		"generated_at": "2021-07-05T11:43:26.134009Z",
+		"invocation_id": "ebb384bf-f2f3-4303-bb1b-98b1daa6d2d4",
+		"env": {}
+	},
+	"results": [{
+		"status": "fail",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:14.752733Z",
+			"completed_at": "2021-07-05T11:43:14.756125Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:14.756283Z",
+			"completed_at": "2021-07-05T11:43:16.146647Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 1.5134623050689697,
+		"adapter_response": {},
+		"message": "Test failure",
+		"failures": 1,
+		"unique_id": "test.jaffle_shop.unique_customers_customer_id.d48e126d80"
+	}, {
+		"status": "fail",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:16.267161Z",
+			"completed_at": "2021-07-05T11:43:16.270995Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:16.271247Z",
+			"completed_at": "2021-07-05T11:43:17.218104Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 1.0679519176483154,
+		"adapter_response": {},
+		"message": null,
+		"failures": "Test failure",
+		"unique_id": "test.jaffle_shop.not_null_customers_customer_id.923d2d910a"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:17.336143Z",
+			"completed_at": "2021-07-05T11:43:17.338653Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:17.338870Z",
+			"completed_at": "2021-07-05T11:43:18.375002Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 1.151458501815796,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.unique_orders_order_id.0d77ddcf59"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:18.489684Z",
+			"completed_at": "2021-07-05T11:43:18.498060Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:18.498280Z",
+			"completed_at": "2021-07-05T11:43:21.900891Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 3.539695978164673,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_order_id.4daff5eed7"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:18.489684Z",
+			"completed_at": "2021-07-05T11:43:18.498060Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:18.498280Z",
+			"completed_at": "2021-07-05T11:43:21.900891Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 3.539695978164673,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_customer_id.70722cc05f"
+	}, {
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.e153c026e4"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.2e6d271b93"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_amount.f7bae8de1b"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.f6f7978042"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.edd08a4b47"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.402a8a1daa"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.6205906a88"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.5530022331"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.4ab9034fe1"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.unique_stg_orders_order_id.99e62d7d48"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.052f14ae90"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.1b7358ad3f"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.5f5522e7d6"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.ece096e012"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.59d3da1081"
+	},{
+		"status": "pass",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-05T11:43:22.030881Z",
+			"completed_at": "2021-07-05T11:43:22.037396Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-05T11:43:22.037678Z",
+			"completed_at": "2021-07-05T11:43:24.406553Z"
+		}],
+		"thread_id": "Thread-1",
+		"execution_time": 2.5174121856689453,
+		"adapter_response": {},
+		"message": "SUCCESS 1",
+		"failures": null,
+		"unique_id": ""
+	}],
+	"elapsed_time": 16.22612500190735,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/no_test_metadata",
+		"use_cache": true,
+		"version_check": true,
+		"which": "test",
+		"rpc_method": "test"
+	}
+}

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -70,9 +70,16 @@ def test_dbt_parse_and_compare_event(path, parent_run_metadata):
         assert match(json.load(f), events)
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/dbt/test",
+        "tests/dbt/no_test_metadata",
+    ],
+)
 @mock.patch("openlineage.common.provider.dbt.processor.generate_new_uuid")
 @mock.patch("datetime.datetime")
-def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata):
+def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata, path):
     mock_datetime.now.return_value.isoformat.return_value = "2021-08-25T11:00:25.277467+00:00"
     mock_uuid.side_effect = [
         "6edf42ed-d8d0-454a-b819-d09b9067ff99",
@@ -85,7 +92,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
     processor = DbtLocalArtifactProcessor(
         producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         job_namespace="dbt-test-namespace",
-        project_dir="tests/dbt/test",
+        project_dir=path,
     )
     processor.dbt_run_metadata = parent_run_metadata
 
@@ -94,7 +101,7 @@ def test_dbt_parse_dbt_test_event(mock_datetime, mock_uuid, parent_run_metadata)
         attr.asdict(event, value_serializer=serialize)
         for event in dbt_events.starts + dbt_events.completes + dbt_events.fails
     ]
-    with open("tests/dbt/test/result.json") as f:
+    with open(f"{path}/result.json") as f:
         assert match(json.load(f), events)
 
 


### PR DESCRIPTION
Signed-off-by: Niels Janssen [n.janssen1@portofrotterdam.com](mailto:n.janssen1@portofrotterdam.com)
### Problem

DbtArtifactProcessor.parse_assertions() reads the node's name from a test_metadata field. However, the schema of the DBT manifest has changed and the name of a node is no longer in the test_metadata field. Instead, name is a field of each node.

Closes: #3222 

### Solution

Check manifest version whether to select `test_metadata` or not

#### One-line summary:
Fix bug due to DBT manifest change in DBT v1.8

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project