### PR TITLE
spark: catch Java 17 add opens exception

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java
@@ -47,7 +47,7 @@ public final class SparkOpenLineageExtensionVisitorWrapper {
       "io.openlineage.spark.extension.OpenLineageExtensionProvider";
 
   private static ByteBuffer providerClassBytes;
-  private static boolean providerFailWarned = false;
+  private static boolean providerFailWarned;
 
   static {
     try {


### PR DESCRIPTION
In Java 17 on EMR, not catching this causes

```
25/03/13 13:00:48 ERROR SparkOpenLineageExtensionVisitorWrapper: jdk.internal.loader.ClassLoaders$AppClassLoader@2b2fa4f7: Failed to load OpenLineageExtensionProvider class 
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.security.SecureClassLoader.defineClass(java.lang.String,java.nio.ByteBuffer,java.security.CodeSource) accessible: module java.base does not "opens java.security" to unnamed module @6f6e219e
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354) ~[?:?]
	at java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) ~[?:?]
	at java.lang.reflect.Method.checkCanSetAccessible(Method.java:200) ~[?:?]
	at java.lang.reflect.Method.setAccessible(Method.java:194) ~[?:?]
	at io.openlineage.spark.shaded.org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:830) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.shaded.org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:793) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper.lambda$loadProviderToAvailableClassloaders$6(SparkOpenLineageExtensionVisitorWrapper.java:281) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper.loadProviderToAvailableClassloaders(SparkOpenLineageExtensionVisitorWrapper.java:278) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper.init(SparkOpenLineageExtensionVisitorWrapper.java:232) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper.<init>(SparkOpenLineageExtensionVisitorWrapper.java:76) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.lifecycle.ContextFactory.createSparkApplicationExecutionContext(ContextFactory.java:59) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.OpenLineageSparkListener.getSparkApplicationExecutionContext(OpenLineageSparkListener.java:263) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.OpenLineageSparkListener.lambda$onApplicationStart$20(OpenLineageSparkListener.java:334) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.client.circuitBreaker.NoOpCircuitBreaker.run(NoOpCircuitBreaker.java:27) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
	at io.openlineage.spark.agent.OpenLineageSparkListener.onApplicationStart(OpenLineageSparkListener.java:332) ~[openlineage-spark_2.12-1.29.0.jar:1.29.0]
...
```

We can't catch the actual `java.lang.reflect.InaccessibleObjectException` because it was added in Java 9.