### PR TITLE
nit: Improve composite transport logging

### DIFF
--- a/client/python/openlineage/client/transport/console.py
+++ b/client/python/openlineage/client/transport/console.py
@@ -11,6 +11,8 @@ from openlineage.client.transport.transport import Config, Transport
 if TYPE_CHECKING:
     from openlineage.client.client import Event
 
+log = logging.getLogger(__name__)
+
 
 class ConsoleConfig(Config):
     ...
@@ -21,10 +23,9 @@ class ConsoleTransport(Transport):
     config_class = ConsoleConfig
 
     def __init__(self, config: ConsoleConfig) -> None:  # noqa: ARG002
-        self.log = logging.getLogger(__name__)
-        self.log.debug("Constructing OpenLineage transport that will send events to console or logs")
+        log.debug("Constructing OpenLineage transport that will send events to console or logs")
 
     def emit(self, event: Event) -> None:
         # Note: When the logging level is set to DEBUG, the content of events is logged twice:
         # here on the INFO level and in client.py on the DEBUG level for when different transport is used.
-        self.log.info(Serde.to_json(event))
+        log.info(Serde.to_json(event))

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -74,12 +74,7 @@ class KafkaTransport(Transport):
         self.producer = None
         if not self._is_airflow_sqlalchemy:
             self._setup_producer(self.kafka_config.config)
-        log.debug(
-            "Constructing OpenLineage transport that will send events "
-            "to kafka topic `%s` using the following config: %s",
-            self.topic,
-            self.kafka_config,
-        )
+        log.debug("Constructing OpenLineage transport that will send events to kafka topic `%s`", self.topic)
 
     def _get_message_key(self, event: Event) -> str | None:
         if isinstance(event, (DatasetEvent, event_v2.DatasetEvent)):

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -44,6 +44,9 @@ class Transport:
     def emit(self, event: Event) -> Any:
         raise NotImplementedError
 
+    def __str__(self) -> str:
+        return f"<{self.__class__.__name__}(name={self.name}, kind={self.kind})>"
+
 
 class TransportFactory:
     def create(self, config: dict[str, str] | None = None) -> Transport:


### PR DESCRIPTION
### Problem
When using composite transport, it's hard to tell which transport is currently emitting events if they are of the same type. 

### Solution

Added name to __str__ of Transport base class and improved logging in composite transport. Also removed kafka's config from logging as it may contain some sensitive details? Not sure, but it's a dict and not a custom class, so all the key:valu pairs can be logged without masking.

#### One-line summary:
Improve composite transport logging

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project