### PR TITLE
Fix dataset namespace resolvers for flink2

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolver.java
@@ -8,10 +8,12 @@ package io.openlineage.client.dataset.namespace.resolver;
 import io.openlineage.client.OpenLineageConfig;
 import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.Symlink;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Utility class to resolve hosts based on the dataset host resolver configured. Methods of the
@@ -56,8 +58,12 @@ public class DatasetNamespaceCombinedResolver {
   }
 
   public DatasetIdentifier resolve(DatasetIdentifier identifier) {
+    List<Symlink> resolvedSymlinks =
+        identifier.getSymlinks().stream()
+            .map(s -> new Symlink(s.getName(), resolve(s.getNamespace()), s.getType()))
+            .collect(Collectors.toList());
     return new DatasetIdentifier(
-        identifier.getName(), resolve(identifier.getNamespace()), identifier.getSymlinks());
+        identifier.getName(), resolve(identifier.getNamespace()), resolvedSymlinks);
   }
 
   /**

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternMatchingGroupNamespaceResolverBuilder.java
@@ -19,7 +19,9 @@ public class PatternMatchingGroupNamespaceResolverBuilder
   }
 
   @Override
-  public HostListNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
-    return new HostListNamespaceResolver(name, (HostListNamespaceResolverConfig) config);
+  public PatternMatchingGroupNamespaceResolver build(
+      String name, DatasetNamespaceResolverConfig config) {
+    return new PatternMatchingGroupNamespaceResolver(
+        (PatternMatchingGroupNamespaceResolverConfig) config);
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverBuilder.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/namespace/resolver/PatternNamespaceResolverBuilder.java
@@ -18,7 +18,7 @@ public class PatternNamespaceResolverBuilder implements DatasetNamespaceResolver
   }
 
   @Override
-  public HostListNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
-    return new HostListNamespaceResolver(name, (HostListNamespaceResolverConfig) config);
+  public PatternNamespaceResolver build(String name, DatasetNamespaceResolverConfig config) {
+    return new PatternNamespaceResolver(name, (PatternNamespaceResolverConfig) config);
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/namespace/resolver/DatasetNamespaceCombinedResolverTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.dataset.DatasetConfig;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.DatasetIdentifier.SymlinkType;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -107,5 +108,23 @@ class DatasetNamespaceCombinedResolverTest {
       URI someUri = new URI("kafka://other-host:9091");
       assertThat(resolvers.resolveHost(someUri)).isEqualTo(someUri);
     }
+  }
+
+  @Test
+  void testResolveSymlinks() {
+    HostListNamespaceResolverConfig resolverConfig =
+        new HostListNamespaceResolverConfig(Arrays.asList("host1", "host2"), null);
+    this.config = new DatasetConfig();
+    this.config.setNamespaceResolvers(Collections.singletonMap("cluster", resolverConfig));
+
+    DatasetIdentifier identifier =
+        new DatasetIdentifier(
+            "name",
+            "host1",
+            Collections.singletonList(
+                new DatasetIdentifier.Symlink("name", "host2", SymlinkType.TABLE)));
+
+    DatasetIdentifier resolved = new DatasetNamespaceCombinedResolver(config).resolve(identifier);
+    assertThat(resolved.getSymlinks().get(0).getNamespace()).isEqualTo("cluster");
   }
 }

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenlineageListenerIntegrationTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenlineageListenerIntegrationTest.java
@@ -85,6 +85,11 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
     configuration.setString("openlineage.transport.type", "file");
     configuration.setString("openlineage.transport.location", EVENTS_FILE);
 
+    configuration.setString(
+        "openlineage.dataset.namespaceResolvers.kafka-cluster.type", "hostList");
+    configuration.setString(
+        "openlineage.dataset.namespaceResolvers.kafka-cluster.hosts", "[localhost;localhost2]");
+
     // To check events with local Marquez
     // configuration.setString("openlineage.transport.type", "http");
     // configuration.setString("openlineage.transport.url", "http://localhost:9000");
@@ -163,7 +168,7 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
         InputDataset inputDataset = LineageTestUtils.getInputDatasets(events).get(0);
         OutputDataset outputDateset = LineageTestUtils.getOutputDatasets(events).get(0);
 
-        assertThat(outputDateset.getNamespace()).startsWith("kafka://localhost");
+        assertThat(outputDateset.getNamespace()).startsWith("kafka://kafka-cluster");
         assertThat(outputDateset.getName()).startsWith(OUTPUT_TOPIC);
 
         assertThat(outputDateset.getFacets().getSchema().getFields()).hasSize(2);
@@ -174,7 +179,7 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
             .hasFieldOrPropertyWithValue("name", "value")
             .hasFieldOrPropertyWithValue("type", "int");
 
-        assertThat(inputDataset.getNamespace()).startsWith("kafka://localhost");
+        assertThat(inputDataset.getNamespace()).startsWith("kafka://kafka-cluster");
         assertThat(inputDataset.getName()).startsWith(TOPIC1);
 
         assertThat(inputDataset.getFacets().getSchema().getFields()).hasSize(2);
@@ -329,13 +334,13 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
               .map(e -> e.getInputs().get(0))
               .findAny();
       assertThat(input).isPresent();
-      assertThat(input.get().getNamespace()).startsWith("kafka://localhost:");
+      assertThat(input.get().getNamespace()).startsWith("kafka://kafka-cluster:");
       assertThat(input.get().getName()).isEqualTo(inputTopic);
       assertThat(input.get().getFacets().getSymlinks().getIdentifiers().get(0))
           .hasFieldOrPropertyWithValue("type", "TABLE")
           .hasFieldOrPropertyWithValue("name", "default_catalog.default_database.kafka_input");
       assertThat(input.get().getFacets().getSymlinks().getIdentifiers().get(0).getNamespace())
-          .startsWith("kafka://localhost:");
+          .startsWith("kafka://kafka-cluster:");
       List<SchemaDatasetFacetFields> inputFields = input.get().getFacets().getSchema().getFields();
       assertThat(inputFields).hasSize(5);
       assertFieldPresent(inputFields, "price", "DECIMAL(38, 18)");
@@ -358,7 +363,7 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
               .filter(e -> e.getOutputs().size() > 0)
               .map(e -> e.getOutputs().get(0))
               .findAny();
-      assertThat(output.get().getNamespace()).startsWith("kafka://localhost:");
+      assertThat(output.get().getNamespace()).startsWith("kafka://kafka-cluster:");
       assertThat(output.get().getName()).isEqualTo(outputTopic);
       List<SchemaDatasetFacetFields> outputFields =
           output.get().getFacets().getSchema().getFields();
@@ -373,7 +378,7 @@ public class OpenlineageListenerIntegrationTest extends TestLogger {
           .hasFieldOrPropertyWithValue("type", "TABLE")
           .hasFieldOrPropertyWithValue("name", "default_catalog.default_database.kafka_output");
       assertThat(output.get().getFacets().getSymlinks().getIdentifiers().get(0).getNamespace())
-          .startsWith("kafka://localhost:");
+          .startsWith("kafka://kafka-cluster:");
 
       // test SQL comments
       assertThat(input.get().getFacets().getDocumentation())

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -15,17 +15,17 @@
   },
   "inputs": [
     {
-      "namespace": "kafka://kafka-host:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input2"
     },
     {
-      "namespace": "kafka://kafka-host:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.input1"
     }
   ],
   "outputs": [
     {
-      "namespace": "kafka://kafka-host:9092",
+      "namespace": "kafka://kafka-cluster-prod:9092",
       "name": "io.openlineage.flink.kafka.output_topic"
     }
   ]

--- a/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
@@ -15,7 +15,7 @@
     }
   },
   "inputs" : [ {
-    "namespace" : "kafka://kafka-host:9092",
+    "namespace" : "kafka://kafka-cluster-prod:9092",
     "name" : "io.openlineage.flink.kafka.input1",
     "facets" : {
       "schema" : {
@@ -49,7 +49,7 @@
         },
         "symlinks" : {
         "identifiers" : [ {
-          "namespace" : "kafka://kafka-host:9092",
+          "namespace" : "kafka://kafka-cluster-prod:9092",
           "name" : "default_catalog.default_database.kafka_input",
           "type" : "TABLE"
         } ]
@@ -57,7 +57,7 @@
     }
   } ],
   "outputs" : [ {
-    "namespace" : "kafka://kafka-host:9092",
+    "namespace" : "kafka://kafka-cluster-prod:9092",
     "name" : "io.openlineage.flink.kafka.output",
     "facets" : {
       "schema" : {
@@ -89,7 +89,7 @@
       },
       "symlinks" : {
         "identifiers" : [ {
-          "namespace" : "kafka://kafka-host:9092",
+          "namespace" : "kafka://kafka-cluster-prod:9092",
           "name" : "default_catalog.default_database.kafka_output",
           "type" : "TABLE"
         } ]


### PR DESCRIPTION
Turn on dataset namespaces resolvers for Flink2 integration. 
Prepare a test to verify the behaviour. 
Fix config builders for pattern matching resolvers. 