### PR TITLE
[dbt][structured logs] Handle skipped dbt nodes

### DIFF
--- a/integration/common/tests/dbt/structured_logs/postgres/events/logs/skipped_test_NodeFinished.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/logs/skipped_test_NodeFinished.yaml
@@ -1,0 +1,98 @@
+[
+  # Command started dbt event
+  {
+    "data": {
+      "log_version": 3,
+      "version": "=1.8.2"
+    },
+    "info": {
+      "category": "",
+      "code": "A001",
+      "extra": { },
+      "invocation_id": "b0ed168e-1926-42da-aa25-6b3eb826074b",
+      "level": "info",
+      "msg": "Running with dbt=1.8.2",
+      "name": "MainReportVersion",
+      "pid": 278,
+      "thread": "MainThread",
+      "ts": "2024-11-22T15:58:03.518877Z"
+    }
+  },
+  # Test Node started dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "test",
+        "meta": { },
+        "node_finished_at": "",
+        "node_name": "accepted_values_customers_first_name__Jane",
+        "node_path": "accepted_values_customers_first_name__Jane.sql",
+        "node_relation": {
+          "alias": "accepted_values_customers_first_name__Jane",
+          "database": "postgres",
+          "relation_name": "",
+          "schema": "public_dbt_test__audit"
+        },
+        "node_started_at": "2024-12-17T10:03:22.210376",
+        "node_status": "started",
+        "resource_type": "test",
+        "unique_id": "test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312"
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q024",
+      "extra": { },
+      "invocation_id": "899a81ce-1512-451a-b34a-480863ac4005",
+      "level": "debug",
+      "msg": "Began running node test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312",
+      "name": "NodeStart",
+      "pid": 841,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-12-17T10:03:22.211861Z"
+    }
+  },
+  # Test Node finished dbt event
+  {
+    "data": {
+      "node_info": {
+        "materialized": "test",
+        "meta": { },
+        "node_finished_at": "", # this is empty for skipped nodes
+        "node_name": "accepted_values_customers_first_name__Jane",
+        "node_path": "accepted_values_customers_first_name__Jane.sql",
+        "node_relation": {
+          "alias": "accepted_values_customers_first_name__Jane",
+          "database": "postgres",
+          "relation_name": "",
+          "schema": "public_dbt_test__audit"
+        },
+        "node_started_at": "2024-12-17T10:03:22.210376",
+        "node_status": "skipped",
+        "resource_type": "test",
+        "unique_id": "test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312"
+      },
+      "run_result": {
+        "adapter_response": { },
+        "execution_time": 0,
+        "message": "",
+        "num_failures": 0,
+        "status": "skipped",
+        "thread": "Thread-1 (worker)",
+        "timing_info": [ ]
+      }
+    },
+    "info": {
+      "category": "",
+      "code": "Q025",
+      "extra": { },
+      "invocation_id": "899a81ce-1512-451a-b34a-480863ac4005",
+      "level": "debug",
+      "msg": "Finished running node test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312",
+      "name": "NodeFinished",
+      "pid": 841,
+      "thread": "Thread-1 (worker)",
+      "ts": "2024-12-17T10:03:22.805536Z"
+    }
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/skipped_test_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/skipped_test_NodeFinished_OL.yaml
@@ -1,0 +1,260 @@
+[
+  {
+    "eventTime":"2024-11-22T15:58:03.518877Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "dbt_version":{
+          "version":"1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"dbt-run-jaffle_shop",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"JOB"
+        }
+      }
+    },
+    "eventType":"START",
+    "inputs":[ ],
+    "outputs":[ ]
+  },
+  {
+    "eventTime":"2024-12-17T10:03:22.210376Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version":{
+          "version":"1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"TEST"
+        }
+      }
+    },
+    "eventType":"START",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"This is a unique identifier for a customer",
+                "fields":[ ]
+              },
+              {
+                "name":"first_name",
+                "type":"",
+                "description":"Customer's first name. PII.",
+                "fields":[ ]
+              },
+              {
+                "name":"last_name",
+                "type":"",
+                "description":"Customer's last name. PII.",
+                "fields":[ ]
+              },
+              {
+                "name":"first_order",
+                "type":"",
+                "description":"Date (UTC) of a customer's first order",
+                "fields":[ ]
+              },
+              {
+                "name":"most_recent_order",
+                "type":"",
+                "description":"Date (UTC) of a customer's most recent order",
+                "fields":[ ]
+              },
+              {
+                "name":"number_of_orders",
+                "type":"",
+                "description":"Count of the number of orders a customer has placed",
+                "fields":[ ]
+              },
+              {
+                "name":"total_order_amount",
+                "type":"",
+                "description":"Total value (AUD) of a customer's orders",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":"This table has basic information about a customer, as well as some derived facts based on a customer's orders"
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public_dbt_test__audit.accepted_values_customers_first_name__Jane",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  },
+  {
+    "eventTime":"2024-12-17T10:03:22.210376Z",
+    "run":{
+      "runId":"{{ any(result) }}",
+      "facets":{
+        "parent":{
+          "run":{
+            "runId":"{{ any(result) }}"
+          },
+          "job":{
+            "namespace":"dbt-test-namespace",
+            "name":"dbt-run-jaffle_shop"
+          }
+        },
+        "dbt_version":{
+          "version":"1.8.2"
+        }
+      }
+    },
+    "job":{
+      "namespace":"dbt-test-namespace",
+      "name":"test.jaffle_shop.accepted_values_customers_first_name__Jane.21e890a312",
+      "facets":{
+        "jobType":{
+          "processingType":"BATCH",
+          "integration":"DBT",
+          "jobType":"TEST"
+        }
+      }
+    },
+    "eventType":"ABORT",
+    "inputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public.customers",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[
+              {
+                "name":"customer_id",
+                "type":"",
+                "description":"This is a unique identifier for a customer",
+                "fields":[ ]
+              },
+              {
+                "name":"first_name",
+                "type":"",
+                "description":"Customer's first name. PII.",
+                "fields":[ ]
+              },
+              {
+                "name":"last_name",
+                "type":"",
+                "description":"Customer's last name. PII.",
+                "fields":[ ]
+              },
+              {
+                "name":"first_order",
+                "type":"",
+                "description":"Date (UTC) of a customer's first order",
+                "fields":[ ]
+              },
+              {
+                "name":"most_recent_order",
+                "type":"",
+                "description":"Date (UTC) of a customer's most recent order",
+                "fields":[ ]
+              },
+              {
+                "name":"number_of_orders",
+                "type":"",
+                "description":"Count of the number of orders a customer has placed",
+                "fields":[ ]
+              },
+              {
+                "name":"total_order_amount",
+                "type":"",
+                "description":"Total value (AUD) of a customer's orders",
+                "fields":[ ]
+              }
+            ]
+          },
+          "documentation":{
+            "description":"This table has basic information about a customer, as well as some derived facts based on a customer's orders"
+          },
+          "dataQualityAssertions":{
+            "assertions":[
+              {
+                "assertion":"accepted_values",
+                "success":false,
+                "column":"first_name"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "namespace":"postgres://postgres:5432",
+        "name":"postgres.public_dbt_test__audit.accepted_values_customers_first_name__Jane",
+        "facets":{
+          "dataSource":{
+            "name":"postgres://postgres:5432",
+            "uri":"postgres://postgres:5432"
+          },
+          "schema":{
+            "fields":[ ]
+          },
+          "documentation":{
+            "description":""
+          }
+        },
+        "outputFacets":{ }
+      }
+    ]
+  }
+]

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -311,6 +311,12 @@ def test_dataset_namespace(target, expected_dataset_namespace, monkeypatch):
             "NodeFinished",
             "./tests/dbt/structured_logs/postgres/test/target/manifest.json",
         ),
+        (
+            "./tests/dbt/structured_logs/postgres/events/logs/skipped_test_NodeFinished.yaml",
+            "./tests/dbt/structured_logs/postgres/events/results/skipped_test_NodeFinished_OL.yaml",
+            "NodeFinished",
+            "./tests/dbt/structured_logs/postgres/test/target/manifest.json",
+        ),
     ],
     ids=[
         "MainReportVersion",
@@ -324,6 +330,7 @@ def test_dataset_namespace(target, expected_dataset_namespace, monkeypatch):
         "failed_SQLQueryStatus",
         "failed_test_NodeFinished",
         "successful_test_NodeFinished",
+        "skipped_test_NodeFinished",
     ],
 )
 def test_parse_dbt_events(dbt_log_events, expected_ol_events, dbt_event_type, manifest_path, monkeypatch):


### PR DESCRIPTION
### Problem

Some dbt nodes can be skipped. Their `finished_at` field is then empty. It's causing exceptions. 

### Solution

Here we handle the case where dbt nodes are skipped by doing the following:
1. Take the `started_at` as the `finished_at` value
2. Put `ABORT` as the the OL event type


#### One-line summary:

Handle skipped dbt nodes

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project