### PR TITLE
[Maintain][dbt] Add unit tests for structured logs parsing

### DIFF
--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/MainReportVersion.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/MainReportVersion.yaml
@@ -1,0 +1,20 @@
+[
+  {
+    "data":{
+      "log_version":3,
+      "version":"=1.8.2"
+    },
+    "info":{
+      "category":"",
+      "code":"A001",
+      "extra":{ },
+      "invocation_id":"b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level":"info",
+      "msg":"Running with dbt=1.8.2",
+      "name":"MainReportVersion",
+      "pid":278,
+      "thread":"MainThread",
+      "ts":"2024-11-22T15:58:03.518877Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/NodeStart.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/NodeStart.yaml
@@ -1,0 +1,55 @@
+[
+  # Command started dbt event
+  {
+    "data":{
+      "log_version":3,
+      "version":"=1.8.2"
+    },
+    "info":{
+      "category":"",
+      "code":"A001",
+      "extra":{ },
+      "invocation_id":"b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level":"info",
+      "msg":"Running with dbt=1.8.2",
+      "name":"MainReportVersion",
+      "pid":278,
+      "thread":"MainThread",
+      "ts":"2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data":{
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-11-20T19:45:51.614844",
+        "node_status":"started",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      }
+    },
+    "info":{
+      "category":"",
+      "code":"Q024",
+      "extra":{ },
+      "invocation_id":"917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level":"debug",
+      "msg":"Began running node model.jaffle_shop.stg_customers",
+      "name":"NodeStart",
+      "pid":248,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-11-20T19:45:51.616078Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/SQLQuery.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/SQLQuery.yaml
@@ -1,0 +1,91 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "started",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Began running node model.jaffle_shop.stg_customers",
+      "name": "NodeStart",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.616078Z"
+    }
+  },
+  # SQL Query started dbt event
+  {
+    "data":{
+      "conn_name":"model.jaffle_shop.stg_customers",
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-11-20T19:45:51.614844",
+        "node_status":"executing",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      },
+      "sql":"BEGIN"
+    },
+    "info":{
+      "category":"",
+      "code":"E016",
+      "extra":{ },
+      "invocation_id":"917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level":"debug",
+      "msg":"On model.jaffle_shop.stg_customers: BEGIN",
+      "name":"SQLQuery",
+      "pid":248,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-11-20T19:45:51.957829Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_CommandCompleted.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_CommandCompleted.yaml
@@ -1,0 +1,43 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Command finished dbt event
+  {
+    "data":{
+      "command":"dbt run",
+      "completed_at":"2024-11-22T15:58:09.771069Z",
+      "elapsed":6.5994663,
+      "success":false
+    },
+    "info":{
+      "category":"",
+      "code":"Q039",
+      "extra":{ },
+      "invocation_id":"b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level":"debug",
+      "msg":"Command `dbt run` failed at 15:58:09.771069 after 6.60 seconds",
+      "name":"CommandCompleted",
+      "pid":278,
+      "thread":"MainThread",
+      "ts":"2024-11-22T15:58:09.772392Z"
+    }
+  }
+
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_NodeFinished.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_NodeFinished.yaml
@@ -1,0 +1,109 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "started",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Began running node model.jaffle_shop.stg_customers",
+      "name": "NodeStart",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.616078Z"
+    }
+  },
+  # Node finished dbt event
+  {
+    "data":{
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"2024-12-23T15:26:34.681189",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-12-23T15:26:34.117532",
+        "node_status":"error",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      },
+      "run_result":{
+        "adapter_response":{ },
+        "execution_time":0.54660153,
+        "message":"Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql",
+        "num_failures":0,
+        "status":"error",
+        "thread":"Thread-1 (worker)",
+        "timing_info":[
+          {
+            "completed_at":"2024-12-23T15:26:34.229089Z",
+            "name":"compile",
+            "started_at":"2024-12-23T15:26:34.153870Z"
+          },
+          {
+            "completed_at":"2024-12-23T15:26:34.655611Z",
+            "name":"execute",
+            "started_at":"2024-12-23T15:26:34.242691Z"
+          }
+        ]
+      }
+    },
+    "info":{
+      "category":"",
+      "code":"Q025",
+      "extra":{ },
+      "invocation_id":"4a93eca8-2ed0-4e91-95fc-e8d27dd775a6",
+      "level":"debug",
+      "msg":"Finished running node model.jaffle_shop.stg_customers",
+      "name":"NodeFinished",
+      "pid":966,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-12-23T15:26:34.705652Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_SQLQueryStatus.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/failed_SQLQueryStatus.yaml
@@ -1,0 +1,127 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "started",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Began running node model.jaffle_shop.stg_customers",
+      "name": "NodeStart",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.616078Z"
+    }
+  },
+  # SQL Query started dbt event
+  {
+    "data": {
+      "conn_name": "model.jaffle_shop.stg_customers",
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "executing",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      },
+      "sql": "BEGIN"
+    },
+    "info": {
+      "category": "",
+      "code": "E016",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "On model.jaffle_shop.stg_customers: BEGIN",
+      "name": "SQLQuery",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.957829Z"
+    }
+  },
+  # SQL Query status event
+  {
+    "data":{
+      "exc":"Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql",
+      "exc_info":"Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/postgres/connections.py\", line 74, in exception_handler\n    yield\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 93, in add_query\n    cursor.execute(sql, bindings)\npsycopg2.errors.SyntaxError: syntax error at or near \"renamed\"\nLINE 12: renamed as (\n         ^\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 368, in safe_run\n    result = self.compile_and_execute(manifest, ctx)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 314, in compile_and_execute\n    result = self.run(ctx.node, manifest)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 415, in run\n    return self.execute(compiled_node, manifest)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/run.py\", line 298, in execute\n    result = MacroGenerator(\n  File \"/usr/local/lib/python3.10/site-packages/dbt/clients/jinja.py\", line 84, in __call__\n    return self.call_macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt_common/clients/jinja.py\", line 322, in call_macro\n    return macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 768, in __call__\n    return self._invoke(arguments, autoescape)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 782, in _invoke\n    rv = self._func(*arguments)\n  File \"<template>\", line 81, in macro\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/sandbox.py\", line 394, in call\n    return __context.call(__obj, *args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 303, in call\n    return __obj(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/clients/jinja.py\", line 84, in __call__\n    return self.call_macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt_common/clients/jinja.py\", line 322, in call_macro\n    return macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 768, in __call__\n    return self._invoke(arguments, autoescape)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 782, in _invoke\n    rv = self._func(*arguments)\n  File \"<template>\", line 52, in macro\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/sandbox.py\", line 394, in call\n    return __context.call(__obj, *args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 303, in call\n    return __obj(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/base/impl.py\", line 390, in execute\n    return self.connections.execute(sql=sql, auto_begin=auto_begin, fetch=fetch, limit=limit)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 157, in execute\n    _, cursor = self.add_query(sql, auto_begin)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 76, in add_query\n    with self.exception_handler(sql):\n  File \"/usr/local/lib/python3.10/contextlib.py\", line 153, in __exit__\n    self.gen.throw(typ, value, traceback)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/postgres/connections.py\", line 85, in exception_handler\n    raise DbtDatabaseError(str(e).strip()) from e\ndbt_common.exceptions.base.DbtDatabaseError: Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql\n",
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-12-23T15:26:34.117532",
+        "node_status":"executing",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      }
+    },
+    "info":{
+      "category":"",
+      "code":"W002",
+      "extra":{ },
+      "invocation_id":"4a93eca8-2ed0-4e91-95fc-e8d27dd775a6",
+      "level":"debug",
+      "msg":"Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql",
+      "name":"CatchableExceptionOnRun",
+      "pid":966,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-12-23T15:26:34.673602Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_CommandCompleted.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_CommandCompleted.yaml
@@ -1,0 +1,42 @@
+[
+  # Command started dbt event
+  {
+    "data":{
+      "log_version":3,
+      "version":"=1.8.2"
+    },
+    "info":{
+      "category":"",
+      "code":"A001",
+      "extra":{ },
+      "invocation_id":"b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level":"info",
+      "msg":"Running with dbt=1.8.2",
+      "name":"MainReportVersion",
+      "pid":278,
+      "thread":"MainThread",
+      "ts":"2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Command finished dbt event
+  {
+    "data": {
+      "command": "dbt run",
+      "completed_at": "2024-11-20T19:45:55.112200Z",
+      "elapsed": 8.384022,
+      "success": true
+    },
+    "info": {
+      "category": "",
+      "code": "Q039",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Command `dbt run` succeeded at 19:45:55.112200 after 8.38 seconds",
+      "name": "CommandCompleted",
+      "pid": 248,
+      "thread": "MainThread",
+      "ts": "2024-11-20T19:45:55.113359Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_NodeFinished.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_NodeFinished.yaml
@@ -1,0 +1,113 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "started",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Began running node model.jaffle_shop.stg_customers",
+      "name": "NodeStart",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.616078Z"
+    }
+  },
+  # Node finished dbt event
+  {
+    "data":{
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"2024-11-20T19:45:52.437355",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-11-20T19:45:51.614844",
+        "node_status":"success",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      },
+      "run_result":{
+        "adapter_response":{
+          "_message":"CREATE VIEW",
+          "code":"CREATE VIEW",
+          "rows_affected":-1.0
+        },
+        "execution_time":0.8032694,
+        "message":"CREATE VIEW",
+        "num_failures":0,
+        "status":"success",
+        "thread":"Thread-1 (worker)",
+        "timing_info":[
+          {
+            "completed_at":"2024-11-20T19:45:51.714549Z",
+            "name":"compile",
+            "started_at":"2024-11-20T19:45:51.647115Z"
+          },
+          {
+            "completed_at":"2024-11-20T19:45:52.429938Z",
+            "name":"execute",
+            "started_at":"2024-11-20T19:45:51.722484Z"
+          }
+        ]
+      }
+    },
+    "info":{
+      "category":"",
+      "code":"Q025",
+      "extra":{ },
+      "invocation_id":"917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level":"debug",
+      "msg":"Finished running node model.jaffle_shop.stg_customers",
+      "name":"NodeFinished",
+      "pid":248,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-11-20T19:45:52.457427Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_SQLQueryStatus.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/successful_SQLQueryStatus.yaml
@@ -1,0 +1,128 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "started",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "Began running node model.jaffle_shop.stg_customers",
+      "name": "NodeStart",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.616078Z"
+    }
+  },
+  # SQL Query started dbt event
+  {
+    "data": {
+      "conn_name": "model.jaffle_shop.stg_customers",
+      "node_info": {
+        "materialized": "view",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "stg_customers",
+        "node_path": "staging/stg_customers.sql",
+        "node_relation": {
+          "alias": "stg_customers",
+          "database": "postgres",
+          "relation_name": "\"postgres\".\"public\".\"stg_customers\"",
+          "schema": "public"
+        },
+        "node_started_at": "2024-11-20T19:45:51.614844",
+        "node_status": "executing",
+        "resource_type": "model",
+        "unique_id": "model.jaffle_shop.stg_customers"
+      },
+      "sql": "BEGIN"
+    },
+    "info": {
+      "category": "",
+      "code": "E016",
+      "extra": { },
+      "invocation_id": "917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level": "debug",
+      "msg": "On model.jaffle_shop.stg_customers: BEGIN",
+      "name": "SQLQuery",
+      "pid": 248,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-11-20T19:45:51.957829Z"
+    }
+  },
+  # SQL Status dbt event
+  {
+    "data":{
+      "elapsed":0.09596204,
+      "node_info":{
+        "materialized":"view",
+        "meta":{ },
+        "node_finished_at":"",
+        "node_name":"stg_customers",
+        "node_path":"staging/stg_customers.sql",
+        "node_relation":{
+          "alias":"stg_customers",
+          "database":"postgres",
+          "relation_name":"\"postgres\".\"public\".\"stg_customers\"",
+          "schema":"public"
+        },
+        "node_started_at":"2024-11-20T19:45:51.614844",
+        "node_status":"executing",
+        "resource_type":"model",
+        "unique_id":"model.jaffle_shop.stg_customers"
+      },
+      "query_id":"",
+      "status":"BEGIN"
+    },
+    "info":{
+      "category":"",
+      "code":"E017",
+      "extra":{ },
+      "invocation_id":"917ea72a-ecb5-4fd3-bd1f-b52ffeed4d0d",
+      "level":"debug",
+      "msg":"SQL status: BEGIN in 0.096 seconds",
+      "name":"SQLQueryStatus",
+      "pid":248,
+      "thread":"Thread-1 (worker)",
+      "ts":"2024-11-20T19:45:52.063535Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
@@ -1,0 +1,21 @@
+[
+  {
+    "eventTime":"2024-11-22T15:58:03.518877Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"dbt-run-jaffle_shop",
+      "facets":{ }
+    },
+    "eventType":"START",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
@@ -1,0 +1,99 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime":"2024-11-20T19:45:51.614844Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"MODEL"
+        }
+      }
+    },
+    "eventType":"START",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.raw_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.stg_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
@@ -1,0 +1,137 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime": "2024-11-20T19:45:51.614844Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "MODEL"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.raw_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [ ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.stg_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "customer_id",
+                "type": "",
+                "description": "",
+                "fields": [ ]
+              }
+            ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        },
+        "outputFacets": { }
+      }
+    ]
+  },
+  # OL event for SQL Start
+  {
+    "eventTime":"2024-11-20T19:45:51.957829Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"postgres.public.jaffle_shop.stg_customers"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers.sql.1",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"SQL"
+        },
+        "sql":{
+          "query":"BEGIN"
+        }
+      }
+    },
+    "eventType":"START",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
@@ -1,0 +1,47 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for command finished
+  {
+    "eventTime":"2024-11-22T15:58:09.771069Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "errorMessage":{
+          "message":"Command `dbt run` failed at 15:58:09.771069 after 6.60 seconds",
+          "programmingLanguage":"sql",
+          "stackTrace":null
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"dbt-run-jaffle_shop",
+      "facets":{ }
+    },
+    "eventType":"FAIL",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
@@ -1,0 +1,181 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime":"2024-11-20T19:45:51.614844Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"MODEL"
+        }
+      }
+    },
+    "eventType":"START",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.raw_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.stg_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  },
+  # OL event for Node finished
+  {
+    "eventTime":"2024-12-23T15:26:34.681189Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version":{
+          "version":"1.8.2"
+        },
+        "errorMessage":{
+          "message":"Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql",
+          "programmingLanguage":"sql",
+          "stackTrace":null
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"MODEL"
+        }
+      }
+    },
+    "eventType":"FAIL",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.raw_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.stg_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
@@ -1,0 +1,180 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime": "2024-11-20T19:45:51.614844Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "MODEL"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.raw_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [ ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.stg_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "customer_id",
+                "type": "",
+                "description": "",
+                "fields": [ ]
+              }
+            ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        },
+        "outputFacets": { }
+      }
+    ]
+  },
+  # OL event for SQL Start
+  {
+    "eventTime": "2024-11-20T19:45:51.957829Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "postgres.public.jaffle_shop.stg_customers"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers.sql.1",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "SQL"
+        },
+        "sql": {
+          "query": "BEGIN"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for SQL Status
+  {
+    "eventTime":"2024-12-23T15:26:34.673602Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"postgres.public.jaffle_shop.stg_customers"
+          }
+        },
+        "dbt_version":{
+          "version":"1.8.2"
+        },
+        "errorMessage":{
+          "message":"Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql",
+          "programmingLanguage":"sql",
+          "stackTrace":"Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/postgres/connections.py\", line 74, in exception_handler\n    yield\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 93, in add_query\n    cursor.execute(sql, bindings)\npsycopg2.errors.SyntaxError: syntax error at or near \"renamed\"\nLINE 12: renamed as (\n         ^\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 368, in safe_run\n    result = self.compile_and_execute(manifest, ctx)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 314, in compile_and_execute\n    result = self.run(ctx.node, manifest)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/base.py\", line 415, in run\n    return self.execute(compiled_node, manifest)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/task/run.py\", line 298, in execute\n    result = MacroGenerator(\n  File \"/usr/local/lib/python3.10/site-packages/dbt/clients/jinja.py\", line 84, in __call__\n    return self.call_macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt_common/clients/jinja.py\", line 322, in call_macro\n    return macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 768, in __call__\n    return self._invoke(arguments, autoescape)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 782, in _invoke\n    rv = self._func(*arguments)\n  File \"<template>\", line 81, in macro\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/sandbox.py\", line 394, in call\n    return __context.call(__obj, *args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 303, in call\n    return __obj(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/clients/jinja.py\", line 84, in __call__\n    return self.call_macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt_common/clients/jinja.py\", line 322, in call_macro\n    return macro(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 768, in __call__\n    return self._invoke(arguments, autoescape)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 782, in _invoke\n    rv = self._func(*arguments)\n  File \"<template>\", line 52, in macro\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/sandbox.py\", line 394, in call\n    return __context.call(__obj, *args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/jinja2/runtime.py\", line 303, in call\n    return __obj(*args, **kwargs)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/base/impl.py\", line 390, in execute\n    return self.connections.execute(sql=sql, auto_begin=auto_begin, fetch=fetch, limit=limit)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 157, in execute\n    _, cursor = self.add_query(sql, auto_begin)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/sql/connections.py\", line 76, in add_query\n    with self.exception_handler(sql):\n  File \"/usr/local/lib/python3.10/contextlib.py\", line 153, in __exit__\n    self.gen.throw(typ, value, traceback)\n  File \"/usr/local/lib/python3.10/site-packages/dbt/adapters/postgres/connections.py\", line 85, in exception_handler\n    raise DbtDatabaseError(str(e).strip()) from e\ndbt_common.exceptions.base.DbtDatabaseError: Database Error in model stg_customers (models/staging/stg_customers.sql)\n  syntax error at or near \"renamed\"\n  LINE 12: renamed as (\n           ^\n  compiled code at target/run/jaffle_shop/models/staging/stg_customers.sql\n"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers.sql.1",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"SQL"
+        },
+        "sql":{
+          "query":"BEGIN"
+        }
+      }
+    },
+    "eventType":"FAIL",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
@@ -1,0 +1,42 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for command finished
+  {
+    "eventTime":"2024-11-20T19:45:55.112200Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"dbt-run-jaffle_shop",
+      "facets":{ }
+    },
+    "eventType":"COMPLETE",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
@@ -1,0 +1,175 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime": "2024-11-20T19:45:51.614844Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "MODEL"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.raw_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [ ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.stg_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "customer_id",
+                "type": "",
+                "description": "",
+                "fields": [ ]
+              }
+            ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        },
+        "outputFacets": { }
+      }
+    ]
+  },
+  {
+    "eventTime":"2024-11-20T19:45:52.437355Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"MODEL"
+        }
+      }
+    },
+    "eventType":"COMPLETE",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.raw_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.stg_customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  },
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
@@ -1,0 +1,175 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": { }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for Node start
+  {
+    "eventTime": "2024-11-20T19:45:51.614844Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "MODEL"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.raw_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [ ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "postgres://postgres:5432",
+        "name": "postgres.public.stg_customers",
+        "facets": {
+          "dataSource": {
+            "name": "postgres://postgres:5432",
+            "uri": "postgres://postgres:5432"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "customer_id",
+                "type": "",
+                "description": "",
+                "fields": [ ]
+              }
+            ]
+          },
+          "documentation": {
+            "description": ""
+          }
+        },
+        "outputFacets": { }
+      }
+    ]
+  },
+  # OL event for SQL Start
+  {
+    "eventTime": "2024-11-20T19:45:51.957829Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "run": {
+            "runId": "{{ any(result) }}"
+          },
+          "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "postgres.public.jaffle_shop.stg_customers"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "postgres.public.jaffle_shop.stg_customers.sql.1",
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "SQL"
+        },
+        "sql": {
+          "query": "BEGIN"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for SQL Status
+  {
+    "eventTime":"2024-11-20T19:45:52.063535Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"postgres.public.jaffle_shop.stg_customers"
+          }
+        },
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"postgres.public.jaffle_shop.stg_customers.sql.1",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"SQL"
+        },
+        "sql":{
+          "query":"BEGIN"
+        }
+      }
+    },
+    "eventType":"COMPLETE",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]

