### PR TITLE
[FLINK] enhance JDBC extractors with more types

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/CrateJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/CrateJdbcExtractor.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+/**
+ * Implementation of {@link JdbcExtractor} for CreateDB.
+ *
+ * @see <a href="https://cratedb.com/docs/jdbc/en/latest/connect.html">CrateDB URL Format</a>
+ */
+public class CrateJdbcExtractor implements JdbcExtractor {
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("crate", "5432");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    return delegate().extract(rawUri, properties);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/Db2JdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/Db2JdbcExtractor.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+/**
+ * Implementation of {@link JdbcExtractor} for DB2.
+ *
+ * @see <a href="https://www.ibm.com/docs/en/db2woc?topic=programmatically-jdbc">DB2 URL Format</a>
+ */
+public class Db2JdbcExtractor implements JdbcExtractor {
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("db2", "6789");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    return delegate().extract(rawUri, properties);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -23,6 +23,10 @@ public class JdbcDatasetUtils {
     new SqlServerJdbcExtractor(),
     new TeradataJdbcExtractor(),
     new DerbyJdbcExtractor(),
+    new CrateJdbcExtractor(),
+    new Db2JdbcExtractor(),
+    new TrinoJdbcExtractor(),
+    new OceanBaseJdbcExtractor(),
     new GenericJdbcExtractor()
   };
 

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/OceanBaseJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/OceanBaseJdbcExtractor.java
@@ -1,0 +1,36 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+/**
+ * Implementation of {@link JdbcExtractor} for OceanBase.
+ *
+ * @see <a
+ *     href="https://en.oceanbase.com/docs/common-oceanbase-connector-j-en-10000000000381036">OceanBase
+ *     URL Format</a>
+ */
+public class OceanBaseJdbcExtractor implements JdbcExtractor {
+  private static final String PROTOCOL_PART = "^[\\w+:]+://";
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("oceanbase", "2881");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    // Schema could be 'oceanbase', 'oceanbase:hamode'. Convert it to 'oceanbase'
+    String normalizedUri = rawUri.replaceFirst(PROTOCOL_PART, "oceanbase://");
+    return delegate().extract(normalizedUri, properties);
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/TrinoJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/TrinoJdbcExtractor.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+/**
+ * Implementation of {@link JdbcExtractor} for Trino.
+ *
+ * @see <a href="https://trino.io/docs/current/client/jdbc.html">Trino URL Format</a>
+ */
+public class TrinoJdbcExtractor implements JdbcExtractor {
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("trino", "443");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    return delegate().isDefinedAt(jdbcUri);
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    return delegate().extract(rawUri, properties);
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForCrate.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForCrate.java
@@ -1,0 +1,50 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForCrate {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:crate://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "crate://test-host.com:5432")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithMultipleHosts() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:crate://test-host.com,test-host2.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "crate://test-host.com:5432,test-host2.com:5432")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIP() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:crate://198.51.100.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "crate://198.51.100.1:5432")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithMultipleIPs() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:crate://198.51.100.1,198.51.100.2", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "crate://198.51.100.1:5432,198.51.100.2:5432")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForDb2.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForDb2.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForDb2 {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:db2://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "db2://test-host.com:6789")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIP() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:db2://198.51.100.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "db2://198.51.100.1:6789")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOceanBase.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForOceanBase.java
@@ -1,0 +1,41 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForOceanBase {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oceanbase://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oceanbase://test-host.com:2881")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithHAModeHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oceanbase:hamode://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oceanbase://test-host.com:2881")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIP() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:oceanbase://198.51.100.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "oceanbase://198.51.100.1:2881")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTrino.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForTrino.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForTrino {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:trino://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "trino://test-host.com:443")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIP() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:trino://198.51.100.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "trino://198.51.100.1:443")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}


### PR DESCRIPTION
#### One-line summary:
Add more JDBC extractor types, including oceanbase, trino, db2.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project