### PR TITLE
Fix: run full-tests in nightly run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,9 @@ jobs:
                   python dev/filter_approvals.py
       - run: |
           export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.labels[]; .name == "full-tests")')
+          if [ "<< pipeline.parameters.nightly-run >>" == "active" ]; then
+            export IS_FULL_TESTS=1
+          fi
           echo $IS_FULL_TESTS
           if [ -z "$IS_FULL_TESTS" ] || [ "$IS_FULL_TESTS" == "0" ]; then
             pip install pyyaml==6.0.1

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
@@ -147,7 +147,6 @@ class SparkStreamingTest {
 
     SparkSession spark =
         createSparkSession(server.getAddress().getPort(), "testKafkaSourceToKafkaSink");
-    spark.sparkContext().setLogLevel("ERROR");
 
     String userDirProperty = System.getProperty("user.dir");
     Path userDirPath = Paths.get(userDirProperty);

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_to_table.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_rdd_to_table.py
@@ -4,6 +4,7 @@
 import random
 import shutil
 import string
+import time
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StringType, StructField, StructType
@@ -19,6 +20,7 @@ def rand_word():
 
 
 def tuple_to_csv(x):
+    time.sleep(0.01)  # catching active job won't work for super fast RDD operations
     return ",".join([str(i) for i in x])
 
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -121,7 +121,9 @@ public class RddPathUtils {
       try {
         Object data = FieldUtils.readField(rdd, "data", true);
         log.debug("ParallelCollectionRDD data: {}", data);
-        if ((data instanceof Seq) && ((Seq) data).head() instanceof Tuple2) {
+        if ((data instanceof Seq)
+            && (!((Seq<?>) data).isEmpty())
+            && ((Seq) data).head() instanceof Tuple2) {
           // exit if the first element is invalid
           Seq data_slice = (Seq) ((Seq) data).slice(0, SEQ_LIMIT);
           return ScalaConversionUtils.fromSeq(data_slice).stream()

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/NameNormalizer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/NameNormalizer.java
@@ -12,6 +12,9 @@ import lombok.experimental.UtilityClass;
 public class NameNormalizer {
   /** Normalizes the input stream into the version_with_underscores_only. */
   public static String normalize(String input) {
+    if (input == null) {
+      return "";
+    }
     /*
     First, trim non-letters on both ends.
      */

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/naming/NameNormalizerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/naming/NameNormalizerTest.java
@@ -12,6 +12,7 @@ class NameNormalizerTest {
   @Test
   @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
   void testNormalize() {
+    assertEquals("", NameNormalizer.normalize(null));
     assertEquals("", NameNormalizer.normalize(""));
     assertEquals("word", NameNormalizer.normalize("word"));
     assertEquals("more_than_one_words", NameNormalizer.normalize("@ more than one     words !"));


### PR DESCRIPTION
Fixes applied:
 * After introducing full tests to CI, nightly build does not run `full-tests` which is wrong. 
 * `spark_rdd_to_table` test is flaky. Our RDD integration relies on `setActiveJob` set during the run. However, in case of super quick jobs, `setActiveJob` is run after a job finishes and as a result of this OpenLineage does not capture output dataset and a test is failing. To prevent millisecond rdd operations, `time.sleep(0.01)` is added to a test for each rdd map call. 
 * `NameNormalizer` throws `NullPointerException` when called with null argument. 
 * `RddPathUtils` calls `head` on the sequence even if the sequence is empty which results in exception in the logs. 
 *  Last but not least, `setLogLevel` in Streaming Tests results from time to time in `ConcurrentModificationException` 
