### PR TITLE
spark: bump tested version

### DIFF
--- a/.circleci/workflows/openlineage-spark.yml
+++ b/.circleci/workflows/openlineage-spark.yml
@@ -31,10 +31,10 @@ workflows:
                 'java:17-spark:3.3.4-scala:2.13-full-tests',
                 'java:8-spark:3.4.3-scala:2.12-full-tests',
                 'java:8-spark:3.4.3-scala:2.13-full-tests',
-                'java:8-spark:3.5.2-scala:2.12-full-tests',
-                'java:8-spark:3.5.2-scala:2.13-full-tests',
-                'java:17-spark:3.5.2-scala:2.12-full-tests',
-                'java:17-spark:3.5.2-scala:2.13',
+                'java:8-spark:3.5.4-scala:2.12-full-tests',
+                'java:8-spark:3.5.4-scala:2.13-full-tests',
+                'java:17-spark:3.5.4-scala:2.12-full-tests',
+                'java:17-spark:3.5.4-scala:2.13',
                 'java:17-spark:4.0.0-scala:2.13'
               ]
           requires:
@@ -123,10 +123,10 @@ workflows:
                 'java:17-spark:3.3.4-scala:2.13-full-tests',
                 'java:8-spark:3.4.3-scala:2.12-full-tests',
                 'java:8-spark:3.4.3-scala:2.13-full-tests',
-                'java:8-spark:3.5.2-scala:2.12-full-tests',
-                'java:8-spark:3.5.2-scala:2.13-full-tests',
-                'java:17-spark:3.5.2-scala:2.12-full-tests',
-                'java:17-spark:3.5.2-scala:2.13',
+                'java:8-spark:3.5.4-scala:2.12-full-tests',
+                'java:8-spark:3.5.4-scala:2.13-full-tests',
+                'java:17-spark:3.5.4-scala:2.12-full-tests',
+                'java:17-spark:3.5.4-scala:2.13',
                 'java:17-spark:4.0.0-scala:2.13'
               ]
           requires:

--- a/integration/spark-docker/manifest.json
+++ b/integration/spark-docker/manifest.json
@@ -56,19 +56,19 @@
     "sparkVersion": "3.4.3"
   },
   {
-    "baseImageTag": "3.5.2",
+    "baseImageTag": "3.5.4",
     "scalaBinaryVersion": "2.12",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3.tgz.asc",
-    "sparkVersion": "3.5.2"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3.tgz.asc",
+    "sparkVersion": "3.5.4"
   },
   {
-    "baseImageTag": "3.5.2",
+    "baseImageTag": "3.5.4",
     "scalaBinaryVersion": "2.13",
     "sparkPgpKeys": "https://www.apache.org/dist/spark/KEYS",
-    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3-scala2.13.tgz",
-    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.2/spark-3.5.2-bin-hadoop3-scala2.13.tgz.asc",
-    "sparkVersion": "3.5.2"
+    "sparkSourceBinaries": "https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3-scala2.13.tgz",
+    "sparkSourceBinariesAsc": "https://archive.apache.org/dist/spark/spark-3.5.4/spark-3.5.4-bin-hadoop3-scala2.13.tgz.asc",
+    "sparkVersion": "3.5.4"
   }
 ]

--- a/integration/spark/app/build.gradle
+++ b/integration/spark/app/build.gradle
@@ -530,7 +530,7 @@ List<Dependency> icebergDependencies(String spark, String scala) {
                     dependencies.create("org.scala-lang:scala-reflect:${scalaVersion}"),
                     dependencies.create("org.scala-lang.modules:scala-collection-compat_${scala}:2.11.0"),
             ],
