### PR TITLE
[feature][sql] Add minimal support for Snowflake LATERAL

### DIFF
--- a/integration/sql/impl/src/visitor.rs
+++ b/integration/sql/impl/src/visitor.rs
@@ -137,6 +137,12 @@ impl Visit for TableFactor {
                 // We can skip them as we don't support extracting lineage from functions
                 Ok(())
             }
+            TableFactor::Function { .. } => {
+                // https://github.com/apache/datafusion-sqlparser-rs/pull/1026/files#r1373705587
+                // This variant provides distinct functionality from TableFunction but can be
+                // treated the same here
+                Ok(())
+            }
             _ => Err(anyhow!(
                 "TableFactor other than table or subquery not implemented: {self}"
             )),

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -218,3 +218,25 @@ fn select_identifier_function() {
         }
     }
 }
+
+#[test]
+fn select_snowflake_lateral() {
+    assert_eq!(
+        test_sql_dialect(
+            "SELECT id as ID,
+        f.value AS Contact,
+        f1.value:type AS Type,
+        f1.value:content AS Details
+        FROM my_snowflake_schema.persons p,
+        lateral flatten(input => p.c, path => 'contact') f,
+        lateral flatten(input => f.value:business) f1;",
+            "snowflake"
+        )
+        .unwrap()
+        .table_lineage,
+        TableLineage {
+            in_tables: vec![table("my_snowflake_schema.persons")],
+            out_tables: vec![],
+        }
+    )
+}


### PR DESCRIPTION
### Problem

Currently, Snowflake queries involving the `LATERAL` keyword will result in an error since they utilize the `Function` variant of the `TableFactor` enum. See [1026](https://github.com/apache/datafusion-sqlparser-rs/pull/1026) in the [datafusion-sqlparser-rs](https://github.com/apache/datafusion-sqlparser-rs) project.

Closes: #3356 

### Solution

@JDarDagran recommended a simple solution of treating `Function` like `TableFunction` in `Visit`: i. e., skipping the node. This change should allow for table lineage for queries containing the `LATERAL` keyword.

#### One-line summary:

Skip `Function` just like the variant `TableFunction` in `impl Visit for TableFactor`

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project