### PR TITLE
[CI] Fix run-pmd.sh on non-CI environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,17 +169,17 @@ repos:
         require_serial: true
       - id: spotless-client-java
         name: spotless-client-java
-        description: "Runs the Spotless formatter."
+        description: "Runs the Spotless formatter - Java client."
         language: system
-        entry: bash -c "cd client/java && ./gradlew spotlessApply"
+        entry: .pre_commit/run-spotless.sh --java-version 17 --location client/java
         files: ^client/java/src/.*\.java$
         exclude: ".*test.*"
         pass_filenames: false
       - id: spotless-integration-spark
         name: spotless-integration-spark
-        description: "Runs the Spotless formatter for Spark."
+        description: "Runs the Spotless formatter - Spark."
         language: system
-        entry: bash -c "cd integration/spark && ./gradlew spotlessApply"
+        entry: .pre_commit/run-spotless.sh --java-version 17 --location integration/spark
         files: ^integration/spark/.*\.java$
         exclude: ".*test.*"
         pass_filenames: false

--- a/.pre_commit/run-pmd.sh
+++ b/.pre_commit/run-pmd.sh
@@ -5,7 +5,6 @@
 
 set -e
 
-source "$(dirname "${BASH_SOURCE[0]}")/set-java-version.sh"
 JAVA_VERSION=${JAVA_VERSION:-17}
 RULESET_FILE=${RULESET_FILE:-client/java/pmd-openlineage.xml}
 
@@ -24,7 +23,6 @@ for arg in "$@"; do
 done
 
 echo "Using Java version: $JAVA_VERSION"
-
 source "$(dirname "${BASH_SOURCE[0]}")/set-java-version.sh"
 set_java_version "$JAVA_VERSION"
 

--- a/.pre_commit/run-spotless.sh
+++ b/.pre_commit/run-spotless.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+JAVA_VERSION=${JAVA_VERSION:-17}
+LOCATION=.
+
+# Parse command-line arguments
+for arg in "$@"; do
+  case $arg in
+    --java-version)
+      JAVA_VERSION=$2
+      shift 2
+      ;;
+    --location)
+      LOCATION=$2
+      shift 2
+      ;;
+  esac
+done
+
+echo "Using Java version: $JAVA_VERSION"
+source "$(dirname "${BASH_SOURCE[0]}")/set-java-version.sh"
+set_java_version "$JAVA_VERSION"
+
+echo "Changing directory to: $LOCATION"
+cd "$LOCATION"
+./gradlew spotlessApply
+

--- a/.pre_commit/set-java-version.sh
+++ b/.pre_commit/set-java-version.sh
@@ -3,14 +3,17 @@
 # Copyright 2018-2025 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
-# Function to set Java version on Ubuntu
-set_java_version_ubuntu() {
+# Function to get Java home on Ubuntu
+set_java_home_ubuntu() {
   local version="$1"
 
   echo "Setting Java version to $version on Ubuntu..."
   if [ -d "/usr/lib/jvm/java-${version}-openjdk-amd64" ]; then
-    sudo update-alternatives --set java "/usr/lib/jvm/java-${version}-openjdk-amd64/bin/java"
-    sudo update-alternatives --set javac "/usr/lib/jvm/java-${version}-openjdk-amd64/bin/javac"
+    export JAVA_HOME="/usr/lib/jvm/java-${version}-openjdk-amd64"
+    export PATH="${JAVA_HOME}:${PATH}"
+  elif [ -d "/usr/lib/jvm/java-${version}-openjdk" ]; then
+    export JAVA_HOME="/usr/lib/jvm/java-${version}-openjdk"
+    export PATH="${JAVA_HOME}:${PATH}"
   else
     echo "Java version ${version} is not installed on your Ubuntu system."
     exit 1
@@ -18,13 +21,8 @@ set_java_version_ubuntu() {
 }
 
 # Function to set Java version on macOS
-set_java_version_macos() {
+set_java_home_macos() {
   local version="$1"
-  
-  if [[ -n "$JAVA_HOME" && "$JAVA_HOME" =~ $version ]]; then
-    echo "JAVA_HOME is already set to a compatible version: $JAVA_HOME"
-    return 0
-  fi
 
   echo "Setting Java version to $version on macOS..."
 
@@ -37,20 +35,17 @@ set_java_version_macos() {
     exit 1
   fi
 
-  export JAVA_HOME="$java_home_path"
-  echo "JAVA_HOME set to $JAVA_HOME"
-  # Append the JAVA_HOME export to the user's profile if not already set
-  if ! grep -q "export JAVA_HOME=$JAVA_HOME" ~/.bash_profile; then
-    echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bash_profile
-  fi
-
-  # Apply the changes to the current shell session
-  source ~/.bash_profile
+  export JAVA_HOME="$java_home_path";
 }
 
 # Main function to set Java version based on OS
 set_java_version() {
   local version="$1"
+  
+  if [[ -n "$JAVA_HOME" && "$JAVA_HOME" =~ $version ]]; then
+    echo "JAVA_HOME is already set to a compatible version: $JAVA_HOME"
+    return 0
+  fi
 
   if [ -z "$version" ]; then
     echo "No Java version specified. Usage: set_java_version <java_version>"
@@ -64,10 +59,10 @@ set_java_version() {
 
   case "$os_name" in
     Linux*)
-      set_java_version_ubuntu "$version"
+      set_java_home_ubuntu "$version"
       ;;
     Darwin*)
-      set_java_version_macos "$version"
+      set_java_home_macos "$version"
       ;;
     *)
       echo "Unsupported operating system: $os_name"


### PR DESCRIPTION
### Problem

`pdm-client-java` and other PDM checks in pre-commit are failing on my local machine. Fixing them.

Closes: #3587

### Solution

Update `set-java-version.sh`:
* If JAVA_HOME is already set to expected version, do nothing
* Instead of calling `sudo update-alternatives`, just prepend Java bin folder to `PATH` env variable, and set `JAVA_HOME`. `pdm.sh` just calls `java ...`, so this should be enough.
* Instead of adding `export JAVA_HOME=...` to `~/.bash_profile` on MacOS, just pass this environment variable to child processes, like `pdm.sh`.
* Add alternative path for searching Java home (without `-amd64` suffix).

Also added `run-spotless.sh` with same fix applied, but for Spotless instead of PMD.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project