### PR TITLE
Allowing events from SerializedFromObject for non-delta plans

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/EventFilterUtils.java
@@ -9,12 +9,14 @@ import io.openlineage.spark.agent.util.SparkSessionUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Optional;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerEvent;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 
+@Slf4j
 public class EventFilterUtils {
 
   /**
@@ -28,7 +30,22 @@ public class EventFilterUtils {
             new SparkNodesFilter(context),
             new CreateViewFilter(context),
             new AdaptivePlanEventFilter(context))
-        .anyMatch(filter -> filter.isDisabled(event.getClass().cast(event)));
+        .anyMatch(
+            filter -> {
+              boolean isDisabled = filter.isDisabled(event.getClass().cast(event));
+              if (isDisabled) {
+                String logicalPlanNode =
+                    getLogicalPlan(context)
+                        .map(plan -> plan.getClass().getCanonicalName())
+                        .orElse("UnparsableLogicalPlan");
+                log.debug(
+                    "Rejecting event : {} with plan : {} due to filter : {}",
+                    event.toString(),
+                    logicalPlanNode,
+                    filter.getClass().getCanonicalName());
+              }
+              return isDisabled;
+            });
   }
 
   static Optional<LogicalPlan> getLogicalPlan(OpenLineageContext context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/filters/DatabricksEventFilterTest.java
@@ -29,6 +29,7 @@ class DatabricksEventFilterTest {
   DatabricksEventFilter filter = new DatabricksEventFilter(context);
   QueryExecution queryExecution = mock(QueryExecution.class, RETURNS_DEEP_STUBS);
   WholeStageCodegenExec node = mock(WholeStageCodegenExec.class);
+  SerializeFromObject serializedObjectNode = mock(SerializeFromObject.class);
   SparkListenerEvent sparkListenerEvent = mock(SparkListenerEvent.class);
 
   @BeforeEach
@@ -82,6 +83,19 @@ class DatabricksEventFilterTest {
             .contains("spark.databricks.workspaceUrl"))
         .thenReturn(false);
     when(node.nodeName()).thenReturn("collect_Limit");
+    assertThat(filter.isDisabled(event)).isFalse();
+  }
+
+  @Test
+  void testSerializedFromObjectEventIsNotFiltered() {
+    when(queryExecution
+            .sparkSession()
+            .sparkContext()
+            .getConf()
+            .contains("spark.databricks.workspaceUrl"))
+        .thenReturn(false);
+
+    when(queryExecution.optimizedPlan()).thenReturn(serializedObjectNode);
     assertThat(filter.isDisabled(event)).isFalse();
   }
 }


### PR DESCRIPTION
### Problem

Events from sql collect are being filtered even its not run in a Databricks env/delta write command. 
Closes: #ISSUE-NUMBER

### Solution

Filter out SerializedFromObjectPlans only for Data Bricks. This ensure we get complete lineage coverage for all other usecases.

#### One-line summary:

### Checklist

- [ x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project