### PR TITLE
python: allow to add additional properties in Python client facets.

### DIFF
--- a/.pre_commit/generate-facets/generate.py
+++ b/.pre_commit/generate-facets/generate.py
@@ -168,7 +168,7 @@ def parse_and_generate(locations):
             keep_model_order=True,
             custom_template_dir=TEMPLATES_LOCATION,
             extra_template_data=defaultdict(dict, deep_merge_dicts(extra_redact_fields, extra_schema_urls)),
-            additional_imports=["typing.ClassVar", "openlineage.client.constants.DEFAULT_PRODUCER"],
+            additional_imports=["typing.ClassVar", "typing.Any", "typing.cast", "openlineage.client.constants.DEFAULT_PRODUCER"],
         )
 
         # keep information about uuid and date-time formats

--- a/.pre_commit/generate-facets/templates/dataclass.jinja2
+++ b/.pre_commit/generate-facets/templates/dataclass.jinja2
@@ -134,7 +134,6 @@ class {{ class_name }}:
     {%- else %}
     _additional_skip_redact
     {%- endif -%}: ClassVar[list[str]] = {{ redact_fields["fields"] }}
-{#- {%- else -%} # {{ module.name }} {{ redactions }} -#}
 {%- endif -%}
 {#- base classes have additional logic for deprecations and producer & schemaURL fields -#}
 {%- if class_name in ['BaseFacet', 'BaseEvent'] %}
@@ -149,6 +148,28 @@ class {{ class_name }}:
     @property
     def skip_redact(self) -> list[str]:
         return self._base_skip_redact + self._additional_skip_redact
+{%- endif -%}
+{#- add additional properties method -#}
+{%- if additionalProperties == True %}
+    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "{{ class_name }}":
+        """Add additional properties to updated class instance."""
+        current_attrs = [a.name for a in attr.fields(self.__class__)]
+
+        new_class = attr.make_class(
+                self.__class__.__name__,
+                {k: attr.field() for k in kwargs if k not in current_attrs},
+                bases=(self.__class__,),
+            )
+        new_class.__module__ = self.__class__.__module__
+        attrs = attr.fields(self.__class__)
+        for a in attrs:
+            if not a.init:
+                continue
+            attr_name = a.name  # To deal with private attributes.
+            init_name = a.alias
+            if init_name not in kwargs:
+                kwargs[init_name] = getattr(self, attr_name)
+        return cast({{ class_name }}, new_class(**kwargs))
 {%- endif -%}
 {#- staticmethod serves as placeholder for static fields in child classes -#}
 {%- if _schemaURL %}

--- a/client/python/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/openlineage/client/generated/column_lineage_dataset.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 import attr
 from openlineage.client.generated.base import DatasetFacet
@@ -38,6 +38,26 @@ class Fields(RedactMixin):
     original data available (like a hash of PII for example)
     """
 
+    def with_additional_properties(self, **kwargs: dict[str, Any]) -> Fields:
+        """Add additional properties to updated class instance."""
+        current_attrs = [a.name for a in attr.fields(self.__class__)]
+
+        new_class = attr.make_class(
+            self.__class__.__name__,
+            {k: attr.field() for k in kwargs if k not in current_attrs},
+            bases=(self.__class__,),
+        )
+        new_class.__module__ = self.__class__.__module__
+        attrs = attr.fields(self.__class__)
+        for a in attrs:
+            if not a.init:
+                continue
+            attr_name = a.name  # To deal with private attributes.
+            init_name = a.alias
+            if init_name not in kwargs:
+                kwargs[init_name] = getattr(self, attr_name)
+        return cast(Fields, new_class(**kwargs))
+
 
 @attr.define
 class InputField(RedactMixin):
@@ -54,6 +74,26 @@ class InputField(RedactMixin):
 
     transformations: list[Transformation] | None = attr.field(factory=list)
     _skip_redact: ClassVar[list[str]] = ["namespace", "name", "field"]
+
+    def with_additional_properties(self, **kwargs: dict[str, Any]) -> InputField:
+        """Add additional properties to updated class instance."""
+        current_attrs = [a.name for a in attr.fields(self.__class__)]
+
+        new_class = attr.make_class(
+            self.__class__.__name__,
+            {k: attr.field() for k in kwargs if k not in current_attrs},
+            bases=(self.__class__,),
+        )
+        new_class.__module__ = self.__class__.__module__
+        attrs = attr.fields(self.__class__)
+        for a in attrs:
+            if not a.init:
+                continue
+            attr_name = a.name  # To deal with private attributes.
+            init_name = a.alias
+            if init_name not in kwargs:
+                kwargs[init_name] = getattr(self, attr_name)
+        return cast(InputField, new_class(**kwargs))
 
     @staticmethod
     def _get_schema() -> str:
@@ -75,3 +115,23 @@ class Transformation(RedactMixin):
     """is transformation masking the data or not"""
 
     _skip_redact: ClassVar[list[str]] = ["type", "subtype", "masking"]
+
+    def with_additional_properties(self, **kwargs: dict[str, Any]) -> Transformation:
+        """Add additional properties to updated class instance."""
+        current_attrs = [a.name for a in attr.fields(self.__class__)]
+
+        new_class = attr.make_class(
+            self.__class__.__name__,
+            {k: attr.field() for k in kwargs if k not in current_attrs},
+            bases=(self.__class__,),
+        )
+        new_class.__module__ = self.__class__.__module__
+        attrs = attr.fields(self.__class__)
+        for a in attrs:
+            if not a.init:
+                continue
+            attr_name = a.name  # To deal with private attributes.
+            init_name = a.alias
+            if init_name not in kwargs:
+                kwargs[init_name] = getattr(self, attr_name)
+        return cast(Transformation, new_class(**kwargs))

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -66,9 +66,11 @@ run.plugins = ["covdefaults"]
 
 [tool.mypy]
 disable_error_code = "no-redef"
+warn_redundant_casts = true
 show_error_codes = true
 overrides = [
   { ignore_missing_imports = true, module = [
   "confluent_kafka.*",
 ] } ]
 strict = true
+pretty = true

--- a/client/python/tests/test_facet_v2.py
+++ b/client/python/tests/test_facet_v2.py
@@ -6,7 +6,7 @@ import json
 import os
 from unittest import mock
 
-from attr import define
+from attr import asdict, define
 from openlineage.client.client import OpenLineageClient
 from openlineage.client.event_v2 import (
     BaseEvent,
@@ -202,3 +202,47 @@ def test_full_core_event_serializes_properly() -> None:
             expected_event = json.load(f)
 
         assert expected_event == event_sent
+
+
+def test_with_additional_properties_adds_new_properties():
+    base_facet = BaseFacet()
+    changed_facet = base_facet.with_additional_properties(new_prop="new_value")
+
+    assert hasattr(changed_facet, "new_prop")
+    assert changed_facet.new_prop == "new_value"
+
+
+def test_with_additional_properties_updates_existing_properties():
+    documentation_facet = documentation_job.DocumentationJobFacet(description="desc")
+    changed_facet = documentation_facet.with_additional_properties(description="new_value")
+
+    assert changed_facet.description == "new_value"
+
+
+def test_with_additional_properties_does_not_overwrite_class_level_attributes():
+    base_facet = BaseFacet()
+    original_attrs = base_facet.__class__.__attrs_attrs__
+    base_facet.with_additional_properties(new_prop="new_value")
+
+    assert base_facet.__class__.__attrs_attrs__ == original_attrs
+
+
+def test_with_additional_properties_works_with_attr_asdict():
+    documentation_facet = documentation_job.DocumentationJobFacet(description="desc")
+    changed_facet = documentation_facet.with_additional_properties(new_prop="new_value")
+
+    assert asdict(changed_facet) == {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/DocumentationJobFacet.json#/$defs/DocumentationJobFacet",
+        "_deleted": None,
+        "description": "desc",
+        "new_prop": "new_value",
+    }
+
+
+def test_with_additional_properties_isinstance_works():
+    documentation_facet = documentation_job.DocumentationJobFacet(description="desc")
+    changed_facet = documentation_facet.with_additional_properties(new_prop="new_value")
+
+    assert isinstance(changed_facet, documentation_job.DocumentationJobFacet)
+    assert isinstance(changed_facet, BaseFacet)


### PR DESCRIPTION
### Problem

Closes: #3389 

### Solution

Generate `with_additonal_properties` method that allows to create modified instance.
The solution uses some hacky lines to force attr-decorated class to be properly translated to dict/JSON.

#### One-line summary:
Allow to add additional properties in Python client facets.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project