### PR TITLE
Attaching custom facets to RDDExecContext events

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -79,7 +79,11 @@ public class ContextFactory {
             .openLineageConfig(config)
             .sparkExtensionVisitorWrapper(new SparkOpenLineageExtensionVisitorWrapper(config))
             .build();
-    return new RddExecutionContext(olContext, openLineageEventEmitter);
+
+    OpenLineageRunEventBuilder runEventBuilder =
+        new OpenLineageRunEventBuilder(olContext, handlerFactory);
+
+    return new RddExecutionContext(olContext, openLineageEventEmitter, runEventBuilder);
   }
 
   public Optional<ExecutionContext> createSparkSQLExecutionContext(long executionId) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -63,15 +63,20 @@ class RddExecutionContext implements ExecutionContext {
   private static final String SPARK_JOB_TYPE = "RDD_JOB";
 
   private final EventEmitter eventEmitter;
+  private final OpenLineageRunEventBuilder runEventBuilder;
   private final UUID runId = UUIDUtils.generateNewUUID();
   private final OpenLineageContext olContext;
   private List<URI> inputs = Collections.emptyList();
   private List<URI> outputs = Collections.emptyList();
   private String jobSuffix;
 
-  public RddExecutionContext(OpenLineageContext olContext, EventEmitter eventEmitter) {
+  public RddExecutionContext(
+      OpenLineageContext olContext,
+      EventEmitter eventEmitter,
+      OpenLineageRunEventBuilder runEventBuilder) {
     this.eventEmitter = eventEmitter;
     this.olContext = olContext;
+    this.runEventBuilder = runEventBuilder;
   }
 
   @Override
@@ -273,6 +278,8 @@ class RddExecutionContext implements ExecutionContext {
     addSparkPropertyFacet(runFacetsBuilder, event);
     addGcpRunFacet(runFacetsBuilder, event);
     addSparkJobDetailsFacet(runFacetsBuilder, event);
+
+    runEventBuilder.buildRunFacets(event, runFacetsBuilder);
 
     return runFacetsBuilder.build();
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/LibraryTest.java
@@ -20,6 +20,7 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
+import io.openlineage.spark.agent.util.TestOpenLineageEventHandlerFactory;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -145,6 +146,14 @@ class LibraryTest {
     assertThat(second.getRun().getFacets().getParent().getJob())
         .hasFieldOrPropertyWithValue("namespace", "ns_name")
         .hasFieldOrPropertyWithValue("name", "test_rdd");
+
+    assertThat(
+            second
+                .getRun()
+                .getFacets()
+                .getAdditionalProperties()
+                .containsKey(TestOpenLineageEventHandlerFactory.TEST_FACET_KEY))
+        .isTrue();
 
     assertThat(second.getOutputs())
         .hasSize(1)

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -15,6 +15,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.spark.agent.EventEmitter;
 import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.TestOpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
@@ -85,7 +86,10 @@ public class StaticExecutionContextFactory extends ContextFactory {
     SparkOpenLineageConfig olConfig = new SparkOpenLineageConfig();
     olConfig.setOverriddenAppName("test_rdd");
     when(olContext.getOpenLineageConfig()).thenReturn(olConfig);
-    return new RddExecutionContext(olContext, openLineageEventEmitter) {
+    OpenLineageRunEventBuilder runEventBuilder =
+        new OpenLineageRunEventBuilder(olContext, new TestOpenLineageEventHandlerFactory());
+
+    return new RddExecutionContext(olContext, openLineageEventEmitter, runEventBuilder) {
       @Override
       public void start(SparkListenerJobStart jobStart) {
         try {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -454,4 +454,9 @@ class OpenLineageRunEventBuilder {
                         .record(() -> fn.accept(event, runFacetsBuilder::put))));
     return runFacetsBuilder.build();
   }
+
+  public RunFacets buildRunFacets(SparkListenerEvent event, RunFacetsBuilder builder) {
+    runFacetBuilders.forEach(customFacetBuilder -> customFacetBuilder.accept(event, builder::put));
+    return builder.build();
+  }
 }


### PR DESCRIPTION
### Problem

Events emitted from RDDExecutionContext do not include custom facets that get loaded as part of InternalHandlerFactory

### Solution

Updating the buildRunFacet method in RddExecutionContext to call the InternalHandlerFactories facet creation. 

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project