### PR TITLE
Update TSC meeting RSVP link to use Zoom LFX platform

### DIFF
--- a/website/src/pages/meetings/index.mdx
+++ b/website/src/pages/meetings/index.mdx
@@ -20,7 +20,7 @@ TSC Meetings
 <p className="text-2xl">The OpenLineage Technical Steering Committee meets monthly on the third Wednesday from 9:30am to 10:30am US Pacific.</p>
 <p>TSC meetings are open to all who RSVP. During them, we review recent releases, hear from contributors of major new developments, and feature guest speakers on various topics of interest to the community.</p>
 <p>These meetings take place on Zoom. Meetings are recorded and published on the <a href="https://www.youtube.com/@openlineageproject6897/videos">OpenLineage YouTube Channel</a>. Notes for the meeting are published in a page on the <a href="https://wiki.lfaidata.foundation/display/OpenLineage/Monthly+TSC+meeting">OpenLineage Wiki</a>.</p>
-<p>To RSVP, select a meeting from the list or <a href="https://www.addevent.com/calendar/pP575215">click this link</a> (or the Subscribe link at the top of the list) to be invited to the complete series. Once you RSVP, you will receive a calendar invite with the video meeting link and password.</p> 
+<p>To RSVP, select the TSC meeting from the <a href="https://zoom-lfx.platform.linuxfoundation.org/meetings/open-lineage?view=week">OpenLineage calendar</a>.</p> 
 </div>
 <div className="col col--4">
 <AddEvent />


### PR DESCRIPTION
This PR updates the TSC meeting RSVP link from addevent.com to the new Zoom LFX platform link. The change simplifies the RSVP process by directing users to the official OpenLineage calendar on the Linux Foundation platform.