### PR TITLE
Feature/tags facets v2

### DIFF
--- a/client/python/openlineage/client/facet_v2.py
+++ b/client/python/openlineage/client/facet_v2.py
@@ -29,6 +29,9 @@ from openlineage.client.generated import (
     sql_job,
     storage_dataset,
     symlinks_dataset,
+    tags_dataset,
+    tags_job,
+    tags_run,
 )
 from openlineage.client.generated.base import (
     PRODUCER,
@@ -77,4 +80,7 @@ __all__ = [
     "sql_job",
     "storage_dataset",
     "symlinks_dataset",
+    "tags_dataset",
+    "tags_job",
+    "tags_run",
 ]

--- a/client/python/openlineage/client/generated/tags_dataset.py
+++ b/client/python/openlineage/client/generated/tags_dataset.py
@@ -1,0 +1,37 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import attr
+from openlineage.client.generated.base import DatasetFacet
+from openlineage.client.utils import RedactMixin
+
+
+@attr.define
+class TagsDatasetFacet(DatasetFacet):
+    tags: list[TagsDatasetFacetFields] | None = attr.field(factory=list)
+    """The tags applied to the dataset facet"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsDatasetFacet.json#/$defs/TagsDatasetFacet"
+
+
+@attr.define
+class TagsDatasetFacetFields(RedactMixin):
+    key: str
+    """Key that identifies the tag"""
+
+    value: str
+    """The value of the field"""
+
+    source: str | None = attr.field(default=None)
+    """The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc."""
+
+    field: str | None = attr.field(default=None)
+    """Identifies the field in a dataset if a tag applies to one"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsDatasetFacet.json#/$defs/TagsDatasetFacetFields"

--- a/client/python/openlineage/client/generated/tags_job.py
+++ b/client/python/openlineage/client/generated/tags_job.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import attr
+from openlineage.client.generated.base import JobFacet
+from openlineage.client.utils import RedactMixin
+
+
+@attr.define
+class TagsJobFacet(JobFacet):
+    tags: list[TagsJobFacetFields] | None = attr.field(factory=list)
+    """The tags applied to the job facet"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsJobFacet.json#/$defs/TagsJobFacet"
+
+
+@attr.define
+class TagsJobFacetFields(RedactMixin):
+    key: str
+    """Key that identifies the tag"""
+
+    value: str
+    """The value of the field"""
+
+    source: str | None = attr.field(default=None)
+    """The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc."""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsJobFacet.json#/$defs/TagsJobFacetFields"

--- a/client/python/openlineage/client/generated/tags_run.py
+++ b/client/python/openlineage/client/generated/tags_run.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import attr
+from openlineage.client.generated.base import RunFacet
+from openlineage.client.utils import RedactMixin
+
+
+@attr.define
+class TagsRunFacet(RunFacet):
+    tags: list[TagsRunFacetFields] | None = attr.field(factory=list)
+    """The tags applied to the run facet"""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json#/$defs/TagsRunFacet"
+
+
+@attr.define
+class TagsRunFacetFields(RedactMixin):
+    key: str
+    """Key that identifies the tag"""
+
+    value: str
+    """The value of the field"""
+
+    source: str | None = attr.field(default=None)
+    """The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc."""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json#/$defs/TagsRunFacetFields"

--- a/client/python/redact_fields.yml
+++ b/client/python/redact_fields.yml
@@ -210,3 +210,21 @@
       redact_fields: []
     - class_name: SymlinksDatasetFacet
       redact_fields: []
+- module: tags_dataset
+  classes:
+    - class_name: TagsDatasetFacetFields
+      redact_fields: []
+    - class_name: TagsDatasetFacet
+      redact_fields: []
+- module: tags_job
+  classes:
+    - class_name: TagsJobFacetFields
+      redact_fields: []
+    - class_name: TagsJobFacet
+      redact_fields: []
+- module: tags_run
+  classes:
+    - class_name: TagsRunFacetFields
+      redact_fields: []
+    - class_name: TagsRunFacet
+      redact_fields: []

--- a/spec/facets/TagsDatasetFacet.json
+++ b/spec/facets/TagsDatasetFacet.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsDatasetFacet.json",
+  "$defs": {
+    "TagsDatasetFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string"
+        },
+        "field": {
+          "description": "Identifies the field in a dataset if a tag applies to one",
+          "type": "string",
+          "example": "email_address"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the dataset facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsDatasetFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsDatasetFacet"
+    }
+  }
+}

--- a/spec/facets/TagsJobFacet.json
+++ b/spec/facets/TagsJobFacet.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsJobFacet.json",
+  "$defs": {
+    "TagsJobFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string",
+          "example": "SPARK"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsJobFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the job facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsJobFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsJobFacet"
+    }
+  }
+}

--- a/spec/facets/TagsRunFacet.json
+++ b/spec/facets/TagsRunFacet.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json",
+  "$defs": {
+    "TagsRunFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string",
+          "example": "SPARK"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the run facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsRunFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsRunFacet"
+    }
+  }
+}

--- a/spec/tests/TagsDatasetFacet/1.json
+++ b/spec/tests/TagsDatasetFacet/1.json
@@ -1,0 +1,18 @@
+{
+  "tags": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.27.0/client/python",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/TagsDatasetFacet.json#/$defs/TagsDatasetFacet",
+    "tags": [
+      {
+        "key": "test_tag",
+        "value": "test_value",
+        "field": "email",
+        "source": "test_source"
+      },
+      {
+        "key": "test_tag2",
+        "value": "test_value2"
+      }
+    ]
+  }
+}

--- a/spec/tests/TagsJobFacet/1.json
+++ b/spec/tests/TagsJobFacet/1.json
@@ -1,0 +1,17 @@
+{
+  "tags": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.27.0/client/python",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/TagsJobFacet.json#/$defs/TagsJobFacet",
+    "tags": [
+      {
+        "key": "test_tag",
+        "value": "test_value",
+        "source": "test_source"
+      },
+      {
+        "key": "test_tag2",
+        "value": "test_value2"
+      }
+    ]
+  }
+}

--- a/spec/tests/TagsRunFacet/1.json
+++ b/spec/tests/TagsRunFacet/1.json
@@ -1,0 +1,17 @@
+{
+  "tags": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.27.0/client/python",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json#/$defs/TagsRunFacet",
+    "tags": [
+      {
+        "key": "test_tag",
+        "value": "test_value",
+        "source": "test_source"
+      },
+      {
+        "key": "test_tag2",
+        "value": "test_value2"
+      }
+    ]
+  }
+}

--- a/website/static/spec/facets/1-0-0/TagsDatasetFacet.json
+++ b/website/static/spec/facets/1-0-0/TagsDatasetFacet.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsDatasetFacet.json",
+  "$defs": {
+    "TagsDatasetFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string"
+        },
+        "field": {
+          "description": "Identifies the field in a dataset if a tag applies to one",
+          "type": "string",
+          "example": "email_address"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the dataset facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsDatasetFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsDatasetFacet"
+    }
+  }
+}

--- a/website/static/spec/facets/1-0-0/TagsJobFacet.json
+++ b/website/static/spec/facets/1-0-0/TagsJobFacet.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsJobFacet.json",
+  "$defs": {
+    "TagsJobFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string",
+          "example": "SPARK"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsJobFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the job facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsJobFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsJobFacet"
+    }
+  }
+}

--- a/website/static/spec/facets/1-0-0/TagsRunFacet.json
+++ b/website/static/spec/facets/1-0-0/TagsRunFacet.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json",
+  "$defs": {
+    "TagsRunFacetFields": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key that identifies the tag",
+          "type": "string",
+          "example": "pii"
+        },
+        "value": {
+          "description": "The value of the field",
+          "type": "string",
+          "example": "true|@user1|production"
+        },
+        "source": {
+          "description": "The source of the tag. INTEGRATION|USER|DBT CORE|SPARK|etc.",
+          "type": "string",
+          "example": "SPARK"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "TagsRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "description": "The tags applied to the run facet",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/TagsRunFacetFields"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tags": {
+      "$ref": "#/$defs/TagsRunFacet"
+    }
+  }
+}


### PR DESCRIPTION
### Problem

Arbitrary metadata, often referred to as tagging, concerns adding additional datapoints that are not part of the OL spec to events. Several use cases exist for this type of data.

- Environment information for jobs
- Setting PII/security information for columns
- Grain for datasets
- Technology-specific attributes i.e. (dbt Cloud project, Airflow tags, etc.)
- Downstream notification information like Slack channels, email addresses, etc.
- Configuration information for downstream automation (A message to re-run a pipeline, create Jira ticket, kick off reverse ETL, etc.)
- Enriching events with domain-specific tags
- etc.

No matter how many fields OpenLineage adds to the spec, there will always be a need for additional metadata both supplied by the client and the user. In order to allow OpenLineage to support more use cases, we should consider a generalized and automatable approach to capturing this type of metadata.

See these discussions for additional context:

https://github.com/OpenLineage/OpenLineage/issues/2779
https://github.com/OpenLineage/OpenLineage/issues/2748
https://github.com/OpenLineage/OpenLineage/pull/1630

Closes: #3169

### Solution

For this implementation I created separate facets for runs, jobs and datasets. Each facet has a facet fields object that holds the properties for the tag. We do this instead of inheriting a single TagsFacetField object because the code generator requires external refs to already be published. 

TagsDatasetFacetFields:
- key - Name of the tag
- value - Value of the tag
- field - Dataset field the tag applies to if it applies to a field
- source - Where the tag is coming from i.e. (DBT, SPARK, etc...)

TagsJobFacetFields:
- key - Name of the tag
- value - Value of the tag
- source - Where the tag is coming from i.e. (DBT, SPARK, etc...)

TagsRunFacetFields:
- key - Name of the tag
- value - Value of the tag
- source - Where the tag is coming from i.e. (DBT, SPARK, etc...)

Issue: [Tags for arbitrary metadata](https://github.com/OpenLineage/OpenLineage/issues/3169) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### Add Tags Facets for Run, Job and Dataset

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project