### PR TITLE
added proper databricks configuration to fix Databricks SparkUI issue

### DIFF
--- a/integration/spark/databricks/open-lineage-init-script.sh
+++ b/integration/spark/databricks/open-lineage-init-script.sh
@@ -12,7 +12,7 @@ echo "END: Upload Spark Listener JARs"
 echo "BEGIN: Modify Spark config settings"
 cat << 'EOF' > /databricks/driver/conf/openlineage-spark-driver-defaults.conf
 [driver] {
-  "spark.extraListeners" = "io.openlineage.spark.agent.OpenLineageSparkListener"
+  "spark.extraListeners" = "com.databricks.backend.daemon.driver.DBCEventLoggingListener,io.openlineage.spark.agent.OpenLineageSparkListener"
 }
 EOF
 echo "END: Modify Spark config settings"


### PR DESCRIPTION
### Problem

In Databricks, the `spark.extraListeners` configuration is non-additive. If the default listener `com.databricks.backend.daemon.driver.DBCEventLoggingListener` is replaced by `io.openlineage.spark.agent.OpenLineageSparkListener`, the Spark UI becomes inaccessible after a cluster shutdown.

### Solution

After a discussion with Databricks support team, I updated the documentation and configuration examples to include both `com.databricks.backend.daemon.driver.DBCEventLoggingListener` and `io.openlineage.spark.agent.OpenLineageSparkListener` in the `spark.extraListeners` setting for Databricks environments. Added notes highlighting this requirement in all relevant sections.

#### One-line summary:

Fix Spark UI compatibility issue for Databricks users by preserving default listener in `spark.extraListeners` configuration.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project