### PR TITLE
docs: make edit link variable to version.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -68,8 +68,13 @@ const config = {
                 docs: {
                     sidebarPath: require.resolve('./sidebars.js'),
                     exclude: ['**/partials/**'],
-                    editUrl:
-                        'https://github.com/OpenLineage/OpenLineage/tree/main/website/',
+                    editUrl: ({versionDocsDirPath, docPath, version}) => {
+                        if (version === 'current') {
+                            return `https://github.com/OpenLineage/OpenLineage/tree/main/website/docs/${docPath}`;
+                        } else {
+                            return `https://github.com/OpenLineage/openlineage-site/tree/main/${versionDocsDirPath}/${docPath}`;
+                        }
+                    }
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Edit link now depends on whether the document is current or versioned.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

For versioned docs the edit link does not work.

### Solution

Consider if document is current or versioned.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project