### PR TITLE
Add docs for creating new facets

### DIFF
--- a/website/docs/spec/schemas.md
+++ b/website/docs/spec/schemas.md
@@ -14,7 +14,7 @@ The following guidelines may help you to correctly introduce new changes.
 Before you decide to make any changes, it is best advised that you first label your issue with `spec`. This will indicate the the issue is related to any changes in the current OpenLineage spec.
 
 ## Make changes to the spec's version
-Whenever there is a change to existing spec file (JSON), you need to bump up the version of the existing current spec, so that the changes can go through the code generation and gradle build. Consider the following spec file, where you will see the URL in `$id` that shows what is the current spec version the file currently is.
+Versioning occurs on a per-file basis. Any new spec files start at 1-0-0. Whenever there is a change to existing spec file (JSON), you need to bump up the version of the existing current spec, so that the changes can go through the code generation and gradle build. Consider the following spec file, where you will see the URL in `$id` that shows what is the current spec version the file currently is.
 
 ```
 {
@@ -34,14 +34,38 @@ In this example, bumping up the version to the new value, should be changed from
 
 > If you do not bump the version to higher number, the code generation of Java client will fail.
 
-## Python client's codes need to be manually updated
-Java client's build process does involve `code generation` that automatically produces OpenLineage classes derived from the spec files, so you do not need to do anything in terms of coding the client. However, python client libraries does not depend on the spec files to be generated, so you have to make sure to add changes to the python code in order for it to know and use the changes. As for the facets, they are implemented [here](https://github.com/OpenLineage/OpenLineage/blob/main/client/python/openlineage/client/facet.py), so generally, you need to apply necessary changes to it. As for the general structure of OpenLineage's run events, it can be found [here](https://github.com/OpenLineage/OpenLineage/blob/main/client/python/openlineage/client/run.py).
+## Adding and Updating the Schema
 
-## Add test cases
-Make sure to add changes to the unit tests for [python](https://github.com/OpenLineage/OpenLineage/tree/main/client/python/tests) and [java](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/test/java/io/openlineage/client) to make sure the unit test can be performed against your new SPEC changes. Refer to existing test codes to add yours in.
+Both Python and Java clients automatically generate code to handle the schema, so there is generally little work to do for modifications and new facets. Core logic changes may require manual code in both the Java and Python clients. These changes are rare and require additional planning in the proposal to plan out the steps. Thee are the steps for adding a new facet, which covers the majority of schema changes.  
 
-## Test the SPEC change using code generation and integration tests
-When you have modified the SPEC file(s), always make sure to perform code generation and unit tests by going into `client/java` and running `./gradlew generateCode` and `./gradlew test`. As for python, cd into `client/python` and run `pytest`.
+> It is important to have pre-commit installed by running `pre-commit install` before committing to the repository. All commits should be signed off with -s `git commit -s -m "commit message"`
 
-> Note: Some of the tests may fail due to the fact that they require external systems like kafka. You can ignore those errors.
+> The OpenLineage commutity is very helpful. Do not hesitate to reach out to [#dev-discuss](https://openlineage.slack.com/archives/C065PQ4TL8K) with questions. 
+
+Make your changes
+
+1. Create the facet in `/spec/facets/` (Core spec changes go in `/spec/OpenLineage.json`) 
+1. Create an example JSON representation of the facet in `/spec/facets/tests/` 
+
+Configure Java clent
+
+1. cd `/client/java`
+1. `./gradlew clean publishToMavenLocal` (Publish code to the local Maven project.)
+1. `./gradlew generateCode` (Generate the Java classes for new schema changes.)
+1. `./gradlew test` (Ensure things are working)
+
+Configure Python client
+
+1. `cd client/python`
+1. Update `/client/python/redact_fields.yml` to set any fields that need redaction. (Usually set redact_fields: [])
+1. `pip install -r pyproject.toml --extras test --extras msk-iam --extras kafka` (Install dependencies)
+1. `pytest` (Ensure tests run. DeprecationWarnings are OK. If any errors occur, check on [#dev-discuss](https://openlineage.slack.com/archives/C065PQ4TL8K))
+
+Commit your code to run Python code generation, various tests, and update website docs. 
+
+1. Optional `pre-commit run` (See if your commit will work.)
+1. `git commit -s -m "commit message"` (If anything goes wrong, verify your code.)
+
+## Add test cases (For spec changes that require manual client code.)
+Some spec changes require logic changes in the client. See [this PR](https://github.com/OpenLineage/OpenLineage/pull/3186/files#diff-0f689ced46667a2b465edd8311bc217da3ad752877a3515a092b3d46273cb190) that automatically adds an environment variable facet to run events. These types of changes require additional tests. Simply adding or modifying facets do not require new tests. When changing core logic, make sure to add changes to the unit tests for [python](https://github.com/OpenLineage/OpenLineage/tree/main/client/python/tests) and [java](https://github.com/OpenLineage/OpenLineage/tree/main/client/java/src/test/java/io/openlineage/client) to make sure the unit test can be performed against your new SPEC changes. Refer to existing test codes to add yours in.
 

--- a/website/docs/spec/schemas.md
+++ b/website/docs/spec/schemas.md
@@ -14,7 +14,7 @@ The following guidelines may help you to correctly introduce new changes.
 Before you decide to make any changes, it is best advised that you first label your issue with `spec`. This will indicate the the issue is related to any changes in the current OpenLineage spec.
 
 ## Make changes to the spec's version
-Versioning occurs on a per-file basis. Any new spec files start at 1-0-0. Whenever there is a change to existing spec file (JSON), you need to bump up the version of the existing current spec, so that the changes can go through the code generation and gradle build. Consider the following spec file, where you will see the URL in `$id` that shows what is the current spec version the file currently is.
+[Versioning](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Versioning.md) occurs on a per-file basis. Any new spec files start at 1-0-0. Whenever there is a change to existing spec files (JSON), you need to bump up the version of the existing current spec, so that the changes can go through the code generation and gradle build. Consider the following spec file, where you will see the URL in `$id` that shows what is the current spec version the file currently is.
 
 ```
 {
@@ -36,7 +36,7 @@ In this example, bumping up the version to the new value, should be changed from
 
 ## Adding and Updating the Schema
 
-Both Python and Java clients automatically generate code to handle the schema, so there is generally little work to do for modifications and new facets. Core logic changes may require manual code in both the Java and Python clients. These changes are rare and require additional planning in the proposal to plan out the steps. Thee are the steps for adding a new facet, which covers the majority of schema changes.  
+Both Python and Java clients automatically generate code to handle the schema, so there is generally little work to do for modifications and new facets. Core logic changes may require manual code in both the Java and Python clients. These changes are rare and require additional planning in the proposal to plan out the steps. These are the steps for adding a new facet, which covers the majority of schema changes.  
 
 > It is important to have pre-commit installed by running `pre-commit install` before committing to the repository. All commits should be signed off with -s `git commit -s -m "commit message"`
 


### PR DESCRIPTION
### Problem

Adding new facets is a common task for first-time contributors. While the process is simple, understanding what needs to be done can be confusing. 

### Solution

Create simplified docs for adding new facets. 

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project