### PR TITLE
Store test results as artifacts

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1008,9 +1008,14 @@ jobs:
           command: cat app/build/test-results/integrationTest/TEST-*.xml
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - store_test_results:
-          path: app/build/test-results/integrationTest
+          path: flink1/build/test-results/integrationTest
       - store_artifacts:
-          path: app/build/reports/tests/integrationTest
+          path: flink1/build/reports/tests/integrationTest
+          destination: test-report
+      - store_test_results:
+          path: flink2/build/test-results/integrationTest
+      - store_artifacts:
+          path: flink2/build/reports/tests/integrationTest
           destination: test-report
       - save_cache:
           key: v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
@@ -1076,11 +1081,16 @@ jobs:
           command: cat build/test-results/test/TEST-*.xml
       - run: ./gradlew --no-daemon --console=plain jacocoTestReport
       - run: ./gradlew --console=plain javadoc
-      - store_test_results:
-          path: app/build/test-results/test
-      - store_artifacts:
-          path: app/build/reports/tests/test
-          destination: test-report
+      - store_submodule_tests:
+          submodule: flink1
+      - store_submodule_tests:
+          submodule: flink2
+      - store_submodule_tests:
+          submodule: flink115
+      - store_submodule_tests:
+          submodule: flink117
+      - store_submodule_tests:
+          submodule: flink118
       - save_cache:
           key: v1-integration-flink-{{ checksum "/tmp/checksum.txt" }}
           paths:


### PR DESCRIPTION
Test reports should be stored as artifacts, same way it's done for Spark. 

Examples:
 - https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/14478/workflows/b110e5a0-1a02-4125-92af-622d52fcef60/jobs/364739/artifacts
 - https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/14479/workflows/07ce6e8c-ea41-433d-a309-602e8e4302bb/jobs/364831/artifacts