### PR TITLE
[SPARK] Add direct methods to the OpenLineageContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   *This presents no functional change to the listener, however it will allow for improved initialisation of the listener in the future.*
 * **Spark: Unsupported catalog exception should be less verbose.** [`#3435`](https://github.com/OpenLineage/OpenLineage/pull/3435) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
   *In case of unsupported classes, `warn` logs without a stacktrace should be produced.*
+* **Spark: Directly expose the LogicalPlan and SparkPlan objects inside OpenLineageContext.* [`#3443`](https://github.com/OpenLineage/OpenLineage/pull/3443) [@d-m-h](https://github.com/d-m-h)
+  *This is an initial refactor to a larger code base change that will see the removal of direct access of the QueryExecution object. It has no functional change on the way the integration behaves.*
 
 ### Fixed
 

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -378,6 +378,7 @@ tasks.register("createVersionProperties") {
 }
 
 def integrationTestDependencies = [
+        tasks.named("testClasses"),
         tasks.named("shadowJar"),
         tasks.named("copyDependencies"),
         tasks.named("copyIntegrationTestFixtures"),

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -28,6 +29,7 @@ import org.apache.spark.package$;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.SparkPlan;
 import scala.PartialFunction;
 
 /**
@@ -114,10 +116,144 @@ public class OpenLineageContext {
   final List<ColumnLevelLineageVisitor> columnLevelLineageVisitors = new ArrayList<>();
 
   /** Optional {@link QueryExecution} for runs that are Spark SQL queries. */
-  final QueryExecution queryExecution;
+  private final QueryExecution queryExecution;
 
+  /**
+   * @deprecated Use the direct methods like {@link #getLogicalPlan()}, {@link #getAnalyzedPlan()},
+   *     {@link #getOptimizedPlan()}, or {@link #getSparkPlan()} to access the underlying plans.
+   *     This method exposes the internal {@link QueryExecution} object, which breaks the Law of
+   *     Demeter and is not intended for direct use. The direct methods provide a cleaner API for
+   *     accessing plan information and also centralize logic for handling cases where the plan may
+   *     need to be augmented.
+   * @return an Optional {@link QueryExecution}
+   */
+  @Deprecated
   public Optional<QueryExecution> getQueryExecution() {
     return Optional.ofNullable(queryExecution);
+  }
+
+  /**
+   * Checks if a logical plan is available for the current query execution.
+   *
+   * @return true if a logical plan exists, false otherwise.
+   */
+  public boolean hasLogicalPlan() {
+    return queryExecution != null && queryExecution.logical() != null;
+  }
+
+  /**
+   * Checks if an analyzed logical plan is available for the current query execution.
+   *
+   * @return true if an analyzed logical plan exists, false otherwise.
+   */
+  public boolean hasAnalyzedPlan() {
+    return queryExecution != null && queryExecution.analyzed() != null;
+  }
+
+  /**
+   * Checks if an optimized logical plan is available for the current query execution.
+   *
+   * @return true if an optimized logical plan exists, false otherwise.
+   */
+  public boolean hasOptimizedPlan() {
+    return queryExecution != null && queryExecution.optimizedPlan() != null;
+  }
+
+  /**
+   * Returns the logical plan for the current query execution.
+   *
+   * @return The logical plan.
+   * @throws NullPointerException if there is no query execution or the logical plan is not present
+   */
+  public LogicalPlan getLogicalPlan() {
+    return queryExecution.logical();
+  }
+
+  /**
+   * Returns the analyzed logical plan for the current query execution.
+   *
+   * @return The analyzed logical plan.
+   * @throws NullPointerException if there is no query execution or the analyzed logical plan is not
+   *     present
+   */
+  public LogicalPlan getAnalyzedPlan() {
+    return queryExecution.analyzed();
+  }
+
+  /**
+   * Returns the optimized logical plan for the current query execution.
+   *
+   * @return The optimized logical plan.
+   * @throws NullPointerException if there is no query execution or the optimized logical plan is
+   *     not present
+   */
+  public LogicalPlan getOptimizedPlan() {
+    return queryExecution.optimizedPlan();
+  }
+
+  /**
+   * Returns an Optional containing the logical plan for the current query execution.
+   *
+   * @return An Optional containing the logical plan, or an empty Optional if not present.
+   */
+  public Optional<LogicalPlan> getLogicalPlanOptional() {
+    return Optional.ofNullable(queryExecution.logical());
+  }
+
+  /**
+   * Returns an Optional containing the analyzed logical plan for the current query execution.
+   *
+   * @return An Optional containing the analyzed logical plan, or an empty Optional if not present.
+   */
+  public Optional<LogicalPlan> getAnalyzedPlanOptional() {
+    return Optional.ofNullable(queryExecution.analyzed());
+  }
+
+  /**
+   * Returns an Optional containing the optimized logical plan for the current query execution.
+   *
+   * @return An Optional containing the optimized logical plan, or an empty Optional if not present.
+   */
+  public Optional<LogicalPlan> getOptimizedPlanOptional() {
+    return Optional.ofNullable(queryExecution.optimizedPlan());
+  }
+
+  /**
+   * Checks if an executed plan is available for the current query execution.
+   *
+   * @return true if an executed plan exists, false otherwise.
+   */
+  public boolean hasExecutedPlan() {
+    return queryExecution != null && queryExecution.executedPlan() != null;
+  }
+
+  /**
+   * Returns the executed plan for the current query execution.
+   *
+   * @return The executed plan.
+   * @throws NullPointerException if there is no query execution or the executed plan is not present
+   */
+  public SparkPlan getExecutedPlan() {
+    return queryExecution.executedPlan();
+  }
+
+  /**
+   * Checks if a spark plan is available for the current query execution.
+   *
+   * @return true if a spark plan exists, false otherwise.
+   */
+  public boolean hasSparkPlan() {
+    return queryExecution != null && queryExecution.sparkPlan() != null;
+  }
+
+  /**
+   * Returns the spark plan for the current query execution.
+   *
+   * @return The spark plan.
+   * @throws NullPointerException if there is no query execution or the spark plan is not present
+   */
+  public SparkPlan getSparkPlan() {
+    return queryExecution.sparkPlan();
   }
 
   /** Spark version of currently running job */
@@ -159,4 +295,13 @@ public class OpenLineageContext {
    * and the extension implementations provided by spark-extension-interfaces.
    */
   @Getter final SparkOpenLineageExtensionVisitorWrapper sparkExtensionVisitorWrapper;
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", OpenLineageContext.class.getSimpleName() + "[", "]")
+        .add("applicationUuid=" + applicationUuid)
+        .add("runUuid=" + runUuid)
+        .add("jobName='" + jobName + "'")
+        .toString();
+  }
 }


### PR DESCRIPTION
### Problem

Currently, a lot of the code in the code base "reaches through" the `OpenLineageContext` object to obtain the `QueryExecution` object, and in turn reaches through the `QueryExecution` object in order to obtain one of the logical or physical plans.

For example:

```java
OpenLineageContext ctx = ...;
LogicalPlan plan = ctx.getQueryExecution().get().optimizedPlan();
```

Why is this a problem?

1. None of the callers actually want the `QueryExecution` object. They pretty much want only the plans.
2. If we encounter a case where we need to do something to the returned plans, we would be forced to duplicate this logic everywhere.

### Solution

Initially, we will deprecate the `getQueryExecution` method and directly expose the various plans that the `QueryExecution` object holds.

In later PRs, we will actually refactor the code base to use these methods.

#### One-line summary: Add direct methods exposing the underlying LogicalPlan and SparkPlan objects.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project