### PR TITLE
Fix refresh table command visitor

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32VisitorFactoryImpl.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32VisitorFactoryImpl.java
@@ -32,7 +32,6 @@ class Spark32VisitorFactoryImpl extends BaseVisitorFactory {
         .add(new CreateTableLikeCommandVisitor(context))
         .add(new DropTableVisitor(context))
         .add(new WriteToDataSourceV2Visitor(context))
-        .add(new RefreshTableCommandVisitor(context))
         .add(new RepairTableCommandVisitor(context))
         .build();
   }
@@ -43,6 +42,7 @@ class Spark32VisitorFactoryImpl extends BaseVisitorFactory {
     return ImmutableList.<PartialFunction<LogicalPlan, List<InputDataset>>>builder()
         .addAll(super.getInputVisitors(context))
         .add(new StreamingDataSourceV2RelationVisitor(context))
+        .add(new RefreshTableCommandVisitor(context))
         .build();
   }
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3VisitorFactoryImpl.java
@@ -32,7 +32,6 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
         .add(new CreateTableLikeCommandVisitor(context))
         .add(new DropTableVisitor(context))
         .add(new WriteToDataSourceV2Visitor(context))
-        .add(new RefreshTableCommandVisitor(context))
         .add(new RepairTableCommandVisitor(context))
         .build();
   }
@@ -43,6 +42,7 @@ class Spark3VisitorFactoryImpl extends BaseVisitorFactory {
     return ImmutableList.<PartialFunction<LogicalPlan, List<InputDataset>>>builder()
         .addAll(super.getInputVisitors(context))
         .add(new StreamingDataSourceV2RelationVisitor(context))
+        .add(new RefreshTableCommandVisitor(context))
         .build();
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/filters/SparkNodesFilter.java
@@ -35,6 +35,7 @@ public class SparkNodesFilter implements EventFilter {
           Aggregate.class.getCanonicalName(),
           Repartition.class.getCanonicalName(),
           CreateDatabaseCommand.class.getCanonicalName(),
+          "org.apache.spark.sql.execution.command.RefreshTableCommand",
           LocalRelation.class.getCanonicalName());
 
   public SparkNodesFilter(OpenLineageContext context) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitor.java
@@ -21,14 +21,14 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.command.RefreshTableCommand;
 
 public class RefreshTableCommandVisitor
-    extends QueryPlanVisitor<RefreshTableCommand, OpenLineage.OutputDataset> {
+    extends QueryPlanVisitor<RefreshTableCommand, OpenLineage.InputDataset> {
 
   public RefreshTableCommandVisitor(OpenLineageContext context) {
     super(context);
   }
 
   @Override
-  public List<OpenLineage.OutputDataset> apply(LogicalPlan x) {
+  public List<OpenLineage.InputDataset> apply(LogicalPlan x) {
     Optional<CatalogTable> tableOption = catalogTableFor(((RefreshTableCommand) x).tableIdent());
 
     if (!tableOption.isPresent()) {
@@ -48,7 +48,7 @@ public class RefreshTableCommandVisitor
                 OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER)
             .build();
 
-    DatasetFactory<OpenLineage.OutputDataset> factory = outputDataset();
+    DatasetFactory<OpenLineage.InputDataset> factory = inputDataset();
 
     DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
     datasetFacetsBuilder

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/RefreshTableCommandVisitorTest.java
@@ -113,19 +113,19 @@ class RefreshTableCommandVisitorTest {
       RefreshTableCommand command = RefreshTableCommand$.MODULE$.apply(tableIdentifier);
 
       assertThat(visitor.isDefinedAt(command)).isTrue();
-      List<OpenLineage.OutputDataset> datasets = visitor.apply(command);
+      List<OpenLineage.InputDataset> datasets = visitor.apply(command);
 
       assertEquals(1, datasets.size());
-      OpenLineage.OutputDataset outputDataset = datasets.get(0);
+      OpenLineage.InputDataset inputDataset = datasets.get(0);
 
       assertEquals(
           OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER,
-          outputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
-      assertEquals("s3://bucket", outputDataset.getNamespace());
-      assertEquals("some-uri", outputDataset.getName());
+          inputDataset.getFacets().getLifecycleStateChange().getLifecycleStateChange());
+      assertEquals("s3://bucket", inputDataset.getNamespace());
+      assertEquals("some-uri", inputDataset.getName());
       assertEquals(
           DATABASE + "." + TABLE,
-          outputDataset.getFacets().getSymlinks().getIdentifiers().get(0).getName());
+          inputDataset.getFacets().getSymlinks().getIdentifiers().get(0).getName());
     }
   }
 }


### PR DESCRIPTION
Refresh table should not produce output dataset in OL event. According to the docs:
```
A command to refresh all cached entries associated with the table.
The syntax of using this command in SQL is:
REFRESH TABLE [db_name.] table_name
```
What's even harder, the Spark's code is simply calling:
```
sparkSession.catalog.refreshTable(tableIdent.quotedString)
```
which means the behaviour of the method call can differ per catalog. 

This definitely does not affect output dataset and it can be argued if this should be even considered as affecting lineage at all. 

*Solution chosen*: Make refresh table visitor an input table visitor and filter this command from the commands which generate the lineage. The advantage of this approach is that, in case needed, a user can allow RefreshCommand in the filter and get input dataset for such commands.This makes sense as sometimes touching table metadata can be considered as using it as job input, so it may be worth to leave it optional for users interested in this. 