### PR TITLE
refactor python HTTP transport

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "attrs>=20.0",
   "python-dateutil>=2.8.2",
   "pyyaml>=5.4",
-  "requests>=2.20.0",
+  "requests>=2.32.3",
   "packaging>=21.0",
 ]
 optional-dependencies.kafka = [

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -104,7 +104,7 @@ def test_client_sends_proper_json_with_minimal_run_event() -> None:
     session.post.assert_called_with(
         url="http://example.com/api/v1/lineage",
         data=body,
-        headers={},
+        headers={"Content-Type": "application/json"},
         timeout=5.0,
         verify=True,
     )
@@ -132,7 +132,7 @@ def test_client_sends_proper_json_with_minimal_dataset_event() -> None:
     session.post.assert_called_with(
         url="http://example.com/api/v1/lineage",
         data=body,
-        headers={},
+        headers={"Content-Type": "application/json"},
         timeout=5.0,
         verify=True,
     )
@@ -161,7 +161,7 @@ def test_client_sends_proper_json_with_minimal_job_event() -> None:
     session.post.assert_called_with(
         url="http://example.com/api/v1/lineage",
         data=body,
-        headers={},
+        headers={"Content-Type": "application/json"},
         timeout=5.0,
         verify=True,
     )
@@ -863,6 +863,28 @@ class TestOpenLineageConfigLoader:
                     "tags": {
                         "job": {"a": "b", "c": "d"},
                         "run": {"a": "b", "c": "d"},
+                    }
+                },
+            ),
+            (
+                {
+                    "OPENLINEAGE__TRANSPORT__TYPE": "http",
+                    "OPENLINEAGE__TRANSPORT__URL": "http://localhost:5050",
+                    "OPENLINEAGE__TRANSPORT__RETRY__TOTAL": "5",
+                    "OPENLINEAGE__TRANSPORT__RETRY__BACKOFF_FACTOR": "0.2",
+                    "OPENLINEAGE__TRANSPORT__RETRY__ALLOWED_METHODS": '["GET", "POST"]',
+                    "OPENLINEAGE__TRANSPORT__RETRY__STATUS_FORCELIST": "[500, 502, 503, 504]",
+                },
+                {
+                    "transport": {
+                        "type": "http",
+                        "url": "http://localhost:5050",
+                        "retry": {
+                            "total": 5,
+                            "backoff_factor": 0.2,
+                            "allowed_methods": ["GET", "POST"],
+                            "status_forcelist": [500, 502, 503, 504],
+                        },
                     }
                 },
             ),

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -232,6 +232,13 @@ Allows sending events to HTTP endpoint, using [requests](https://requests.readth
   - `apiKey` - string setting the Authentication HTTP header as the Bearer. Required if `type` is `api_key`.
 - `compression` - string, name of algorithm used by HTTP client to compress request body. Optional, default value `null`, allowed values: `gzip`. Added in v1.13.0.
 - `custom_headers` - dictionary of additional headers to be sent with each request. Optional, default: `{}`.
+- `retry` - dictionary of additional configuration options passed to [`urllib3.util.Retry`](https://urllib3.readthedocs.io/en/1.26.20/reference/urllib3.util.html) object. Added in v1.33.0. Defaults are below; those are non-exhaustive options, but the ones that are set by default. Look at  [`urllib3.util.Retry`](https://urllib3.readthedocs.io/en/1.26.20/reference/urllib3.util.html) options for full reference.
+  - `total` - total number of retries to be attempted. Default is `5`.
+  - `read` - number of retries to be attempted on read errors. Default is `5`.
+  - `connect` - number of retries to be attempted on connection errors. Default is `5`.
+  - `backoff_factor` - a backoff factor to apply between attempts after the second try, default is `0.3`.
+  - `status_forcelist` - a set of integer HTTP status codes that we should force a retry on, default is `[500, 502, 503, 504]`.
+  - `allowed_methods` - a set of HTTP methods that we should retry on, default is `["HEAD", "POST"]`.
 
 #### Behavior
 
@@ -253,6 +260,13 @@ transport:
     type: api_key
     apiKey: f048521b-dfe8-47cd-9c65-0cb07d57591e
   compression: gzip
+  retry:
+    total: 5
+    read: 5
+    connect: 5
+    backoff_factor: 0.3
+    status_forcelist: [500, 502, 503, 504]
+    allowed_methods: ["HEAD", "POST"]
 ```
 
 </TabItem>


### PR DESCRIPTION
- set headers in one place
- set session params in one place
- add default retry config
