### PR TITLE
Flink 2 - support jdbc naming

### DIFF
--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
@@ -11,6 +11,7 @@ import io.openlineage.flink.visitor.facet.DatasetFacetVisitor;
 import io.openlineage.flink.visitor.facet.TableLineageFacetVisitor;
 import io.openlineage.flink.visitor.facet.TypeDatasetFacetVisitor;
 import io.openlineage.flink.visitor.identifier.DatasetIdentifierVisitor;
+import io.openlineage.flink.visitor.identifier.JdbcTableLineageDatasetIdentifierVisitor;
 import io.openlineage.flink.visitor.identifier.KafkaTableLineageDatasetIdentifierVisitor;
 import io.openlineage.flink.visitor.identifier.KafkaTopicListDatasetIdentifierVisitor;
 import io.openlineage.flink.visitor.identifier.KafkaTopicPatternDatasetIdentifierVisitor;
@@ -40,6 +41,7 @@ public class OpenLineageJobStatusChangedListenerFactory implements JobStatusChan
         return Arrays.asList(
             new KafkaTopicPatternDatasetIdentifierVisitor(context),
             new KafkaTopicListDatasetIdentifierVisitor(),
+            new JdbcTableLineageDatasetIdentifierVisitor(),
             new KafkaTableLineageDatasetIdentifierVisitor());
       }
     };

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/JdbcTableLineageDatasetIdentifierVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/JdbcTableLineageDatasetIdentifierVisitor.java
@@ -1,0 +1,66 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.identifier;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.client.utils.jdbc.JdbcDatasetUtils;
+import io.openlineage.flink.wrapper.TableLineageDatasetWrapper;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.planner.lineage.TableLineageDataset;
+
+/** Class to extract dataset identifier from {@link TableLineageDataset}. */
+@Slf4j
+public class JdbcTableLineageDatasetIdentifierVisitor implements DatasetIdentifierVisitor {
+  private static final String JDBC_CONNECTOR = "jdbc";
+
+  @Override
+  public boolean isDefinedAt(LineageDataset dataset) {
+    log.debug("Calling isDefinedAt for dataset {}", dataset);
+
+    CatalogBaseTable table = new TableLineageDatasetWrapper(dataset).getTable().orElse(null);
+
+    if (table == null) {
+      log.info("Table is null for dataset {}", dataset);
+      return false;
+    }
+
+    Map<String, String> options = table.getOptions();
+    if (options == null) {
+      log.info("Table options are null for dataset {}", dataset);
+      return false;
+    }
+
+    if (!options.containsKey("connector")) {
+      log.info("Table options does not contain connector for dataset {}", dataset);
+      return false;
+    }
+
+    log.debug("Table options contains connector {}", options.get("connector"));
+    return JDBC_CONNECTOR.equals(options.get("connector"));
+  }
+
+  @Override
+  public Collection<DatasetIdentifier> apply(LineageDataset dataset) {
+    CatalogBaseTable table = new TableLineageDatasetWrapper(dataset).getTable().orElseThrow();
+
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Extracting dataset identifier from table options bootstrap-servers={} topics={}",
+          table.getOptions().get("url"),
+          table.getOptions().get("table-name"));
+    }
+
+    return Collections.singletonList(
+        JdbcDatasetUtils.getDatasetIdentifier(
+            table.getOptions().get("url"), table.getOptions().get("table-name"), new Properties()));
+  }
+}

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/JdbcTableLineageDatasetIdentifierVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/JdbcTableLineageDatasetIdentifierVisitorTest.java
@@ -1,0 +1,88 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.identifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.planner.lineage.TableLineageDataset;
+import org.apache.flink.table.planner.lineage.TableLineageDatasetImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JdbcTableLineageDatasetIdentifierVisitorTest {
+  JdbcTableLineageDatasetIdentifierVisitor visitor = new JdbcTableLineageDatasetIdentifierVisitor();
+
+  ContextResolvedTable contextResolvedTable = mock(ContextResolvedTable.class, RETURNS_DEEP_STUBS);
+  CatalogBaseTable catalogBaseTable = mock(CatalogBaseTable.class);
+  TableLineageDataset table;
+
+  @BeforeEach
+  void setup() {
+    when(contextResolvedTable.getTable()).thenReturn(catalogBaseTable);
+    when(contextResolvedTable.getIdentifier().asSummaryString()).thenReturn("tableName");
+
+    table =
+        new TableLineageDatasetImpl(
+            contextResolvedTable,
+            Optional.of(
+                new LineageDataset() {
+                  @Override
+                  public String name() {
+                    return "tableName";
+                  }
+
+                  @Override
+                  public String namespace() {
+                    return "";
+                  }
+
+                  @Override
+                  public Map<String, LineageDatasetFacet> facets() {
+                    return Map.of();
+                  }
+                }));
+  }
+
+  @Test
+  void testIsDefinedAt() {
+    assertThat(visitor.isDefinedAt(mock(LineageDataset.class))).isFalse();
+    assertThat(visitor.isDefinedAt(table)).isFalse();
+
+    when(table.table().getOptions()).thenReturn(Map.of("connector", "jdbc"));
+    assertThat(visitor.isDefinedAt(table)).isTrue();
+  }
+
+  @Test
+  void testApply() {
+    when(catalogBaseTable.getOptions())
+        .thenReturn(
+            Map.of(
+                "connector",
+                "jbcc",
+                "url",
+                "jdbc:trino://trino:8080",
+                "table-name",
+                "catalog.schema.some-table"));
+
+    Collection<DatasetIdentifier> datasetIdentifiers = visitor.apply(table);
+
+    assertThat(datasetIdentifiers.size()).isEqualTo(1);
+    assertThat(datasetIdentifiers.iterator().next())
+        .hasFieldOrPropertyWithValue("name", "catalog.schema.some-table")
+        .hasFieldOrPropertyWithValue("namespace", "trino://trino:8080");
+  }
+}


### PR DESCRIPTION
Implement visitor to stick to OpenLineage JDBC dataset naming for JDBC connector in Flink SQL