### PR TITLE
Set java toolchain & fix spark build deps script

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -40,6 +40,14 @@ pmdMain {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()

--- a/integration/spark-extension-interfaces/build.gradle
+++ b/integration/spark-extension-interfaces/build.gradle
@@ -48,6 +48,14 @@ pmdTest {
     dependsOn shadowJar
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 repositories {
     mavenLocal()
     mavenCentral()

--- a/integration/spark/buildDependencies.sh
+++ b/integration/spark/buildDependencies.sh
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -x -e
-(cd ../../client/java && ./gradlew clean publishToMavenLocal)
-(cd ../spark-extension-interfaces && ./gradlew clean publishToMavenLocal)
+(cd ../../client/java && ./gradlew clean publishToMavenLocal -x test)
+(cd ../spark-extension-interfaces && ./gradlew clean publishToMavenLocal -x test)
 (cd ../sql/iface-java && ./script/compile.sh && ./script/build.sh)


### PR DESCRIPTION
 * Turning of tests for java client and spark extensions. For example java client has a docker based s3 test which is not working on latest Mac and of course requires running docker environment.
 * Setting toolchain java 17 for client-java and spark extensions makes sure, the projects are build with a proper java version regardless of default `java` set. 