### PR TITLE
client: Add task queue based async circuit breaker

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreaker.java
@@ -20,6 +20,8 @@ public interface CircuitBreaker {
    */
   <T> T run(Callable<T> callable);
 
+  void close();
+
   default int getCheckIntervalMillis() {
     return CIRCUIT_CHECK_INTERVAL_IN_MILLIS;
   }

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerState.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerState.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 @ToString
 public class CircuitBreakerState {
   @Getter private final boolean isClosed;
-
   @Getter private final Optional<String> reason;
 
   public CircuitBreakerState(boolean isClosed) {

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/ExecutorCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/ExecutorCircuitBreaker.java
@@ -90,6 +90,11 @@ public abstract class ExecutorCircuitBreaker implements CircuitBreaker {
     return circuitCheckIntervalInMillis;
   }
 
+  @Override
+  public void close() {
+    log.info("No-op close");
+  }
+
   public Optional<Duration> getTimeout() {
     return timeout;
   }

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
@@ -1,0 +1,113 @@
+package io.openlineage.client.circuitBreaker;
+
+import io.micrometer.common.lang.NonNull;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Queues every openlineage task for execution by a bounded threadpool to prevent creation of too
+ * many threads (unlike cachedthreadpool) and resulting impact on the spark job. Once queued, the
+ * circuit breaker waits for some configured time for the task to finish execution in an effort to
+ * preseve the ordering of completion of tasks. If queue is full, it gives up on the task. An
+ * explicit close() that need to be called after the application end event is processed shuts it
+ * down after waiting for a while (configurable) to finish pending tasks. Also the circuit breaker
+ * maintains the count of rejected, canceled tasks, or submission timeouts.
+ */
+@Slf4j
+public class TaskQueueCircuitBreaker implements CircuitBreaker {
+  private BlockingQueue<Runnable> eventQueue;
+  private ExecutorService eventProcessingExecutor;
+  private Long timeoutSeconds;
+  private Long shutdownTimeoutSeconds;
+
+  private final AtomicLong dropped = new AtomicLong();
+  private final AtomicLong timedOut = new AtomicLong();
+  private final AtomicLong failed = new AtomicLong();
+
+  public TaskQueueCircuitBreaker(@NonNull TaskQueueCircuitBreakerConfig config) {
+    this.timeoutSeconds = config.getTimeoutSeconds();
+    this.shutdownTimeoutSeconds = config.getShutdownTimeoutSeconds();
+    eventQueue = new ArrayBlockingQueue<>(config.getQueueSize());
+    eventProcessingExecutor =
+        new ThreadPoolExecutor(
+            config.getThreadCount(), config.getThreadCount(), 60L, TimeUnit.SECONDS, eventQueue);
+  }
+
+  @Override
+  public CircuitBreakerState currentState() {
+    return new CircuitBreakerState(false);
+  }
+
+  @Override
+  public <T> T run(Callable<T> callable) {
+    try {
+      T result = eventProcessingExecutor.submit(callable).get(timeoutSeconds, TimeUnit.SECONDS);
+      return result;
+    } catch (RejectedExecutionException re) {
+      dropped.incrementAndGet();
+      return null;
+    } catch (TimeoutException e) {
+      timedOut.incrementAndGet();
+      return null;
+    } catch (Exception e) {
+      failed.incrementAndGet();
+      return null;
+    } finally {
+      log.info(
+          "Openlineage async stats: dropped={}, timeout={}, queueDepth={}, failed={}",
+          dropped.get(),
+          timedOut.get(),
+          getPendingTasks(),
+          failed.get());
+    }
+  }
+
+  public long getDroppedCount() {
+    return dropped.get();
+  }
+
+  public long getFailedCount() {
+    return failed.get();
+  }
+
+  public long getTimedoutCount() {
+    return timedOut.get();
+  }
+
+  public int getPendingTasks() {
+    return eventQueue == null ? 0 : eventQueue.size();
+  }
+
+  @Override
+  public int getCheckIntervalMillis() {
+    return CircuitBreaker.super.getCheckIntervalMillis();
+  }
+
+  @Override
+  public void close() {
+    try {
+      // First just shutdown the executor. It does NOT cancel already submitted tasks, just won't
+      // accept new tasks.
+      eventProcessingExecutor.shutdown();
+      // Wait for a shutdownWait seconds for the pending tasks to be executed. If they are not
+      // executed by that time,
+      // force a shutdown where the pending tasks are also abandoned.
+      eventProcessingExecutor.awaitTermination(shutdownTimeoutSeconds, TimeUnit.SECONDS);
+      // Force shutdown, canceling pending tasks. This will result in loss of events.
+      List<Runnable> canceledTasks = eventProcessingExecutor.shutdownNow();
+      dropped.addAndGet(canceledTasks.size());
+    } catch (Exception e) {
+      log.error("Unable to shutdown pending event processing tasks", e);
+    }
+    // Once pending tasks are complete/conceled, process this end event synchronously
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.circuitBreaker;
 
 import io.micrometer.common.lang.NonNull;
@@ -17,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
  * Queues every openlineage task for execution by a bounded threadpool to prevent creation of too
  * many threads (unlike cachedthreadpool) and resulting impact on the spark job. Once queued, the
  * circuit breaker waits for some configured time for the task to finish execution in an effort to
- * preseve the ordering of completion of tasks. If queue is full, it gives up on the task. An
+ * preserve the ordering of completion of tasks. If queue is full, it gives up on the task. An
  * explicit close() that need to be called after the application end event is processed shuts it
  * down after waiting for a while (configurable) to finish pending tasks. Also the circuit breaker
  * maintains the count of rejected, canceled tasks, or submission timeouts.

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerBuilder.java
@@ -1,0 +1,18 @@
+package io.openlineage.client.circuitBreaker;
+
+public class TaskQueueCircuitBreakerBuilder implements CircuitBreakerBuilder {
+  @Override
+  public String getType() {
+    return "asyncTaskQueue";
+  }
+
+  @Override
+  public CircuitBreakerConfig getConfig() {
+    return new TaskQueueCircuitBreakerConfig();
+  }
+
+  @Override
+  public CircuitBreaker build(CircuitBreakerConfig config) {
+    return new TaskQueueCircuitBreaker((TaskQueueCircuitBreakerConfig) config);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerBuilder.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.circuitBreaker;
 
 public class TaskQueueCircuitBreakerBuilder implements CircuitBreakerBuilder {

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.circuitBreaker;
 
 import static io.openlineage.client.circuitBreaker.CircuitBreaker.CIRCUIT_CHECK_INTERVAL_IN_MILLIS;

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
@@ -1,0 +1,43 @@
+package io.openlineage.client.circuitBreaker;
+
+import static io.openlineage.client.circuitBreaker.CircuitBreaker.CIRCUIT_CHECK_INTERVAL_IN_MILLIS;
+
+import io.openlineage.client.MergeConfig;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode
+public class TaskQueueCircuitBreakerConfig
+    implements CircuitBreakerConfig, MergeConfig<TaskQueueCircuitBreakerConfig> {
+  private static final Integer DEFAULT_THREAD_COUNT = 2;
+  private static final Integer DEFAULT_QUEUE_SIZE = 2;
+  private static final Long DEFAULT_TIMEOUT = 1L;
+  private static final Long DEFAULT_SHUTDOWN_TIMEOUT = 60L;
+
+  @Getter @Setter private Integer threadCount = DEFAULT_THREAD_COUNT;
+  @Getter @Setter private Integer queueSize = DEFAULT_QUEUE_SIZE;
+  @Getter @Setter private Long timeoutSeconds = DEFAULT_TIMEOUT;
+  @Getter @Setter private Long shutdownTimeoutSeconds = DEFAULT_SHUTDOWN_TIMEOUT;
+  @Getter @Setter private Integer circuitCheckIntervalInMillis = CIRCUIT_CHECK_INTERVAL_IN_MILLIS;
+
+  @Override
+  public TaskQueueCircuitBreakerConfig mergeWithNonNull(TaskQueueCircuitBreakerConfig other) {
+    return new TaskQueueCircuitBreakerConfig(
+        mergeWithDefaultValue(threadCount, other.threadCount, DEFAULT_THREAD_COUNT),
+        mergeWithDefaultValue(this.queueSize, other.queueSize, DEFAULT_QUEUE_SIZE),
+        mergeWithDefaultValue(this.timeoutSeconds, other.timeoutSeconds, DEFAULT_TIMEOUT),
+        mergeWithDefaultValue(
+            this.shutdownTimeoutSeconds, other.shutdownTimeoutSeconds, DEFAULT_SHUTDOWN_TIMEOUT),
+        mergeWithDefaultValue(
+            this.circuitCheckIntervalInMillis,
+            other.circuitCheckIntervalInMillis,
+            CIRCUIT_CHECK_INTERVAL_IN_MILLIS));
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerTest.java
@@ -1,3 +1,8 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
 package io.openlineage.client.circuitBreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/client/java/src/test/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerTest.java
+++ b/client/java/src/test/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerTest.java
@@ -1,0 +1,26 @@
+package io.openlineage.client.circuitBreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.Test;
+
+class TaskQueueCircuitBreakerTest {
+  TaskQueueCircuitBreaker circuitBreaker =
+      new TaskQueueCircuitBreaker(new TaskQueueCircuitBreakerConfig(1, 1, 1L, 1L, 200));
+
+  @Test
+  void testTaskQueueBasedExecution() {
+    Callable<Object> infiniteCallable =
+        () -> {
+          while (true) Thread.sleep(1000);
+        };
+    assertThat(circuitBreaker.<Object>run(infiniteCallable)).isNull();
+    assertThat(circuitBreaker.<Object>run(infiniteCallable)).isNull();
+    assertThat(circuitBreaker.<Object>run(infiniteCallable)).isNull();
+    assertThat(circuitBreaker.getTimedoutCount()).isEqualTo(2L);
+    assertThat(circuitBreaker.getDroppedCount()).isEqualTo(1L);
+    assertThat(circuitBreaker.getPendingTasks()).isEqualTo(1L);
+    circuitBreaker.close();
+  }
+}


### PR DESCRIPTION
### Problem

In some cases spark applications generate too many events and processing all those events by the connector may have adverse effect on the spark application itself, e.g. choking the listener bus and making other listeners sharing the listener bus not able to catch up. We needed the connector to process as many events as possible in such cases, while minimizing impact on the spark job. The existing ExecutorCircuitBreaker fullfils that partially, but it has a cachedthreadpool, which can result in creation of too many threads and high memory footprint. It also rejects a task right away if there's no thread to pick up. 

Closes: #ISSUE-NUMBER

### Solution

We are introducing a circuit breaker that executes task on a queue backed threadpool, gives up tasks if the queue is full, and keeps track of rejected tasks. 


- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:
A queue backed threadpool based circuit breaker for asynchronous task execution

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project