### PR TITLE
Inject metrics reporter to RESTCatalog

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -26,6 +26,7 @@ import io.openlineage.client.OpenLineageClientUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -601,6 +602,65 @@ class SparkIcebergIntegrationTest {
         .extracting("metadata")
         .asInstanceOf(InstanceOfAssertFactories.MAP)
         .containsEntry("engine-name", "spark");
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testMultipleScanReportsForSameDataset() {
+    if (JAVA_VERSION.startsWith("1.8") && System.getProperty(SPARK_VERSION).startsWith("3.5")) {
+      // This test will not work as Iceberg classes used are Java 11
+      assertThat(true).isTrue();
+      return;
+    }
+
+    clearTables("temp", "scan_source1", "scan_target1", "scan_target2");
+    createTempDataset(10).createOrReplaceTempView("temp");
+
+    spark.sql("CREATE TABLE scan_source1 USING iceberg AS SELECT * FROM temp");
+
+    // same dataset with same snapshot id will be read, but different columns will be projected
+    spark.sql("CREATE TABLE scan_target1 USING iceberg AS SELECT a FROM scan_source1");
+    spark.sql("CREATE TABLE scan_target2 USING iceberg AS SELECT b FROM scan_source1");
+
+    List<InputDatasetInputFacets> inputFacets1 =
+        getEventsEmittedWithJobName(mockServer, "scan_target1").stream()
+            .flatMap(e -> e.getInputs().stream())
+            .filter(e -> e.getName().endsWith("scan_source1"))
+            .map(InputDataset::getInputFacets)
+            .collect(Collectors.toList());
+
+    // get scan report facet
+    AbstractObjectAssert<?, ?> icebergScanReport1 =
+        assertThat(inputFacets1.stream())
+            .map(l -> l.getAdditionalProperties())
+            .filteredOn(e -> e.containsKey("icebergScanReport"))
+            .map(e -> e.get("icebergScanReport"))
+            .map(e -> e.getAdditionalProperties())
+            .singleElement();
+
+    icebergScanReport1
+        .extracting("projectedFieldNames")
+        .isEqualTo(new ArrayList<>(Collections.singletonList("a")));
+
+    List<InputDatasetInputFacets> inputFacets2 =
+        getEventsEmittedWithJobName(mockServer, "scan_target2").stream()
+            .flatMap(e -> e.getInputs().stream())
+            .filter(e -> e.getName().endsWith("scan_source1"))
+            .map(InputDataset::getInputFacets)
+            .collect(Collectors.toList());
+
+    // get scan report facet
+    AbstractObjectAssert<?, ?> icebergScanReport2 =
+        assertThat(inputFacets2.stream())
+            .map(l -> l.getAdditionalProperties())
+            .filteredOn(e -> e.containsKey("icebergScanReport"))
+            .map(e -> e.get("icebergScanReport"))
+            .map(e -> e.getAdditionalProperties())
+            .singleElement();
+
+    icebergScanReport2
+        .extracting("projectedFieldNames")
+        .isEqualTo(new ArrayList<>(Collections.singletonList("b")));
   }
 
   @Test

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/CatalogMetricsReporterHolder.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/CatalogMetricsReporterHolder.java
@@ -8,18 +8,22 @@ package io.openlineage.spark.agent.vendor.iceberg.metrics;
 import com.google.common.annotations.VisibleForTesting;
 import io.openlineage.spark.agent.facets.IcebergCommitReportOutputDatasetFacet;
 import io.openlineage.spark.agent.facets.IcebergScanReportInputDatasetFacet;
+import io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper.BaseMetastoreCatalogWrapper;
+import io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper.CatalogWrapper;
+import io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper.RESTCatalogWrapper;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.VendorsContext;
-import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.RESTCatalog;
 
 /**
  * Class to store static map of Catalogs onto MetricsReporters. This is necessary as Spark session
@@ -57,45 +61,47 @@ public class CatalogMetricsReporterHolder {
     }
     log.debug("Registering catalog: {}", catalog);
 
-    Field metricsReporterField = FieldUtils.getField(catalog.getClass(), "metricsReporter", true);
-
-    if (metricsReporterField == null) {
-      log.warn("Could not inject metrics reporter: no such field");
+    CatalogWrapper catalogWrapper;
+    if (catalog instanceof BaseMetastoreCatalog) {
+      catalogWrapper = new BaseMetastoreCatalogWrapper((BaseMetastoreCatalog) catalog);
+    } else if (catalog instanceof RESTCatalog) {
+      catalogWrapper = new RESTCatalogWrapper((RESTCatalog) catalog);
+    } else {
+      log.warn("Catalog type not supported: {}", catalog.getClass().getName());
       return;
     }
 
-    MetricsReporter existing;
+    MetricsReporter existing = catalogWrapper.getExistingReporter();
+    OpenLineageMetricsReporter openLineageMetricsReporter;
+
+    if (existing instanceof OpenLineageMetricsReporter) {
+      // in case the metrics reporter is manually set to OpenLineageMetricsReporter
+      holder.catalogMetricsReporter.putIfAbsent(
+          catalog.name(), (OpenLineageMetricsReporter) existing);
+      log.debug(
+          "Existing OpenLineageMetricsReporter found, replacing metrics reporter map with: {} for runId {}",
+          existing,
+          context.getRunUuid());
+      return;
+    }
+
+    if (existing != null) {
+      log.debug("Existing metrics reporter found: {}", existing.getClass().getName());
+      openLineageMetricsReporter = new OpenLineageMetricsReporter(existing);
+    } else if (holder.catalogMetricsReporter.containsKey(catalog.name())) {
+      log.debug("Use reporter available in the holder");
+      openLineageMetricsReporter = holder.catalogMetricsReporter.get(catalog.name());
+    } else {
+      log.debug("No existing metrics reporter found");
+      openLineageMetricsReporter = new OpenLineageMetricsReporter();
+    }
+
+    // set metrics reporter in context
+    holder.catalogMetricsReporter.put(catalog.name(), openLineageMetricsReporter);
+
     try {
-      existing = (MetricsReporter) metricsReporterField.get(catalog);
-
-      OpenLineageMetricsReporter openLineageMetricsReporter;
-      if (existing instanceof OpenLineageMetricsReporter) {
-        // in case the metrics reporter is manually set to OpenLineageMetricsReporter
-        holder.catalogMetricsReporter.putIfAbsent(
-            catalog.name(), (OpenLineageMetricsReporter) existing);
-        log.debug(
-            "Existing OpenLineageMetricsReporter found, replacing metrics reporter map with: {} for runId {}",
-            existing,
-            context.getRunUuid());
-        return;
-      }
-
-      if (existing != null) {
-        log.debug("Existing metrics reporter found: {}", existing.getClass().getName());
-        openLineageMetricsReporter = new OpenLineageMetricsReporter(existing);
-      } else if (holder.catalogMetricsReporter.containsKey(catalog.name())) {
-        log.debug("Use reporter available in the holder");
-        openLineageMetricsReporter = holder.catalogMetricsReporter.get(catalog.name());
-      } else {
-        log.debug("No existing metrics reporter found");
-        openLineageMetricsReporter = new OpenLineageMetricsReporter();
-      }
-
-      // set metrics reporter in context
-      holder.catalogMetricsReporter.put(catalog.name(), openLineageMetricsReporter);
-
       // set metrics reporter in catalog
-      metricsReporterField.set(catalog, openLineageMetricsReporter);
+      catalogWrapper.updateMetricsReporter(openLineageMetricsReporter);
       log.info("Injected metrics reporter into Iceberg catalog and runId {}", context.getRunUuid());
     } catch (IllegalAccessException e) {
       log.warn("Unable to inject metrics reporter", e);
@@ -111,11 +117,13 @@ public class CatalogMetricsReporterHolder {
   public Optional<IcebergScanReportInputDatasetFacet> getScanReportFacet(long snapshotId) {
     Optional<IcebergScanReportInputDatasetFacet> scanReport = Optional.empty();
     for (OpenLineageMetricsReporter reporter : catalogMetricsReporter.values()) {
-      synchronized (reporter.getCommitReportFacets()) {
+      List<IcebergScanReportInputDatasetFacet> scanReportFacets = reporter.getScanReportFacets();
+      synchronized (scanReportFacets) {
         scanReport =
-            reporter.getScanReportFacets().stream()
+            scanReportFacets.stream()
                 .filter(facet -> facet.getSnapshotId() == snapshotId)
                 .findAny();
+        scanReport.ifPresent(scanReportFacets::remove);
       }
     }
 
@@ -143,9 +151,11 @@ public class CatalogMetricsReporterHolder {
   public Optional<IcebergCommitReportOutputDatasetFacet> getCommitReportFacet(long snapshotId) {
     Optional<IcebergCommitReportOutputDatasetFacet> commitReport = Optional.empty();
     for (OpenLineageMetricsReporter reporter : catalogMetricsReporter.values()) {
-      synchronized (reporter.getCommitReportFacets()) {
+      List<IcebergCommitReportOutputDatasetFacet> commitReportFacets =
+          reporter.getCommitReportFacets();
+      synchronized (commitReportFacets) {
         commitReport =
-            reporter.getCommitReportFacets().stream()
+            commitReportFacets.stream()
                 .filter(facet -> facet.getSnapshotId() == snapshotId)
                 .findAny();
       }

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/BaseMetastoreCatalogWrapper.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/BaseMetastoreCatalogWrapper.java
@@ -23,24 +23,35 @@ public class BaseMetastoreCatalogWrapper implements CatalogWrapper {
     this.catalog = catalog;
   }
 
+  /**
+   * Get the metricsReporter field from {@link BaseMetastoreCatalog}. Returns null if the field is
+   * not found.
+   *
+   * @return MetricsReporter
+   */
   @Override
   public MetricsReporter getExistingReporter() {
     Field metricsReporterField =
         FieldUtils.getField(BaseMetastoreCatalog.class, METRICS_REPORTER, true);
 
     if (metricsReporterField == null) {
-      log.warn("Could not inject metrics reporter: no such field");
+      log.warn("Could obtain metrics reporter: no such field");
       return null;
     }
 
     try {
       return (MetricsReporter) metricsReporterField.get(catalog);
     } catch (IllegalAccessException e) {
-      log.warn("Could not inject metrics reporter: {}", e.getMessage());
+      log.warn("Could obtain metrics reporter: {}", e.getMessage());
       return null;
     }
   }
 
+  /**
+   * Update the metricsReporter field. Throws IllegalAccessException if the field is not found.
+   *
+   * @param reporter OpenLineageMetricsReporter
+   */
   @Override
   public void updateMetricsReporter(OpenLineageMetricsReporter reporter)
       throws IllegalAccessException {

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/CatalogWrapper.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/CatalogWrapper.java
@@ -1,0 +1,26 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper;
+
+import io.openlineage.spark.agent.vendor.iceberg.metrics.OpenLineageMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
+
+public interface CatalogWrapper {
+
+  /**
+   * Get the existing metrics reporter from the catalog. Returns null if the field is not found.
+   *
+   * @return MetricsReporter
+   */
+  MetricsReporter getExistingReporter();
+
+  /**
+   * Update the metrics reporter in the catalog. Throws IllegalAccessException if the field is not.
+   *
+   * @param reporter OpenLineageMetricsReporter
+   */
+  void updateMetricsReporter(OpenLineageMetricsReporter reporter) throws IllegalAccessException;
+}

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/CatalogWrapper.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/CatalogWrapper.java
@@ -8,6 +8,10 @@ package io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper;
 import io.openlineage.spark.agent.vendor.iceberg.metrics.OpenLineageMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 
+/**
+ * Interface used to inject MetricsReporter into Iceberg Catalogs. Uses reflection to access private
+ * fields.
+ */
 public interface CatalogWrapper {
 
   /**

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/RESTCatalogWrapper.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/RESTCatalogWrapper.java
@@ -1,0 +1,58 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.vendor.iceberg.metrics.wrapper;
+
+import io.openlineage.spark.agent.vendor.iceberg.metrics.OpenLineageMetricsReporter;
+import java.lang.reflect.Field;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+
+/** Wrapper to inject MetricsReporter into RESTCatalog. Uses reflection to access private fields. */
+@Slf4j
+public class RESTCatalogWrapper implements CatalogWrapper {
+
+  public static final String REPORTER = "reporter";
+  RESTCatalog catalog;
+  RESTSessionCatalog restSessionCatalog;
+
+  public RESTCatalogWrapper(RESTCatalog catalog) {
+    this.catalog = catalog;
+    loadRestSessionCatalog();
+  }
+
+  private void loadRestSessionCatalog() {
+    try {
+      Field sessionCatalogField = FieldUtils.getField(RESTCatalog.class, "sessionCatalog", true);
+      restSessionCatalog = (RESTSessionCatalog) sessionCatalogField.get(catalog);
+    } catch (IllegalAccessException | ClassCastException e) {
+      log.warn("Unable to inject metrics reporter to RESTCatalog {}", e.getMessage());
+    }
+  }
+
+  public MetricsReporter getExistingReporter() {
+    Field reporterField = FieldUtils.getField(RESTSessionCatalog.class, REPORTER, true);
+    if (reporterField == null) {
+      log.warn("Could not inject metrics reporter: no such field");
+      return null;
+    }
+    try {
+      return (MetricsReporter) reporterField.get(restSessionCatalog);
+    } catch (IllegalAccessException e) {
+      log.warn("Could not inject metrics reporter: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  @Override
+  public void updateMetricsReporter(OpenLineageMetricsReporter reporter)
+      throws IllegalAccessException {
+    Field reporterField = FieldUtils.getField(RESTSessionCatalog.class, REPORTER, true);
+    reporterField.set(restSessionCatalog, reporter);
+  }
+}

--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/RESTCatalogWrapper.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/metrics/wrapper/RESTCatalogWrapper.java
@@ -35,20 +35,32 @@ public class RESTCatalogWrapper implements CatalogWrapper {
     }
   }
 
+  /**
+   * Get the reporter field from {@link RESTSessionCatalog} within {@link RESTCatalog}. Returns null
+   * if the field is not found.
+   *
+   * @return MetricsReporter
+   */
   public MetricsReporter getExistingReporter() {
     Field reporterField = FieldUtils.getField(RESTSessionCatalog.class, REPORTER, true);
     if (reporterField == null) {
-      log.warn("Could not inject metrics reporter: no such field");
+      log.warn("Could obtain metrics reporter: no such field");
       return null;
     }
     try {
       return (MetricsReporter) reporterField.get(restSessionCatalog);
     } catch (IllegalAccessException e) {
-      log.warn("Could not inject metrics reporter: {}", e.getMessage());
+      log.warn("Could obtain metrics reporter: {}", e.getMessage());
       return null;
     }
   }
 
+  /**
+   * Update the reporter field of {@link RESTSessionCatalog} within {@link RESTCatalog}. Throws
+   * IllegalAccessException if the field is not found.
+   *
+   * @param reporter OpenLineageMetricsReporter
+   */
   @Override
   public void updateMetricsReporter(OpenLineageMetricsReporter reporter)
       throws IllegalAccessException {

--- a/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/metrics/CatalogMetricsReporterHolderTest.java
+++ b/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/metrics/CatalogMetricsReporterHolderTest.java
@@ -13,38 +13,44 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.VendorsContext;
+import java.lang.reflect.Field;
 import java.util.List;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class CatalogMetricsReporterHolderTest {
 
   public static final String CATALOG_NAME = "catalog-name";
-  TestingIcebergCatalog icebergCatalog = new TestingIcebergCatalog();
+  TestingIcebergCatalog icebergCatalog;
   OpenLineageContext context = mock(OpenLineageContext.class, RETURNS_DEEP_STUBS);
 
   @BeforeEach
   public void setup() {
     when(context.getVendors().getVendorsContext()).thenReturn(new VendorsContext());
+    icebergCatalog = new TestingIcebergCatalog();
   }
 
   @Test
   void testRegister() {
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
 
-    assertThat(icebergCatalog.metricsReporter)
+    assertThat(getMetricsReporter(icebergCatalog))
         .isNotNull()
         .isInstanceOf(OpenLineageMetricsReporter.class);
 
     assertThat(getMetricHolder().getReporterFor(CATALOG_NAME))
-        .isEqualTo(icebergCatalog.metricsReporter);
+        .isEqualTo(getMetricsReporter(icebergCatalog));
   }
 
   @Test
@@ -54,13 +60,32 @@ public class CatalogMetricsReporterHolderTest {
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
     CatalogMetricsReporterHolder.register(context, anotherCatalog);
 
-    assertThat(anotherCatalog.metricsReporter).isNull();
+    assertThat(getMetricsReporter(anotherCatalog)).isNull();
   }
 
   @Test
+  @SneakyThrows
+  void testRegisterRestCatalog() {
+    MetricsReporter reporter = mock(MetricsReporter.class);
+    RESTCatalog restCatalog = new RESTCatalog();
+    Field sessionCatalogField = FieldUtils.getField(RESTCatalog.class, "sessionCatalog", true);
+    RESTSessionCatalog sessionCatalog = (RESTSessionCatalog) sessionCatalogField.get(restCatalog);
+    FieldUtils.writeField(sessionCatalog, "reporter", reporter, true);
+    FieldUtils.writeField(sessionCatalog, "name", CATALOG_NAME, true);
+
+    CatalogMetricsReporterHolder.register(context, restCatalog);
+
+    assertThat(getMetricHolder().getReporterFor(CATALOG_NAME))
+        .isInstanceOf(OpenLineageMetricsReporter.class)
+        .extracting("delegate")
+        .isEqualTo(reporter);
+  }
+
+  @Test
+  @SneakyThrows
   void testRegisterWithExistingReporter() {
     MetricsReporter existingReporter = mock(MetricsReporter.class);
-    icebergCatalog.metricsReporter = existingReporter;
+    FieldUtils.writeField(icebergCatalog, "metricsReporter", existingReporter, true);
 
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
 
@@ -69,9 +94,10 @@ public class CatalogMetricsReporterHolderTest {
   }
 
   @Test
+  @SneakyThrows
   void testRegisterDoesNotOverwriteOpenLineageMetricsReporter() {
     MetricsReporter existingReporter = mock(OpenLineageMetricsReporter.class);
-    icebergCatalog.metricsReporter = existingReporter;
+    FieldUtils.writeField(icebergCatalog, "metricsReporter", existingReporter, true);
 
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
 
@@ -84,15 +110,16 @@ public class CatalogMetricsReporterHolderTest {
     when(scanReport.snapshotId()).thenReturn(1L);
 
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
-    icebergCatalog.metricsReporter = getMetricHolder().getReporterFor(CATALOG_NAME);
-
-    icebergCatalog.metricsReporter.report(scanReport);
+    getMetricsReporter(icebergCatalog).report(scanReport);
 
     assertThat(getMetricHolder().getScanReportFacet(1L))
         .isPresent()
         .get()
         .extracting("snapshotId")
         .isEqualTo(1L);
+
+    // Test that the facet is removed after being retrieved
+    assertThat(getMetricHolder().getScanReportFacet(1L)).isEmpty();
   }
 
   @Test
@@ -101,9 +128,7 @@ public class CatalogMetricsReporterHolderTest {
     when(commitReport.snapshotId()).thenReturn(1L);
 
     CatalogMetricsReporterHolder.register(context, icebergCatalog);
-    icebergCatalog.metricsReporter = getMetricHolder().getReporterFor(CATALOG_NAME);
-
-    icebergCatalog.metricsReporter.report(commitReport);
+    getMetricsReporter(icebergCatalog).report(commitReport);
 
     assertThat(getMetricHolder().getCommitReportFacet(1L))
         .isPresent()
@@ -117,9 +142,28 @@ public class CatalogMetricsReporterHolderTest {
         context.getVendors().getVendorsContext().fromVendorsContext(VENDOR_CONTEXT_KEY).get());
   }
 
-  private static class TestingIcebergCatalog implements Catalog {
+  @SneakyThrows
+  private MetricsReporter getMetricsReporter(BaseMetastoreCatalog catalog) {
+    Field field = FieldUtils.getField(catalog.getClass(), "metricsReporter", true);
+    return (MetricsReporter) field.get(catalog);
+  }
 
-    public MetricsReporter metricsReporter;
+  private static class TestingIcebergCatalog extends BaseMetastoreCatalog {
+
+    @Override
+    public String name() {
+      return CATALOG_NAME;
+    }
+
+    @Override
+    protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+      return "";
+    }
 
     @Override
     public List<TableIdentifier> listTables(Namespace namespace) {
@@ -133,14 +177,5 @@ public class CatalogMetricsReporterHolderTest {
 
     @Override
     public void renameTable(TableIdentifier tableIdentifier, TableIdentifier tableIdentifier1) {}
-
-    @Override
-    public Table loadTable(TableIdentifier tableIdentifier) {
-      return null;
-    }
-
-    public String name() {
-      return CATALOG_NAME;
-    }
   }
 }


### PR DESCRIPTION
 * Fix support on Iceberg RESTCatalog,
 * Remove ScanReport from in-memory queue once it's included in the facet.