### PR TITLE
Java: Add UUIDUtils.generateStaticUUID method

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
@@ -4,9 +4,11 @@
 */
 package io.openlineage.client.utils;
 
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.UUID;
+import lombok.SneakyThrows;
 
 /** Class used to generate UUID values. */
 public class UUIDUtils {
@@ -46,5 +48,40 @@ public class UUIDUtils {
     long msb = (time << 16) | (random.nextLong() & 0x0fffL) | 0x7000L;
     long lsb = (random.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L;
     return new UUID(msb, lsb);
+  }
+
+  /**
+   * Generate UUID for instant of time and input data. Calling function with same arguments always
+   * produces the same result.
+   *
+   * <p>UUID version is an implementation detail, and <b>should not</b> be relied on. For now it is
+   * <a href="https://datatracker.ietf.org/doc/rfc9562/">UUIDv7</a>, so for increasing instant
+   * values, returned UUID is always greater than previous one. The only difference from RFC 9562 is
+   * that least significant bytes are not random, but instead a SHA-1 hash of input data.
+   *
+   * <p>Based on <a
+   * href="https://github.com/f4b6a3/uuid-creator/blob/98628c29ac9da704d215245f2099d9b439bc3084/src/main/java/com/github/f4b6a3/uuid/UuidCreator.java#L584-L593"
+   * target="_top">com.github.f4b6a3.uuid.UuidCreator.getTimeOrderedEpoch</a> implementation (MIT
+   * License).
+   *
+   * @param instant a given instant
+   * @param data a given data
+   * @return {@link UUID} v7
+   * @since 1.32.0
+   */
+  @SneakyThrows
+  public static UUID generateStaticUUID(Instant instant, byte[] data) {
+    MessageDigest md = MessageDigest.getInstance("SHA-1");
+    byte[] hash = md.digest(data);
+
+    long hasbMsb = 0;
+    long hasbLsb = 0;
+    for (int i = 0; i < 8; i++) hasbMsb = (hasbMsb << 8) | (hash[i] & 0xff);
+    for (int i = 8; i < 16; i++) hasbLsb = (hasbLsb << 8) | (hash[i] & 0xff);
+
+    long time = instant.toEpochMilli();
+    long uuidMsb = (time << 16) | (hasbMsb & 0x0fffL) | 0x7000L;
+    long uuidLsb = (hasbLsb & 0x3fffffffffffffffL) | 0x8000000000000000L;
+    return new UUID(uuidMsb, uuidLsb);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
@@ -5,32 +5,73 @@
 
 package io.openlineage.client.utils;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class UUIDUtilsTest {
 
   @Test
-  void testgenerateNewUUIDResultIsAlwaysDifferent() {
-    assertThat(UUIDUtils.generateNewUUID().version()).isEqualTo(7);
-
+  void testGenerateNewUUIDResultIsAlwaysDifferent() {
     UUID uuid1 = UUIDUtils.generateNewUUID();
     UUID uuid2 = UUIDUtils.generateNewUUID();
 
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
+    assertThat(uuid1).isNotEqualTo(uuid2);
+
+    Instant instant = Instant.now();
+    uuid1 = UUIDUtils.generateNewUUID(instant);
+    uuid2 = UUIDUtils.generateNewUUID(instant);
+
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
     assertThat(uuid1).isNotEqualTo(uuid2);
   }
 
   @Test
-  void testgenerateNewUUIDForInstantResultIsIncreasing() {
+  void testGenerateNewUUIDForInstantResultIsIncreasing() {
+    Instant instant1 = Instant.now();
+    Instant instant2 = instant1.plusMillis(1);
+
+    UUID uuid1 = UUIDUtils.generateNewUUID(instant1);
+    UUID uuid2 = UUIDUtils.generateNewUUID(instant2);
+
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
+    assertThat(uuid1).isNotEqualTo(uuid2);
+    assertThat(uuid1).isLessThan(uuid2);
+  }
+
+  @Test
+  void testGenerateStaticUUIDReturnsSameResultForSameInput() {
     Instant instant = Instant.now();
-    assertThat(UUIDUtils.generateNewUUID(instant).version()).isEqualTo(7);
+    byte[] data = "some".getBytes(UTF_8);
 
-    UUID uuid1 = UUIDUtils.generateNewUUID(instant);
-    UUID uuid2 = UUIDUtils.generateNewUUID(instant.plusMillis(1));
+    UUID uuid1 = UUIDUtils.generateStaticUUID(instant, data);
+    UUID uuid2 = UUIDUtils.generateStaticUUID(instant, data);
 
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
+    assertThat(uuid1).isEqualTo(uuid2);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"some,some", "some,other"})
+  void testGenerateStaticUUIDResultIsIncreasingWithInstantIncrement(String data1, String data2) {
+    Instant instant1 = Instant.now();
+    Instant instant2 = instant1.plusMillis(1);
+
+    UUID uuid1 = UUIDUtils.generateStaticUUID(instant1, data1.getBytes(UTF_8));
+    UUID uuid2 = UUIDUtils.generateStaticUUID(instant2, data2.getBytes(UTF_8));
+
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
     assertThat(uuid1).isNotEqualTo(uuid2);
     assertThat(uuid1).isLessThan(uuid2);
   }

--- a/client/python/tests/test_uuid.py
+++ b/client/python/tests/test_uuid.py
@@ -12,7 +12,11 @@ def test_generate_new_uuid_returns_uuidv7():
     assert generate_new_uuid().version == 7  # noqa: PLR2004
 
 
-def test_generate_static_uuid_returns_different_result_on_each_call():
+def test_generate_new_uuid_returns_different_result_on_each_call():
+    result1 = generate_new_uuid()
+    result2 = generate_new_uuid()
+    assert result1 != result2
+
     instant = datetime.now()
     result1 = generate_new_uuid(instant)
     result2 = generate_new_uuid(instant)


### PR DESCRIPTION
### Problem

Python client already has `generate_static_uuid` util function, but Java client doesn't. Fixing that, using the same implementation under the hood.

This can be used for some integrations, like [Trino](https://github.com/trinodb/trino/pull/25683).

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

Java: Add UUIDUtils.generateStaticUUID method

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project