### PR TITLE
[dbt][structured logs] Fix race condition on dbt log file

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -500,7 +500,6 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         dbt_command_line = add_or_replace_command_line_option(
             dbt_command_line, option="--write-json", replace_option="--no-write-json"
         )
-
         self._open_dbt_log_file()
         process = subprocess.Popen(dbt_command_line, stdout=sys.stdout, stderr=sys.stderr, text=True)
 
@@ -532,6 +531,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             return
 
         if not os.path.exists(self.dbt_log_file_path):
+            logs_directory = os.path.dirname(self.dbt_log_file_path)
+            os.makedirs(logs_directory, exist_ok=True)
             with open(self.dbt_log_file_path, "w"):
                 pass
 


### PR DESCRIPTION
### Problem

The log file is the main artifact used to construct the dbt OL events, structured logs are saved there.
The issue here is that the process executing `dbt` command is started and THEN the log file is read.
Since it's append only (think mulitple executions of the dbt command with the same loging configuration), all the lines are read on first open. 
There is a race condition that skips more lines then needed and it's causing subsequent issues down the road (KeyErrors, dbt resources not found because not read from the log file)


### Solution

The log file is read before the process is started. We have two scenarios:
1. if the log file doesn't exist, it's created
2. if the log file exists, it's open and all the previous lines (related to previous executions) are read

#### One-line summary:

Fix race condition on log file

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project