### PR TITLE
[spark] Extract column lineage out of query string

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/JdbcSparkUtils.java
@@ -64,12 +64,12 @@ public class JdbcSparkUtils {
                   JdbcDatasetUtils.getDatasetIdentifier(
                       jdbcUrl, dbtm.qualifiedName(), jdbcProperties);
               return datasetFactory.getDataset(
-                  di.getName(), di.getNamespace(), generateJDBCSchema(dbtm, schema, meta));
+                  di.getName(), di.getNamespace(), generateSchemaFromSqlMeta(dbtm, schema, meta));
             })
         .collect(Collectors.toList());
   }
 
-  private static StructType generateJDBCSchema(
+  public static StructType generateSchemaFromSqlMeta(
       DbTableMeta origin, StructType schema, SqlMeta sqlMeta) {
     StructType originSchema = new StructType();
     for (StructField f : schema.fields()) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ExpressionDependencyCollector.java
@@ -19,6 +19,7 @@ import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.ExpressionDependencyVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.IcebergMergeIntoDependencyVisitor;
 import io.openlineage.spark3.agent.lifecycle.plan.column.visitors.UnionDependencyVisitor;
+import io.openlineage.spark3.agent.utils.ExtensionDataSourceV2Utils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -62,6 +63,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Union;
 import org.apache.spark.sql.catalyst.plans.logical.Window;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.Seq;
@@ -155,6 +157,9 @@ public class ExpressionDependencyCollector {
       if (((LogicalRelation) node).relation() instanceof JDBCRelation) {
         JdbcColumnLineageCollector.extractExpressionsFromJDBC(context, node);
       }
+    } else if (node instanceof DataSourceV2Relation
+        && ExtensionDataSourceV2Utils.hasQueryExtensionLineage((DataSourceV2Relation) node)) {
+      QueryRelationColumnLineageCollector.extractExpressionsFromQuery(context, node);
     }
     expressions.stream()
         .forEach(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollector.java
@@ -17,6 +17,7 @@ import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import io.openlineage.spark3.agent.utils.ExtensionDataSourceV2Utils;
 import io.openlineage.sql.SqlMeta;
 import java.net.URI;
 import java.util.ArrayList;
@@ -72,6 +73,8 @@ public class InputFieldsCollector {
     List<DatasetIdentifier> datasetIdentifiers = extractDatasetIdentifier(context, node);
     if (isJDBCNode(node)) {
       JdbcColumnLineageCollector.extractExternalInputs(context, node, datasetIdentifiers);
+    } else if (isQueryRelationNode(node)) {
+      QueryRelationColumnLineageCollector.extractExternalInputs(context, node);
     } else {
       extractInternalInputs(node, context.getBuilder(), datasetIdentifiers);
     }
@@ -80,6 +83,17 @@ public class InputFieldsCollector {
   private static boolean isJDBCNode(LogicalPlan node) {
     return node instanceof LogicalRelation
         && ((LogicalRelation) node).relation() instanceof JDBCRelation;
+  }
+
+  private static boolean isQueryRelationNode(LogicalPlan node) {
+    if (node instanceof DataSourceV2Relation) {
+      return ExtensionDataSourceV2Utils.hasQueryExtensionLineage((DataSourceV2Relation) node);
+    }
+    if (node instanceof DataSourceV2ScanRelation) {
+      return ExtensionDataSourceV2Utils.hasQueryExtensionLineage(
+          ((DataSourceV2ScanRelation) node).relation());
+    }
+    return false;
   }
 
   private static void extractInternalInputs(
@@ -175,9 +189,7 @@ public class InputFieldsCollector {
   private static List<DatasetIdentifier> extractDatasetIdentifier(
       ColumnLevelLineageContext context, DataSourceV2Relation relation) {
     return DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
-            context.getOlContext(), relation)
-        .map(Collections::singletonList)
-        .orElse(Collections.emptyList());
+        context.getOlContext(), relation);
   }
 
   private static List<DatasetIdentifier> extractDatasetIdentifier(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollector.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollector.java
@@ -1,0 +1,112 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
+import io.openlineage.sql.ColumnLineage;
+import io.openlineage.sql.ColumnMeta;
+import io.openlineage.sql.OpenLineageSql;
+import io.openlineage.sql.SqlMeta;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
+
+public class QueryRelationColumnLineageCollector {
+
+  public static void extractExternalInputs(ColumnLevelLineageContext context, LogicalPlan plan) {
+    if (plan instanceof DataSourceV2ScanRelation) {
+      extractExternalInputs(context, ((DataSourceV2ScanRelation) plan).relation());
+    }
+    if (plan instanceof DataSourceV2Relation) {
+      extractExternalInputs(context, (DataSourceV2Relation) plan);
+    }
+  }
+
+  public static void extractExternalInputs(
+      ColumnLevelLineageContext context, DataSourceV2Relation relation) {
+    String namespace = relation.table().properties().get("openlineage.dataset.namespace");
+    String query = relation.table().properties().get("openlineage.dataset.query");
+    Optional<SqlMeta> optionalSqlMeta =
+        OpenLineageSql.parse(Collections.singletonList(query), namespace);
+    optionalSqlMeta.ifPresent(
+        sqm -> {
+          List<ColumnLineage> columnLineages = sqm.columnLineage();
+          Set<ColumnMeta> inputs =
+              columnLineages.stream()
+                  .flatMap(cl -> cl.lineage().stream())
+                  .collect(Collectors.toSet());
+          columnLineages.forEach(cl -> inputs.remove(cl.descendant()));
+          List<DatasetIdentifier> dis =
+              sqm.inTables().stream()
+                  .map(dbtm -> new DatasetIdentifier(dbtm.qualifiedName(), namespace))
+                  .collect(Collectors.toList());
+          dis.forEach(
+              di ->
+                  inputs.stream()
+                      .filter(
+                          cm ->
+                              cm.origin()
+                                  .map(origin -> origin.qualifiedName().equals(di.getName()))
+                                  .orElse(false))
+                      .forEach(
+                          cm ->
+                              context
+                                  .getBuilder()
+                                  .addInput(context.getBuilder().getMapping(cm), di, cm.name())));
+        });
+  }
+
+  public static void extractExpressionsFromQuery(
+      ColumnLevelLineageContext context, LogicalPlan node) {
+    extractExpressionsFromQuery(
+        context, (DataSourceV2Relation) node, ScalaConversionUtils.fromSeq(node.output()));
+  }
+
+  public static void extractExpressionsFromQuery(
+      ColumnLevelLineageContext context, DataSourceV2Relation relation, List<Attribute> output) {
+    String namespace = relation.table().properties().get("openlineage.dataset.namespace");
+    String query = relation.table().properties().get("openlineage.dataset.query");
+    Optional<SqlMeta> optionalSqlMeta =
+        OpenLineageSql.parse(Collections.singletonList(query), namespace);
+    optionalSqlMeta.ifPresent(
+        meta ->
+            meta.columnLineage()
+                .forEach(
+                    p -> {
+                      ExprId descendantId = getDescendantId(output, p.descendant());
+                      context.getBuilder().addExternalMapping(p.descendant(), descendantId);
+
+                      p.lineage()
+                          .forEach(
+                              e ->
+                                  context
+                                      .getBuilder()
+                                      .addExternalMapping(e, NamedExpression.newExprId()));
+                      if (!p.lineage().isEmpty()) {
+                        p.lineage().stream()
+                            .map(context.getBuilder()::getMapping)
+                            .forEach(eid -> context.getBuilder().addDependency(descendantId, eid));
+                      }
+                    }));
+  }
+
+  private static ExprId getDescendantId(List<Attribute> output, ColumnMeta column) {
+    return output.stream()
+        .filter(e -> e.name().equals(column.name()))
+        .map(NamedExpression::exprId)
+        .findFirst()
+        .orElseGet(NamedExpression::newExprId);
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.spark3.agent.utils;
 
+import static io.openlineage.spark.agent.util.JdbcSparkUtils.generateSchemaFromSqlMeta;
+
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
@@ -19,10 +21,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class DataSourceV2RelationDatasetExtractor {
@@ -38,11 +42,14 @@ public class DataSourceV2RelationDatasetExtractor {
       DataSourceV2Relation relation,
       DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
     OpenLineage openLineage = context.getOpenLineage();
-    Optional<DatasetIdentifier> di = getDatasetIdentifierExtended(context, relation);
-    return di.map(
+    if (ExtensionDataSourceV2Utils.hasQueryExtensionLineage(relation)) {
+      return getQueryDatasets(datasetFactory, relation);
+    }
+    List<DatasetIdentifier> di = getDatasetIdentifierExtended(context, relation);
+    return di.stream()
+        .map(
             identifier -> {
-              if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)
-                  || ExtensionDataSourceV2Utils.hasQueryExtensionLineage(relation)) {
+              if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
                 ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
               } else {
                 TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
@@ -58,8 +65,48 @@ public class DataSourceV2RelationDatasetExtractor {
                   .schema(PlanUtils.schemaFacet(openLineage, relation.schema()))
                   .dataSource(PlanUtils.datasourceFacet(openLineage, identifier.getNamespace()));
 
-              return Collections.singletonList(
-                  datasetFactory.getDataset(identifier, datasetFacetsBuilder));
+              return datasetFactory.getDataset(identifier, datasetFacetsBuilder);
+            })
+        .collect(Collectors.toList());
+  }
+
+  private static <D extends OpenLineage.Dataset> @NotNull List<D> getQueryDatasets(
+      DatasetFactory<D> datasetFactory, DataSourceV2Relation relation) {
+    String namespace = relation.table().properties().get("openlineage.dataset.namespace");
+    String query = relation.table().properties().get("openlineage.dataset.query");
+    Optional<SqlMeta> optionalSqlMeta =
+        OpenLineageSql.parse(Collections.singletonList(query), namespace);
+    return optionalSqlMeta
+        .map(
+            sqm -> {
+              if (sqm.columnLineage().isEmpty()) {
+                int numberOfTables = sqm.inTables().size();
+                return sqm.inTables().stream()
+                    .map(
+                        dbtm -> {
+                          DatasetIdentifier di =
+                              new DatasetIdentifier(dbtm.qualifiedName(), namespace);
+
+                          if (numberOfTables > 1) {
+                            return datasetFactory.getDataset(di.getName(), di.getNamespace());
+                          }
+
+                          return datasetFactory.getDataset(
+                              di.getName(), di.getNamespace(), relation.schema());
+                        })
+                    .collect(Collectors.toList());
+              }
+              return sqm.inTables().stream()
+                  .map(
+                      dbtm -> {
+                        DatasetIdentifier di =
+                            new DatasetIdentifier(dbtm.qualifiedName(), namespace);
+                        return datasetFactory.getDataset(
+                            di.getName(),
+                            di.getNamespace(),
+                            generateSchemaFromSqlMeta(dbtm, relation.schema(), sqm));
+                      })
+                  .collect(Collectors.toList());
             })
         .orElse(Collections.emptyList());
   }
@@ -87,11 +134,11 @@ public class DataSourceV2RelationDatasetExtractor {
                     r.table().properties()));
   }
 
-  public static Optional<DatasetIdentifier> getDatasetIdentifierExtended(
+  public static List<DatasetIdentifier> getDatasetIdentifierExtended(
       OpenLineageContext context, DataSourceV2Relation relation) {
     // Check if the dataset has extension lineage
     if (ExtensionDataSourceV2Utils.hasExtensionLineage(relation)) {
-      return Optional.of(ExtensionDataSourceV2Utils.getDatasetIdentifier(relation));
+      return Collections.singletonList(ExtensionDataSourceV2Utils.getDatasetIdentifier(relation));
     }
 
     if (ExtensionDataSourceV2Utils.hasQueryExtensionLineage(relation)) {
@@ -101,23 +148,27 @@ public class DataSourceV2RelationDatasetExtractor {
               Collections.singletonList(
                   relation.table().properties().get("openlineage.dataset.query")),
               namespace);
-      return sqlMeta.flatMap(
-          meta ->
-              meta.inTables().stream()
-                  .findFirst()
-                  .map(dbtm -> new DatasetIdentifier(dbtm.qualifiedName(), namespace)));
+      return sqlMeta
+          .map(
+              meta ->
+                  meta.inTables().stream()
+                      .map(dbtm -> new DatasetIdentifier(dbtm.qualifiedName(), namespace))
+                      .collect(Collectors.toList()))
+          .orElse(Collections.emptyList());
     }
 
     // Check if the relation identifier is empty
     if (relation.identifier().isEmpty()) {
       log.warn("Couldn't find identifier for dataset in plan {}", relation);
-      return getDatasetIdentifier(context, relation);
+      return getDatasetIdentifier(context, relation)
+          .map(Collections::singletonList)
+          .orElse(Collections.emptyList());
     }
 
     // Check if the catalog is present and is an instance of TableCatalog
     if (relation.catalog().isEmpty() || !(relation.catalog().get() instanceof TableCatalog)) {
       log.warn("Couldn't find catalog for dataset in plan {}", relation);
-      return Optional.empty();
+      return Collections.emptyList();
     }
 
     Identifier identifier = relation.identifier().get();
@@ -125,12 +176,13 @@ public class DataSourceV2RelationDatasetExtractor {
     Map<String, String> tableProperties = relation.table().properties();
 
     // Get the dataset identifier
-    return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+    return PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties)
+        .map(Collections::singletonList)
+        .orElse(Collections.emptyList());
   }
 
   private static Optional<DatasetIdentifier> getDatasetIdentifierFromRelation(
       DataSourceV2Relation relation) {
-
     try {
       return (Optional.of(CatalogUtils3.getDatasetIdentifierFromRelation(relation)));
     } catch (UnsupportedCatalogException ex) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/ExtensionDataSourceV2Utils.java
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 
 /** Utility class to load serialized facets json string into a dataset builder */
 @Slf4j
-class ExtensionDataSourceV2Utils {
+public class ExtensionDataSourceV2Utils {
 
   public static final String OPENLINEAGE_DATASET_FACETS_PREFIX = "openlineage.dataset.facets.";
   private static Map<String, TypeReference> predefinedFacets;

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/InputFieldsCollectorTest.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.rdd.RDD;
@@ -95,7 +94,7 @@ class InputFieldsCollectorTest {
     try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       when(DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
               context.getOlContext(), relation))
-          .thenReturn(Optional.of(di));
+          .thenReturn(Collections.singletonList(di));
       InputFieldsCollector.collect(context, plan);
     }
     verify(builder, times(1)).addInput(exprId, di, SOME_NAME);
@@ -119,7 +118,7 @@ class InputFieldsCollectorTest {
     try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       when(DataSourceV2RelationDatasetExtractor.getDatasetIdentifierExtended(
               context.getOlContext(), relation))
-          .thenReturn(Optional.of(di));
+          .thenReturn(Collections.singletonList(di));
       InputFieldsCollector.collect(context, plan);
     }
     verify(builder, times(1)).addInput(exprId, di, SOME_NAME);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollectorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/QueryRelationColumnLineageCollectorTest.java
@@ -1,0 +1,96 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.sql.ColumnMeta;
+import io.openlineage.sql.DbTableMeta;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class QueryRelationColumnLineageCollectorTest {
+
+  ColumnLevelLineageBuilder builder = mock(ColumnLevelLineageBuilder.class);
+  ColumnLevelLineageContext context = mock(ColumnLevelLineageContext.class);
+  OpenLineageContext openLineageContext = mock(OpenLineageContext.class);
+  DataSourceV2Relation relation = mock(DataSourceV2Relation.class);
+  Table table = mock(Table.class);
+
+  @BeforeEach
+  void setup() {
+    when(relation.table()).thenReturn(table);
+    when(context.getBuilder()).thenReturn(builder);
+    when(context.getOlContext()).thenReturn(openLineageContext);
+  }
+
+  @Test
+  void testInputCollection() {
+    // given
+    ExprId exprId1 = ExprId.apply(1);
+    ExprId exprId2 = ExprId.apply(2);
+    Map<ColumnMeta, ExprId> mockMap = new HashMap();
+    mockMap.put(
+        new ColumnMeta(new DbTableMeta("some-project", "dataset", "t1"), "some_column1"), exprId1);
+    mockMap.put(
+        new ColumnMeta(new DbTableMeta("some-project", "dataset", "t2"), "some_column2"), exprId2);
+
+    when(builder.getMapping(any(ColumnMeta.class)))
+        .thenAnswer(invocation -> mockMap.get(invocation.getArgument(0)));
+    String query =
+        "SELECT t1.some_column1, t2.some_column2 FROM `some-project.dataset.t1` t1 JOIN"
+            + " `some-project.dataset.t2` t2 ON t2.foreign_id = t1.id";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("openlineage.dataset.query", query);
+    String namespace = "bigquery";
+    properties.put("openlineage.dataset.namespace", namespace);
+    when(table.properties()).thenReturn(properties);
+
+    // when
+    QueryRelationColumnLineageCollector.extractExternalInputs(context, relation);
+
+    DatasetIdentifier datasetIdentifier1 =
+        new DatasetIdentifier("some-project.dataset.t1", namespace);
+    DatasetIdentifier datasetIdentifier2 =
+        new DatasetIdentifier("some-project.dataset.t2", namespace);
+
+    // then
+    verify(builder, times(1)).addInput(exprId1, datasetIdentifier1, "some_column1");
+    verify(builder, times(1)).addInput(exprId2, datasetIdentifier2, "some_column2");
+  }
+
+  @Test
+  void testInvalidQuery() {
+    // given
+    String query =
+        "SELECT t3.some_not_existing_column FROM `some-project.dataset.t1` t1 JOIN"
+            + " `some-project.dataset.t2` t2 ON t2.foreign_id = t1.id";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("openlineage.dataset.query", query);
+    properties.put("openlineage.dataset.namespace", "bigquery");
+    when(table.properties()).thenReturn(properties);
+
+    // when
+    QueryRelationColumnLineageCollector.extractExternalInputs(context, relation);
+
+    // then
+    verify(builder, never())
+        .addInput(any(ExprId.class), any(DatasetIdentifier.class), any(String.class));
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractorTest.java
@@ -259,10 +259,5 @@ class DataSourceV2RelationDatasetExtractorTest {
     assertThat(result.get(0))
         .hasFieldOrPropertyWithValue("name", "bigquery-public-data.samples.shakespeare")
         .hasFieldOrPropertyWithValue("namespace", "bigquery");
-
-    OpenLineage.DatasetFacet datasetFacet =
-        result.get(0).getFacets().getAdditionalProperties().get("customFacet");
-    assertThat(datasetFacet.getAdditionalProperties())
-        .hasFieldOrPropertyWithValue("property", "value");
   }
 }


### PR DESCRIPTION
### Problem

The solution for parsing query passed by `DataSourcev2Relation` properties, didn't provide column lineage.

Closes: #3484

### Solution

Adds column lineage for queries passed by `openlineage.dataset.query` property.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project