### PR TITLE
[SPARK] Use all of the underlying classloaders to find `META-INF/services` resources

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ExtensionClassloader.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/ExtensionClassloader.java
@@ -4,8 +4,14 @@
 */
 package io.openlineage.spark.agent.util;
 
+import com.google.common.collect.Iterators;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,5 +37,17 @@ public class ExtensionClassloader extends ClassLoader {
       }
     }
     throw new ClassNotFoundException(name);
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    List<Enumeration<URL>> enumerations = new ArrayList<>();
+
+    for (ClassLoader classLoader : classLoaders) {
+      enumerations.add(classLoader.getResources(name));
+    }
+
+    return Iterators.asEnumeration(
+        Iterators.concat(enumerations.stream().map(Iterators::forEnumeration).iterator()));
   }
 }


### PR DESCRIPTION
### Problem

Closes: #3482 

### Solution

Use in ExtensionCloassloader all of the underlying classloaders to find `META-INF/services` resources

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project