### PR TITLE
Prevent initialint Flink1 listener for Flink2

### DIFF
--- a/integration/flink/flink1/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
+++ b/integration/flink/flink1/src/main/java/io/openlineage/flink/OpenLineageFlinkJobListener.java
@@ -8,6 +8,7 @@ package io.openlineage.flink;
 import io.openlineage.flink.api.OpenLineageContext.JobIdentifier;
 import io.openlineage.flink.tracker.OpenLineageContinousJobTracker;
 import io.openlineage.flink.tracker.OpenLineageContinousJobTrackerFactory;
+import io.openlineage.flink.utils.ClassUtils;
 import io.openlineage.flink.utils.JobTypeUtils;
 import io.openlineage.flink.visitor.lifecycle.FlinkExecutionContext;
 import io.openlineage.flink.visitor.lifecycle.FlinkExecutionContextFactory;
@@ -88,6 +89,11 @@ public class OpenLineageFlinkJobListener implements JobListener {
     @Override
     public OpenLineageFlinkJobListener build() {
       Validate.notNull(super.executionEnvironment, "StreamExecutionEnvironment has to be provided");
+      Validate.isTrue(
+          !ClassUtils.hasFlink2Classes(),
+          "OpenLineageFlinkJobListener detected Flink 2 classes. "
+              + "This integration method is not supposed to work with Flink 2 - "
+              + "please check docs https://openlineage.io/docs/next/integrations/flink/flink2");
 
       if (super.jobNamespace == null) {
         super.jobNamespace(

--- a/integration/flink/flink1/src/test/java/io/openlineage/flink/OpenLineageFlinkJobListenerTest.java
+++ b/integration/flink/flink1/src/test/java/io/openlineage/flink/OpenLineageFlinkJobListenerTest.java
@@ -1,0 +1,33 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.flink.utils.ClassUtils;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class OpenLineageFlinkJobListenerTest {
+
+  @Test
+  void testJobListenerFailsForFlink2() {
+    try (MockedStatic<ClassUtils> contextFactory = mockStatic(ClassUtils.class)) {
+      when(ClassUtils.hasFlink2Classes()).thenReturn(true);
+      assertThatThrownBy(
+              () ->
+                  OpenLineageFlinkJobListener.builder()
+                      .executionEnvironment(mock(StreamExecutionEnvironment.class))
+                      .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("OpenLineageFlinkJobListener detected Flink 2 classes.");
+    }
+  }
+}

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ClassUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ClassUtils.java
@@ -48,4 +48,16 @@ public class ClassUtils {
     }
     return false;
   }
+
+  public static boolean hasFlink2Classes() {
+    try {
+      ClassUtils.class
+          .getClassLoader()
+          .loadClass("org.apache.flink.streaming.api.lineage.LineageGraph");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
openlineage-flink package contains two listeners for Flink 1.x and 2.x.
While Flink2 is initiated via configuration, flink1 is started manually through the code. 
This PR prevents initiating Flink1 listener for Flink2. 

Closes #3631 