### PR TITLE
Use create release notes script.

### DIFF
--- a/.github/workflows/website-new-version.yml
+++ b/.github/workflows/website-new-version.yml
@@ -1,9 +1,8 @@
 name: Version documentation
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 permissions:
   id-token: write
@@ -21,7 +20,7 @@ jobs:
           fetch-tags: true
       - uses: actions/checkout@v4
         with:
-          repository: 'Openlineage/openlineage-site'
+          repository: 'OpenLineage/openlineage-site'
           path: 'target'
           token:  ${{ secrets.ACTIONS_GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
@@ -33,17 +32,20 @@ jobs:
         run:  |
           cd target
           yarn install --frozen-lockfile
+      - name: Generate release notes
+        run: |
+          cd target
+          python scripts/create_release_notes.py '${{ github.event.release.tag_name }}' '${{ github.event.release.published_at }}' '${{ github.event.release.body }}'
       - name: Generate new version
         run: |
-          cd source
-          echo latest version is $GITHUB_REF_NAME
-          cd ../target
-          if [ -d "versioned_docs/version-$GITHUB_REF_NAME" ]
+          echo latest version is ${{ github.event.release.tag_name }}
+          cd target
+          if [ -d "versioned_docs/version-${{ github.event.release.tag_name }}" ]
           then
             echo "Version already exists. skipping"
           else
-            echo "Generating version $GITHUB_REF_NAME"
-            yarn run docusaurus docs:version $GITHUB_REF_NAME
+            echo "Generating version ${{ github.event.release.tag_name }}"
+            yarn run docusaurus docs:version ${{ github.event.release.tag_name }}
           fi
       - name: Push target repo
         run: |

--- a/website/scripts/create_release_notes.py
+++ b/website/scripts/create_release_notes.py
@@ -1,0 +1,60 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import pathlib
+import re
+import sys
+
+
+def replace_links(text):
+    text = re.sub(
+        r"(?<!\[`)\#(\d+)(?!\))", r"[`#\1`](https://github.com/OpenLineage/OpenLineage/pull/\1)", text
+    )
+    return re.sub(r"(?<!\[)@(\w+)(?!\))", r"[@\1](https://github.com/\1)", text)
+
+
+def main(tag, date, content):
+    # Count the number of .md files in the directory
+    releases_dir = pathlib.Path(__file__).resolve().parent / "../docs/releases"
+    md_files_count = len(list(releases_dir.glob("*.md")))
+
+    # Calculate sidebar_position
+    sidebar_position = 10000 - md_files_count - 1
+
+    # Create new .md file
+    filename = f"{tag.replace('.', '_')}.md"
+    new_file_path = releases_dir / filename
+
+    # Replace links in the content
+    content = replace_links(content.replace("\\r\\n", "\r\n"))
+
+    # Extract formatted date from date string in following format 2025-01-16T12:17:08Z
+    date = datetime.datetime.fromisoformat(date[:-1]).strftime("%Y-%m-%d")
+
+    # Template for the new .md file
+    template = f"""---
+title: {tag}
+sidebar_position: {sidebar_position}
+---
+
+# {tag} - {date}
+
+{content}
+"""
+    # Write the content to the new file
+    new_file_path.write_text(template)
+    print(f"Release note created: {new_file_path}")
+    print(template)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4: # noqa: PLR2004
+        print("Usage: create_release_note.py <tag> <date> <content>")
+        sys.exit(1)
+
+    tag = sys.argv[1]
+    date = sys.argv[2]
+    content = sys.argv[3]
+
+    main(tag, date, content)


### PR DESCRIPTION
Publish new docs version on GH release.

Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

New version of docs should be created with GH release, not with push to main with matching tag.

Release notes in docs require manual action currently.

### Solution

Change trigger to release published.

Use `create_release_note.py` script to generate release notes.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2024 contributors to the OpenLineage project