### PR TITLE
[dbt][structured logs][fix] Read dbt log file incrementally

### DIFF
--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -170,7 +170,7 @@ class IncrementalFileReader:
     def __init__(self, text_file: TextIO):
         self.text_file = text_file
         self.incomplete_line = ""
-        self.chunk_size = 1024
+        self.chunk_size = 4096
 
     def read_lines(self):
         """
@@ -191,5 +191,5 @@ class IncrementalFileReader:
                     line = []
                     next_line_start = i + 1
 
-            self.incomplete_line = chunk[next_line_start::]
+            self.incomplete_line = chunk[next_line_start:]
             chunk = self.incomplete_line + self.text_file.read(self.chunk_size)

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -163,9 +163,8 @@ def has_lines(text_file: TextIO):
 
 class IncrementalFileReader:
     """
-    The dbt log file is being written to incrementally by the dbt process.
-    this class is responsible of reading the log file.
-    Some lines are written incomplete. This class reads complete lines.
+    dbt process writes to the log file incrementally. Sometimes lines are written incomplete.
+    This class is responsible of reading complete lines only and returns them via its methods.
     """
 
     def __init__(self, text_file: TextIO):
@@ -176,7 +175,7 @@ class IncrementalFileReader:
     def read_lines(self):
         """
         This reads as many complete lines as possible.
-        incomplete line chars are saved in the self.incomplete_line
+        incomplete line chars are saved in the incomplete_line member
         """
 
         chunk = self.incomplete_line + self.text_file.read(self.chunk_size)

--- a/integration/common/tests/test_utils.py
+++ b/integration/common/tests/test_utils.py
@@ -172,11 +172,18 @@ def test_remove_command_line_option(command_line, command_option, expected_comma
 )
 def test_incremental_file_reader(incremental_reads, expected_lines):
     class DummyTextFile:
+        """
+        This simulates a text file that reads incomplete lines.
+        """
+
         def __init__(self):
             self.incremental_reads = incremental_reads
             self.i = 0
 
         def read(self, *args, **kwargs):
+            """
+            This simulates incomplete reads.
+            """
             next_read = self.incremental_reads[self.i] if self.i < len(incremental_reads) else ""
             self.i += 1
             return next_read


### PR DESCRIPTION
### Problem

For some reason I don't [know](https://github.com/dbt-labs/dbt-common/blob/e9efd8343ce4dd9e694814716a115cab27e8bcf7/dbt_common/events/event_manager.py#L76) dbt process is writing incomplete JSONs to the dbt log file. 
Consequently, the integration is reading incomplete lines (incomplete JSONs) and it skips some events.
<img width="990" alt="image" src="https://github.com/user-attachments/assets/310a43ac-859d-4d1f-aa91-94e7b8e330b5" />
The resulting error is a `KeyError`. This happens very rarely which suggests that some race condition is causing it.

I added some piggybacks to this PR too.

### Solution

Instead of relying on python's `readlines` I added a class dedicated to reading the log file chunk by chunk. That class only returns complete lines.

#### One-line summary:
Consume only complete lines from dbt log file

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project