### PR TITLE
ci: fix detection of spec changes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,6 +131,7 @@ repos:
         files: ^spec/
         exclude: ".*tests.*"
         entry: .pre_commit/run-spec-snapshot.sh
+        pass_filenames: false
       - id: pmd-client-java
         name: pmd-client-java
         description: "Runs the PMD static code analyzer - Java client."

--- a/.pre_commit/run-spec-snapshot.sh
+++ b/.pre_commit/run-spec-snapshot.sh
@@ -42,7 +42,7 @@ while read -r LINE; do
     echo "Change detected in $LINE: $LOC is untracked"
     CHANGE_DONE=1  # Mark as change detected
   fi
-done < <(git diff --name-only HEAD -- 'spec/*.json' 'spec/OpenLineage.yml')
+done < <(git diff --name-only origin/main -- 'spec/OpenLineage.json' 'spec/facets/*.json' 'spec/OpenLineage.yml')
 
 # Exit with the value of CHANGE_DONE (0 if no changes, 1 if there were changes)
 exit $CHANGE_DONE


### PR DESCRIPTION
### Problem

`run-spec-snapshot.sh` does not take `spec/facets` into consideration.

### Solution

Fix the script.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project