### PR TITLE
Fix 1.28.0 position.

### DIFF
--- a/website/docs/releases/1_28_0.md
+++ b/website/docs/releases/1_28_0.md
@@ -1,6 +1,6 @@
 ---
 title: 1.28.0
-sidebar_position: 9930
+sidebar_position: 9929
 ---
 
 # 1.28.0 - 2025-02-07


### PR DESCRIPTION
### Problem


Follow-up fix of 1.28.0 release notes position for [3474](https://github.com/OpenLineage/OpenLineage/pull/3474)


----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project