--- a/integration/dbt/openlineage/tests/test_main.py
+++ b/integration/dbt/openlineage/tests/test_main.py
@@ -1,0 +1,115 @@
+# Copyright 2018-2024 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+from openlineage.common.provider.dbt.utils import CONSUME_STRUCTURED_LOGS_COMMAND_OPTION, PRODUCER
+from openlineage.dbt import consume_structured_logs, logger, main
+
+
+@pytest.mark.parametrize(
+    "command_line, number_of_calls",
+    [
+        # consume dbt structured logs
+        (["dbt-ol", CONSUME_STRUCTURED_LOGS_COMMAND_OPTION, "run", "--select", "orders"], 1),
+        # consume local artifacts
+        (["dbt-ol", "run", "--select", "orders"], 0),
+    ],
+    ids=[
+        "dbt_ol_consumes_structured_logs",
+        "dbt_ol_consumes_local_artifacts",
+    ],
+)
+def test_structured_logs(command_line: str, number_of_calls: int, monkeypatch):
+    mock_consume_structured_logs = Mock()
+    mock_consume_local_artifacts = Mock()
+    monkeypatch.setattr("openlineage.dbt.consume_structured_logs", mock_consume_structured_logs)
+    monkeypatch.setattr("openlineage.dbt.consume_local_artifacts", mock_consume_local_artifacts)
+    monkeypatch.setattr("sys.argv", command_line)
+
+    main()
+
+    assert mock_consume_structured_logs.called == number_of_calls
+    assert mock_consume_local_artifacts.called == 1 - number_of_calls
+
+
+@pytest.mark.parametrize(
+    "command_line, os_envs, function_kwargs",
+    [
+        (
+            [
+                "dbt-ol",
+                CONSUME_STRUCTURED_LOGS_COMMAND_OPTION,
+                "run",
+                "--select",
+                "orders",
+                "--profiles-dir",
+                "~/dbt/profiles-foo",
+                "--project-dir",
+                "~/dbt",
+                "--target",
+                "production",
+                "--target-path",
+                "dbt-target-1234",
+                "--vars",
+                '\'{"foo": "bar"}\'',
+            ],
+            {"OPENLINEAGE_NAMESPACE": "dbt"},
+            {
+                "target": "production",
+                "project_dir": "~/dbt",
+                "profile_name": None,
+                "model_selector": None,
+                "models": [],
+            },
+        )
+    ],
+    ids=["with_canonical_kwargs_for_consume_structured_logs"],
+)
+def test_consume_structured_logs(command_line, os_envs, function_kwargs, monkeypatch):
+    mock_consume_structured_logs = Mock()
+    mockOpenLineageClient = Mock()
+
+    mock_dbt_structured_logs_processor = Mock()
+    mock_dbt_structured_logs_processor.parse = Mock(return_value=[])
+    mockDbtStructuredLogsProcessor = Mock(
+        return_value=mock_dbt_structured_logs_processor
+    )  # instance returned
+
+    monkeypatch.setattr("os.environ", os_envs)
+    monkeypatch.setattr("openlineage.dbt.consume_structured_logs", mock_consume_structured_logs)
+    monkeypatch.setattr("sys.argv", command_line)
+    monkeypatch.setattr("openlineage.dbt.OpenLineageClient", mockOpenLineageClient)
+    monkeypatch.setattr("openlineage.dbt.DbtStructuredLogsProcessor", mockDbtStructuredLogsProcessor)
+
+    consume_structured_logs(**function_kwargs)
+
+    expected_dbt_command = [
+        "dbt",
+        "run",
+        "--select",
+        "orders",
+        "--profiles-dir",
+        "~/dbt/profiles-foo",
+        "--project-dir",
+        "~/dbt",
+        "--target",
+        "production",
+        "--target-path",
+        "dbt-target-1234",
+        "--vars",
+        '\'{"foo": "bar"}\'',
+    ]
+
+    mockDbtStructuredLogsProcessor.assert_called_once_with(
+        project_dir=function_kwargs["project_dir"],
+        dbt_command_line=expected_dbt_command,
+        producer=PRODUCER,
+        target=function_kwargs["target"],
+        job_namespace=os_envs["OPENLINEAGE_NAMESPACE"],
+        profile_name=function_kwargs["profile_name"],
+        logger=logger,
+        models=function_kwargs["models"],
+        selector=function_kwargs["model_selector"],
+    )


### PR DESCRIPTION
### Problem

Follow-up to this PR https://github.com/OpenLineage/OpenLineage/pull/3314.
Test coverage can be better.



### Solution

This PR add unit tests to verify:

1. the relationships between START/COMPLET/FAIL OL events, to check that they have the same `runId`
2. the relationships between parent/child OL events, to check that the `parent` facet has the appropriate `runId`
3. the usage of the `consume_struct_logs_function`

#### One-line summary:

Add unit tests for dbt structured logs parsing

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project