### PR TITLE
feat: Add extension to filepath in file transport not in append mode

### DIFF
--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -49,7 +49,7 @@ class FileTransport(Transport):
             log_file_path = self.config.log_file_path
         else:
             time_str = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
-            log_file_path = f"{self.config.log_file_path}-{time_str}"
+            log_file_path = f"{self.config.log_file_path}-{time_str}.json"
 
         log.debug("Openlineage event will be emitted to file: `%s`", log_file_path)
         try:


### PR DESCRIPTION
### Problem

When using FileTransport with `append=False`, file paths we get have no extension (e.g. `ol-event-"20250115-131540.190883"`).

### Solution

I think when creating new files, we can provide .json extension, so now the file path would be `ol-event-20250115-131540.190883.json`

#### One-line summary:
Added .json extension to filepath in FileTransport when not in append mode.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project