### PR TITLE
Fix infinite loop in RDD flatten & perf optimization

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -97,7 +98,7 @@ class RddExecutionContext implements ExecutionContext {
     log.debug("setActiveJob within RddExecutionContext {}", activeJob);
     RDD<?> finalRDD = activeJob.finalStage().rdd();
     this.jobSuffix = nameRDD(finalRDD);
-    Set<RDD<?>> rdds = Rdds.flattenRDDs(finalRDD);
+    Set<RDD<?>> rdds = Rdds.flattenRDDs(finalRDD, new HashSet<>());
     log.debug("flattenRDDs {}", rdds);
     this.inputs = findInputs(rdds);
     Configuration jc = new JobConf();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineage.ParentRunFacet;
 import io.openlineage.client.OpenLineage.RunEventBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,11 +59,11 @@ public class OpenLineageRunEventContext {
       RDD<?> rdd = stage.rdd();
 
       nodes.addAll(Arrays.asList(stageInfo, stage));
-      nodes.addAll(Rdds.flattenRDDs(rdd));
+      nodes.addAll(Rdds.flattenRDDs(rdd, new HashSet<>()));
     } else if (jobId.isPresent() && jobMap.containsKey(jobId.get())) {
       ActiveJob activeJob = jobMap.get(jobId.get());
       nodes.add(activeJob);
-      nodes.addAll(Rdds.flattenRDDs(activeJob.finalStage().rdd()));
+      nodes.addAll(Rdds.flattenRDDs(activeJob.finalStage().rdd(), new HashSet<>()));
     }
 
     return nodes;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/RddsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/RddsTest.java
@@ -2,22 +2,81 @@
 /* Copyright 2018-2025 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
-
 package io.openlineage.spark.agent.lifecycle;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.spark.Dependency;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SparkSession$;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
 
+@SuppressWarnings("PMD")
 class RddsTest {
+
+  @AfterEach
+  void tearDown() {
+    SparkSession$.MODULE$.cleanupAnyExistingSession();
+  }
+
   @Test
-  void testFindFileLikeRddsWhenDependeciesAreNull() {
+  void assertFindFileLikeRddsWhenDependeciesAreNull() {
     RDD<?> rdd = mock(RDD.class);
     when(rdd.getDependencies()).thenReturn(null);
-
     assertThat(Rdds.findFileLikeRdds(rdd)).isEmpty();
+  }
+
+  @Test
+  void assertFlattenRdds() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    List<Integer> seqNumList = IntStream.rangeClosed(10, 20).boxed().collect(Collectors.toList());
+
+    JavaSparkContext jsc = new JavaSparkContext(session.sparkContext());
+
+    JavaRDD<Integer> parallelRdd = jsc.parallelize(seqNumList, 5);
+    JavaRDD<Integer> mappedRdd = parallelRdd.map(i -> i + 1);
+    JavaRDD<Integer> filteredRdd = mappedRdd.filter(i -> i % 2 == 0);
+    JavaRDD<Integer> mappedRdd2 = filteredRdd.map(i -> i + 10);
+
+    assertThat(Rdds.flattenRDDs(mappedRdd2.rdd(), new HashSet<>()).size() == 4);
+  }
+
+  @Test
+  void assertCyclesInRdds() {
+    SparkSession session = SparkSession.builder().master("local").getOrCreate();
+    List<Integer> seqNumList = IntStream.rangeClosed(10, 20).boxed().collect(Collectors.toList());
+
+    JavaSparkContext jsc = new JavaSparkContext(session.sparkContext());
+    Dependency mockDep = mock(Dependency.class);
+    Seq<Dependency> mockDepSeq =
+        JavaConverters.asScalaIteratorConverter(Arrays.asList(mockDep).iterator())
+            .asScala()
+            .toSeq();
+
+    JavaRDD<Integer> parallelRdd = jsc.parallelize(seqNumList, 5);
+    RDD<Integer> spyRdd = spy(parallelRdd.rdd());
+
+    when(mockDep.rdd()).thenReturn(spyRdd);
+    doReturn(mockDepSeq).when(spyRdd).dependencies();
+
+    Set<RDD<?>> flattenedRdds = Rdds.flattenRDDs(spyRdd, new HashSet<>());
+
+    assertThat(flattenedRdds.size() == 1);
   }
 }


### PR DESCRIPTION
### Problem

👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:

In some complex Spark Jobs with very large/nested RDD Trees, it is possible to have cycles. Currently the flattenRDD method doesnt handle cycles and as a result, the OL Connector gets stuck in an infinite loop and makes no progress. 


Attaching a dump from an older Version of OL Connector 
```
83	spark-listener-group-shared	RUNNABLE	
java.base@11.0.22/java.util.AbstractCollection.addAll(AbstractCollection.java:351)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:33)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.Rdds.flattenRDDs(Rdds.java:37)
app//io.openlineage.spark.agent.lifecycle.plan.SqlExecutionRDDVisitor.containsSqlExecution(SqlExecutionRDDVisitor.java:33)
app//io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor.isDefinedAt(LogicalRDDVisitor.java:38)
app//io.openlineage.spark.agent.lifecycle.plan.LogicalRDDVisitor.isDefinedAt(LogicalRDDVisitor.java:26)
app//io.openlineage.spark.agent.util.PlanUtils.safeIsDefinedAt(PlanUtils.java:289)
app//io.openlineage.spark.agent.util.PlanUtils$1.lambda$isDefinedAt$0(PlanUtils.java:84)
app//io.openlineage.spark.agent.util.PlanUtils$1$$Lambda$4785/0x000000080262d440.test(Unknown Source)
java.base@11.0.22/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
java.base@11.0.22/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1632)
```


### Solution

Keeping track of visited Rdds by its id() in the flatten method to ensure cycles aren't traversed repeatedly. Also added some minor optimization to reduce the number of calls to flatten. This helps improve performance when RDD Trees are very large.



> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project