### PR TITLE
fix Spark structured streaming query context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * **Flink: Experimental version for flink native lineage listener.** [`#3099`](https://github.com/OpenLineage/OpenLineage/pull/3099) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
   *New flink listener to extract lineage through native Flink interfaces. Supports Flink SQL. Requires Flink 2.0.*
 
+### Fixed
+
+* **Spark: fix lineage for SQLs run within structured streaming queries.** [`#3405`](https://github.com/OpenLineage/OpenLineage/pull/3405) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *When a streaming query gets executed, treat SQL executed within a streaming query as parts of a streaming job.*
 
 ## [1.26.0](https://github.com/OpenLineage/OpenLineage/compare/1.25.0...1.26.0) - 2024-12-20
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -143,7 +143,7 @@ public class StaticExecutionContextFactory extends ContextFactory {
                   visitorFactory.getOutputVisitors(olContext);
               olContext.getOutputDatasetQueryPlanVisitors().addAll(outputDatasets);
               return new SparkSQLExecutionContext(
-                  executionId, openLineageEventEmitter, olContext, runEventBuilder) {
+                  executionId, openLineageEventEmitter, olContext, runEventBuilder, false) {
                 @Override
                 public void start(SparkListenerSQLExecutionStart startEvent) {
                   try {
@@ -177,6 +177,7 @@ public class StaticExecutionContextFactory extends ContextFactory {
         executionId,
         emitter,
         olContext,
-        new OpenLineageRunEventBuilder(olContext, new InternalEventHandlerFactory()));
+        new OpenLineageRunEventBuilder(olContext, new InternalEventHandlerFactory()),
+        false);
   }
 }


### PR DESCRIPTION
Problem: https://github.com/OpenLineage/OpenLineage/issues/3398 - when a stream processing query is started, Spark can still run batch SQL jobs. Openlineage connector treats those jobs as separate which is breaking a lineage.

This PR modifies OpenLineage listener in a way that, when streaming query is started, all the SQL jobs are getting the same runId and jobName as a streaming query. For the inner SQLs `start` and `complete` events are not emitted (events are of a `running` type). When a streaming job terminates, `complete` event is published. 

The alternative approach to this are:
 * Do nothing and let backend correlate the events through application id.
 * Add another logical parent run hierarchy level for the streaming jobs. So a streaming job would be a child of an application job, while all the SQLs run during the streaming job would be its children. On one hand this makes sense, but on the other hand I think this adds unnecessary complexity on the backend side. Example: if a job reads events from Kafka, windows them, and modifies a table with a window aggregation, then I think that reading a stream and writing to a table is the same job. Breaking this into two jobs is what Spark implementation does, but does not reflect what the jobs is about. 