### PR TITLE
Fix multiline release body.

### DIFF
--- a/.github/workflows/website-new-version.yml
+++ b/.github/workflows/website-new-version.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Generate release notes
         run: |
           cd target
-          python scripts/create_release_notes.py '${{ github.event.release.tag_name }}' '${{ github.event.release.published_at }}' '${{ github.event.release.body }}'
+          echo 
+          python scripts/create_release_notes.py '${{ github.event.release.tag_name }}' '${{ github.event.release.published_at }}' "$(cat << 'EOM'
+          ${{ github.event.release.body }}
+          EOM
+          )"
       - name: Generate new version
         run: |
           echo latest version is ${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Problem

https://github.com/OpenLineage/OpenLineage/actions/runs/12884960069/job/35922382015 failed.

### Solution

Attempt to fix with `cat << 'EOM'`.  Ran same release on my fork: https://github.com/JDarDagran/OpenLineage/actions/runs/12886253929/job/35926430677

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project