### PR TITLE
Enable filtering through transform transport

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/TransformTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransformTransport.java
@@ -58,7 +58,8 @@ public class TransformTransport extends Transport {
       throw new TransformTransportException("Error transforming RunEvent", e);
     }
     if (updatedRunEvent == null) {
-      throw new TransformTransportException("Transformed RunEvent is null, not emitting");
+      log.warn("Transformed RunEvent is null, not emitting");
+      return;
     }
     transport.emit(updatedRunEvent);
   }
@@ -72,7 +73,8 @@ public class TransformTransport extends Transport {
       throw new TransformTransportException("Error transforming DatasetEvent", e);
     }
     if (updatedDatasetEvent == null) {
-      throw new TransformTransportException("Transformed DatasetEvent is null, not emitting");
+      log.warn("Transformed DatasetEvent is null, not emitting");
+      return;
     }
     transport.emit(updatedDatasetEvent);
   }
@@ -86,7 +88,8 @@ public class TransformTransport extends Transport {
       throw new TransformTransportException("Error transforming JobEvent", e);
     }
     if (updatedJobEvent == null) {
-      throw new TransformTransportException("Transformed JobEvent is null, not emitting");
+      log.warn("Transformed JobEvent is null, not emitting");
+      return;
     }
     transport.emit(updatedJobEvent);
   }

--- a/client/java/src/test/java/io/openlineage/client/transports/TransformTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/TransformTransportTest.java
@@ -97,25 +97,19 @@ class TransformTransportTest {
   @Test
   void testTransportWhenTransformReturnsNull() {
     transformConfig.setTransformerClass(EventTransformerReturningNull.class.getName());
-    transformTransport = new TransformTransport(transformConfig);
+    transformTransport = new TransformTransport(transformConfig, subTransport);
 
-    assertThrows(
-        TransformTransportException.class,
-        () -> {
-          transformTransport.emit(mock(RunEvent.class));
-        });
+    RunEvent runEvent = mock(RunEvent.class);
+    DatasetEvent datasetEvent = mock(DatasetEvent.class);
+    JobEvent jobEvent = mock(JobEvent.class);
 
-    assertThrows(
-        TransformTransportException.class,
-        () -> {
-          transformTransport.emit(mock(DatasetEvent.class));
-        });
+    transformTransport.emit(runEvent);
+    transformTransport.emit(datasetEvent);
+    transformTransport.emit(jobEvent);
 
-    assertThrows(
-        TransformTransportException.class,
-        () -> {
-          transformTransport.emit(mock(JobEvent.class));
-        });
+    verify(subTransport, times(0)).emit((RunEvent) argThat(event -> event instanceof RunEvent));
+    verify(subTransport, times(0)).emit((RunEvent) argThat(event -> event instanceof DatasetEvent));
+    verify(subTransport, times(0)).emit((RunEvent) argThat(event -> event instanceof JobEvent));
   }
 
   @Test

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -662,6 +662,7 @@ send different events into multiple backends.
 
 - The configured `transformerClass` will be used to alter events before the emission.
 - Modified events will be passed into the configured `transport` for further processing.
+- In case of returning `null`, the event will be skipped.
 
 #### `EventTransformer` interface
 

--- a/website/static/ecosystem/consumers.tsx
+++ b/website/static/ecosystem/consumers.tsx
@@ -131,7 +131,8 @@ export const Consumers: Array<Partner> = [
     image: "select_star_logo.png",
     org: "Select Star",
     full_name: "Select Star",
-    description:  "Select Star uses OpenLineage events to extract and generate column-level lineage, enabling precise metadata tracking, impact analysis, and comprehensive documentation of data pipelines.",
+    description:
+      "Select Star uses OpenLineage events to extract and generate column-level lineage, enabling precise metadata tracking, impact analysis, and comprehensive documentation of data pipelines.",
     docs_url: "https://docs.selectstar.com/",
     org_url: "https://www.selectstar.com/",
   },


### PR DESCRIPTION
Currently a `transform` transport throws an exception If a transformer class returns null. It makes more sense to log warning in this case while not throwing an exception. This will allow filtering the events within transformer classes. 