### PR TITLE
ci: fix running full-tests from forked branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,22 @@ jobs:
                   pip install pyyaml==6.0.1
                   python dev/filter_approvals.py
       - run: |
-          export IS_FULL_TESTS=$(gh pr view --json labels | jq 'any(.labels[]; .name == "full-tests")')
+          export PR_NUM=$(echo $CIRCLE_PULL_REQUEST | cut -d'/' -f7)
+          export HAS_FULL_TESTS_LABEL=$(gh pr view $CIRCLE_PULL_REQUEST --repo OpenLineage/OpenLineage --json labels | jq 'any(.labels[]; .name == "full-tests")')
           if [ "<< pipeline.parameters.nightly-run >>" == "active" ]; then
             export IS_FULL_TESTS=1
+          elif [ "<< pipeline.git.branch >>" == "main" ]; then
+            export IS_FULL_TESTS=1
+          elif [ "$HAS_FULL_TESTS_LABEL" == "true" ]; then
+            export IS_FULL_TESTS=1
+          else
+            export IS_FULL_TESTS=0
           fi
+
           echo $IS_FULL_TESTS
+
           if [ -z "$IS_FULL_TESTS" ] || [ "$IS_FULL_TESTS" == "0" ]; then
+            echo "Skipping full tests"
             pip install pyyaml==6.0.1
             python dev/filter_matrix.py 
           fi

--- a/dev/filter_matrix.py
+++ b/dev/filter_matrix.py
@@ -20,7 +20,7 @@ for _, workflow_definition in d["workflows"].items():
         elif "integration-test-integration-spark" in job:
             integration_test_job = job["integration-test-integration-spark"]
 
-    for job in filter(None, [test_job, integration_test_job]):
+    for job in [x for x in [test_job, integration_test_job] if x is not None]:
         variants = [
             x for x in test_job.get("matrix").get("parameters").get("env-variant") if "full-tests" not in x
         ]


### PR DESCRIPTION
gh cli now will correctly look up origin repo, properly assigning full tests option if it's true.