### PR TITLE
[Java] Added support for LDAP connection strings.

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -80,10 +80,7 @@ public class OracleJdbcExtractor implements JdbcExtractor {
     String firstLdapUri = null;
     for (String token : tokens) {
       String lowerToken = token.toLowerCase(Locale.ROOT);
-      if (lowerToken.contains("ldap://")
-          || lowerToken.contains("ldaps://")
-          || lowerToken.contains("ldap:")
-          || lowerToken.contains("ldaps:")) {
+      if (lowerToken.contains("ldap:") || lowerToken.contains("ldaps:")) {
         // In case a prefix like "jdbc:oracle:thin:@" exists, take the substring starting from
         // "ldap"
         int idx = lowerToken.indexOf("ldap");

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -38,6 +38,7 @@ public class OracleJdbcExtractor implements JdbcExtractor {
     return extractUri(uri, properties);
   }
 
+  @SuppressWarnings("PMD")
   private JdbcLocation extractUri(String uri, Properties properties) throws URISyntaxException {
     // Handle LDAP connection strings, including cases with multiple LDAP URIs
     if (uri.toLowerCase(Locale.ROOT).contains("ldap")) {
@@ -72,15 +73,19 @@ public class OracleJdbcExtractor implements JdbcExtractor {
    * @param uri The original URI string that might contain LDAP connection information
    * @return A normalized URI with host/port and database name extracted from the LDAP string
    */
+  @SuppressWarnings("PMD")
   private String handleLdapConnectionString(String uri) {
     // Split original URI by whitespace to cover scenarios with multiple LDAP URIs
     String[] tokens = uri.split("\\\\s+");
     String firstLdapUri = null;
     for (String token : tokens) {
       String lowerToken = token.toLowerCase(Locale.ROOT);
-      if (lowerToken.contains("ldap://") || lowerToken.contains("ldaps://") ||
-              lowerToken.contains("ldap:") || lowerToken.contains("ldaps:")) {
-        // In case a prefix like "jdbc:oracle:thin:@" exists, take the substring starting from "ldap"
+      if (lowerToken.contains("ldap://")
+          || lowerToken.contains("ldaps://")
+          || lowerToken.contains("ldap:")
+          || lowerToken.contains("ldaps:")) {
+        // In case a prefix like "jdbc:oracle:thin:@" exists, take the substring starting from
+        // "ldap"
         int idx = lowerToken.indexOf("ldap");
         firstLdapUri = token.substring(idx);
         break;
@@ -88,21 +93,21 @@ public class OracleJdbcExtractor implements JdbcExtractor {
     }
 
     if (firstLdapUri != null) {
-      String withoutPrefix = firstLdapUri.replaceFirst("(?i)ldaps?:(//)?/*", "");
+      String withoutPrefix = firstLdapUri.replaceFirst("(?i)ldaps?:(//)?", "");
 
-        // Split the string by "/" into all segments.
-        // The first segment is the host:port and the last segment is the database name.
-        String[] parts = withoutPrefix.split("/");
-        if (parts.length >= 1) {
-          String hostPort = parts[0];
-          String dbName = "";
-          if (parts.length > 1) {
-            // Use the last segment as the database name.
-            dbName = parts[parts.length - 1].split(",")[0];
-          }
-          // Normalize the URI for further processing.
-          return hostPort + "/" + dbName;
+      // Split the string by "/" into all segments.
+      // The first segment is the host:port and the last segment is the database name.
+      String[] parts = withoutPrefix.split("/");
+      if (parts.length >= 1) {
+        String hostPort = parts[0];
+        String dbName = "";
+        if (parts.length > 1) {
+          // Use the last segment as the database name.
+          dbName = parts[parts.length - 1].split(",")[0];
         }
+        // Normalize the URI for further processing.
+        return hostPort + "/" + dbName;
+      }
     }
 
     return uri;

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OracleJdbcExtractor.java
@@ -39,6 +39,17 @@ public class OracleJdbcExtractor implements JdbcExtractor {
   }
 
   private JdbcLocation extractUri(String uri, Properties properties) throws URISyntaxException {
+    // Handle LDAP connection strings
+    if (uri.toLowerCase(Locale.ROOT).startsWith("ldap://")) {
+      String[] ldapParts = uri.split("/", 4);
+      if (ldapParts.length >= 3) {
+        String hostPort = ldapParts[2];
+        String dbName = ldapParts.length > 3 ? ldapParts[3].split(",")[0] : "";
+        // Convert to a normalized form that can be processed by OverridingJdbcExtractor
+        uri = hostPort + "/" + dbName;
+      }
+    }
+
     // convert 'tcp://'' protocol to 'oracle://'', convert ':sid' format to '/sid'
     String normalizedUri = uri.replaceFirst(PROTOCOL_PART, "");
     normalizedUri = SCHEME + "://" + fixSidFormat(normalizedUri);

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -244,44 +244,58 @@ class JdbcDatasetUtilsTestForOracle {
   void testGetDatasetIdentifierWithLDAPFormat() {
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                "jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com", "schema.table1", new Properties()))
+                "jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com",
+                "schema.table1",
+                new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://oid:5000")
         .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap:ldap.example.com:5000/mydb1,cn=OracleContext,dc=com", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldap:ldap.example.com:5000/mydb1,cn=OracleContext,dc=com",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldap.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldaps:ldaps.example.com:5000/mydb1,cn=OracleContext,dc=com", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldaps.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldaps:ldaps.example.com:5000/mydb1,cn=OracleContext,dc=com",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldaps.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
 
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+                "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -127,12 +127,6 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@//hostname:1522/serviceName", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "serviceName.schema.table1");
-
-    assertThat(
-            JdbcDatasetUtils.getDatasetIdentifier(
-                    "jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com", "schema.table1", new Properties()))
-            .hasFieldOrPropertyWithValue("namespace", "oracle://oid:5000")
-            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
   }
 
   @Test
@@ -244,5 +238,50 @@ class JdbcDatasetUtilsTestForOracle {
             "namespace",
             "oracle:oci@(DESCRIPTION= (ADDRESS_LIST= (LOAD_BALANCE=ON) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver1)(PORT=1521)) (ADDRESS=(PROTOCOL=tcp)(HOST=salesserver2)(PORT=1522))(ADDRESS=(PROTOCOL=tcp)(HOST=salesserver3)(PORT=1522)))(CONNECT_DATA=(SERVICE_NAME=sales.us.example.com)))")
         .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithLDAPFormat() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oracle://oid:5000")
+        .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap:ldap.example.com:5000/mydb1,cn=OracleContext,dc=com", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldaps:ldaps.example.com:5000/mydb1,cn=OracleContext,dc=com", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldaps.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap://ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap://ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap:ldap1.example.com:5000/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap2.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1 ldap:ldap3.example.com:3500/cn=salesdept,cn=OracleContext,dc=com/mydb1", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://ldap1.example.com:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOracle.java
@@ -127,6 +127,12 @@ class JdbcDatasetUtilsTestForOracle {
                 "jdbc:oracle:thin:@//hostname:1522/serviceName", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "oracle://hostname:1522")
         .hasFieldOrPropertyWithValue("name", "serviceName.schema.table1");
+
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                    "jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com", "schema.table1", new Properties()))
+            .hasFieldOrPropertyWithValue("namespace", "oracle://oid:5000")
+            .hasFieldOrPropertyWithValue("name", "mydb1.schema.table1");
   }
 
   @Test


### PR DESCRIPTION
### Problem

OracleJDBCUtils does not currently support parsing Oracle LDAP connection strings. This leads to producing the wrong dataset namespace and name.

Closes: https://github.com/OpenLineage/OpenLineage/issues/3581

### Solution

See One-line summary :)

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Fix OpenLineage Java client producing wrong dataset namespace and name for Oracle Thin JDBC LDAP URLs.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project