### PR TITLE
[dbt][fix][structured logs] Fix parent_run facet of root dbt event

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/openlineage/common/provider/dbt/utils.py
@@ -107,7 +107,7 @@ def get_parent_run_metadata():
         parent_namespace, parent_job_name, parent_run_id = parent_id.split("/")
         parent_run_metadata = ParentRunMetadata(
             run_id=parent_run_id, job_name=parent_job_name, job_namespace=parent_namespace
-        )
+        ).to_openlineage()
     return parent_run_metadata
 
 

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_with_parent_id_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_with_parent_id_OL.yaml
@@ -1,0 +1,72 @@
+[
+  # OL event for command start
+  {
+    "eventTime": "2024-11-22T15:58:03.518877Z",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job": {
+      "namespace": "dbt-test-namespace",
+      "name": "dbt-run-jaffle_shop",
+      "facets": {
+        "parent": {
+          "run": { # parent runID passed via environment variable is present
+            "runId": "e2c4a0ab-d119-4828-b9c4-96ffd4c79d4f"
+          },
+          "job": {
+            "namespace": "my_parent_namespace",
+            "name": "my_parent_job_name"
+          }
+        },
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
+    },
+    "eventType": "START",
+    "inputs": [ ],
+    "outputs": [ ]
+  },
+  # OL event for command finished
+  {
+    "eventTime":"2024-11-20T19:45:55.112200Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "dbt_version": {
+          "version": "1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"dbt-run-jaffle_shop",
+      "facets":{
+        "parent": {
+          "run": {
+            "runId": "e2c4a0ab-d119-4828-b9c4-96ffd4c79d4f"
+          },
+          "job": {
+            "namespace": "my_parent_namespace",
+            "name": "my_parent_job_name"
+          }
+        },
+        "jobType": {
+          "processingType": "BATCH",
+          "integration": "DBT",
+          "jobType": "JOB"
+        }
+      }
+    },
+    "eventType":"COMPLETE",
+    "inputs":[ ],
+    "outputs":[ ]
+  }
+]


### PR DESCRIPTION
### Problem

Related to the dbt structured logs part only.

When the `OPENLINEAGE_PARENT_ID` is specified, the `ParentRun` facet is not  represented as it is defined in the spec.  Example below
```json
...
"run": {
    "facets": {
      ...
      "parent": {
        "job_name": "my_parent_job_name",
        "job_namespace": "my_parent_namespace",
        "run_id": "01948d6a-35a7-787d-a791-992dd696e224"
      }
     ....
  }
```
Where is should be defined as 
```json
... 
 "facets":{
        "parent": {
          "run": {
            "runId": "01948d6a-35a7-787d-a791-992dd696e224"
          },
          "job": {
            "namespace": "my_parent_namespace",
            "name": "my_parent_job_name"
          }
 },
```
The `runId` is inside the `run` dict and not 

### Solution
I was missing a call to `.to_openlineage()`. I added it.



#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project