### PR TITLE
define equals for TransformedInput to avoid duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.31.0...HEAD)
 
+### Fixed
+
+* **Spark:** define equals for TransformedInput to avoid duplicates [`#3644`](https://github.com/OpenLineage/OpenLineage/pull/3644) [@tnazarew](https://github.com/tnazarew)
+
 ## [1.31.0](https://github.com/OpenLineage/OpenLineage/compare/1.30.1...1.31.0) - 2025-04-10
 
 ### Added

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/column/ColumnLineageWithTransformationTypesTest.java
@@ -403,6 +403,26 @@ class ColumnLineageWithTransformationTypesTest {
     assertCountDatasetDependencies(facet, 0);
   }
 
+  @Test
+  void simpleQueryMultipleJoinsToSameTable() {
+    createTable("t1", "oder_id;int", "order_date;int", "shipped_date;int");
+    createTable("t2", "date_id;int");
+    OpenLineage.ColumnLineageDatasetFacet facet =
+        getFacetForQuery(
+            getSchemaFacet("oder_id;int", "order_date;int", "shipped_date;int"),
+            "SELECT "
+                + "t1.oder_id, "
+                + "t2alias1.date_id as order_date, "
+                + "t2alias2.date_id as shipped_date "
+                + "FROM t1 "
+                + "LEFT JOIN t2 t2alias1 ON t1.order_date = t2alias1.date_id "
+                + "LEFT JOIN t2 t2alias2 ON t1.shipped_date = t2alias2.date_id "
+                + "WHERE t1.order_date IS NOT NULL "
+                + "AND t1.shipped_date IS NOT NULL");
+    assertCountColumnDependencies(facet, 3);
+    assertCountDatasetDependencies(facet, 6);
+  }
+
   @NotNull
   private OpenLineage.ColumnLineageDatasetFacet getFacetForQuery(
       OpenLineage.SchemaDatasetFacet schemaFacet, String query) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformedInput.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformedInput.java
@@ -26,8 +26,12 @@ public class TransformedInput {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     TransformedInput that = (TransformedInput) o;
     return Objects.equals(input, that.input)
         && Objects.equals(transformationInfo, that.transformationInfo);

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformedInput.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/TransformedInput.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark.agent.lifecycle.plan.column;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,5 +22,19 @@ public class TransformedInput {
 
   public String getName() {
     return input.getFieldName();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TransformedInput that = (TransformedInput) o;
+    return Objects.equals(input, that.input)
+        && Objects.equals(transformationInfo, that.transformationInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(input, transformationInfo);
   }
 }


### PR DESCRIPTION
### Problem

When building CLL for queries with multiple joins with the same table, there are duplicates in dataset dependencies. This happens even though there is deduplication.

### Solution

Define equals method for `TransformedInput` so when the `Input` and `TransformationInfo` objects are equal, it can be register it as duplicate


If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Define equals for `TransformedInput` so deduplication works

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project