### PR TITLE
[dbt] forward dbt's returncode

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -77,6 +77,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         self._dbt_log_file: Optional[TextIO] = None
         self.received_dbt_command_completed = False
 
+        self.dbt_command_return_code = 0
+
     @cached_property
     def dbt_command(self) -> str:
         return get_dbt_command(self.dbt_command_line)
@@ -592,6 +594,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         finally:
             if self._dbt_log_file is not None:
                 self._dbt_log_file.close()
+            self.dbt_command_return_code = process.returncode
 
     def _open_dbt_log_file(self):
         """

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -149,7 +149,7 @@ def consume_structured_logs(
     target: str, project_dir: str, profile_name: str, model_selector: str, models: List[str]
 ):
     logger.info("This wrapper will send OpenLineage events while the models are executing.")
-    return_code = 0
+    dbt_integration_return_code = 0
     job_namespace = os.environ.get("OPENLINEAGE_NAMESPACE", "dbt")
     dbt_command_line = remove_command_line_option(sys.argv, CONSUME_STRUCTURED_LOGS_COMMAND_OPTION)
     dbt_command_line = ["dbt"] + dbt_command_line[1:]
@@ -182,11 +182,11 @@ def consume_structured_logs(
                 )
     except UnsupportedDbtCommand as e:
         logger.error(e)
-        return_code = 1
+        dbt_integration_return_code = 1
 
     logger.info("Emitted %d OpenLineage events", emitted_events)
-    logger.info("Underlying dbt execution returned %d", return_code)
-    return return_code
+    logger.info("Underlying dbt execution returned %d", processor.dbt_command_return_code)
+    return processor.dbt_command_return_code or dbt_integration_return_code
 
 
 def consume_local_artifacts(


### PR DESCRIPTION
### Problem

dbt-integration starts a dbt process under the hood. Now the return code of this process is also forwarded in `dbt-ol`

#### One-line summary:

forward dbt's underlying retruncode

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project