### PR TITLE
Flink2 - include SQL comments in OL events

### DIFF
--- a/integration/flink/flink2/README.md
+++ b/integration/flink/flink2/README.md
@@ -72,7 +72,6 @@ Run the integration tests of this package:
  * Support schema extraction from nested Generic Records.
  * Support extracting dataset schema from Avro.
  * Support extracting dataset scheme from Protobuf.
- * Extract table comment property into OpenLineage facet. 
  * For Kafka table, include symlink with the table name. 
  * Implement a check which will not allow turning on the listener if the Flink version is 2.
  * Prepare documentation for the package. Document some flink config entries work for Flink 2 only like - resolveTopicPattern.

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
@@ -53,6 +53,13 @@ public class TableLineageFacetVisitor implements DatasetFacetVisitor {
                         .build())
             .collect(Collectors.toList());
 
+    table
+        .getDescription()
+        .ifPresent(
+            description ->
+                builder.documentation(
+                    context.getOpenLineage().newDocumentationDatasetFacet(description)));
+
     builder.schema(context.getOpenLineage().newSchemaDatasetFacet(datasetFacetFields));
   }
 }


### PR DESCRIPTION
Minor change to include table and field comments within generated OL events. 