### PR TITLE
Spark - input duplicates for subquery alias

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkDeltaIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -446,6 +447,13 @@ class SparkDeltaIntegrationTest {
         mockServer,
         "pysparkV2MergeIntoDeltaTableStartEvent.json",
         "pysparkV2MergeIntoDeltaTableCompleteEvent.json");
+
+    assertThat(
+            MockServerUtils.getEventsEmitted(mockServer).stream()
+                .map(e -> e.getInputs().size())
+                .collect(Collectors.toList()))
+        .describedAs("Number of inputs in each event")
+        .containsOnly(0, 1, 2);
   }
 
   @Test

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/SubqueryAliasInputDatasetBuilder.java
@@ -32,8 +32,8 @@ public class SubqueryAliasInputDatasetBuilder
 
   @Override
   protected List<InputDataset> apply(SparkListenerEvent event, SubqueryAlias x) {
-    return delegate(
-            context.getInputDatasetQueryPlanVisitors(), context.getInputDatasetBuilders(), event)
+    // this should not run query visitors again
+    return delegate(Collections.emptyList(), context.getInputDatasetBuilders(), event)
         .applyOrElse(
             x.child(),
             ScalaConversionUtils.toScalaFn((lp) -> Collections.<InputDataset>emptyList()))


### PR DESCRIPTION
Closes: https://github.com/OpenLineage/OpenLineage/issues/3529

Subquery alias seems to be duplicating inputs. Turning off `SubqueryAliasInputDatasetBuilder` seems to be solving the issue. However, it was introduced to support some marge into scenario for delta.

Solution: Subquery alias input builder should not delegate input visitors.