### PR TITLE
Handle errors in parse_assertions for dbt integration

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -392,7 +392,7 @@ class DbtArtifactProcessor:
 
             model_node = None
             for node in context.manifest["parent_map"][run["unique_id"]]:
-                if node.startswith("model.") or node.startswith("source."):
+                if any(node.startswith(prefix) for prefix in ["model.", "source.", "seed."]):
                     model_node = node
 
             if self.manifest_version >= 12:  # type: ignore
@@ -412,7 +412,7 @@ class DbtArtifactProcessor:
             )
 
             if not model_node:
-                raise ValueError(f"Model node connected to test {nodes[run['unique_id']]} not found")
+                self.logger.warning(f"Model node connected to test {nodes[run['unique_id']]} not found")
         return assertions  # type: ignore
 
     def to_openlineage_events(self, *args, **kwargs) -> Optional[DbtRunResult]:


### PR DESCRIPTION
### Problem

When `parse_assertions` runs at the end of a dbt pipeline it fails to parse tests on seed files because we only look for the prefixes "model." and "source." when looking at the parent map of `manifest.json`. We also raise a `ValueError` for any test without an identifiable parent model which crashes the entire job and causes no events to be sent to the backend.

```json
    "test.core.test_on_some_seed": [
      "seed.core.some_seed"
    ],
```

Closes: N/A

### Solution

Added "seed." as an additional prefix to check so that we end up with a valid `model_node` in that case. Also removed the `ValueError` at the end and replaced it with a warning log. This is important because of one-off tests that use custom data rather than referencing a specific model, for instance when testing a macro or UDF.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project