### PR TITLE
[SPARK] Modify the OpenLineageSparkListener to have a public, single-argument constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.27.0...HEAD)
 
+### Added
+
+### Changed
+
+* **Spark: the OpenLineageSparkListener was refactored to have a public, single-argument constructor taking an instance of SparkConf. [`#3425`](https://github.com/OpenLineage/OpenLineage/pull/3425) [@d-m-h](https://github.com/d-m-h)
+  *This presents no functional change to the listener, however it will allow for improved initialisation of the listener in the future.*
+
+### Fixed
+
 ## [1.27.0](https://github.com/OpenLineage/OpenLineage/compare/1.26.0...1.27.0) - 2025-01-20
 
 ### Added

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -84,6 +85,14 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
    * which are collected within RddExecutionContext but emitted within SparkSQLExecutionContext.
    */
   private Optional<Integer> activeJobId = Optional.empty();
+
+  @SuppressWarnings("PMD")
+  private final SparkConf conf;
+
+  public OpenLineageSparkListener(SparkConf conf) {
+    super();
+    this.conf = Objects.requireNonNull(conf).clone();
+  }
 
   /**
    * called by the tests

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -62,6 +62,7 @@ class OpenLineageSparkListenerTest {
   EventEmitter emitter = mock(EventEmitter.class);
   QueryExecution qe = mock(QueryExecution.class);
   SparkPlan plan = mock(SparkPlan.class);
+  SparkConf sparkConf = new SparkConf();
 
   OpenLineageContext olContext;
 
@@ -156,7 +157,7 @@ class OpenLineageSparkListenerTest {
       when(contextFactory.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
       OpenLineageSparkListener.init(contextFactory);
-      OpenLineageSparkListener listener = new OpenLineageSparkListener();
+      OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
 
       listener.onApplicationStart(mock(SparkListenerApplicationStart.class));
       listener.onApplicationEnd(mock(SparkListenerApplicationEnd.class));
@@ -202,7 +203,7 @@ class OpenLineageSparkListenerTest {
     olContext
         .getOutputDatasetQueryPlanVisitors()
         .add(new InsertIntoHadoopFsRelationVisitor(olContext));
-    OpenLineageSparkListener listener = new OpenLineageSparkListener();
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
     OpenLineageSparkListener.init(
         new StaticExecutionContextFactory(
             emitter, new SimpleMeterRegistry(), new SparkOpenLineageConfig()));
@@ -228,7 +229,7 @@ class OpenLineageSparkListenerTest {
   @Test
   void testApplicationStartEvent() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    OpenLineageSparkListener listener = new OpenLineageSparkListener();
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
     OpenLineageSparkListener.init(
         new StaticExecutionContextFactory(emitter, meterRegistry, new SparkOpenLineageConfig()));
     SparkListenerApplicationStart event = mock(SparkListenerApplicationStart.class);
@@ -243,7 +244,7 @@ class OpenLineageSparkListenerTest {
 
   @Test
   void testApplicationEndEvent() {
-    OpenLineageSparkListener listener = new OpenLineageSparkListener();
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
     OpenLineageSparkListener.init(
         new StaticExecutionContextFactory(
             emitter, new SimpleMeterRegistry(), new SparkOpenLineageConfig()));
@@ -260,7 +261,7 @@ class OpenLineageSparkListenerTest {
   @Test
   void testCheckSparkApplicationEventsAreEmitted() {
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    OpenLineageSparkListener listener = new OpenLineageSparkListener();
+    OpenLineageSparkListener listener = new OpenLineageSparkListener(sparkConf);
     OpenLineageSparkListener.init(
         new StaticExecutionContextFactory(emitter, meterRegistry, new SparkOpenLineageConfig()));
     SparkListenerApplicationStart startEvent = mock(SparkListenerApplicationStart.class);


### PR DESCRIPTION
### Problem

The `OpenLineageSparkListener` currently uses static methods to perform some initialisation. 

### Solution

This change introduces a public, single-argument constructor to the `OpenLineageSparkListener` that takes an instance of `SparkConf` which we can use to initialise the listener (and its components) up-front.

#### One-line summary: Add a public, single-argument constructor to the `OpenLineageSparkListener`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project