### PR TITLE
Fix metrics sent through DebugFacet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.29.0...HEAD)
 
+### Fixed
+* **Spark: fix internal metrics sent through DebugFacet.** [`#3594`](https://github.com/OpenLineage/OpenLineage/pull/3594) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)
+  *Register simple micrometer registry when no other registry configured.*
+
 ## [1.30.1](https://github.com/OpenLineage/OpenLineage/compare/1.29.0...1.30.0) - 2025-03-26
 
 ### Fixed

--- a/client/java/src/main/java/io/openlineage/client/transports/FacetsConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/FacetsConfig.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.MergeConfig;
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -167,5 +168,16 @@ public class FacetsConfig implements MergeConfig<FacetsConfig> {
               });
     }
     return disabledFacetsSet.toArray(new String[0]);
+  }
+
+  /**
+   * Checks if the facet is enabled. The method checks if a given facet is not in the list of
+   * effectively disabled facets. Useful for checking facets which are disabled by default.
+   *
+   * @param facetName
+   * @return
+   */
+  public boolean isFacetEnabled(String facetName) {
+    return Arrays.stream(getEffectiveDisabledFacets()).noneMatch(facetName::equals);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/transports/FacetsConfigTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/FacetsConfigTest.java
@@ -87,5 +87,8 @@ class FacetsConfigTest {
                 true,
                 "facetG",
                 true));
+
+    assertThat(facetsConfig.isFacetEnabled("facetD")).isFalse();
+    assertThat(facetsConfig.isFacetEnabled("subsystemA.facetE")).isTrue();
   }
 }

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.openlineage.client.Environment;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.circuitBreaker.CircuitBreaker;
@@ -381,6 +382,14 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
   private static void initializeMetrics(OpenLineageConfig<?> openLineageConfig) {
     meterRegistry =
         MicrometerProvider.addMeterRegistryFromConfig(openLineageConfig.getMetricsConfig());
+
+    // register SimpleMeterRegistry if no other registries are present and debug facet is enabled
+    if (((CompositeMeterRegistry) meterRegistry).getRegistries().isEmpty()
+        && openLineageConfig.getFacetsConfig() != null
+        && openLineageConfig.getFacetsConfig().isFacetEnabled("debug")) {
+      ((CompositeMeterRegistry) meterRegistry).add(new SimpleMeterRegistry());
+    }
+
     String disabledFacets;
     if (openLineageConfig.getFacetsConfig() != null
         && openLineageConfig.getFacetsConfig().getDisabledFacets() != null) {
@@ -392,6 +401,7 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     } else {
       disabledFacets = "";
     }
+
     meterRegistry
         .config()
         .commonTags(


### PR DESCRIPTION
DebugFacet contains only zero valued metrics if no micrometer-registry is declared. 