### PR TITLE
Fix User Tags in Event v2 Events

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -42,6 +42,9 @@ Event_v1 = Union[RunEvent, DatasetEvent, JobEvent]
 Event_v2 = Union[event_v2.RunEvent, event_v2.DatasetEvent, event_v2.JobEvent]
 Event = Union[Event_v1, Event_v2]
 
+Run_event = Union[RunEvent, event_v2.RunEvent]
+Run_and_job_event = Union[RunEvent, event_v2.RunEvent, JobEvent, event_v2.JobEvent]
+
 
 @attr.s
 class OpenLineageClientOptions:
@@ -421,12 +424,12 @@ class OpenLineageClient:
         Creates or updates job and run tag facets based on user-supplied environment variables
         """
         tags_job = self.config.tags.job
-        if (isinstance(event, (JobEvent, RunEvent))) and tags_job:
+        if isinstance(event, Run_and_job_event) and tags_job:
             tags_facet = event.job.facets.get("tags", TagsJobFacet())
             event.job.facets["tags"] = self._update_tag_facet(tags_facet, tags_job)  # type: ignore [arg-type]
 
         tags_run = self.config.tags.run
-        if (isinstance(event, RunEvent)) and tags_run:
+        if isinstance(event, Run_event) and tags_run:
             tags_facet = event.run.facets.get("tags", TagsRunFacet())
             event.run.facets["tags"] = self._update_tag_facet(tags_facet, tags_run)  # type: ignore [arg-type]
 

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -421,21 +421,20 @@ class OpenLineageClient:
         Creates or updates job and run tag facets based on user-supplied environment variables
         """
         run_event_types = (RunEvent, event_v2.RunEvent)
-        run_and_job_event_types = (
-            RunEvent,
-            event_v2.RunEvent,
-            JobEvent,
-            event_v2.JobEvent
-        )
+        run_and_job_event_types = (RunEvent, event_v2.RunEvent, JobEvent, event_v2.JobEvent)
         tags_job = self.config.tags.job
         if isinstance(event, run_and_job_event_types) and tags_job:
+            # Ensure facets exists
+            event.job.facets = {} if not event.job.facets else event.job.facets
             tags_facet = event.job.facets.get("tags", TagsJobFacet())
-            event.job.facets["tags"] = self._update_tag_facet(tags_facet, tags_job)  # type: ignore [arg-type]
+            event.job.facets["tags"] = self._update_tag_facet(tags_facet, tags_job)  # type: ignore [arg-type, assignment]
 
         tags_run = self.config.tags.run
         if isinstance(event, run_event_types) and tags_run:
+            # Ensure facets exists
+            event.run.facets = {} if not event.run.facets else event.run.facets
             tags_facet = event.run.facets.get("tags", TagsRunFacet())
-            event.run.facets["tags"] = self._update_tag_facet(tags_facet, tags_run)  # type: ignore [arg-type]
+            event.run.facets["tags"] = self._update_tag_facet(tags_facet, tags_run)  # type: ignore [arg-type, assignment]
 
         return event
 

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -42,9 +42,6 @@ Event_v1 = Union[RunEvent, DatasetEvent, JobEvent]
 Event_v2 = Union[event_v2.RunEvent, event_v2.DatasetEvent, event_v2.JobEvent]
 Event = Union[Event_v1, Event_v2]
 
-Run_event = Union[RunEvent, event_v2.RunEvent]
-Run_and_job_event = Union[RunEvent, event_v2.RunEvent, JobEvent, event_v2.JobEvent]
-
 
 @attr.s
 class OpenLineageClientOptions:
@@ -423,13 +420,20 @@ class OpenLineageClient:
         """
         Creates or updates job and run tag facets based on user-supplied environment variables
         """
+        run_event_types = (RunEvent, event_v2.RunEvent)
+        run_and_job_event_types = (
+            RunEvent,
+            event_v2.RunEvent,
+            JobEvent,
+            event_v2.JobEvent
+        )
         tags_job = self.config.tags.job
-        if isinstance(event, Run_and_job_event) and tags_job:
+        if isinstance(event, run_and_job_event_types) and tags_job:
             tags_facet = event.job.facets.get("tags", TagsJobFacet())
             event.job.facets["tags"] = self._update_tag_facet(tags_facet, tags_job)  # type: ignore [arg-type]
 
         tags_run = self.config.tags.run
-        if isinstance(event, Run_event) and tags_run:
+        if isinstance(event, run_event_types) and tags_run:
             tags_facet = event.run.facets.get("tags", TagsRunFacet())
             event.run.facets["tags"] = self._update_tag_facet(tags_facet, tags_run)  # type: ignore [arg-type]
 


### PR DESCRIPTION
### Problem

User-supplied tags work for V1 events, but not for V2. This is due to faulty type checking . 

### Solution

* Add V2 events to the type checking
* Refactored tests
* Ensured all tests verify V1 and V2 events

#### One-line summary: Fix user-supplied tags missing for V2 events

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project