### PR TITLE
introduce transform transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.25.0...HEAD)
 
+* **Java: Add `transform` transport to allow event modification.** [`#3301`](https://github.com/OpenLineage/OpenLineage/pull/3301) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *New transport type allows to modify the event based on the specified transformer class.*
 
 ## [1.25.0](https://github.com/OpenLineage/OpenLineage/compare/1.24.2...1.25.0) - 2024-11-25
 

--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeConfig.java
@@ -40,7 +40,10 @@ public final class CompositeConfig implements TransportConfig, MergeConfig<Compo
       // Handle List<Map<String, Object>> case
       this.transports =
           ((List<Map<String, Object>>) transports)
-              .stream().map(this::createTransportConfig).collect(Collectors.toList());
+              .stream()
+                  .map(this::createTransportConfig)
+                  .sorted(TransportConfig::compareTo)
+                  .collect(Collectors.toList());
     } else if (transports instanceof Map) {
       // Handle Map<String, Object> case
       Map<String, Object> transportMap = (Map<String, Object>) transports;
@@ -54,6 +57,7 @@ public final class CompositeConfig implements TransportConfig, MergeConfig<Compo
                     return nestedMap;
                   })
               .map(this::createTransportConfig)
+              .sorted(TransportConfig::compareTo)
               .collect(Collectors.toList());
     } else {
       throw new IllegalArgumentException("Invalid transports type");

--- a/client/java/src/main/java/io/openlineage/client/transports/EventTransformer.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/EventTransformer.java
@@ -31,7 +31,9 @@ public interface EventTransformer {
    * @param event
    * @return
    */
-  RunEvent transform(RunEvent event);
+  default RunEvent transform(RunEvent event) {
+    return event;
+  }
 
   /**
    * Transforms the DatasetEvent into a new DatasetEvent.
@@ -39,7 +41,9 @@ public interface EventTransformer {
    * @param event
    * @return
    */
-  DatasetEvent transform(DatasetEvent event);
+  default DatasetEvent transform(DatasetEvent event) {
+    return event;
+  }
 
   /**
    * Transforms the JobEvent into a new JobEvent.
@@ -47,5 +51,7 @@ public interface EventTransformer {
    * @param event
    * @return
    */
-  JobEvent transform(JobEvent event);
+  default JobEvent transform(JobEvent event) {
+    return event;
+  }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/EventTransformer.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/EventTransformer.java
@@ -1,0 +1,51 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import io.openlineage.client.OpenLineage.DatasetEvent;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import java.util.Map;
+
+/**
+ * EventTransformer is an interface that defines the transformation of an event. An implementation
+ * of this interface is required to instantiate transform interface.
+ *
+ * <p>Class implementing it needs to provide no-arg constructor
+ */
+public interface EventTransformer {
+
+  /**
+   * Initialize the transformer with properties.
+   *
+   * @param properties
+   */
+  default void initialize(Map<String, String> properties) {}
+
+  /**
+   * Transforms the RunEvent into a new RunEvent.
+   *
+   * @param event
+   * @return
+   */
+  RunEvent transform(RunEvent event);
+
+  /**
+   * Transforms the DatasetEvent into a new DatasetEvent.
+   *
+   * @param event
+   * @return
+   */
+  DatasetEvent transform(DatasetEvent event);
+
+  /**
+   * Transforms the JobEvent into a new JobEvent.
+   *
+   * @param event
+   * @return
+   */
+  JobEvent transform(JobEvent event);
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/TransformConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransformConfig.java
@@ -1,0 +1,61 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openlineage.client.MergeConfig;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * CompositeConfig is a configuration class for CompositeTransport, implementing TransportConfig.
+ */
+@ToString
+@NoArgsConstructor
+public final class TransformConfig implements TransportConfig, MergeConfig<TransformConfig> {
+
+  @Getter @Setter private TransportConfig transport;
+
+  @Getter @Setter private String transformerClass;
+
+  @Getter @Setter private Map<String, String> transformerProperties;
+
+  @JsonCreator
+  @SuppressWarnings("unchecked")
+  public TransformConfig(
+      @JsonProperty("transport") Object transport,
+      @JsonProperty("transformClass") String transformClass) {
+    this.transformerClass = transformClass;
+    this.transport = createTransportConfig((Map<String, Object>) transport);
+  }
+
+  private TransportConfig createTransportConfig(Map<String, Object> map) {
+    // Convert the Map to a JSON string
+    ObjectMapper objectMapper = new ObjectMapper();
+    String jsonString;
+    try {
+      jsonString = objectMapper.writeValueAsString(map);
+      return objectMapper.readValue(jsonString, TransportConfig.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Error creating transport config", e);
+    }
+  }
+
+  @Override
+  public TransformConfig mergeWithNonNull(TransformConfig other) {
+    // Merge the transports and continueOnFailure fields from both configs
+    TransportConfig mergedTransport = mergePropertyWith(transport, other.getTransport());
+    String mergedTransformClass = mergePropertyWith(transformerClass, other.transformerClass);
+
+    return new TransformConfig(mergedTransport, mergedTransformClass);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/TransformTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransformTransport.java
@@ -1,0 +1,98 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetEvent;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TransformTransport extends Transport {
+
+  @Getter private final Transport transport;
+  @Getter private final EventTransformer transformer;
+
+  public TransformTransport(@NonNull TransformConfig config) {
+    super();
+    this.transport = TransportResolver.resolveTransportByConfig(config.getTransport());
+    this.transformer = initializeTransformClass(config);
+  }
+
+  public TransformTransport(@NonNull TransformConfig config, Transport transport) {
+    super();
+    this.transport = transport;
+    this.transformer = initializeTransformClass(config);
+  }
+
+  private EventTransformer initializeTransformClass(TransformConfig config) {
+    try {
+      Class<?> transformerClass = Class.forName(config.getTransformerClass());
+      EventTransformer instance =
+          (EventTransformer) transformerClass.getConstructor().newInstance();
+      instance.initialize(config.getTransformerProperties());
+      return instance;
+    } catch (ClassNotFoundException e) {
+      throw new TransformTransportException("Cannot find transformer class", e);
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new TransformTransportException("Cannot instantiate transformer class", e);
+    } catch (ClassCastException e) {
+      throw new TransformTransportException("Transform class not an EventTransformer", e);
+    } catch (Exception e) {
+      throw new TransformTransportException("Error initializing transformer class", e);
+    }
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.RunEvent runEvent) {
+    RunEvent updatedRunEvent;
+    try {
+      updatedRunEvent = transformer.transform(runEvent);
+    } catch (Exception e) {
+      throw new TransformTransportException("Error transforming RunEvent", e);
+    }
+    if (updatedRunEvent == null) {
+      throw new TransformTransportException("Transformed RunEvent is null, not emitting");
+    }
+    transport.emit(updatedRunEvent);
+  }
+
+  @Override
+  public void emit(@NonNull DatasetEvent datasetEvent) {
+    DatasetEvent updatedDatasetEvent;
+    try {
+      updatedDatasetEvent = transformer.transform(datasetEvent);
+    } catch (Exception e) {
+      throw new TransformTransportException("Error transforming DatasetEvent", e);
+    }
+    if (updatedDatasetEvent == null) {
+      throw new TransformTransportException("Transformed DatasetEvent is null, not emitting");
+    }
+    transport.emit(updatedDatasetEvent);
+  }
+
+  @Override
+  public void emit(@NonNull JobEvent jobEvent) {
+    JobEvent updatedJobEvent;
+    try {
+      updatedJobEvent = transformer.transform(jobEvent);
+    } catch (Exception e) {
+      throw new TransformTransportException("Error transforming JobEvent", e);
+    }
+    if (updatedJobEvent == null) {
+      throw new TransformTransportException("Transformed JobEvent is null, not emitting");
+    }
+    transport.emit(updatedJobEvent);
+  }
+
+  @Override
+  public void close() throws Exception {
+    transport.close();
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/TransformTransportBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransformTransportBuilder.java
@@ -1,0 +1,24 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+public class TransformTransportBuilder implements TransportBuilder {
+
+  @Override
+  public TransportConfig getConfig() {
+    return new TransformConfig();
+  }
+
+  @Override
+  public Transport build(TransportConfig config) {
+    return new TransformTransport((TransformConfig) config);
+  }
+
+  @Override
+  public String getType() {
+    return "transform";
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/TransformTransportException.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransformTransportException.java
@@ -1,0 +1,18 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+public class TransformTransportException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  public TransformTransportException(String message) {
+    super(message);
+  }
+
+  public TransformTransportException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportConfig.java
@@ -11,7 +11,7 @@ import java.util.WeakHashMap;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonTypeIdResolver(TransportConfigTypeIdResolver.class)
-public interface TransportConfig {
+public interface TransportConfig extends Comparable<TransportConfig> {
   WeakHashMap<TransportConfig, String> nameRegistry = new WeakHashMap<>();
 
   default String getName() {
@@ -20,5 +20,16 @@ public interface TransportConfig {
 
   default void setName(String name) {
     nameRegistry.put(this, name);
+  }
+
+  @Override
+  default int compareTo(TransportConfig o) {
+    if (o == null || o.getName() == null) {
+      return 1;
+    }
+    if (getName() == null) {
+      return -1;
+    }
+    return getName().compareTo(o.getName());
   }
 }

--- a/client/java/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
+++ b/client/java/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
@@ -3,3 +3,4 @@ io.openlineage.client.transports.KafkaTransportBuilder
 io.openlineage.client.transports.ConsoleTransportBuilder
 io.openlineage.client.transports.FileTransportBuilder
 io.openlineage.client.transports.CompositeTransportBuilder
+io.openlineage.client.transports.TransformTransportBuilder

--- a/client/java/src/test/java/io/openlineage/client/TestingEventTransformer.java
+++ b/client/java/src/test/java/io/openlineage/client/TestingEventTransformer.java
@@ -1,0 +1,37 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client;
+
+import io.openlineage.client.OpenLineage.DatasetEvent;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.transports.EventTransformer;
+import java.util.Map;
+
+public class TestingEventTransformer implements EventTransformer {
+
+  public Map<String, String> properties;
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public RunEvent transform(RunEvent event) {
+    return null;
+  }
+
+  @Override
+  public DatasetEvent transform(DatasetEvent event) {
+    return null;
+  }
+
+  @Override
+  public JobEvent transform(JobEvent event) {
+    return null;
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/transports/CompositeTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/CompositeTransportTest.java
@@ -204,8 +204,8 @@ class CompositeTransportTest {
       config.put("myFakeA", fakeTransportAConfig);
       config.put("myFakeB", fakeTransportBConfig);
       CompositeConfig compositeConfig = new CompositeConfig(config, true);
-      assertEquals(compositeConfig.getTransports().get(1).getName(), "myFakeA");
-      assertEquals(compositeConfig.getTransports().get(0).getName(), "myFakeB");
+      assertEquals(compositeConfig.getTransports().get(0).getName(), "myFakeA");
+      assertEquals(compositeConfig.getTransports().get(1).getName(), "myFakeB");
     }
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/transports/TransformTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/TransformTransportTest.java
@@ -1,0 +1,236 @@
+/*
+/* Copyright 2018-2024 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.openlineage.client.OpenLineage.DatasetEvent;
+import io.openlineage.client.OpenLineage.JobEvent;
+import io.openlineage.client.OpenLineage.RunEvent;
+import java.util.Collections;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransformTransportTest {
+  TransformConfig transformConfig;
+  TransformTransport transformTransport;
+  Transport subTransport;
+
+  @BeforeEach
+  void setup() {
+    transformConfig = new TransformConfig();
+    transformConfig.setTransport(new ConsoleConfig());
+    transformConfig.setTransformerProperties(Collections.emptyMap());
+
+    subTransport = mock(Transport.class);
+  }
+
+  @Test
+  void testTransportWhenTransformClassDoesNotExist() {
+    transformConfig.setTransformerClass("io.openlineage.FakeClass");
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport = new TransformTransport(transformConfig);
+        });
+  }
+
+  @Test
+  void testTransportWhenTransformClassNotAnInterface() {
+    transformConfig.setTransformerClass(EventTransformerNotImplementingInterface.class.getName());
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport = new TransformTransport(transformConfig);
+        });
+  }
+
+  @Test
+  void testTransportWhenTransformClassDoesNotHaveDefaultConstructor() {
+    transformConfig.setTransformerClass(EventTransformerWithoutDefaultConstructor.class.getName());
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport = new TransformTransport(transformConfig);
+        });
+  }
+
+  @Test
+  void testTransportWhenTransformThrowingException() {
+    transformConfig.setTransformerClass(EventTransformerThrowingException.class.getName());
+    transformTransport = new TransformTransport(transformConfig);
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(RunEvent.class));
+        });
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(DatasetEvent.class));
+        });
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(JobEvent.class));
+        });
+  }
+
+  @Test
+  void testTransportWhenTransformReturnsNull() {
+    transformConfig.setTransformerClass(EventTransformerReturningNull.class.getName());
+    transformTransport = new TransformTransport(transformConfig);
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(RunEvent.class));
+        });
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(DatasetEvent.class));
+        });
+
+    assertThrows(
+        TransformTransportException.class,
+        () -> {
+          transformTransport.emit(mock(JobEvent.class));
+        });
+  }
+
+  @Test
+  void testTransportWhenTransformIsSuccessful() {
+    transformConfig.setTransformerClass(SuccessfulEventTransformer.class.getName());
+    transformTransport = new TransformTransport(transformConfig, subTransport);
+
+    RunEvent runEvent = mock(RunEvent.class);
+    DatasetEvent datasetEvent = mock(DatasetEvent.class);
+    JobEvent jobEvent = mock(JobEvent.class);
+
+    transformTransport.emit(runEvent);
+    transformTransport.emit(datasetEvent);
+    transformTransport.emit(jobEvent);
+
+    verify(runEvent, times(1)).getProducer();
+    verify(subTransport, times(1)).emit(runEvent);
+
+    verify(datasetEvent, times(1)).getProducer();
+    verify(subTransport, times(1)).emit(datasetEvent);
+
+    verify(jobEvent, times(1)).getProducer();
+    verify(subTransport, times(1)).emit(jobEvent);
+  }
+
+  public static class EventTransformerNotImplementingInterface {
+    public EventTransformerNotImplementingInterface() {}
+  }
+
+  public static class EventTransformerWithoutDefaultConstructor implements EventTransformer {
+    private EventTransformerWithoutDefaultConstructor() {}
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+
+    @Override
+    public RunEvent transform(RunEvent event) {
+      return null;
+    }
+
+    @Override
+    public DatasetEvent transform(DatasetEvent event) {
+      return null;
+    }
+
+    @Override
+    public JobEvent transform(JobEvent event) {
+      return null;
+    }
+  }
+
+  public static class EventTransformerThrowingException implements EventTransformer {
+
+    public EventTransformerThrowingException() {}
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+
+    @Override
+    @SneakyThrows
+    public RunEvent transform(RunEvent event) {
+      throw new Exception("whatever");
+    }
+
+    @Override
+    @SneakyThrows
+    public DatasetEvent transform(DatasetEvent event) {
+      throw new Exception("whatever");
+    }
+
+    @Override
+    @SneakyThrows
+    public JobEvent transform(JobEvent event) {
+      throw new Exception("whatever");
+    }
+  }
+
+  public static class EventTransformerReturningNull implements EventTransformer {
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+
+    @Override
+    public RunEvent transform(RunEvent event) {
+      return null;
+    }
+
+    @Override
+    public DatasetEvent transform(DatasetEvent event) {
+      return null;
+    }
+
+    @Override
+    public JobEvent transform(JobEvent event) {
+      return null;
+    }
+  }
+
+  public static class SuccessfulEventTransformer implements EventTransformer {
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+
+    @Override
+    public RunEvent transform(RunEvent event) {
+      event.getProducer();
+      return event;
+    }
+
+    @Override
+    public DatasetEvent transform(DatasetEvent event) {
+      event.getProducer();
+      return event;
+    }
+
+    @Override
+    public JobEvent transform(JobEvent event) {
+      event.getProducer();
+      return event;
+    }
+  }
+}

--- a/client/java/src/test/resources/config/composite-array.yaml
+++ b/client/java/src/test/resources/config/composite-array.yaml
@@ -8,4 +8,7 @@ transport:
         type: api_key
         apiKey: random_token
       compression: gzip
-    - type: console
+    - type: transform
+      transformerClass: io.openlineage.client.TestingEventTransformer
+      transport:
+        type: console

--- a/client/java/src/test/resources/config/composite-map.yaml
+++ b/client/java/src/test/resources/config/composite-map.yaml
@@ -10,4 +10,8 @@ transport:
         apiKey: random_token
       compression: gzip
     second:
-      type: console
+      type: transform
+      transformerClass: io.openlineage.client.TestingEventTransformer
+      transport:
+        type: console
+

--- a/client/java/src/test/resources/config/transform.yaml
+++ b/client/java/src/test/resources/config/transform.yaml
@@ -1,0 +1,14 @@
+transport:
+  type: transform
+  transformerClass: io.openlineage.client.TestingEventTransformer
+  transformerProperties:
+    key1: value1
+    key2: value2
+  transport:
+    type: http
+    url: http://localhost:5050
+    endpoint: api/v1/lineage
+    auth:
+      type: api_key
+      apiKey: random_token
+    compression: gzip

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -165,8 +165,8 @@ class ArgumentParserTest {
       CompositeConfig transportConfig = (CompositeConfig) config.getTransportConfig();
       assertEquals(
           "http://your-openlineage-endpoint/api/v1/lineage",
-          ((HttpConfig) transportConfig.getTransports().get(0)).getUrl().toString());
-      KafkaConfig kafkaConfig = (KafkaConfig) transportConfig.getTransports().get(1);
+          ((HttpConfig) transportConfig.getTransports().get(1)).getUrl().toString());
+      KafkaConfig kafkaConfig = (KafkaConfig) transportConfig.getTransports().get(0);
       assertEquals("test", kafkaConfig.getTopicName());
       assertEquals("explicit-key", kafkaConfig.getMessageKey());
       assertEquals("test1", kafkaConfig.getProperties().get("test1"));


### PR DESCRIPTION
Implement new transport type to allow easy event modification before emitting. 

The `TransformTransport` is designed to enable event manipulation before emitting the event. Together with `CompositeTransport`, it can be used to 
send different events into multiple backends.

#### Configuration

- `type` - string, must be "transform". Required.
- `transformerClass` - class name of the event transformer. Class has to implement `io.openlineage.client.transports.transform.EventTransformer` interface and provide public no-arg constructor. Class needs to be available on the classpath. Required.
- `transformerProperties` - Extra properties that can be passed into `transformerClass` based on the configuration. Optional.
- `transport` - Transport configuration to emit modified events. Required.

#### Behavior

- The configured `transformerClass` will be used to alter events before the emission.
- Modified events will be passed into the configured `transport` for further processing.

#### `EventTransformer` interface

```java
public class CustomEventTransformer implements EventTransformer {
  @Override
  public void initialize(Map<String, String> properties) { ... }

  @Override
  public RunEvent transform(RunEvent event) { ... }

  @Override
  public DatasetEvent transform(DatasetEvent event) { .. }

  @Override
  public JobEvent transform(JobEvent event) { ... }
}
```

