### PR TITLE
[Java] Fix Oracle thin JDBC URL normalization

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -52,8 +52,8 @@ public class OracleJdbcExtractor implements JdbcExtractor {
     }
     List<String> components = Arrays.stream(uri.split(":")).collect(Collectors.toList());
     String last = components.remove(components.size() - 1);
-    if (last.contains("]") || last.matches("^\\d+$")) {
-      // '[ip:v:6]' or 'host:1521'
+    if (last.contains("]") || last.matches("^\\d+$") || last.contains("/")) {
+      // '[ip:v:6]' or 'host:1521' or 'host:1521/serviceName'
       return uri;
     }
     // 'host:1521:sid' -> 'host:1521/sid'

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -121,6 +121,12 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@//hostname/serviceName", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
         .hasFieldOrPropertyWithValue("name", "serviceName.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@//hostname:1522/serviceName", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
+        .hasFieldOrPropertyWithValue("name", "serviceName.schema.table1");
   }
 
   @Test
@@ -129,6 +135,12 @@ class JdbcDatasetUtilsTestForOracle {
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:oracle:thin:@hostname:sid", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1521")
+        .hasFieldOrPropertyWithValue("name", "sid.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@hostname:1522:sid", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "sid.schema.table1");
   }
 


### PR DESCRIPTION
### Problem

`OracleJDBCUtils` successfully parsed URLs containing either port number `jdbc:oracle:thin:@//host/ORCL` or service name `jdbc:oracle:thin:@//host:1521`, but not both at the same time, e.g. `jdbc:oracle:thin:@//host:1521/ORCL`.
This lead to producing wrong dataset namespace and name - `oracle://host` and `1521/ORCL.schema.table` instead of `oracle://host:1521` and `ORCL.schema.table`

Closes: #3581

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Fix OpenLineage Java client producing wrong dataset namespace and name for Oracle Thin JDBC URLs.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project