### PR TITLE
remove native listener references after merging two flink integrations

### DIFF
--- a/new-version.sh
+++ b/new-version.sh
@@ -143,7 +143,6 @@ perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/spark/grad
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/spark-extension-interfaces/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink/examples/stateful/gradle.properties
-perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./integration/flink-native-listener/gradle.properties
 perl -i -pe"s/^version=.*/version=${RELEASE_VERSION}/g" ./proxy/backend/gradle.properties
 
 # (3) Bump version in docs
@@ -180,7 +179,6 @@ perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/spark/gradle.
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/spark-extension-interfaces/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/flink/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/flink/examples/stateful/gradle.properties
-perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./integration/flink-native-listener/gradle.properties
 perl -i -pe"s/^version=.*/version=${NEXT_VERSION}/g" ./proxy/backend/gradle.properties
 echo "version ${NEXT_VERSION}" > integration/spark/spark2/src/test/resources/io/openlineage/spark/agent/version.properties
 echo "version ${NEXT_VERSION}" > integration/spark/spark3/src/test/resources/io/openlineage/spark/agent/version.properties


### PR DESCRIPTION
The `flink-native-listener` does not exist anymore.