### PR TITLE
[Fix][dbt][structured logs] Add `JobType` facet to dbt command's start/end OL event

### DIFF
--- a/integration/common/tests/dbt/structured_logs/postgres/build_command/results/build_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/build_command/results/build_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -9028,7 +9034,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"FAIL",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],
@@ -38,7 +44,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType":"FAIL",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_test_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_test_NodeFinished_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],
@@ -33,7 +39,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_test_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_test_NodeFinished_OL.yaml
@@ -13,7 +13,13 @@
     "job": {
       "namespace": "dbt-test-namespace",
       "name": "dbt-run-jaffle_shop",
-      "facets": { }
+      "facets": {
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
     },
     "eventType": "START",
     "inputs": [ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/run/results/failed_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/run/results/failed_run_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -534,7 +540,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"FAIL",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/run/results/successful_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/run/results/successful_run_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -3417,7 +3423,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/seed/results/seed_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/seed/results/seed_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -431,7 +437,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/snapshot/results/snapshot_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/snapshot/results/snapshot_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -539,7 +545,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/postgres/test/results/test_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/test/results/test_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -1648,7 +1654,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"FAIL",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/snowflake/run/results/failed_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/run/results/failed_run_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -452,7 +458,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"FAIL",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/snowflake/run/results/successful_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/run/results/successful_run_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -437,7 +443,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/snowflake/seed/results/seed_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/seed/results/seed_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -579,7 +585,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],

--- a/integration/common/tests/dbt/structured_logs/snowflake/snapshot/results/snapshot_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/snapshot/results/snapshot_ol_events.json
@@ -12,7 +12,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"START",
     "inputs":[ ],
@@ -1057,7 +1063,13 @@
     "job":{
       "namespace":"dbt-test-namespace",
       "name":"dbt-run-jaffle_shop",
-      "facets":{ }
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
     },
     "eventType":"COMPLETE",
     "inputs":[ ],


### PR DESCRIPTION
### Problem

OL events sent when a dbt command is started/finished don't contain the `jobType` facet. It's only affecting part of the integration that's consuming structured logs.

An issue I discovered when tyring to fix the above: `_get_sql_job_name` method returns a different string on the same input.

### Solution

This adds the `jobType` facet to OL events related to dbt command's start/end.
This also fixes how the SQL job names are generated: `_get_sql_job_name` returns the same string for a given dbt event.


#### One-line summary:

Add `JobType` facet to dbt command's start/end OL event

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project