-            "3.5.2": [
+            "3.5.4": [
                     dependencies.create("org.apache.iceberg:iceberg-spark-runtime-3.5_${scala}:1.6.0"),
                     dependencies.create("org.scala-lang:scala-library:${scalaVersion}"),
                     dependencies.create("org.scala-lang:scala-reflect:${scalaVersion}"),
@@ -563,7 +563,7 @@ List<Dependency> gcsDependencies(String spark, String scala) {
             "3.2.4": "hadoop3-2.2.9",
             "3.3.4": "hadoop3-2.2.9",
             "3.4.3": "hadoop3-2.2.9",
-            "3.5.2": "hadoop3-2.2.9",
+            "3.5.4": "hadoop3-2.2.9",
     ]
 
     def gcs = registry.get(spark)
@@ -583,7 +583,7 @@ List<Dependency> hadoopClientDependencies(String spark, String scala) {
             "3.2.4": "3.3.4",
             "3.3.4": "3.3.2",
             "3.4.3": "3.3.4",
-            "3.5.2": "3.3.4",
+            "3.5.4": "3.3.4",
     ]
 
     def hadoopClient = registry.get(spark)
@@ -643,7 +643,7 @@ List<Dependency> additionalJars(String spark, String scala) {
                     }),
                     dependencies.create("org.apache.iceberg:iceberg-spark-runtime-3.4_${scala}:1.6.0")
             ],
-            "3.5.2": [
+            "3.5.4": [
                     dependencies.create("org.slf4j:slf4j-api:2.0.10"),
                     dependencies.create("org.slf4j:slf4j-reload4j:2.0.16"),
                     dependencies.create("org.apache.spark:spark-mllib_${scala}:${spark}", {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksDynamicParameter.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/DatabricksDynamicParameter.java
@@ -28,7 +28,7 @@ public enum DatabricksDynamicParameter implements DynamicParameter {
   // CLUSTER PARAMETERS
 
   /** The Spark version as provided by Gradle. This case is not using the openlineage prefix. */
-  SparkVersion("spark.version", null, "3.5.2"),
+  SparkVersion("spark.version", null, "3.5.4"),
 
   // DEVELOPMENT PARAMETERS
 

--- a/integration/spark/gradle.properties
+++ b/integration/spark/gradle.properties
@@ -11,5 +11,5 @@ spark31.spark.version=3.1.3
 spark32.spark.version=3.2.4
 spark33.spark.version=3.3.4
 spark34.spark.version=3.4.3
-spark35.spark.version=3.5.2
+spark35.spark.version=3.5.4
 spark40.spark.version=4.0.0

--- a/integration/spark/scala-fixtures/build.gradle.kts
+++ b/integration/spark/scala-fixtures/build.gradle.kts
@@ -8,11 +8,11 @@ repositories {
 }
 
 configureScalaVariant("2.11", "2.4.8")
-configureScalaVariant("2.12", "3.5.2")
-configureScalaVariant("2.13", "3.5.2")
+configureScalaVariant("2.12", "3.5.4")
+configureScalaVariant("2.13", "3.5.4")
 
 dependencies {
-    compileOnly("org.apache.spark:spark-sql_2.12:3.5.2")
+    compileOnly("org.apache.spark:spark-sql_2.12:3.5.4")
 }
 
 fun configureScalaVariant(scalaBinaryVersion: String, sparkVersion: String) {

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/IcebergMetricsReporterInjector.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/IcebergMetricsReporterInjector.java
@@ -105,8 +105,8 @@ public class IcebergMetricsReporterInjector<D extends OpenLineage.Dataset>
    * org.apache.spark.sql.catalyst.analysis.ResolvedTable (3.2.4) -
    * org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect (3.2.4) -
    * org.apache.spark.sql.catalyst.analysis.ResolvedDBObjectName (3.3.4) -
-   * org.apache.spark.sql.catalyst.analysis.ResolvedTable (3.3.4, 3.4.3, 3.5.2) -
-   * org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier (3.4.3, 3.5.2)
+   * org.apache.spark.sql.catalyst.analysis.ResolvedTable (3.3.4, 3.4.3, 3.5.4) -
+   * org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier (3.4.3, 3.5.4)
    *
    * @param plan
    * @return

--- a/integration/spark/vendor/snowflake/build.gradle
+++ b/integration/spark/vendor/snowflake/build.gradle
@@ -28,7 +28,7 @@ ext {
 
     sparkProp = project.findProperty('spark.version').toString()
     // because snowflake doesn't have a 3.5.0 connector yet
-    spark = (sparkProp == "3.5.2" || sparkProp.toString().startsWith("4")) ? "3.4.3" : sparkProp
+    spark = (sparkProp == "3.5.4" || sparkProp.toString().startsWith("4")) ? "3.4.3" : sparkProp
 
     series = spark.substring(0, 3)
     scala = project.findProperty('scala.binary.version').toString()


### PR DESCRIPTION
Spark 3.5.4 is out, we should use it for building and testing purposes.