### PR TITLE
java client: remove TransportType enum

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
@@ -19,7 +19,6 @@ public class CompositeTransport extends Transport {
   private final List<Transport> transports = new ArrayList<>();
 
   public CompositeTransport(@NonNull CompositeConfig config) {
-    super(Type.NOOP); // Type doesn't matter for CompositeTransport
     this.config = config;
     initializeTransports();
   }

--- a/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/ConsoleTransport.java
@@ -12,10 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public final class ConsoleTransport extends Transport {
-  public ConsoleTransport() {
-    super(Type.CONSOLE);
-  }
-
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
     emit(OpenLineageClientUtils.toJson(runEvent));

--- a/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FileTransport.java
@@ -26,7 +26,6 @@ public class FileTransport extends Transport {
   File file;
 
   public FileTransport(@NonNull final FileConfig fileConfig) {
-    super(Type.FILE);
     file = new File(fileConfig.getLocation());
   }
 

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -98,7 +98,6 @@ public final class HttpTransport extends Transport {
 
   public HttpTransport(
       @NonNull final CloseableHttpClient httpClient, @NonNull final HttpConfig httpConfig) {
-    super(Type.HTTP);
     this.http = httpClient;
     try {
       this.uri = getUri(httpConfig);

--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -25,7 +25,6 @@ public final class KafkaTransport extends Transport {
   public KafkaTransport(
       @NonNull final KafkaProducer<String, String> kafkaProducer,
       @NonNull final KafkaConfig kafkaConfig) {
-    super(Type.KAFKA);
     this.topicName = kafkaConfig.getTopicName();
     this.messageKey = kafkaConfig.getMessageKey();
     this.producer = kafkaProducer;

--- a/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/NoopTransport.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NoopTransport extends Transport {
   public NoopTransport() {
-    super(Type.NOOP);
     log.info("OpenLineage client is disabled");
   }
 

--- a/client/java/src/main/java/io/openlineage/client/transports/Transport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/Transport.java
@@ -11,17 +11,6 @@ import lombok.NonNull;
 
 @NoArgsConstructor
 public abstract class Transport implements AutoCloseable {
-  enum Type {
-    CONSOLE,
-    FILE,
-    HTTP,
-    KAFKA,
-    NOOP
-  };
-
-  @SuppressWarnings("PMD") // unused constructor type used for @NonNull validation
-  Transport(@NonNull final Type type) {}
-
   public abstract void emit(@NonNull OpenLineage.RunEvent runEvent);
 
   public abstract void emit(@NonNull OpenLineage.DatasetEvent datasetEvent);

--- a/client/java/src/test/java/io/openlineage/client/transports/CompositeTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/CompositeTransportTest.java
@@ -24,10 +24,6 @@ import org.mockito.Mockito;
 abstract class FakeTransport extends Transport {
   private boolean emitted;
 
-  public FakeTransport() {
-    super(Type.NOOP); // Using NOOP or any placeholder type
-  }
-
   public boolean isEmitted() {
     return emitted;
   }


### PR DESCRIPTION
We're not using it for anything now, when we have pluggable mechanism with TransportBuilder. 