### PR TITLE
[dbt] Handle dbt log file rotation

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -27,6 +27,7 @@ from openlineage.common.provider.dbt.processor import (
     UnsupportedDbtCommand,
 )
 from openlineage.common.provider.dbt.utils import (
+    DBT_LOG_FILE_MAX_BYTES,
     HANDLED_COMMANDS,
     generate_run_event,
     get_dbt_command,
@@ -60,6 +61,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         self.dbt_command_line: List[str] = dbt_command_line
         self.profiles_dir: str = get_dbt_profiles_dir(command=self.dbt_command_line)
         self.dbt_log_file_path: str = get_dbt_log_path(command=self.dbt_command_line)
+        self.dbt_log_dirname: str = self.dbt_log_file_path.split("/")[-2]
         self.parent_run_metadata: ParentRunMetadata = get_parent_run_metadata()
 
         self.node_id_to_ol_run_id: Dict[str, str] = defaultdict(lambda: str(generate_new_uuid()))
@@ -558,8 +560,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         """
         dbt_command_line = add_command_line_args(
             self.dbt_command_line,
-            arg_names=["--log-format-file", "--log-level-file"],
-            arg_values=["json", "debug"],
+            arg_names=["--log-format-file", "--log-level-file", "--log-path", "--log-file-max-bytes"],
+            arg_values=["json", "debug", self.dbt_log_dirname, DBT_LOG_FILE_MAX_BYTES],
         )
         dbt_command_line = add_or_replace_command_line_option(
             dbt_command_line, option="--write-json", replace_option="--no-write-json"

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -734,6 +734,10 @@ def test_run_dbt_command(dbt_process_return_code, expected_processor_return_code
     process_mock = mock.Mock()
     monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.subprocess.Popen", popen_mock)
     monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.IncrementalFileReader", mock.Mock())
+    monkeypatch.setattr(
+        "openlineage.common.provider.dbt.structured_logs.DbtStructuredLogsProcessor._open_dbt_log_file",
+        mock.Mock(),
+    )
     popen_mock.return_value = process_mock
     process_mock.returncode = dbt_process_return_code
     process_mock.poll.return_value = 1
@@ -827,6 +831,10 @@ def test_executed_dbt_command_line(input_dbt_command_line, expected_dbt_command_
     popen_mock = mock.Mock()
     monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.subprocess.Popen", popen_mock)
     monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.IncrementalFileReader", mock.Mock())
+    monkeypatch.setattr(
+        "openlineage.common.provider.dbt.structured_logs.DbtStructuredLogsProcessor._open_dbt_log_file",
+        mock.Mock(),
+    )
     monkeypatch.setattr(
         "openlineage.common.provider.dbt.utils.generate_random_log_file_name", lambda: DUMMY_RANDOM_LOG_FILE
     )

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 from openlineage.common.provider.dbt.processor import Adapter
 from openlineage.common.provider.dbt.structured_logs import DbtStructuredLogsProcessor
+from openlineage.common.provider.dbt.utils import DBT_LOG_FILE_MAX_BYTES
 from openlineage.common.test import match
 from openlineage.common.utils import get_from_nullable_chain
 
@@ -18,6 +19,7 @@ from openlineage.common.utils import get_from_nullable_chain
 # helpers
 ###########
 DUMMY_UUID_4 = "e2c4a0ab-d119-4828-b9c4-96ffd4c79d4f"
+DUMMY_RANDOM_LOG_FILE = "dbt-logs-e2c4a0ab-d119-4828-b9c4-96ffd4c79d4f"
 
 
 def ol_event_to_dict(event) -> Dict:
@@ -749,3 +751,141 @@ def test_run_dbt_command(dbt_process_return_code, expected_processor_return_code
     list(processor._run_dbt_command())
 
     assert expected_processor_return_code == processor.dbt_command_return_code
+
+
+@pytest.mark.parametrize(
+    "input_dbt_command_line, expected_dbt_command_line",
+    [
+        (
+            [
+                "dbt",
+                "run",
+                "--select",
+                "orders",
+                "--vars",
+                "{'foo': 'bar'}",
+                "--profiles-dir",
+                "my_profiles_dir",
+            ],
+            [
+                "dbt",
+                "run",
+                "--select",
+                "orders",
+                "--vars",
+                "{'foo': 'bar'}",
+                "--profiles-dir",
+                "my_profiles_dir",
+                "--log-format-file",
+                "json",
+                "--log-level-file",
+                "debug",
+                "--log-path",
+                DUMMY_RANDOM_LOG_FILE,
+                "--log-file-max-bytes",
+                DBT_LOG_FILE_MAX_BYTES,
+                "--write-json",
+            ],
+        ),
+        (
+            [
+                "dbt",
+                "run",
+                "--select",
+                "orders",
+                "--vars",
+                "{'foo': 'bar'}",
+                "--profiles-dir",
+                "my_profiles_dir",
+                "--log-path",
+                "dbt-logs-1234",
+            ],
+            [
+                "dbt",
+                "run",
+                "--select",
+                "orders",
+                "--vars",
+                "{'foo': 'bar'}",
+                "--profiles-dir",
+                "my_profiles_dir",
+                "--log-path",
+                "dbt-logs-1234",
+                "--log-format-file",
+                "json",
+                "--log-level-file",
+                "debug",
+                "--log-file-max-bytes",
+                DBT_LOG_FILE_MAX_BYTES,
+                "--write-json",
+            ],
+        ),
+    ],
+    ids=["with_no_log_path", "with_log_path"],
+)
+def test_executed_dbt_command_line(input_dbt_command_line, expected_dbt_command_line, monkeypatch):
+    popen_mock = mock.Mock()
+    monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.subprocess.Popen", popen_mock)
+    monkeypatch.setattr("openlineage.common.provider.dbt.structured_logs.IncrementalFileReader", mock.Mock())
+    monkeypatch.setattr(
+        "openlineage.common.provider.dbt.utils.generate_random_log_file_name", lambda: DUMMY_RANDOM_LOG_FILE
+    )
+
+    processor = DbtStructuredLogsProcessor(
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="dbt-test-namespace",
+        project_dir="tests/dbt/structured_logs",
+        target="postgres",
+        dbt_command_line=input_dbt_command_line,
+    )
+    processor.manifest_path = "./tests/dbt/structured_logs/postgres/run/target/manifest.json"
+    processor.received_dbt_command_completed = True
+
+    list(processor._run_dbt_command())
+
+    actual_command_line = popen_mock.call_args[0][0]
+    assert actual_command_line == expected_dbt_command_line
+
+
+@pytest.mark.parametrize(
+    "input_dbt_command_line, expected_dbt_log_file_path",
+    [
+        (
+            ["dbt", "run", "--select", "orders", "--project-dir", "my-dbt-project"],
+            f"my-dbt-project/{DUMMY_RANDOM_LOG_FILE}/dbt.log",
+        ),
+        (
+            [
+                "dbt",
+                "run",
+                "--select",
+                "orders",
+                "--project-dir",
+                "my-dbt-project",
+                "--log-path",
+                "dbt-logs-1234",
+            ],
+            "my-dbt-project/dbt-logs-1234/dbt.log",
+        ),
+        (
+            ["dbt", "run", "--select", "orders", "--log-path", "dbt-logs-1234"],
+            "./dbt-logs-1234/dbt.log",
+        ),
+    ],
+    ids=["with_no_log_path", "with_log_path", "without_project_dir"],
+)
+def test_logfile_path(input_dbt_command_line, expected_dbt_log_file_path, monkeypatch):
+    monkeypatch.setattr(
+        "openlineage.common.provider.dbt.utils.generate_random_log_file_name", lambda: DUMMY_RANDOM_LOG_FILE
+    )
+
+    processor = DbtStructuredLogsProcessor(
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="dbt-test-namespace",
+        project_dir="tests/dbt/structured_logs",
+        target="postgres",
+        dbt_command_line=input_dbt_command_line,
+    )
+    processor.manifest_path = "./tests/dbt/structured_logs/postgres/run/target/manifest.json"
+
+    assert processor.dbt_log_file_path == expected_dbt_log_file_path

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -164,7 +164,7 @@ def consume_structured_logs(
         models=models,
         selector=model_selector,
     )
-
+    logger.info(f"dbt-ol will read logs from {processor.dbt_log_file_path}")
     client = OpenLineageClient()
     emitted_events = 0
     try:

--- a/integration/dbt/openlineage/tests/test_main.py
+++ b/integration/dbt/openlineage/tests/test_main.py
@@ -76,6 +76,7 @@ def test_consume_structured_logs(command_line, os_envs, function_kwargs, monkeyp
     mockDbtStructuredLogsProcessor = Mock(
         return_value=mock_dbt_structured_logs_processor
     )  # instance returned
+    mock_dbt_structured_logs_processor.dbt_command_return_code = 0
 
     monkeypatch.setattr("os.environ", os_envs)
     monkeypatch.setattr("openlineage.dbt.consume_structured_logs", mock_consume_structured_logs)


### PR DESCRIPTION
### Problem

dbt rotates the log file when it reaches the default size of 10MB. This prevents the integration from reading the whole logfile. 

### Solution

We increase the log file size to 100MB (10 times the default) and we randomize the localisation of the log file to prevent successive dbt calls from writing to the same log file. This only works when no `log-path` is provided. 

If `log-path` is provided then users have to make sure to use a different one for subsequent commands.

#### One-line summary:

Randomize dbt `log-path` and set its size to 100MB

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project