### PR TITLE
close circuit breakers

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -315,6 +315,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
 
   /** To close the underlying resources. */
   public static void close() {
+    circuitBreaker.close();
     clear();
   }
 


### PR DESCRIPTION
Circuit breakers should be `closed` when Spark listener closes. 