### PR TITLE
feature: Upload Databricks integration tests logs

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -865,6 +865,8 @@ jobs:
                 at: ~/
             - set_java_spark_scala_version:
                   env-variant: << parameters.env-variant >>
+            - run: mkdir -p app/build/logs
+            - run: mkdir -p app/build/events
             - run: ./gradlew --console=plain clean shadowJar -x test -Pjava.compile.home=${JAVA17_HOME}
             - run: ./gradlew --no-daemon --console=plain databricksIntegrationTest -x test -Pspark.version=${SPARK} -Pscala.binary.version=${SCALA} -Pjava.compile.home=${JAVA17_HOME} -Dopenlineage.tests.databricks.workspace.host=$DATABRICKS_HOST -Dopenlineage.tests.databricks.workspace.token=$DATABRICKS_TOKEN
             - store_test_results:
@@ -873,8 +875,11 @@ jobs:
                 path: app/build/reports/tests/databricksIntegrationTest
                 destination: test-report
             - store_artifacts:
-                path: app/build/cluster-log4j.log
-                destination: cluster-log4j.log
+                path: app/build/logs
+                destination: cluster-logs
+            - store_artifacts:
+                path: app/build/events
+                destination: events
             - save_cache:
                 key: v1-databricks-integration-spark-{{ checksum "/tmp/checksum.txt" }}
                 paths:

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksDynamicParameter.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksDynamicParameter.java
@@ -48,8 +48,8 @@ public enum DatabricksDynamicParameter implements DynamicParameter {
    * The location where the events should be stored for troubleshooting purposes. Each test has its
    * own file with execution timestamp as the prefix and the name of the script being executed.
    */
-  EventsFileLocation("development.eventsFileLocation", "./build"),
-  FetchEvents("development.fetchEvents", "./build"),
+  EventsFileLocation("development.eventsFileLocation", "./build/events"),
+  FetchEvents("development.fetchEvents", "true"),
 
   /**
    * When set to {@code true}, the given logs are fetched and stored under specified location. They
@@ -57,12 +57,12 @@ public enum DatabricksDynamicParameter implements DynamicParameter {
    * minutes for the logs to be available on DBFS, so you may consider keeping this function off if
    * you don't need them.
    */
-  FetchLog4jLogs("development.logs.log4j.enabled", "false"),
-  FetchStdout("development.logs.stdout.enabled", "false"),
-  FetchStderr("development.logs.stderr.enabled", "false"),
-  Log4jLogsLocation("development.logs.log4j.location", "./build"),
-  StdoutLocation("development.logs.stdout.location", "./build"),
-  StderrLocation("development.logs.stderr.location", "./build");
+  FetchLog4jLogs("development.logs.log4j.enabled", "true"),
+  FetchStdout("development.logs.stdout.enabled", "true"),
+  FetchStderr("development.logs.stderr.enabled", "true"),
+  Log4jLogsLocation("development.logs.log4j.location", "./build/logs"),
+  StdoutLocation("development.logs.stdout.location", "./build/logs"),
+  StderrLocation("development.logs.stderr.location", "./build/logs");
 
   private final String parameterName;
   private final String defaultValue;

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -75,6 +76,15 @@ class DatabricksIntegrationTest {
     databricks.deleteEventsFile();
   }
 
+  /**
+   * The assumption that must be true before every test. It is necessary because we want to
+   * gracefully clean the resources and collect the cluster logs even if the initialization failed.
+   */
+  private void assumeClusterRunning() {
+    Assumptions.assumeTrue(
+        databricks.isInitializationSuccessful(), "Cluster not initialized, skipping test.");
+  }
+
   @AfterAll
   public static void shutdown() {
     databricks.fetchLogs();
@@ -84,6 +94,8 @@ class DatabricksIntegrationTest {
   @Test
   @SneakyThrows
   void testCreateTableAsSelect() {
+    assumeClusterRunning();
+
     List<RunEvent> runEvents = databricks.runScript("ctas.py");
     RunEvent lastEvent = runEvents.get(runEvents.size() - 1);
 
@@ -135,6 +147,8 @@ class DatabricksIntegrationTest {
   @Test
   @SneakyThrows
   void testNarrowTransformation() {
+    assumeClusterRunning();
+
     List<RunEvent> runEvents = databricks.runScript("narrow_transformation.py");
     assertThat(runEvents).isNotEmpty();
 
@@ -167,6 +181,8 @@ class DatabricksIntegrationTest {
   @Test
   @SneakyThrows
   void testWideTransformation() {
+    assumeClusterRunning();
+
     List<RunEvent> runEvents = databricks.runScript("wide_transformation.py");
     assertThat(runEvents).isNotEmpty();
 
@@ -192,6 +208,8 @@ class DatabricksIntegrationTest {
 
   @Test
   void testWriteReadFromTableWithLocation() {
+    assumeClusterRunning();
+
     List<RunEvent> runEvents = databricks.runScript("dataset_names.py");
 
     // find complete event with output dataset containing name
@@ -221,6 +239,8 @@ class DatabricksIntegrationTest {
   @Test
   @SneakyThrows
   void testMergeInto() {
+    assumeClusterRunning();
+
     List<RunEvent> runEvents = databricks.runScript("merge_into.py");
 
     RunEvent event =


### PR DESCRIPTION
### Problem

When the cluster initialization fails we have to login to Databricks and retrieve the logs for troubleshooting.

### Solution

The logs should be available as artifacts

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project