### PR TITLE
[Python] Use parent.root facet as a primary source for Kafka messageKey

### DIFF
--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Config, Transport
 
 if TYPE_CHECKING:
     from openlineage.client.client import Event
-from openlineage.client.serde import Serde
 
 log = logging.getLogger(__name__)
 

--- a/website/blog/composite-transport/index.mdx
+++ b/website/blog/composite-transport/index.mdx
@@ -69,7 +69,7 @@ HttpConfig httpConfig = new HttpConfig();
 httpConfig.setUrl("http://example.com/api");
 KafkaConfig kafkaConfig = new KafkaConfig();
 KafkaConfig.setTopicName("openlineage.events");
-KafkaConfig.setLocalServerId("some-value");
+KafkaConfig.setMessageKey("some-key");
 
 CompositeConfig compositeConfig = new CompositeConfig(Arrays.asList(
   new HttpTransport(httpConfig),

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -271,6 +271,7 @@ This transport requires the artifact `org.apache.kafka:kafka-clients:3.1.0` (or 
 - `messageKey` - string, key for all Kafka messages produced by transport. Optional, default value described below. Added in v1.13.0.
 
   Default values for `messageKey` are:
+  - `run:{rootJob.namespace}/{rootJob.name}` - for RunEvent with parent facet containing link to `root` job
   - `run:{parentJob.namespace}/{parentJob.name}` - for RunEvent with parent facet
   - `run:{job.namespace}/{job.name}` - for RunEvent
   - `job:{job.namespace}/{job.name}` - for JobEvent
@@ -351,7 +352,7 @@ kafkaProperties.setProperty("value.serializer", "org.apache.kafka.common.seriali
 KafkaConfig kafkaConfig = new KafkaConfig();
 KafkaConfig.setTopicName("openlineage.events");
 KafkaConfig.setProperties(kafkaProperties);
-KafkaConfig.setLocalServerId("some-value");
+KafkaConfig.setMessageKey("some-key");
 
 OpenLineageClient client = OpenLineageClient.builder()
   .transport(
@@ -367,6 +368,7 @@ It is recommended to provide `messageKey` if Job hierarchy is used. It can be an
 hierarchy, like `Airflow task -> Spark application`.
 
 Default values are:
+- `run:{rootJob.namespace}/{rootJob.name}` - for RunEvent with parent facet containing link to `root` job
 - `run:{parentJob.namespace}/{parentJob.name}/{parentRun.id}` - for RunEvent with parent facet
 - `run:{job.namespace}/{job.name}/{run.id}` - for RunEvent
 - `job:{job.namespace}/{job.name}` - for JobEvent
@@ -630,7 +632,7 @@ HttpConfig httpConfig = new HttpConfig();
 httpConfig.setUrl("http://example.com/api");
 KafkaConfig kafkaConfig = new KafkaConfig();
 KafkaConfig.setTopicName("openlineage.events");
-KafkaConfig.setLocalServerId("some-value");
+KafkaConfig.setMessageKey("some-key");
 
 CompositeConfig compositeConfig = new CompositeConfig(Arrays.asList(
   new HttpTransport(httpConfig),

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -332,6 +332,7 @@ It can be installed also by specifying kafka client extension: `pip install open
 - `messageKey` - string, key for all Kafka messages produced by transport. Optional, default value described below. Added in v1.13.0.
 
   Default values for `messageKey` are:
+  - `run:{rootJob.namespace}/{rootJob.name}` - for RunEvent with parent facet containing link to `root` job
   - `run:{parentJob.namespace}/{parentJob.name}` - for RunEvent with parent facet
   - `run:{job.namespace}/{job.name}` - for RunEvent
   - `job:{job.namespace}/{job.name}` - for JobEvent


### PR DESCRIPTION
### Problem

For run chain `Airflow DAG -> Airflow Task -> Custom Python script`, prefer sending all related events to the same partition, to preserve events order. Introducing `parent.root.job` in #3572 allows to use the starting point of the chain (`Airflow DAG`) to achieve this.

Added the necessary conditions and test for this case.
Also covered cases with v1 and v2 client classes, although these could be moved to separated PR.

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

[Python] Prefer `parent.root` facet as a primary source for Kafka messageKey

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project