### PR TITLE
fix: Check for RunEvent v2 in filters and env_var_facet in Python Client

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -153,7 +153,7 @@ class OpenLineageClient:
     ) -> Event | None:
         """Filters jobs according to config-defined events"""
         for _filter in self._filters:
-            if isinstance(event, RunEvent) and _filter.filter_event(event) is None:
+            if isinstance(event, (RunEvent, event_v2.RunEvent)) and _filter.filter_event(event) is None:
                 return None
         return event
 
@@ -397,7 +397,10 @@ class OpenLineageClient:
         """
         Adds environment variables as facets to the event object.
         """
-        if isinstance(event, RunEvent) and (env_vars := self._collect_environment_variables()):
+        if isinstance(event, (RunEvent, event_v2.RunEvent)) and (
+            env_vars := self._collect_environment_variables()
+        ):
+            event.run.facets = event.run.facets or {}
             event.run.facets["environmentVariables"] = EnvironmentVariablesRunFacet(
                 environmentVariables=[
                     EnvironmentVariable(name=name, value=value) for name, value in env_vars.items()

--- a/client/python/openlineage/client/filter.py
+++ b/client/python/openlineage/client/filter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import logging
 import re
 import typing
 
@@ -9,6 +10,7 @@ import attr
 from openlineage.client.event_v2 import RunEvent as RunEvent_v2
 from openlineage.client.run import RunEvent
 
+log = logging.getLogger(__name__)
 RunEventType = typing.Union[RunEvent, RunEvent_v2]
 
 
@@ -30,6 +32,7 @@ class ExactMatchFilter(Filter):
 
     def filter_event(self, event: RunEventType) -> RunEventType | None:
         if self.match == event.job.name:
+            log.debug("Job name `%s` matches exactly `%s`.", event.job.name, self.match)
             return None
         return event
 
@@ -40,16 +43,20 @@ class RegexFilter(Filter):
 
     def filter_event(self, event: RunEventType) -> RunEventType | None:
         if self.pattern.match(event.job.name):
+            log.debug("Job name `%s` matches regex `%s`.", event.job.name, self.pattern.pattern)
             return None
         return event
 
 
 def create_filter(conf: FilterConfig) -> Filter | None:
     if not conf.type:
+        log.warning("OpenLineage filter config must have a `type`.")
         return None
-    # Switch in 3.10 🙂
     if conf.type == "exact" and conf.match:
+        log.debug("Creating ExactMatchFilter with match='%s'", conf.match)
         return ExactMatchFilter(match=conf.match)
     if conf.type == "regex" and conf.regex:
+        log.debug("Creating RegexFilter with regex='%s'", conf.regex)
         return RegexFilter(regex=conf.regex)
+    log.warning("Unsupported OpenLineage filter type: `%s`", conf.type)
     return None


### PR DESCRIPTION
### Problem

When trying to use filters or env_var facet feature with event_v2.RunEvent, it's not working (are are only checking `isinstance(event, RunEvent)` instead of `isinstance(event, (RunEvent, event_v2.RunEvent))`).

Example snippet to reproduce
```
import os
import logging
from openlineage.client import OpenLineageClient
from openlineage.client.event_v2 import RunEvent, RunState, Run, Job  # This won't work
# from openlineage.client.run import RunEvent, RunState, Run, Job  # This will work

logging.basicConfig(level=logging.DEBUG)

dag_event = RunEvent(job=Job("namespace", "my_dag_id"), eventType=RunState.RUNNING, eventTime="2025-04-27T00:00:00.000000+00:00", run=Run("01960f82-0a68-7c09-8bec-bf6128d06dc2"), producer="someproducer")
task_event = RunEvent(job=Job("namespace", "my_dag_id.my_task_id"), eventType=RunState.RUNNING, eventTime="2025-04-27T00:00:00.000000+00:00", run=Run("01960f82-0a68-7c09-8bec-bf6128d06dc2"), producer="someproducer")
other_event = RunEvent(job=Job("namespace", "other"), eventType=RunState.RUNNING, eventTime="2025-04-27T00:00:00.000000+00:00", run=Run("01960f82-0a68-7c09-8bec-bf6128d06dc2"), producer="someproducer")
os.environ["OPENLINEAGE__FILTERS"] = '[{"type": "regex", "regex": "my_dag_id"}]'

client = OpenLineageClient()

client.emit(dag_event)  # This should skip the emission
client.emit(task_event)  # This should skip the emission
client.emit(other_event)  # This should emit
```

### Solution

I've adjusted the checks in client's code and tests to check v2 RunEvent as well. Also added some logging for filters for easier debugging. This feature also needs documentation and probably some refreshment? Something to explore in future PRs.

#### One-line summary:
fix: Check for RunEvent v2 in filters and env_var_facet in Python Client

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project