### PR TITLE
revert new version changes that error on release

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -47,10 +47,12 @@ usage() {
 # We do this check because bumpversion screws up the search/replace if the current_version and
 # new_version are the same
 function update_py_version_if_needed() {
-  export "$(bump2version manual --new-version "$1" --allow-dirty --list --dry-run | grep version | xargs)"
+  # shellcheck disable=SC2086,SC2046
+  export $(bump2version manual --new-version $1 --allow-dirty --list --dry-run | grep version | xargs)
   # shellcheck disable=SC2154
   if [ "$new_version" != "$current_version" ]; then
-    bump2version manual --new-version "$1" --allow-dirty
+    # shellcheck disable=SC2086
+    bump2version manual --new-version $1 --allow-dirty
   fi
 }
 
@@ -109,7 +111,8 @@ if [[ -n "$(git status --porcelain --untracked-files=no)" ]] ; then
 fi
 
 # Ensure valid versions
-VERSIONS=("$RELEASE_VERSION" "$NEXT_VERSION")
+# shellcheck disable=SC2086,SC2206
+VERSIONS=($RELEASE_VERSION $NEXT_VERSION)
 for VERSION in "${VERSIONS[@]}"; do
   if [[ ! "${VERSION}" =~ ${SEMVER_REGEX} ]]; then
     echo "Error: Version '${VERSION}' must match '${SEMVER_REGEX}'"


### PR DESCRIPTION
Changes to [https://github.com/OpenLineage/OpenLineage/pull/3307](https://github.com/OpenLineage/OpenLineage/pull/3307/files#diff-028ead88c1c45735b6086d8149a06b65aaea626cd59e42a3b9bd234d2742b504) broke new-version.sh script - the bump2version incorrectly updates the version like

```
--- a/integration/airflow/openlineage/airflow/version.py
+++ b/integration/airflow/openlineage/airflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018-2024 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0

-__version__ = "1.26.0"
+__version__ = "__version__ = "1.26.0""
```