### PR TITLE
[flink] default null job manager address

### DIFF
--- a/.pre_commit/set-java-version.sh
+++ b/.pre_commit/set-java-version.sh
@@ -20,6 +20,11 @@ set_java_version_ubuntu() {
 # Function to set Java version on macOS
 set_java_version_macos() {
   local version="$1"
+  
+  if [[ -n "$JAVA_HOME" && "$JAVA_HOME" =~ $version ]]; then
+    echo "JAVA_HOME is already set to a compatible version: $JAVA_HOME"
+    return 0
+  fi
 
   echo "Setting Java version to $version on macOS..."
 

--- a/integration/flink/app/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
@@ -50,11 +50,12 @@ public class OpenLineageContinousJobTracker {
     CloseableHttpClient httpClient = HttpClients.createDefault();
 
     String checkpointApiUrl =
-        String.format(
-            "http://%s:%s/jobs/%s/checkpoints",
-            config.get(RestOptions.ADDRESS),
-            config.get(RestOptions.PORT),
-            context.getJobId().toString());
+            String.format(
+                    "http://%s:%s/jobs/%s/checkpoints",
+                    Optional.ofNullable(config.get(RestOptions.ADDRESS)).
+                            orElse("localhost"),
+                    config.get(RestOptions.PORT),
+                    context.getJobId().toString());
     HttpGet request = new HttpGet(checkpointApiUrl);
 
     trackingThread =

--- a/integration/flink/app/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
+++ b/integration/flink/app/src/main/java/io/openlineage/flink/tracker/OpenLineageContinousJobTracker.java
@@ -50,12 +50,11 @@ public class OpenLineageContinousJobTracker {
     CloseableHttpClient httpClient = HttpClients.createDefault();
 
     String checkpointApiUrl =
-            String.format(
-                    "http://%s:%s/jobs/%s/checkpoints",
-                    Optional.ofNullable(config.get(RestOptions.ADDRESS)).
-                            orElse("localhost"),
-                    config.get(RestOptions.PORT),
-                    context.getJobId().toString());
+        String.format(
+            "http://%s:%s/jobs/%s/checkpoints",
+            Optional.ofNullable(config.get(RestOptions.ADDRESS)).orElse("localhost"),
+            config.get(RestOptions.PORT),
+            context.getJobId().toString());
     HttpGet request = new HttpGet(checkpointApiUrl);
 
     trackingThread =


### PR DESCRIPTION
### Problem

Closes: #3485

### Solution

- Wrapping potentially null Flink Job Manager address to default to localhost, please see #3485 for details
- Patching java setup script to allow configured environments to be used instead

#### One-line summary:

Default null Flink Job Manager address to localhost

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project