### PR TITLE
Flink2: topic pattern resolving test

### DIFF
--- a/integration/flink/examples/flink2-test-apps/build.gradle
+++ b/integration/flink/examples/flink2-test-apps/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     implementation "io.openlineage:openlineage-flink:$project.version"
     implementation "org.apache.flink:flink-connector-kafka:3.4-SNAPSHOT" // need to be built locally
+    implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
+    implementation "org.apache.flink:flink-avro:$flinkVersion"
 
     compileOnly "org.apache.flink:flink-streaming-java:$flinkVersion"
     compileOnly "org.apache.flink:flink-runtime-web:$flinkVersion"
@@ -77,3 +79,6 @@ test {
     useJUnitPlatform()
 }
 
+avro {
+    fieldVisibility = 'PUBLIC'
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/event/InputEvent.avsc
+++ b/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/event/InputEvent.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "io.openlineage.flink.avro.event",
+  "type": "record",
+  "name": "InputEvent",
+  "fields": [
+    {"name": "id", "type": ["null", "string"], "default": null},
+    {"name": "version", "type": ["null", "long"], "default": null}
+  ]
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/event/OutputEvent.avsc
+++ b/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/event/OutputEvent.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "io.openlineage.flink.avro.event",
+  "type": "record",
+  "name": "OutputEvent",
+  "fields": [
+    {"name": "id", "type": ["null", "string"], "default": null},
+    {"name": "version", "type": ["null", "long"], "default": null},
+    {"name": "counter", "type": ["null", "long"], "default": null}
+  ]
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/infrastructure/state/managed/Counter.avsc
+++ b/integration/flink/examples/flink2-test-apps/src/main/avro/io/openlineage/flink/avro/infrastructure/state/managed/Counter.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "io.openlineage.flink.avro.infrastructure.state.managed",
+  "type": "record",
+  "name": "Counter",
+  "fields": [
+    {"name": "counter", "type": ["null", "long"], "default": null},
+    {"name": "lastSeen", "type": ["null", "string"], "default": null}
+  ]
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/FlinkTopicPatternApplication.java
+++ b/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/FlinkTopicPatternApplication.java
@@ -1,0 +1,67 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import static io.openlineage.flink.StreamEnvironment.setupEnv;
+
+import io.openlineage.flink.avro.event.InputEvent;
+import io.openlineage.flink.avro.event.OutputEvent;
+import java.util.regex.Pattern;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroSerializationSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.ParameterTool;
+
+public class FlinkTopicPatternApplication {
+
+  private static final String SCHEMA_REGISTRY_URL = "http://schema-registry:8081";
+
+  public static void main(String[] args) throws Exception {
+    ParameterTool parameters = ParameterTool.fromArgs(args);
+    StreamExecutionEnvironment env = setupEnv(args);
+
+    String bootstraps = parameters.getRequired("bootstraps");
+
+    KafkaSource<InputEvent> source =
+        KafkaSource.<InputEvent>builder()
+            .setBootstrapServers(bootstraps)
+            .setGroupId("testTopicPatternRead")
+            .setTopicPattern(Pattern.compile(parameters.getRequired("input-topics")))
+            .setValueOnlyDeserializer(
+                ConfluentRegistryAvroDeserializationSchema.forSpecific(
+                    InputEvent.class, SCHEMA_REGISTRY_URL))
+            .setStartingOffsets(OffsetsInitializer.earliest())
+            .setBounded(OffsetsInitializer.latest())
+            .build();
+
+    KafkaSink<OutputEvent> sink =
+        KafkaSink.<OutputEvent>builder()
+            .setBootstrapServers(bootstraps)
+            .setRecordSerializer(
+                KafkaRecordSerializationSchema.builder()
+                    .setValueSerializationSchema(
+                        ConfluentRegistryAvroSerializationSchema.forSpecific(
+                            OutputEvent.class, parameters.getRequired("output-topics"), SCHEMA_REGISTRY_URL))
+                    .setTopic(parameters.getRequired("output-topics"))
+                    .build())
+            .build();
+
+    DataStream<InputEvent> stream =
+        env.fromSource(source, WatermarkStrategy.noWatermarks(), "testBasicRead");
+
+    stream
+        .keyBy(InputEvent::getId)
+        .process(new StatefulCounter())
+        .sinkTo(sink);
+    env.execute();
+  }
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/StatefulCounter.java
+++ b/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/StatefulCounter.java
@@ -1,0 +1,53 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import io.openlineage.flink.avro.event.InputEvent;
+import io.openlineage.flink.avro.event.OutputEvent;
+import io.openlineage.flink.avro.infrastructure.state.managed.Counter;
+import io.openlineage.flink.util.StateUtils;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StatefulCounter extends KeyedProcessFunction<String, InputEvent, OutputEvent> {
+
+  public static final long serialVersionUID = 1;
+  public static final ValueStateDescriptor<Counter> COUNTER_DESCRIPTOR;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StatefulCounter.class);
+
+  static {
+    COUNTER_DESCRIPTOR = new ValueStateDescriptor<>("counter", Counter.class);
+    COUNTER_DESCRIPTOR.setQueryable(COUNTER_DESCRIPTOR.getName());
+  }
+
+  private transient ValueState<Counter> counterState;
+
+  @Override
+  public void open(OpenContext context) {
+    counterState = getRuntimeContext().getState(COUNTER_DESCRIPTOR);
+  }
+
+  @Override
+  public void processElement(InputEvent inputEvent, Context ctx, Collector<OutputEvent> output)
+      throws Exception {
+    LOGGER.info("Processing InputEvent={}", inputEvent);
+    Counter counter = StateUtils.value(counterState, new Counter(0L, null));
+    counter.setCounter(counter.getCounter() + 1);
+    counter.setLastSeen(inputEvent.toString());
+    counterState.update(counter);
+    OutputEvent outputEvent =
+        new OutputEvent(inputEvent.id, inputEvent.version, counter.getCounter());
+    LOGGER.info("Preparing OutputEvent={} to sent.", inputEvent);
+    output.collect(outputEvent);
+  }
+}

--- a/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/util/StateUtils.java
+++ b/integration/flink/examples/flink2-test-apps/src/main/java/io/openlineage/flink/util/StateUtils.java
@@ -1,0 +1,22 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.util;
+
+import java.io.IOException;
+import org.apache.flink.api.common.state.ValueState;
+
+public final class StateUtils {
+
+  private StateUtils() {}
+
+  public static <T> T value(ValueState<T> state, T defaultValue) throws IOException {
+    T value = state.value();
+    if (value == null) {
+      value = defaultValue;
+    }
+    return value;
+  }
+}

--- a/integration/flink/flink2/README.md
+++ b/integration/flink/flink2/README.md
@@ -66,7 +66,6 @@ Run the integration tests of this package:
     emitted correctly from the native Flink interfaces. Issues below should be implemented before
     treating the implementation as production ready.
 
- * Write docker integration test for topic pattern resolution.
  * Make sure package does not contain extra dependencies (or relocates them).
  * Add custom Facet with Flink jobId.
  * Create a tracking thread that uses Flink api to get checkpoint data. This shall be done in same way as other OpenLineage Flink integration.

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TypeInformationFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TypeInformationFacetVisitor.java
@@ -47,7 +47,7 @@ public class TypeInformationFacetVisitor implements DatasetFacetVisitor {
     TypeInformation typeInformation =
         TypeDatasetFacetUtil.getFacet(dataset.getFlinkDataset())
             .map(f -> f.getTypeInformation())
-            .get();
+            .orElse(null);
 
     // TODO: support GenericAvroRecord & support protobuf
     if (typeInformation instanceof GenericTypeInfo) {

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KafkaTopicPatternDatasetIdentifierVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KafkaTopicPatternDatasetIdentifierVisitor.java
@@ -41,7 +41,7 @@ public class KafkaTopicPatternDatasetIdentifierVisitor implements DatasetIdentif
             .map(OpenLineageContext::getConfig)
             .map(FlinkOpenLineageConfig::getDatasetConfig)
             .map(FlinkDatasetConfig::getKafkaConfig)
-            .map(FlinkDatasetKafkaConfig::isResolveTopicPattern);
+            .map(FlinkDatasetKafkaConfig::getResolveTopicPattern);
 
     if (resolveTopics.isEmpty() || !resolveTopics.get()) {
       return false;
@@ -63,7 +63,6 @@ public class KafkaTopicPatternDatasetIdentifierVisitor implements DatasetIdentif
       return Collections.emptyList();
     }
     Pattern pattern = getTopicPattern(dataset).get();
-    partitions.forEach(p -> log.info("Partitions: {}", p));
 
     return partitions.stream()
         .flatMap(Collection::stream)

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/ContainerTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/ContainerTest.java
@@ -167,6 +167,24 @@ class ContainerTest {
     verify("events/expected_sql_kafka.json");
   }
 
+  @Test
+  @SneakyThrows
+  void testKafkaTopicPatternJob() {
+    Properties jobProperties = new Properties();
+
+    jobProperties.put("inputTopics", "io.openlineage.flink.kafka.input.*");
+    jobProperties.put("outputTopics", "io.openlineage.flink.kafka.output_topic");
+    jobProperties.put("jobName", "flink_topic_pattern");
+
+    runUntilLogMessage(
+        "io.openlineage.flink.FlinkTopicPatternApplication",
+        jobProperties,
+        generateEvents,
+        "Marking checkpoint 1 as completed for source Source");
+
+    verify("events/expected_kafka_topic_pattern.json");
+  }
+
   @SneakyThrows
   private JsonBody readJson(Path path) {
     return json(new String(readAllBytes(path)), MatchType.ONLY_MATCHING_FIELDS);

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -8,6 +8,7 @@ package io.openlineage.flink;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -82,6 +83,13 @@ public class FlinkContainerUtils {
         .withCopyFileToContainer(
             MountableFile.forHostPath(Resources.getResource("InputEvent.avsc").getPath()),
             "/tmp/InputEvent.avsc")
+        .withCopyFileToContainer(
+            MountableFile.forHostPath(Resources.getResource("events.json").getPath()),
+            "/tmp/events.json")
+        .withCommand(
+            "/bin/bash",
+            "-c",
+            Resources.toString(Resources.getResource("generate_events.sh"), StandardCharsets.UTF_8))
         .withEnv("SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL", "WARN")
         .dependsOn(initTopics);
   }
@@ -106,7 +114,7 @@ public class FlinkContainerUtils {
         jobProperties.getProperty("outputTopics", "io.openlineage.flink.kafka.output");
     String jobNameParam = "";
     if (jobProperties.getProperty("jobName") != null) {
-      jobNameParam = "--job-name " + jobProperties.get("jobName") + " ";
+      jobNameParam = " --job-name " + jobProperties.get("jobName") + " ";
     }
     String configPath = jobProperties.getProperty("configPath", "/opt/flink/lib/openlineage.yml");
     GenericContainer<?> container =

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KafkaTopicPatternDatasetIdentifierVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KafkaTopicPatternDatasetIdentifierVisitorTest.java
@@ -43,7 +43,7 @@ class KafkaTopicPatternDatasetIdentifierVisitorTest {
 
   @BeforeEach
   void setup() {
-    when((context.getConfig().getDatasetConfig().getKafkaConfig()).isResolveTopicPattern())
+    when((context.getConfig().getDatasetConfig().getKafkaConfig()).getResolveTopicPattern())
         .thenReturn(true);
   }
 
@@ -74,7 +74,7 @@ class KafkaTopicPatternDatasetIdentifierVisitorTest {
     when(dataset.facets()).thenReturn(Map.of("kafka", facet));
     assertThat(visitor.isDefinedAt(dataset)).isTrue();
 
-    when((context.getConfig().getDatasetConfig().getKafkaConfig()).isResolveTopicPattern())
+    when((context.getConfig().getDatasetConfig().getKafkaConfig()).getResolveTopicPattern())
         .thenReturn(false);
     assertThat(visitor.isDefinedAt(dataset)).isFalse();
 

--- a/integration/flink/flink2/src/test/resources/events.json
+++ b/integration/flink/flink2/src/test/resources/events.json
@@ -1,0 +1,5 @@
+{ "id":  {"string": "some-id-1"}, "version":  {"long":  7} }
+{ "id":  {"string": "some-id-2"}, "version":  {"long":  7} }
+{ "id":  {"string": "some-id-3"}, "version":  {"long":  7} }
+{ "id":  {"string": "some-id-4"}, "version":  {"long":  7} }
+{ "id":  {"string": "some-id-5"}, "version":  {"long":  7} }

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -1,0 +1,32 @@
+{
+  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+  "eventType": "START",
+  "run": {
+  },
+  "job": {
+    "namespace": "flink-jobs",
+    "facets": {
+      "jobType": {
+        "processingType": "STREAMING",
+        "integration": "FLINK",
+        "jobType": "JOB"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "namespace": "kafka://kafka-host:9092",
+      "name": "io.openlineage.flink.kafka.input2"
+    },
+    {
+      "namespace": "kafka://kafka-host:9092",
+      "name": "io.openlineage.flink.kafka.input1"
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "kafka://kafka-host:9092",
+      "name": "io.openlineage.flink.kafka.output_topic"
+    }
+  ]
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkDatasetConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkDatasetConfig.java
@@ -12,12 +12,10 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @Setter
-@NoArgsConstructor
 @ToString
 @Getter
 @EqualsAndHashCode(callSuper = true)
@@ -26,6 +24,11 @@ public class FlinkDatasetConfig extends DatasetConfig {
 
   @JsonProperty("kafka")
   private FlinkDatasetKafkaConfig kafkaConfig;
+
+  public FlinkDatasetConfig() {
+    super();
+    this.kafkaConfig = new FlinkDatasetKafkaConfig();
+  }
 
   public FlinkDatasetConfig(
       FlinkDatasetKafkaConfig kafkaConfig,

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkDatasetKafkaConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkDatasetKafkaConfig.java
@@ -7,18 +7,31 @@ package io.openlineage.flink.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.MergeConfig;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
+@Setter
+@NoArgsConstructor
+@ToString
+@Getter
+@AllArgsConstructor
 public class FlinkDatasetKafkaConfig implements MergeConfig<FlinkDatasetKafkaConfig> {
 
   @JsonProperty("resolveTopicPattern")
-  @Getter
   @Setter
-  private boolean resolveTopicPattern;
+  private Boolean resolveTopicPattern;
 
   @Override
-  public FlinkDatasetKafkaConfig mergeWithNonNull(FlinkDatasetKafkaConfig flinkDatasetKafkaConfig) {
-    return null;
+  public FlinkDatasetKafkaConfig mergeWithNonNull(FlinkDatasetKafkaConfig other) {
+    return new FlinkDatasetKafkaConfig(
+        mergeWithDefaultValue(resolveTopicPattern, other.resolveTopicPattern, Boolean.TRUE));
+  }
+
+  public Boolean getResolveTopicPattern() {
+    return Optional.ofNullable(resolveTopicPattern).orElse(Boolean.TRUE);
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
@@ -14,18 +14,21 @@ import io.openlineage.client.transports.FacetsConfig;
 import io.openlineage.client.transports.TransportConfig;
 import java.util.Map;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @Getter
-@NoArgsConstructor
 @ToString
 public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageConfig> {
 
   @JsonProperty("dataset")
   @Setter
   private FlinkDatasetConfig datasetConfig;
+
+  public FlinkOpenLineageConfig() {
+    super();
+    datasetConfig = new FlinkDatasetConfig();
+  }
 
   public FlinkOpenLineageConfig(
       TransportConfig transportConfig,

--- a/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
+++ b/integration/flink/shared/src/test/java/io/openlineage/flink/client/FlinkConfigParserTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.io.Resources;
 import io.openlineage.client.transports.HttpConfig;
 import io.openlineage.flink.config.FlinkConfigParser;
+import io.openlineage.flink.config.FlinkDatasetConfig;
+import io.openlineage.flink.config.FlinkDatasetKafkaConfig;
 import io.openlineage.flink.config.FlinkOpenLineageConfig;
 import java.net.URI;
 import lombok.SneakyThrows;
@@ -118,5 +120,23 @@ class FlinkConfigParserTest {
 
     // API config from yaml file
     assertThat(httpConfig.getAuth().getToken()).isEqualTo("Bearer random_token");
+  }
+
+  @Test
+  void testResolveTopicPattern() {
+    FlinkOpenLineageConfig config = FlinkConfigParser.parse(configuration);
+    assertThat(config)
+        .extracting(FlinkOpenLineageConfig::getDatasetConfig)
+        .extracting(FlinkDatasetConfig::getKafkaConfig)
+        .extracting(FlinkDatasetKafkaConfig::getResolveTopicPattern)
+        .isEqualTo(true);
+
+    configuration.set(
+        ConfigOptions.key("openlineage.dataset.kafka.resolveTopicPattern")
+            .booleanType()
+            .noDefaultValue(),
+        false);
+    config = FlinkConfigParser.parse(configuration);
+    assertThat(config.getDatasetConfig().getKafkaConfig().getResolveTopicPattern()).isFalse();
   }
 }


### PR DESCRIPTION
Prepare docker based end-to-end test to verify kafka topic pattern is resolved into topics' list. 

 * PR contains Flink streaming application reading and writing AVRO records. Currently it's not filling schema facet. Test verifies if a topic pattern is properly resolved.
 * PR fixes `TypeInformationFacetVisitor` to avoid errors for Avro type. 
 * PR fixes `resolveTopicPattern` configuration entry, which should be true by default. Currently, default value was not respected. Setting is only applicable for Flink 2. Description will be put in a documentation later. 