### PR TITLE
Add ArrayBuffer support in ParallelCollectionRDDExtractor::extract (#…

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.execution.datasources.FilePartition;
 import org.apache.spark.sql.execution.datasources.FileScanRDD;
 import scala.Tuple2;
 import scala.collection.immutable.Seq;
+import scala.collection.mutable.ArrayBuffer;
 
 /** Utility class to extract paths from RDD nodes. */
 @Slf4j
@@ -140,6 +141,11 @@ public class RddPathUtils {
                     }
                     return path;
                   })
+              .filter(Objects::nonNull);
+        } else if ((data instanceof ArrayBuffer) && !((ArrayBuffer<?>) data).isEmpty()) {
+          ArrayBuffer<?> dataBuffer = (ArrayBuffer<?>) data;
+          return ScalaConversionUtils.fromSeq(dataBuffer.toSeq()).stream()
+              .map(o -> parentOf(o.toString()))
               .filter(Objects::nonNull);
         } else {
           log.warn("Cannot extract path from ParallelCollectionRDD {}", data);


### PR DESCRIPTION
…3445)

### Problem

Reading a partitioned json dataset from HDFS produces an `ArrayBuffer` containing the `Paths` being read, which `ParallelCollectionRDDExtractor::extract` can't process and bails out (see #3445 for more details).

Closes: #3445

### Solution

The PR introduces support for `ArrayBuffer` in `ParallelCollectionRDDExtractor::extract` and an associated unit test to cover for the newly added code.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:
Add ArrayBuffer support in ParallelCollectionRDDExtractor::extract

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project