### PR TITLE
Fix unreleased task queue circuit breaker

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerFactory.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerFactory.java
@@ -21,6 +21,8 @@ public class CircuitBreakerFactory {
           (SimpleMemoryCircuitBreakerConfig) circuitBreakerConfig);
     } else if (circuitBreakerConfig instanceof StaticCircuitBreakerConfig) {
       return new StaticCircuitBreaker((StaticCircuitBreakerConfig) circuitBreakerConfig);
+    } else if (circuitBreakerConfig instanceof TaskQueueCircuitBreakerConfig) {
+      return new TaskQueueCircuitBreaker((TaskQueueCircuitBreakerConfig) circuitBreakerConfig);
     }
 
     return new NoOpCircuitBreaker();

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/CircuitBreakerResolver.java
@@ -17,7 +17,8 @@ public class CircuitBreakerResolver {
       Arrays.asList(
           new StaticCircuitBreakerBuilder(),
           new SimpleMemoryCircuitBreakerBuilder(),
-          new JavaRuntimeCircuitBreakerBuilder());
+          new JavaRuntimeCircuitBreakerBuilder(),
+          new TaskQueueCircuitBreakerBuilder());
 
   public static Class<? extends CircuitBreakerConfig> resolveCircuitBreakerConfigByType(
       String type) {

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
@@ -113,6 +113,6 @@ public class TaskQueueCircuitBreaker implements CircuitBreaker {
     } catch (Exception e) {
       log.error("Unable to shutdown pending event processing tasks", e);
     }
-    // Once pending tasks are complete/conceled, process this end event synchronously
+    // Once pending tasks are complete/canceled, process this end event synchronously
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreakerConfig.java
@@ -22,8 +22,8 @@ import lombok.ToString;
 public class TaskQueueCircuitBreakerConfig
     implements CircuitBreakerConfig, MergeConfig<TaskQueueCircuitBreakerConfig> {
   private static final Integer DEFAULT_THREAD_COUNT = 2;
-  private static final Integer DEFAULT_QUEUE_SIZE = 2;
-  private static final Long DEFAULT_TIMEOUT = 1L;
+  private static final Integer DEFAULT_QUEUE_SIZE = 10;
+  private static final Long DEFAULT_TIMEOUT = 90L;
   private static final Long DEFAULT_SHUTDOWN_TIMEOUT = 60L;
 
   @Getter @Setter private Integer threadCount = DEFAULT_THREAD_COUNT;

--- a/client/java/src/test/java/io/openlineage/client/ConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/ConfigTest.java
@@ -18,6 +18,7 @@ import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreaker;
 import io.openlineage.client.circuitBreaker.JavaRuntimeCircuitBreakerConfig;
 import io.openlineage.client.circuitBreaker.SimpleMemoryCircuitBreaker;
 import io.openlineage.client.circuitBreaker.SimpleMemoryCircuitBreakerConfig;
+import io.openlineage.client.circuitBreaker.TaskQueueCircuitBreaker;
 import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceResolverConfig;
 import io.openlineage.client.dataset.namespace.resolver.PatternMatchingGroupNamespaceResolverConfig;
 import io.openlineage.client.dataset.namespace.resolver.PatternNamespaceResolverConfig;
@@ -220,6 +221,17 @@ class ConfigTest {
         .isInstanceOf(SimpleMemoryCircuitBreaker.class)
         .hasFieldOrPropertyWithValue("config", new SimpleMemoryCircuitBreakerConfig(13, 200, 90));
     assertThat(client.circuitBreaker.get().getCheckIntervalMillis()).isEqualTo(200);
+  }
+
+  @Test
+  void testTaskQueueCircuitBreakerFromYaml() {
+    OpenLineageClient client =
+        Clients.newClient(new TestConfigPathProvider("config/circuitBreaker5.yaml"));
+
+    assertThat(client.circuitBreaker.get())
+        .isInstanceOf(TaskQueueCircuitBreaker.class)
+        .hasFieldOrPropertyWithValue("timeoutSeconds", 3L)
+        .hasFieldOrPropertyWithValue("shutdownTimeoutSeconds", 4L);
   }
 
   @Test

--- a/client/java/src/test/resources/config/circuitBreaker5.yaml
+++ b/client/java/src/test/resources/config/circuitBreaker5.yaml
@@ -1,0 +1,9 @@
+transport:
+  type: console
+circuitBreaker:
+  type: asyncTaskQueue
+  threadCount: 1
+  queueSize: 2
+  timeoutSeconds: 3
+  shutdownTimeoutSeconds: 4
+  circuitCheckIntervalInMillis: 5

--- a/website/docs/client/java/partials/java_circuit_breaker.md
+++ b/website/docs/client/java/partials/java_circuit_breaker.md
@@ -121,18 +121,38 @@ it has a cachedthreadpool, which can result in creation of too many threads and 
 It also rejects a task right away if there's no thread to pick up.
 
 <Tabs groupId="async">
+<TabItem value="yaml" label="Yaml Config">
+
+```yaml
+circuitBreaker:
+  type: asyncTaskQueue
+  threadCount: 2
+  queueSize: 10
+  timeoutSeconds: 90
+  shutdownTimeoutSeconds: 60
+```
+</TabItem>
+<TabItem value="spark" label="Spark Config">
+
+| Parameter                                               | Definition                                                                                                 | Example        |
+----------------------------------------------------------|------------------------------------------------------------------------------------------------------------|----------------
+| spark.openlineage.circuitBreaker.type                   | Circuit breaker type selected                                                                              | asyncTaskQueue |
+| spark.openlineage.circuitBreaker.threadCount            | Num threads to process task                                                                                | 2              |
+| spark.openlineage.circuitBreaker.queueSize              | The size of task queue                                                                                     | 10             |
+| spark.openlineage.circuitBreaker.timeoutInSeconds       | Optional timeout for OpenLineage execution                                                                 | 90             |
+| spark.openlineage.circuitBreaker.shutdownTimeoutSeconds | The duration through which the circuit breaker waits on close to wait for the queued tasks to be processed | 60             |
+
+
+</TabItem>
 <TabItem value="flink" label="Flink Config">
 
-| Parameter                            | Definition                                                                                                 | Example        |
---------------------------------------|------------------------------------------------------------------------------------------------------------|----------------
-| openlineage.circuitBreaker.type | Circuit breaker type selected                                                                              | asyncTaskQueue |
-| openlineage.circuitBreaker.threadCount | Num threads to process task                                                                                | 2              |
-| openlineage.circuitBreaker.queueSize | The size of task queue                                                                                     | 1000           |
-| openlineage.circuitBreaker.circuitCheckIntervalInMillis | Frequency of checking circuit breaker                                                                      | 1000           |
-| spark.openlineage.circuitBreaker.timeoutInSeconds | Optional timeout for OpenLineage execution (Since version 1.13)                                            | 3              |
-| spark.openlineage.circuitBreaker.shutdownTimeoutSeconds | The duration through which the circuit breaker waits on close to wait for the queued tasks to be processed | 100            |
-
-
+| Parameter                                               | Definition                                                                                                 | Example        |
+----------------------------------------------------------|------------------------------------------------------------------------------------------------------------|----------------
+| openlineage.circuitBreaker.type                   | Circuit breaker type selected                                                                              | asyncTaskQueue |
+| openlineage.circuitBreaker.threadCount            | Num threads to process task                                                                                | 2              |
+| openlineage.circuitBreaker.queueSize              | The size of task queue                                                                                     | 10             |
+| openlineage.circuitBreaker.timeoutInSeconds       | Optional timeout for OpenLineage execution                                                                 | 90             |
+| openlineage.circuitBreaker.shutdownTimeoutSeconds | The duration through which the circuit breaker waits on close to wait for the queued tasks to be processed | 60             |
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Fixes applied: 
 * make the config work covered with a test
 * created documentation tabs for Spark & Flink 
 * change defaults - keep timeout to 90sec like for other circuit breakers