### PR TITLE
[SPARK] Fix ClassLoader handling for OpenLineageExtensionProvider

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ExtensionClassloader.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ExtensionClassloader.java
@@ -1,0 +1,35 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.agent.util;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExtensionClassloader extends ClassLoader {
+
+  private final Set<ClassLoader> classLoaders = new LinkedHashSet<>();
+
+  public ExtensionClassloader(Collection<ClassLoader> aclassLoaders) {
+    classLoaders.addAll(aclassLoaders);
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    log.trace("Using multiple classloaders: {}", classLoaders);
+    for (ClassLoader cl : classLoaders) {
+      try {
+        Class<?> aClass = cl.loadClass(name);
+        log.trace("Classloader {} successfully loaded a class: {}", cl, aClass);
+        return aClass;
+      } catch (NoClassDefFoundError | Exception e) {
+        log.error("Classloader {} failed to load {} class", cl, name, e);
+      }
+    }
+    throw new ClassNotFoundException(name);
+  }
+}


### PR DESCRIPTION
### Problem

Closes: #3407

### Solution

The solution works around class loader conflicts by transferring the `OpenLineageExtensionProvider` class between class loaders, albeit using an illegal reflective access. Here's how it works:

1. Serialization: The bytecode of the OpenLineageExtensionProvider class is retrieved from the source class loader and serialized into a ByteBuffer.
2. Reflective Access: Using reflection, the defineClass method of the target class loader is invoked to load the serialized bytecode into its context.
3. Usage: Once defined, the class becomes accessible in the target class loader, resolving the visibility issue.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project