### PR TITLE
Docs: add missing 1.27.0 and 1.28.0 release notes.

### DIFF
--- a/website/docs/releases/1_27_0.md
+++ b/website/docs/releases/1_27_0.md
@@ -1,0 +1,38 @@
+---
+title: 1.27.0
+sidebar_position: 9930
+---
+
+# 1.27.0 - 2025-01-21
+
+### Added
+  
+  * **Flink: Experimental version for flink native lineage listener.** [`#3099`](https://github.com/OpenLineage/OpenLineage/pull/3099) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+    *New flink listener to extract lineage through native Flink interfaces. Supports Flink SQL. Requires Flink 2.0.*
+  * **dbt: add support for consuming dbt structured logs for test and build commands .** [`#3362`](https://github.com/OpenLineage/OpenLineage/pull/3362) [@MassyB](https://github.com/MassyB)
+    *New option for dbt integration now can handle test and build commands too.*
+  * **Spark: allow attaching custom facets to RDDExecContext events.** [`#3379`](https://github.com/OpenLineage/OpenLineage/pull/3379) [@ssanthanam185](https://github.com/ssanthanam185)
+    *Events emitted from RDDExecutionContext now include custom facets that get loaded as part of InternalHandlerFactory.*
+  * **spec: add DatasetTypeDatasetFacet.** [`#3390`](https://github.com/OpenLineage/OpenLineage/pull/3390) [@ssanthanam185](https://github.com/ssanthanam185)
+    *Events emitted from RDDExecutionContext now include custom facets that get loaded as part of InternalHandlerFactory.*
+  
+  ### Changed
+  
+  * **Python: allow adding additionalProperties to Python facets** [`#3391`](https://github.com/OpenLineage/OpenLineage/pull/3391) [@JDarDagran](https://github.com/JDarDagran)
+    *Adds `with_additonal_properties` method that allows to create modified instance of facet with additional properties.*
+  * **Spark: allow attaching custom facets to RDDExecContext events.** [`#3379`](https://github.com/OpenLineage/OpenLineage/pull/3379) [@ssanthanam185](https://github.com/ssanthanam185)
+    *Events emitted from RDDExecutionContext now include custom facets that get loaded as part of InternalHandlerFactory.*
+  * **Spark: SerializedFromObject events aren't filtered for not-delta plans.** [`#3403`](https://github.com/OpenLineage/OpenLineage/pull/3403) [@ssanthanam185](https://github.com/ssanthanam185)
+    *Those events shouldn't be filtered outside Databricks/Delta ecosystem.*
+  
+  ### Fixed
+  * **Spark: fixed ClassLoader handling for OpenLineageExtensionProvider.** [`#3368`](https://github.com/OpenLineage/OpenLineage/pull/3368) [@ddebowczyk92](https://github.com/ddebowczyk92)
+    *Fixes ClassNotFoundException issue when using the openlineage-spark integration alongside a Spark connector that implements the spark-extension-interfaces due to class loader conflicts.*
+  * **SQL: add minimal support for Snowflake LATERAL.** [`#3368`](https://github.com/OpenLineage/OpenLineage/pull/3368) [@cisenbe](https://github.com/cisenbe)
+    *SQL parser won't error on Snowflake's LATERAL keyword.*
+  * **dbt: handle errors in parse_assertions** [`#3311`](https://github.com/OpenLineage/OpenLineage/pull/3311) [@dsaxton-1password](https://github.com/dsaxton-1password)
+    *dbt integration won't fail when looking at tests on seeds.*
+  * **Spark: fix infinite loop in RDD flatten & perf optimization.** [`#3379`](https://github.com/OpenLineage/OpenLineage/pull/3379) [@ssanthanam185](https://github.com/ssanthanam185)
+    *Spark integration now correctly handles complex jobs that have cycles and nested RDD trees.*
+  * **Python: FileTransport now correctly attaches `json` file extension.** [`#3404`](https://github.com/OpenLineage/OpenLineage/pull/3404) [@kacpermuda](https://github.com/kacpermuda)
+    *When append=False, the json file extension wasn't properly added before.*

--- a/website/docs/releases/1_28_0.md
+++ b/website/docs/releases/1_28_0.md
@@ -1,0 +1,35 @@
+---
+title: 1.28.0
+sidebar_position: 9930
+---
+
+# 1.28.0 - 2025-02-07
+
+### Added
+
+* **Java: enable specifying custom SSL context** [`#3444`](https://github.com/OpenLineage/OpenLineage/pull/3444) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Enable providing configuration for SSL context within HTTP transport.*
+* **Spark: make Spark nodes filtering configurable.** [`#3442`](https://github.com/OpenLineage/OpenLineage/pull/3442) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Spark integration filters OpenLineage events for specific plan node classes. This can be now extended with extra config entries: `allowedSparkNodes` and `deniedSparkNodes`. See [Spark Configuration documentation](https://openlineage.io/docs/integrations/spark/configuration/spark_conf) for more details.*
+* **Java: add task queue based async circuit breaker.** [`#3437`](https://github.com/`OpenLineage/OpenLineage/pull/3437) [@aritrabandyo](https://github.com/aritrabandyo)
+  *This circuit breaker that executes task on a queue backed threadpool, gives up tasks if the queue is full, and keeps track of rejected tasks.*
+* **dbt: added initial support for Trino adapter** [`#3429`](https://github.com/OpenLineage/OpenLineage/pull/3429) [@whitleykeith](https://github.com/whitleykeith)
+  *This allows Trino integration to emit proper events containing Trino datasets.*
+* **Spark: increased coverage for Spark DML commands** [`#3430`](https://github.com/OpenLineage/OpenLineage/pull/3430) [@ssanthanam185](https://github.com/ssanthanam185)
+  *Adds coverage for AlterTableRecoverPartitionsCommandVisitor, RefreshTableCommandVisitor, RepairTableCommandVisitor.*
+
+### Changed
+
+* **Spark: the OpenLineageSparkListener was refactored to have a public, single-argument constructor taking an instance of SparkConf.** [`#3425`](https://github.com/OpenLineage/OpenLineage/pull/3425) [@d-m-h](https://github.com/d-m-h)
+  *This presents no functional change to the listener, however it will allow for improved initialisation of the listener in the future.*
+* **Spark: Unsupported catalog exception should be less verbose.** [`#3435`](https://github.com/OpenLineage/OpenLineage/pull/3435) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *In case of unsupported classes, `warn` logs without a stacktrace should be produced.*
+* **Spark: Directly expose the LogicalPlan and SparkPlan objects inside OpenLineageContext.** [`#3443`](https://github.com/OpenLineage/OpenLineage/pull/3443) [@d-m-h](https://github.com/d-m-h)
+  *This is an initial refactor to a larger code base change that will see the removal of direct access of the QueryExecution object. It has no functional change on the way the integration behaves.*
+
+### Fixed
+
+* **Spark: improve column lineage by including inputs within `COMPLETE` events.** [`#3434`](https://github.com/OpenLineage/OpenLineage/pull/3434) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Send input datasets in `COMPLETE` events while making sure version facet is attached on `START` only.
+* **dbt: ParentRunFacet is now correctly attached when using structured logs option.** [`#3432`](https://github.com/OpenLineage/OpenLineage/pull/3432) [@MassyB](https://github.com/MassyB)
+  *Fixes incorrect structure of ParentRunFacet.*


### PR DESCRIPTION
Signed-off-by: Jakub Dardzinski <kuba0221@gmail.com>

### Problem

Current release process is missing adding release notes to latest version of docs kept in monorepo. This PR fills missing release notes.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project