### PR TITLE
dataSource facet reconciliation

### DIFF
--- a/spec/tests/DatasourceDatasetFacet/1.json
+++ b/spec/tests/DatasourceDatasetFacet/1.json
@@ -3,6 +3,6 @@
     "_producer": "https://some.producer.com/version/1.0",
     "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasourceDatasetFacet.json",
     "name": "datasource_one",
-    "url": "https://some.location.com/datsource/one"
+    "uri": "https://some.location.com/datsource/one"
   }
 }

--- a/spec/tests/DatasourceDatasetFacet/1.json
+++ b/spec/tests/DatasourceDatasetFacet/1.json
@@ -1,7 +1,8 @@
 {
-  "version": {
-    "datasetVersion": "2",
-    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
-    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json"
+  "dataSource": {
+    "_producer": "https://some.producer.com/version/1.0",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasourceDatasetFacet.json",
+    "name": "datasource_one",
+    "url": "https://some.location.com/datsource/one"
   }
 }


### PR DESCRIPTION
### Problem

The facet example for "dataSource" was a copy of the dataset "version" facet.

The documentation is also a little misleading comparing against the spec, since it has `url` instead of `uri` as a property.

### Current Documentation
https://openlineage.io/docs/spec/facets/dataset-facets/data_source
```json
"facets": {
    "dataSource": {
        "_producer": "https://some.producer.com/version/1.0",
        "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasourceDatasetFacet.json",
        "name": "datasource_one",
        "url": "https://some.location.com/datsource/one"
    }
}
```

### Solution

This correct the definition according to the spec file at https://openlineage.io/spec/facets/1-0-0/DatasourceDatasetFacet.json

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary: Fix dataSource facet definition

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project