### PR TITLE
fix: Wrong Scala version in Databricks integration tests configuration.

### DIFF
--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -93,8 +93,8 @@ workflows:
           matrix:
             parameters:
               env-variant: [
-                'java:8-spark:3.4.2-scala:2.12-full-tests',
-                'java:17-spark:3.5.2-scala:2.13-full-tests'
+                'java:8-spark:3.4.1-scala:2.12-full-tests',
+                'java:17-spark:3.5.0-scala:2.12-full-tests'
               ]
           requires:
             - approval-integration-spark

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksEnvironment.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksEnvironment.java
@@ -64,9 +64,9 @@ public class DatabricksEnvironment implements AutoCloseable {
 
   public static final String CLUSTER_NAME = "openlineage-test-cluster";
   public static final Map<String, String> PLATFORM_VERSIONS_NAMES =
-      ImmutableMap.of("3.4.2", "13.3.x-scala2.12", "3.5.2", "14.2.x-scala2.12");
+      ImmutableMap.of("3.4.1", "13.3.x-scala2.12", "3.5.0", "14.3.x-scala2.12");
   public static final Map<String, String> PLATFORM_VERSIONS =
-      ImmutableMap.of("3.4.2", "13.3", "3.5.2", "14.2");
+      ImmutableMap.of("3.4.1", "13.3", "3.5.0", "14.3");
   public static final String NODE_TYPE = "Standard_DS3_v2";
   public static final String INIT_SCRIPT_FILE = "/Shared/open-lineage-init-script.sh";
   public static final String DBFS_CLUSTER_LOGS = "dbfs:/databricks/openlineage/cluster-logs";

--- a/integration/sql/iface-py/script/setup-macos.sh
+++ b/integration/sql/iface-py/script/setup-macos.sh
@@ -18,6 +18,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 echo "Installing uv"
 curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
 source $HOME/.cargo/env
 
 rustup target add aarch64-apple-darwin


### PR DESCRIPTION
### Problem

The configuration for Databricks integration tests includes Java 2.13. Databricks supports only Scala 2.12

### Solution

We should replace faulty Scala version

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project