### PR TITLE
Parallel event emitting for composite transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * **Java: Add `transform` transport to allow event modification.** [`#3301`](https://github.com/OpenLineage/OpenLineage/pull/3301) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
   *New transport type allows to modify the event based on the specified transformer class.*
+* **Java: Parallel event emitting for composite transport.** [`#3305`](https://github.com/OpenLineage/OpenLineage/pull/3240)[`#3305`] [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Emit events in parallel for composite transport. Running in parallel is a default behaviour `continueOnFailure` set to `true`. Default value of `continueOnFailure` got changed from `false` to `true`.*
 
 ## [1.25.0](https://github.com/OpenLineage/OpenLineage/compare/1.24.2...1.25.0) - 2024-11-25
 

--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeConfig.java
@@ -28,13 +28,16 @@ public final class CompositeConfig implements TransportConfig, MergeConfig<Compo
 
   @Getter @Setter private List<TransportConfig> transports;
 
-  @Getter @Setter private boolean continueOnFailure;
+  @Getter @Setter private Boolean continueOnFailure;
+
+  @Getter @Setter private Boolean withThreadPool;
 
   @JsonCreator
   @SuppressWarnings("unchecked")
   public CompositeConfig(
       @JsonProperty("transports") Object transports,
-      @JsonProperty("continueOnFailure") boolean continueOnFailure) {
+      @JsonProperty("continueOnFailure") Boolean continueOnFailure,
+      @JsonProperty("withThreadPool") Boolean withThreadPool) {
 
     if (transports instanceof List) {
       // Handle List<Map<String, Object>> case
@@ -63,14 +66,16 @@ public final class CompositeConfig implements TransportConfig, MergeConfig<Compo
       throw new IllegalArgumentException("Invalid transports type");
     }
 
-    this.continueOnFailure = continueOnFailure;
+    this.continueOnFailure = (continueOnFailure == null) ? true : continueOnFailure;
+    this.withThreadPool = (withThreadPool == null) ? true : withThreadPool;
   }
 
   public static CompositeConfig createFromTransportConfigs(
-      List<TransportConfig> transports, boolean continueOnFailure) {
+      List<TransportConfig> transports, boolean continueOnFailure, boolean withThreadPool) {
     CompositeConfig compositeConfig = new CompositeConfig();
     compositeConfig.setTransports(transports);
     compositeConfig.setContinueOnFailure(continueOnFailure);
+    compositeConfig.setWithThreadPool(withThreadPool);
     return compositeConfig;
   }
 
@@ -90,9 +95,10 @@ public final class CompositeConfig implements TransportConfig, MergeConfig<Compo
   public CompositeConfig mergeWithNonNull(CompositeConfig other) {
     // Merge the transports and continueOnFailure fields from both configs
     List<TransportConfig> mergedTransports = mergePropertyWith(transports, other.getTransports());
-    boolean mergedContinueOnFailure =
-        mergePropertyWith(continueOnFailure, other.isContinueOnFailure());
+    Boolean mergedContinueOnFailure = mergePropertyWith(continueOnFailure, other.continueOnFailure);
+    Boolean mergedWithThreadPool = mergePropertyWith(withThreadPool, other.withThreadPool);
 
-    return createFromTransportConfigs(mergedTransports, mergedContinueOnFailure);
+    return createFromTransportConfigs(
+        mergedTransports, mergedContinueOnFailure, mergedWithThreadPool);
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
@@ -6,9 +6,16 @@
 package io.openlineage.client.transports;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.BaseEvent;
 import io.openlineage.client.OpenLineageClientException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,10 +24,17 @@ public class CompositeTransport extends Transport {
 
   private final CompositeConfig config;
   private final List<Transport> transports = new ArrayList<>();
+  private final Optional<ExecutorService> executorService;
 
   public CompositeTransport(@NonNull CompositeConfig config) {
     this.config = config;
     initializeTransports();
+
+    if (config.getWithThreadPool()) {
+      executorService = Optional.of(Executors.newFixedThreadPool(transports.size()));
+    } else {
+      executorService = Optional.empty();
+    }
   }
 
   private void initializeTransports() {
@@ -36,39 +50,82 @@ public class CompositeTransport extends Transport {
 
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
-    for (Transport transport : transports) {
-      try {
-        transport.emit(runEvent);
-      } catch (Exception e) {
-        handleEmissionFailure(transport, e);
-      }
-    }
+    doEmit(runEvent);
   }
 
   @Override
   public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
-    for (Transport transport : transports) {
-      try {
-        transport.emit(datasetEvent);
-      } catch (Exception e) {
-        handleEmissionFailure(transport, e);
-      }
-    }
+    doEmit(datasetEvent);
   }
 
   @Override
   public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
-    for (Transport transport : transports) {
+    doEmit(jobEvent);
+  }
+
+  /**
+   * Emit events in parallel using a thread pool.
+   *
+   * @param event
+   */
+  private void doEmit(BaseEvent event) {
+    if (!config.getContinueOnFailure()) {
+      // Emit events sequentially
+      for (Transport transport : transports) {
+        emit(transport, event);
+      }
+    } else {
+      // Emit events in parallel
+      ExecutorService threadPool =
+          executorService.orElse(Executors.newFixedThreadPool(transports.size()));
+
       try {
-        transport.emit(jobEvent);
-      } catch (Exception e) {
-        handleEmissionFailure(transport, e);
+        threadPool
+            .invokeAll(
+                transports.stream()
+                    .map(
+                        t ->
+                            (Callable<Void>)
+                                () -> {
+                                  emit(t, event);
+                                  return null;
+                                })
+                    .collect(Collectors.toList()))
+            .forEach(
+                f -> {
+                  try {
+                    f.get();
+                  } catch (InterruptedException | ExecutionException e) {
+                    // do nothing, continue with the next transport
+                  }
+                });
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } finally {
+        if (!config.getWithThreadPool()) {
+          threadPool.shutdown();
+        }
       }
     }
   }
 
-  private void handleEmissionFailure(Transport transport, Exception e) {
-    if (!config.isContinueOnFailure()) {
+  /**
+   * @param transport
+   * @param event
+   */
+  private void emit(Transport transport, BaseEvent event) {
+    try {
+      if (event instanceof OpenLineage.RunEvent) {
+        transport.emit((OpenLineage.RunEvent) event);
+      } else if (event instanceof OpenLineage.DatasetEvent) {
+        transport.emit((OpenLineage.DatasetEvent) event);
+      } else if (event instanceof OpenLineage.JobEvent) {
+        transport.emit((OpenLineage.JobEvent) event);
+      } else {
+        throw new IllegalArgumentException("Unsupported event type: " + event.getClass().getName());
+      }
+    } catch (Exception e) {
+      // enrich exception with an information about the failing transport
       throw new RuntimeException(
           "Transport " + transport.getClass().getSimpleName() + " failed to emit event", e);
     }
@@ -76,6 +133,7 @@ public class CompositeTransport extends Transport {
 
   @Override
   public void close() throws Exception {
+    executorService.ifPresent(ExecutorService::shutdown);
     transports.forEach(
         t -> {
           try {

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -159,6 +159,10 @@ class ConfigTest {
           .isInstanceOf(HttpTransport.class)
           .extracting("uri")
           .isEqualTo(new URI("local"));
+      assertThat((CompositeTransport) client.transport)
+          .extracting("config")
+          .extracting("continueOnFailure")
+          .isEqualTo(true);
     }
   }
 

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -480,7 +480,8 @@ The `CompositeTransport` is designed to combine multiple transports, allowing ev
 
 - `type` - string, must be "composite". Required.
 - `transports` - a list or a map of transport configurations. Required.
-- `continueOnFailure` - boolean flag, determines if the process should continue even when one of the transports fails. Default is `false`.
+- `continueOnFailure` - boolean flag, determines if the process should continue even when one of the transports fails. Default is `true`.
+- `withThreadPool` - boolean flag, determines if a thread pool for parallel event emission should be kept between event emissions. Default is `true`.
 
 #### Behavior
 


### PR DESCRIPTION
Make `composite` transport emit the events in parallel for Java client. 
The behaviour should be default if `continueOnFailure` is `true`