### PR TITLE
[Java] Generate Kinesis.partitionKey using Run parent facet

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/KafkaTransport.java
@@ -49,7 +49,7 @@ public final class KafkaTransport extends Transport {
       - run.facets.parent.job
       - run.job
     */
-    String defaultResult = "run:" + job.getNamespace() + "/" + job.getName();
+    final String defaultResult = "run:" + job.getNamespace() + "/" + job.getName();
 
     final OpenLineage.RunFacets runFacets = run.getFacets();
     if (runFacets == null) {

--- a/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisTransport.java
+++ b/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisTransport.java
@@ -57,28 +57,71 @@ public class KinesisTransport extends Transport {
     this.listeningExecutor = Executors.newSingleThreadExecutor();
   }
 
+  private String getPartitionKey(@NonNull OpenLineage.RunEvent runEvent) {
+    /*
+      To keep order of events in Kinesis stream, we need to send them to the same partition.
+      This is the case for:
+        1. different runs of the same job.
+        2. runs in the chain parent -> child -> grandchild.
+
+      For (1) Kinesis partitionKey has format "run:<namespace>/<name>".
+      For (2) source for `<namespace>` and `<name>` is selected using this order:
+      - run.facets.parent.root.job
+      - run.facets.parent.job
+      - run.job
+    */
+    final OpenLineage.Run run = runEvent.getRun();
+    final OpenLineage.Job job = runEvent.getJob();
+    final String defaultResult = "run:" + job.getNamespace() + "/" + job.getName();
+
+    final OpenLineage.RunFacets runFacets = run.getFacets();
+    if (runFacets == null) {
+      return defaultResult;
+    }
+
+    final OpenLineage.ParentRunFacet parentFacet = runFacets.getParent();
+    if (parentFacet == null) {
+      return defaultResult;
+    }
+
+    final OpenLineage.ParentRunFacetRoot rootParent = parentFacet.getRoot();
+    if (rootParent != null) {
+      final OpenLineage.RootJob rootJob = rootParent.getJob();
+      if (rootJob != null) {
+        return "run:" + rootJob.getNamespace() + "/" + rootJob.getName();
+      }
+    }
+
+    final OpenLineage.ParentRunFacetJob parentJob = parentFacet.getJob();
+    if (parentJob == null) {
+      return defaultResult;
+    }
+    return "run:" + parentJob.getNamespace() + "/" + parentJob.getName();
+  }
+
+  private String getPartitionKey(@NonNull OpenLineage.DatasetEvent datasetEvent) {
+    final OpenLineage.Dataset dataset = datasetEvent.getDataset();
+    return "dataset:" + dataset.getNamespace() + "/" + dataset.getName();
+  }
+
+  private String getPartitionKey(@NonNull OpenLineage.JobEvent jobEvent) {
+    final OpenLineage.Job job = jobEvent.getJob();
+    return "job:" + job.getNamespace() + "/" + job.getName();
+  }
+
   @Override
   public void emit(@NonNull OpenLineage.RunEvent runEvent) {
-    final String eventAsJson = OpenLineageClientUtils.toJson(runEvent);
-    final OpenLineage.Job job = runEvent.getJob();
-    final String partitionKey = "run:" + job.getNamespace() + "/" + job.getName();
-    emit(eventAsJson, partitionKey);
+    emit(OpenLineageClientUtils.toJson(runEvent), getPartitionKey(runEvent));
   }
 
   @Override
   public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
-    final String eventAsJson = OpenLineageClientUtils.toJson(datasetEvent);
-    final OpenLineage.Dataset dataset = datasetEvent.getDataset();
-    final String partitionKey = "dataset:" + dataset.getNamespace() + "/" + dataset.getName();
-    emit(eventAsJson, partitionKey);
+    emit(OpenLineageClientUtils.toJson(datasetEvent), getPartitionKey(datasetEvent));
   }
 
   @Override
   public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
-    final String eventAsJson = OpenLineageClientUtils.toJson(jobEvent);
-    final OpenLineage.Job job = jobEvent.getJob();
-    final String partitionKey = "job:" + job.getNamespace() + "/" + job.getName();
-    emit(eventAsJson, partitionKey);
+    emit(OpenLineageClientUtils.toJson(jobEvent), getPartitionKey(jobEvent));
   }
 
   private void emit(String eventAsJson, String partitionKey) {


### PR DESCRIPTION
### Problem

Synchronize partitionKey generation algorithm for Kinesis with Kafka implementation. See #3622. 

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

[Java] Use run.parent facet as a primary source for Kinesis partitionKey.

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project