### PR TITLE
fix docs markdown

### DIFF
--- a/website/docs/client/java/partials/java_namespace_resolver.md
+++ b/website/docs/client/java/partials/java_namespace_resolver.md
@@ -31,20 +31,21 @@ dataset:
 </TabItem>
 <TabItem value="spark" label="Spark Config">
 
-| Parameter                                                             | Definition    | Example |
-------------------- ----------------------------------------------------|---------------|--
-| spark.openlineage.dataset.namespaceResolvers.resolved-name.type  | Resolver type | hostList |
-| spark.openlineage.dataset.namespaceResolvers.resolved-name.hosts | List of hosts | `['kafka-prod13.company.com', 'kafka-prod15.company.com']` |
-| spark.openlineage.dataset.namespaceResolvers.resolved-name.schema | Optional schema to be specified. Resolver will be only applied if schema matches the configure one. | `kafka` |
+| Parameter                                                         | Definition                                                                                          | Example                                                    |
+--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------
+| spark.openlineage.dataset.namespaceResolvers.resolved-name.type   | Resolver type                                                                                       | hostList                                                   |
+| spark.openlineage.dataset.namespaceResolvers.resolved-name.hosts  | List of hosts                                                                                       | `['kafka-prod13.company.com', 'kafka-prod15.company.com']` |
+| spark.openlineage.dataset.namespaceResolvers.resolved-name.schema | Optional schema to be specified. Resolver will be only applied if schema matches the configure one. | `kafka`                                                    |
 
 </TabItem>
 <TabItem value="flink" label="Flink Config">
 
-| Parameter                                                    | Definition    | Example |
-------------------- -------------------------------------------|---------------|--
-| openlineage.dataset.namespaceResolvers.resolved-name.type  | Resolver type | hostList |
-| openlineage.dataset.namespaceResolvers.resolved-name.hosts | List of hosts | `['kafka-prod13.company.com', 'kafka-prod15.company.com']` |
-| openlineage.dataset.namespaceResolvers.resolved-name.schema | Optional schema to be specified. Resolver will be only applied if schema matches the configure one. | `kafka` |
+| Parameter                                                   | Definition                                                                                          | Example                                                    |
+--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------
+| openlineage.dataset.namespaceResolvers.resolved-name.type   | Resolver type                                                                                       | hostList                                                   |
+| openlineage.dataset.namespaceResolvers.resolved-name.hosts  | List of hosts                                                                                       | `['kafka-prod13.company.com', 'kafka-prod15.company.com']` |
+| openlineage.dataset.namespaceResolvers.resolved-name.schema | Optional schema to be specified. Resolver will be only applied if schema matches the configure one. | `kafka`                                                    |
+
 
 
 </TabItem>


### PR DESCRIPTION
![Screenshot 2025-02-03 at 09 55 43](https://github.com/user-attachments/assets/69b1b96a-e282-4467-b40c-c2552c338890)


![Screenshot 2025-02-03 at 10 29 30](https://github.com/user-attachments/assets/e7a606e7-a24f-4325-b153-8f3cb405075a)


This will not fix historical versions, only the future one. Is it OK? 