### PR TITLE
[Java] Use parent.root facet as a primary source for Kafka messageKey

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -37,18 +37,43 @@ public final class KafkaTransport extends Transport {
       return null;
     }
 
+    /*
+      To keep order of events in Kafka topic, we need to send them to the same partition.
+      This is the case for:
+        1. different runs of the same job.
+        2. runs in the chain parent -> child -> grandchild.
+
+      For (1) Kafka messageKey has format "run:<namespace>/<name>".
+      For (2) source for `<namespace>` and `<name>` is selected using this order:
+      - run.facets.parent.root.job
+      - run.facets.parent.job
+      - run.job
+    */
+    String defaultResult = "run:" + job.getNamespace() + "/" + job.getName();
+
     final OpenLineage.RunFacets runFacets = run.getFacets();
-    if (runFacets != null) {
-      final OpenLineage.ParentRunFacet parentRunFacet = runFacets.getParent();
-      if (parentRunFacet != null) {
-        final OpenLineage.ParentRunFacetJob parentJob = parentRunFacet.getJob();
-        final OpenLineage.ParentRunFacetRun parentRun = parentRunFacet.getRun();
-        if (parentRun != null && parentJob != null) {
-          return "run:" + parentJob.getNamespace() + "/" + parentJob.getName();
-        }
+    if (runFacets == null) {
+      return defaultResult;
+    }
+
+    final OpenLineage.ParentRunFacet parentFacet = runFacets.getParent();
+    if (parentFacet == null) {
+      return defaultResult;
+    }
+
+    final OpenLineage.ParentRunFacetRoot rootParent = parentFacet.getRoot();
+    if (rootParent != null) {
+      final OpenLineage.RootJob rootJob = rootParent.getJob();
+      if (rootJob != null) {
+        return "run:" + rootJob.getNamespace() + "/" + rootJob.getName();
       }
     }
-    return "run:" + job.getNamespace() + "/" + job.getName();
+
+    final OpenLineage.ParentRunFacetJob parentJob = parentFacet.getJob();
+    if (parentJob == null) {
+      return defaultResult;
+    }
+    return "run:" + parentJob.getNamespace() + "/" + parentJob.getName();
   }
 
   private String getMessageKey(@NonNull OpenLineage.DatasetEvent datasetEvent) {

--- a/client/java/src/test/java/io/openlineage/client/Events.java
+++ b/client/java/src/test/java/io/openlineage/client/Events.java
@@ -55,6 +55,49 @@ public class Events {
     return openLineage.newRunEventBuilder().job(job).run(run).build();
   }
 
+  public static OpenLineage.RunEvent runEventWithRootParent() {
+    OpenLineage openLineage = new OpenLineage(URI.create("http://test.producer"));
+
+    OpenLineage.RootJob rootJob =
+        new OpenLineage.RootJobBuilder().namespace("root-namespace").name("root-job").build();
+    OpenLineage.RootRun rootRun =
+        new OpenLineage.RootRunBuilder()
+            .runId(UUID.fromString("ad0995e1-49f1-432d-92b6-2e2739034c13"))
+            .build();
+
+    OpenLineage.ParentRunFacetRoot rootParent =
+        new OpenLineage.ParentRunFacetRootBuilder().job(rootJob).run(rootRun).build();
+
+    OpenLineage.ParentRunFacetJob parentJob =
+        new OpenLineage.ParentRunFacetJobBuilder()
+            .namespace("parent-namespace")
+            .name("parent-job")
+            .build();
+    OpenLineage.ParentRunFacetRun parentRun =
+        new OpenLineage.ParentRunFacetRunBuilder()
+            .runId(UUID.fromString("d9cb8e0b-a410-435e-a619-da5e87ba8508"))
+            .build();
+    OpenLineage.ParentRunFacet parentRunFacet =
+        openLineage
+            .newParentRunFacetBuilder()
+            .job(parentJob)
+            .run(parentRun)
+            .root(rootParent)
+            .build();
+    OpenLineage.RunFacets runFacets =
+        new OpenLineage.RunFacetsBuilder().parent(parentRunFacet).build();
+
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    OpenLineage.Run run =
+        new OpenLineage.RunBuilder()
+            .runId(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54"))
+            .facets(runFacets)
+            .build();
+
+    return openLineage.newRunEventBuilder().job(job).run(run).build();
+  }
+
   public static OpenLineage.DatasetEvent datasetEvent() {
     OpenLineage.StaticDataset dataset =
         new OpenLineage.StaticDatasetBuilder()


### PR DESCRIPTION
### Problem

For run chain `Airflow DAG -> Airflow Task -> Spark application -> Spark execution`, prefer sending all related events to the same partition, to preserve events order. Introducing `parent.root.job` in #3572 allows to use the starting point of the chain (`Airflow DAG`) to achieve this.

Added the necessary conditions and test for this case.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Prefer `parent.root` facet as a primary source for Kafka messageKey

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project