### PR TITLE
Log event json in debug mode before checks

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -163,6 +163,11 @@ class OpenLineageClient:
         if type(event) not in get_args(Event):
             msg = "`emit` only accepts RunEvent, DatasetEvent, JobEvent classes"
             raise ValueError(msg)
+        
+        if log.isEnabledFor(logging.DEBUG):
+            val = Serde.to_json(event).encode("utf-8")
+            log.debug("OpenLineageClient will *try* to emit event %s", val)
+            
         if not self.transport:
             log.error("Tried to emit OpenLineage event, but transport is not configured.")
             return
@@ -176,9 +181,6 @@ class OpenLineageClient:
         event = self.add_environment_facets(event)
         event = self.update_event_tags_facets(event)
 
-        if log.isEnabledFor(logging.DEBUG):
-            val = Serde.to_json(event).encode("utf-8")
-            log.debug("OpenLineageClient will emit event %s", val)
         self.transport.emit(event)
         log.debug("OpenLineage event successfully emitted.")
 

--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -163,11 +163,11 @@ class OpenLineageClient:
         if type(event) not in get_args(Event):
             msg = "`emit` only accepts RunEvent, DatasetEvent, JobEvent classes"
             raise ValueError(msg)
-        
+
         if log.isEnabledFor(logging.DEBUG):
             val = Serde.to_json(event).encode("utf-8")
             log.debug("OpenLineageClient will *try* to emit event %s", val)
-            
+
         if not self.transport:
             log.error("Tried to emit OpenLineage event, but transport is not configured.")
             return


### PR DESCRIPTION
Currently, the debug logging of event json is missed due to checks like no transport setup or OL disabled etc. But when debug is enabled, its ideal to get the event json regardless of above checks. The refactor fixes this with a catch that the logs now adds **try** to let the user know that it is being tried and each of the failure/filter scenarios has a clear log that OL event won't be emitted or otherwise.


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project