### PR TITLE
Bump versions for flink-native-listener.

### DIFF
--- a/integration/flink-native-listener/gradle.properties
+++ b/integration/flink-native-listener/gradle.properties
@@ -1,5 +1,5 @@
 jdk8.build=true
-version=1.27.0-SNAPSHOT
+version=1.28.0-SNAPSHOT
 # Set the version of Flink to use - currently snapshot
 flink.version=2.0-preview1
 org.gradle.jvmargs=-Xmx1G

--- a/integration/flink-native-listener/src/test/resources/io/openlineage/flink/client/version.properties
+++ b/integration/flink-native-listener/src/test/resources/io/openlineage/flink/client/version.properties
@@ -1,1 +1,1 @@
-version 1.27.0-SNAPSHOT
+version 1.28.0-SNAPSHOT

--- a/new-version.sh
+++ b/new-version.sh
@@ -143,6 +143,7 @@ perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/spark/grad
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/spark-extension-interfaces/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink/examples/stateful/gradle.properties
+perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink-native-listener/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./proxy/backend/gradle.properties
 
 # (3) Bump version in docs
@@ -185,6 +186,7 @@ echo "version ${NEXT_VERSION}" > integration/spark/spark3/src/test/resources/io/
 echo "version ${NEXT_VERSION}" > integration/spark-extension-interfaces/src/test/resources/io/openlineage/spark/shade/extension/v1/lifecycle/plan/version.properties
 echo "version ${NEXT_VERSION}" > integration/flink/shared/src/test/resources/io/openlineage/flink/client/version.properties
 echo "version ${NEXT_VERSION}" > integration/flink/app/src/test/resources/io/openlineage/flink/client/version.properties
+echo "version ${NEXT_VERSION}" > integration/flink-native-listener/src/test/resources/io/openlineage/flink/client/version.properties
 
 # (7) Prepare next development version commit
 git commit --no-verify -sam "Prepare next development version ${NEXT_VERSION}"


### PR DESCRIPTION
### Problem

New directory was not included in bump version script.

### Solution

Bump versions and include them in the script.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project