### PR TITLE
spec: add CatalogDatasetFacet

### DIFF
--- a/client/python/openlineage/client/facet_v2.py
+++ b/client/python/openlineage/client/facet_v2.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client.generated import (
+    catalog_dataset,
     column_lineage_dataset,
     data_quality_assertions_dataset,
     data_quality_metrics_input_dataset,
@@ -53,6 +54,7 @@ __all__ = [
     "OutputDatasetFacet",
     "RunFacet",
     "set_producer",
+    "catalog_dataset",
     "column_lineage_dataset",
     "data_quality_assertions_dataset",
     "data_quality_metrics_input_dataset",

--- a/client/python/openlineage/client/generated/catalog_dataset.py
+++ b/client/python/openlineage/client/generated/catalog_dataset.py
@@ -1,0 +1,32 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import attr
+from openlineage.client.generated.base import DatasetFacet
+
+
+@attr.define
+class CatalogDatasetFacet(DatasetFacet):
+    framework: str
+    """The storage framework for which the catalog is configured"""
+
+    type: str
+    """Type of the catalog."""
+
+    name: str
+    """Name of the catalog, as configured in the source system."""
+
+    metadataUri: str | None = attr.field(default=None)  # noqa: N815
+    """URI or connection string to the catalog, if applicable."""
+
+    warehouseUri: str | None = attr.field(default=None)  # noqa: N815
+    """URI or connection string to the physical location of the data that the catalog describes."""
+
+    source: str | None = attr.field(default=None)
+    """Source system where the catalog is configured."""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/CatalogDatasetFacet.json#/$defs/CatalogDatasetFacet"

--- a/client/python/redact_fields.yml
+++ b/client/python/redact_fields.yml
@@ -239,3 +239,7 @@
       redact_fields: []
     - class_name: TagsRunFacet
       redact_fields: []
+- module: catalog_dataset
+  classes:
+    - class_name: CatalogDatasetFacet
+      redact_fields: []

--- a/spec/facets/CatalogDatasetFacet.json
+++ b/spec/facets/CatalogDatasetFacet.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/CatalogDatasetFacet.json",
+  "$defs": {
+    "CatalogDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "framework": {
+              "description": "The storage framework for which the catalog is configured",
+              "type": "string",
+              "example": "iceberg, delta, hive"
+            },
+            "type": {
+              "description": "Type of the catalog.",
+              "type": "string",
+              "example": "jdbc, glue, polaris"
+            },
+            "name": {
+              "description": "Name of the catalog, as configured in the source system.",
+              "type": "string",
+              "example": "my_iceberg_catalog"
+            },
+            "metadataUri": {
+              "description": "URI or connection string to the catalog, if applicable.",
+              "type": "string",
+              "example": "jdbc:mysql://host:3306/iceberg_database"
+            },
+            "warehouseUri": {
+              "description": "URI or connection string to the physical location of the data that the catalog describes.",
+              "type": "string",
+              "example": "s3://bucket/path/to/iceberg/warehouse"
+            },
+            "source": {
+              "description": "Source system where the catalog is configured.",
+              "type": "string",
+              "example": "spark, flink, hive"
+            }
+          },
+          "required": ["framework", "type", "name"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "catalog": {
+      "$ref": "#/$defs/CatalogDatasetFacet"
+    }
+  }
+}

--- a/website/static/spec/facets/1-0-0/CatalogDatasetFacet.json
+++ b/website/static/spec/facets/1-0-0/CatalogDatasetFacet.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/CatalogDatasetFacet.json",
+  "$defs": {
+    "CatalogDatasetFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "framework": {
+              "description": "The storage framework for which the catalog is configured",
+              "type": "string",
+              "example": "iceberg, delta, hive"
+            },
+            "type": {
+              "description": "Type of the catalog.",
+              "type": "string",
+              "example": "jdbc, glue, polaris"
+            },
+            "name": {
+              "description": "Name of the catalog, as configured in the source system.",
+              "type": "string",
+              "example": "my_iceberg_catalog"
+            },
+            "metadataUri": {
+              "description": "URI or connection string to the catalog, if applicable.",
+              "type": "string",
+              "example": "jdbc:mysql://host:3306/iceberg_database"
+            },
+            "warehouseUri": {
+              "description": "URI or connection string to the physical location of the data that the catalog describes.",
+              "type": "string",
+              "example": "s3://bucket/path/to/iceberg/warehouse"
+            },
+            "source": {
+              "description": "Source system where the catalog is configured.",
+              "type": "string",
+              "example": "spark, flink, hive"
+            }
+          },
+          "required": ["framework", "type", "name"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "catalog": {
+      "$ref": "#/$defs/CatalogDatasetFacet"
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new CatalogDatasetFacet to the OpenLineage spec. 

More relevant discussion: [issue #3642](https://github.com/OpenLineage/OpenLineage/issues/3642) and [pull request #3639](https://github.com/OpenLineage/OpenLineage/pull/3639).
In short, we don't handle Iceberg tables accessed via JDBC-based or custom catalogs in Spark. Additionally, we don't capture catalog name - and ​this is how users most frequently interact with those tables.

Previously, the approach in PR #3639 attempted to handle JDBC catalogs by creating symlinks with non-compliant dataset information, which was not ideal. The new `CatalogDatasetFacet` standardizes way to include catalog-specific metadata in the lineage events without relying on symlinks.

Drawback of this approach is that consumers who wish to use this information as a dataset identifier need to look at one additional facet: not only top-level dataset name and namespace and symlink facet, but also this one.​