### PR TITLE
Spark: Exclude META-INF/*TransportBuilder from Spark Extension Interfaces 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Changed
 
+* **Spark: Exclude META-INF/\*TransportBuilder from Spark Extension Interfaces** [`#3244`](https://github.com/OpenLineage/OpenLineage/pull/3244) [@tnazarew](https://github.com/tnazarew)
+    *Excludes META-INF/\*TransportBuilder to avoid version conflicts*
 * **Spark: enables building input/output facets through `DatasetFactory`** [`#3207`](https://github.com/OpenLineage/OpenLineage/pull/3207) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
-   *Adds extra capabilities into `DatasetFactory` class, marks some public developers' API methods as deprecated.*
+    *Adds extra capabilities into `DatasetFactory` class, marks some public developers' API methods as deprecated.*
 
 ## [1.24.0](https://github.com/OpenLineage/OpenLineage/compare/1.23.0...1.24.0) - 2024-11-05
 

--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -218,6 +218,7 @@ shadowJar {
         exclude 'io/openlineage/client/circuitBreaker/**'
         exclude 'io/openlineage/client/metrics/**'
         exclude 'io/openlineage/client/transports/**'
+        exclude 'META-INF/services/io.openlineage.client.transports.TransportBuilder'
     }
 
     relocate('io.openlineage.client', 'io.openlineage.spark.shade.client')


### PR DESCRIPTION
### Problem

After building spark extension interfaces there is `META-INF/services/io.openlineage.client.transports.TransportBuilder` in created jar, which causes conflicts when used by e.g. `big-query-connector`.

### Solution

exclude TransportBuilder in jar creation

#### One-line summary:

Remove unnecessary item from `spark-extension-interfaces` to avoid conflicts.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project