### PR TITLE
Add Amazon DataZone transport

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -495,6 +495,8 @@ jobs:
           path: transports-gcs/build/test-results/test
       - store_test_results:
           path: transports-s3/build/test-results/test
+      - store_test_results:
+          path: transports-datazone/build/test-results/test
       - store_artifacts:
           path: build/reports/tests/test
           destination: test-report
@@ -506,6 +508,9 @@ jobs:
           destination: test-report
       - store_artifacts:
           path: transports-s3/build/reports/tests/test
+          destination: test-report
+      - store_artifacts:
+          path: transports-datazone/build/reports/tests/test
           destination: test-report
       - store_artifacts:
           path: build/reports/tests/pmd
@@ -521,6 +526,9 @@ jobs:
           destination: libs
       - store_artifacts:
           path: transports-s3/build/libs
+          destination: libs
+      - store_artifacts:
+          path: transports-datazone/build/libs
           destination: libs
       - save_cache:
           key: v1-client-java-{{ checksum "/tmp/checksum.txt" }}
@@ -553,6 +561,9 @@ jobs:
       - store_artifacts:
           path: ./transports-s3/build/libs
           destination: transports-s3-artifacts
+      - store_artifacts:
+          path: ./transports-datazone/build/libs
+          destination: transports-datazone-artifacts
       - save_cache:
           key: v1-release-client-java-{{ checksum "/tmp/checksum.txt" }}
           paths:

--- a/client/java/settings.gradle
+++ b/client/java/settings.gradle
@@ -10,6 +10,7 @@ include('transports-gcplineage')
 include('transports-gcs')
 include('transports-kinesis')
 include('transports-s3')
+include('transports-datazone')
 
 buildCache {
     local {

--- a/client/java/transports-datazone/README.md
+++ b/client/java/transports-datazone/README.md
@@ -1,0 +1,32 @@
+# Amazon DataZone Transport
+
+This library provides a transport layer that integrates OpenLineage with Amazon Web Service's DataZone & SageMaker Unified Studio service.
+
+## Getting Started
+
+### Adding the Dependency
+
+To use this transport in your project, you need to include the following dependency in your build configuration. This is particularly important for environments like `Spark`, where this transport must be on the classpath for lineage events to be emitted correctly.
+
+
+**Maven:**
+
+```xml
+
+<dependency>
+    <groupId>io.openlineage</groupId>
+    <artifactId>transports-datazone</artifactId>
+    <version>YOUR_VERSION_HERE</version>
+</dependency>
+```
+
+### Configuration
+
+- `type` - string, must be `"amazon_datazone_api"`. Required.
+- `domainId` - string, specifies the DataZone / SageMaker Unified Studio domain id. The lineage events will be then sent to the following domain. Required.
+- `endpointOverride` - string, overrides the default HTTP endpoint for Amazon DataZone client. Optional, default: None
+
+### Behavior
+
+- Events are serialized to JSON, and then dispatched to the `DataZone` endpoint.
+

--- a/client/java/transports-datazone/build.gradle
+++ b/client/java/transports-datazone/build.gradle
@@ -1,0 +1,38 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+plugins {
+    id 'eclipse'
+    id 'jacoco'
+    id 'java'
+    id 'java-library'
+    id 'maven-publish'
+    id 'signing'
+    id 'com.adarshr.test-logger' version '3.2.0'
+    id 'com.diffplug.spotless' version '7.0.2'
+    id 'com.gradleup.shadow' version '8.3.6'
+    id 'pmd'
+    id 'io.freefair.lombok' version '8.13.1'
+}
+
+ext {
+    projectDescription = 'DataZone OpenLineage transport library'
+    awsSdkVersion = '2.31.15'
+}
+
+dependencies {
+    compileOnly('com.google.code.findbugs:jsr305:3.0.2')
+    implementation("software.amazon.awssdk:auth:${awsSdkVersion}")
+    implementation("software.amazon.awssdk:datazone:${awsSdkVersion}")
+    implementation("software.amazon.awssdk:apache-client:${awsSdkVersion}")
+}
+
+shadowJar {
+    relocate 'software.amazon', 'io.openlineage.client.shaded.software.amazon'
+    relocate 'org.apache', 'io.openlineage.client.shaded.org.apache'
+    exclude 'org.slf4j'
+}
+
+apply from: '../transports.build.gradle'

--- a/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneConfig.java
+++ b/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneConfig.java
@@ -1,0 +1,31 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports.datazone;
+
+import io.openlineage.client.MergeConfig;
+import io.openlineage.client.transports.TransportConfig;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public final class AmazonDataZoneConfig
+    implements TransportConfig, MergeConfig<AmazonDataZoneConfig> {
+  @Getter @Setter private String domainId;
+  @Getter @Setter @Nullable private String endpointOverride;
+
+  @Override
+  public AmazonDataZoneConfig mergeWithNonNull(AmazonDataZoneConfig other) {
+    return new AmazonDataZoneConfig(
+        mergePropertyWith(domainId, other.domainId),
+        mergePropertyWith(endpointOverride, other.getEndpointOverride()));
+  }
+}

--- a/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransport.java
+++ b/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransport.java
@@ -1,0 +1,96 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports.datazone;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.client.transports.Transport;
+import java.net.URI;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.datazone.DataZoneClient;
+import software.amazon.awssdk.services.datazone.DataZoneClientBuilder;
+import software.amazon.awssdk.services.datazone.model.PostLineageEventRequest;
+import software.amazon.awssdk.services.datazone.model.PostLineageEventResponse;
+import software.amazon.awssdk.utils.StringUtils;
+
+@Slf4j
+public final class AmazonDataZoneTransport extends Transport {
+  private final DataZoneClient dataZoneClient;
+  private final String domainId;
+
+  public AmazonDataZoneTransport(@NonNull final AmazonDataZoneConfig dataZoneConfig) {
+    this(buildDataZoneClient(dataZoneConfig), dataZoneConfig);
+  }
+
+  public AmazonDataZoneTransport(
+      @NonNull final DataZoneClient dataZoneClient,
+      @NonNull final AmazonDataZoneConfig dataZoneConfig) {
+    validateDataZoneConfig(dataZoneConfig);
+    this.dataZoneClient = dataZoneClient;
+    this.domainId = dataZoneConfig.getDomainId();
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.RunEvent runEvent) {
+    emit(OpenLineageClientUtils.toJson(runEvent));
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.DatasetEvent datasetEvent) {
+    // Not supported in DataZone
+    log.debug(
+        "DatasetEvent is not supported in DataZone {}",
+        OpenLineageClientUtils.toJson(datasetEvent));
+  }
+
+  @Override
+  public void emit(@NonNull OpenLineage.JobEvent jobEvent) {
+    // Not supported in DataZone
+    log.debug("JobEvent is not supported in DataZone {}", OpenLineageClientUtils.toJson(jobEvent));
+  }
+
+  public void emit(String eventAsJson) {
+    try {
+      PostLineageEventResponse response =
+          this.dataZoneClient.postLineageEvent(
+              PostLineageEventRequest.builder()
+                  .domainIdentifier(this.domainId)
+                  .event(SdkBytes.fromUtf8String(eventAsJson))
+                  .build());
+      log.info(
+          "Successfully posted a LineageEvent: {} in Domain: {}",
+          response.id(),
+          response.domainId());
+    } catch (Exception e) {
+      throw new OpenLineageClientException(
+          String.format("Failed to send lineage event to DataZone: %s", eventAsJson), e);
+    }
+  }
+
+  private void validateDataZoneConfig(@NonNull final AmazonDataZoneConfig dataZoneConfig) {
+    if (dataZoneConfig.getDomainId() == null) {
+      throw new OpenLineageClientException(
+          "DomainId can't be null, try setting transport.domainId in config");
+    }
+  }
+
+  private static DataZoneClient buildDataZoneClient(AmazonDataZoneConfig config) {
+    DataZoneClientBuilder builder =
+        DataZoneClient.builder()
+            .httpClientBuilder(ApacheHttpClient.builder())
+            .credentialsProvider(DefaultCredentialsProvider.create());
+    if (!StringUtils.isBlank(config.getEndpointOverride())) {
+      builder.endpointOverride(URI.create(config.getEndpointOverride()));
+    }
+
+    return builder.build();
+  }
+}

--- a/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransportBuilder.java
+++ b/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransportBuilder.java
@@ -1,0 +1,28 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports.datazone;
+
+import io.openlineage.client.transports.Transport;
+import io.openlineage.client.transports.TransportBuilder;
+import io.openlineage.client.transports.TransportConfig;
+
+public class AmazonDataZoneTransportBuilder implements TransportBuilder {
+
+  @Override
+  public TransportConfig getConfig() {
+    return new AmazonDataZoneConfig();
+  }
+
+  @Override
+  public Transport build(TransportConfig config) {
+    return new AmazonDataZoneTransport((AmazonDataZoneConfig) config);
+  }
+
+  @Override
+  public String getType() {
+    return "amazon_datazone_api";
+  }
+}

--- a/client/java/transports-datazone/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
+++ b/client/java/transports-datazone/src/main/resources/META-INF/services/io.openlineage.client.transports.TransportBuilder
@@ -1,0 +1,1 @@
+io.openlineage.client.transports.datazone.AmazonDataZoneTransportBuilder

--- a/client/java/transports-datazone/src/test/java/io/openlineage/client/testdata/OpenLineageEventsDataHelper.java
+++ b/client/java/transports-datazone/src/test/java/io/openlineage/client/testdata/OpenLineageEventsDataHelper.java
@@ -1,0 +1,48 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.client.testdata;
+
+import io.openlineage.client.OpenLineage;
+import java.net.URI;
+import java.util.UUID;
+
+public final class OpenLineageEventsDataHelper {
+  private OpenLineageEventsDataHelper() {}
+
+  public static OpenLineage.RunEvent runEvent() {
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    OpenLineage.Run run =
+        new OpenLineage.RunBuilder()
+            .runId(UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54"))
+            .build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newRunEventBuilder()
+        .job(job)
+        .run(run)
+        .build();
+  }
+
+  public static OpenLineage.DatasetEvent datasetEvent() {
+    OpenLineage.StaticDataset dataset =
+        new OpenLineage.StaticDatasetBuilder()
+            .namespace("test-namespace")
+            .name("test-dataset")
+            .build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newDatasetEventBuilder()
+        .dataset(dataset)
+        .build();
+  }
+
+  public static OpenLineage.JobEvent jobEvent() {
+    OpenLineage.Job job =
+        new OpenLineage.JobBuilder().namespace("test-namespace").name("test-job").build();
+    return new OpenLineage(URI.create("http://test.producer"))
+        .newJobEventBuilder()
+        .job(job)
+        .build();
+  }
+}

--- a/client/java/transports-datazone/src/test/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransportTest.java
+++ b/client/java/transports-datazone/src/test/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransportTest.java
@@ -1,0 +1,150 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports.datazone;
+
+import static io.openlineage.client.testdata.OpenLineageEventsDataHelper.datasetEvent;
+import static io.openlineage.client.testdata.OpenLineageEventsDataHelper.jobEvent;
+import static io.openlineage.client.testdata.OpenLineageEventsDataHelper.runEvent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_ACCESS_KEY_ID;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_REGION;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_SECRET_ACCESS_KEY;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_SESSION_TOKEN;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.OpenLineageClientException;
+import io.openlineage.client.transports.TransportFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.datazone.DataZoneClient;
+import software.amazon.awssdk.services.datazone.model.InternalServerException;
+import software.amazon.awssdk.services.datazone.model.PostLineageEventRequest;
+import software.amazon.awssdk.services.datazone.model.PostLineageEventResponse;
+
+class AmazonDataZoneTransportTests {
+  private static final String DATAZONE_DOMAIN_ID = "dzd_a1b2c3d4e5f6g7";
+
+  private final DataZoneClient dataZoneClient = mock(DataZoneClient.class);
+  private OpenLineageClient openLineageClient;
+
+  @BeforeEach
+  public void beforeEach() {
+    System.setProperty(AWS_REGION.property(), Region.EU_WEST_1.id());
+    System.setProperty(AWS_ACCESS_KEY_ID.property(), "AccessKey");
+    System.setProperty(AWS_SECRET_ACCESS_KEY.property(), "SecretAccessKey");
+    System.setProperty(AWS_SESSION_TOKEN.property(), "AWSSessionToken");
+
+    AmazonDataZoneConfig config = new AmazonDataZoneConfig();
+    config.setDomainId(DATAZONE_DOMAIN_ID);
+    AmazonDataZoneTransport dataZoneTransport = new AmazonDataZoneTransport(dataZoneClient, config);
+    openLineageClient = new OpenLineageClient(dataZoneTransport);
+  }
+
+  @AfterEach
+  void clearAWSSystemProperties() {
+    System.clearProperty(AWS_REGION.property());
+    System.clearProperty(AWS_ACCESS_KEY_ID.property());
+    System.clearProperty(AWS_SECRET_ACCESS_KEY.property());
+    System.clearProperty(AWS_SESSION_TOKEN.property());
+  }
+
+  @Test
+  void transportFactoryCreatesAmazonDataZoneTransport() {
+    AmazonDataZoneConfig config = new AmazonDataZoneConfig();
+    config.setDomainId(DATAZONE_DOMAIN_ID);
+    TransportFactory transportFactory = new TransportFactory(config);
+
+    assertTrue(transportFactory.build() instanceof AmazonDataZoneTransport);
+  }
+
+  @Test
+  void transportFactoryCreatesAmazonDataZoneTransportWithEndpointOverride() {
+    AmazonDataZoneConfig config = new AmazonDataZoneConfig();
+    config.setDomainId(DATAZONE_DOMAIN_ID);
+    config.setEndpointOverride("https://datazone.us-east-1.api.aws");
+    TransportFactory transportFactory = new TransportFactory(config);
+
+    assertTrue(transportFactory.build() instanceof AmazonDataZoneTransport);
+  }
+
+  @Test
+  void dataZoneTransportRaisesExceptionWhenDomainIdNotProvided() {
+    AmazonDataZoneConfig config = new AmazonDataZoneConfig();
+
+    assertThrows(
+        OpenLineageClientException.class,
+        () -> new AmazonDataZoneTransport(dataZoneClient, config));
+  }
+
+  @Test
+  void dataZoneTransportWithoutClientRaisesExceptionWhenDomainIdNotProvided() {
+    AmazonDataZoneConfig config = new AmazonDataZoneConfig();
+
+    assertThrows(OpenLineageClientException.class, () -> new AmazonDataZoneTransport(config));
+  }
+
+  @Test
+  void dataZoneTransportRaisesExceptionOnDataZoneInvocationFailure() {
+    when(dataZoneClient.postLineageEvent(any(PostLineageEventRequest.class)))
+        .thenThrow(InternalServerException.class);
+    OpenLineage.RunEvent runEvent = runEvent();
+
+    assertThrows(OpenLineageClientException.class, () -> openLineageClient.emit(runEvent));
+  }
+
+  @Test
+  void clientEmitsRunEventDataZoneTransport() {
+    when(dataZoneClient.postLineageEvent(any(PostLineageEventRequest.class)))
+        .thenReturn(mock(PostLineageEventResponse.class));
+    ArgumentCaptor<PostLineageEventRequest> captor =
+        ArgumentCaptor.forClass(PostLineageEventRequest.class);
+    OpenLineage.RunEvent runEvent = runEvent();
+
+    openLineageClient.emit(runEvent);
+
+    verify(dataZoneClient, times(1)).postLineageEvent(captor.capture());
+    assertEquals(DATAZONE_DOMAIN_ID, captor.getValue().domainIdentifier());
+    assertNotNull(captor.getValue().event());
+  }
+
+  @Test
+  void clientEmitsDataSetEventDataZoneTransport() {
+    when(dataZoneClient.postLineageEvent(any(PostLineageEventRequest.class)))
+        .thenReturn(mock(PostLineageEventResponse.class));
+    ArgumentCaptor<PostLineageEventRequest> captor =
+        ArgumentCaptor.forClass(PostLineageEventRequest.class);
+    OpenLineage.DatasetEvent datasetEvent = datasetEvent();
+
+    openLineageClient.emit(datasetEvent);
+
+    verify(dataZoneClient, times(0)).postLineageEvent(captor.capture());
+  }
+
+  @Test
+  void clientEmitsJobEventDataZoneTransport() {
+    when(dataZoneClient.postLineageEvent(any(PostLineageEventRequest.class)))
+        .thenReturn(mock(PostLineageEventResponse.class));
+    ArgumentCaptor<PostLineageEventRequest> captor =
+        ArgumentCaptor.forClass(PostLineageEventRequest.class);
+    OpenLineage.JobEvent jobEvent = jobEvent();
+
+    openLineageClient.emit(jobEvent);
+
+    verify(dataZoneClient, times(0)).postLineageEvent(captor.capture());
+  }
+}

--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from openlineage.client.transport.amazon_datazone import AmazonDataZoneConfig, AmazonDataZoneTransport
 from openlineage.client.transport.composite import CompositeTransport
 from openlineage.client.transport.console import ConsoleTransport
 from openlineage.client.transport.factory import DefaultTransportFactory
@@ -25,6 +26,7 @@ _factory.register_transport(ConsoleTransport.kind, ConsoleTransport)
 _factory.register_transport(NoopTransport.kind, NoopTransport)
 _factory.register_transport(FileTransport.kind, FileTransport)
 _factory.register_transport(TransformTransport.kind, TransformTransport)
+_factory.register_transport(AmazonDataZoneTransport.kind, AmazonDataZoneTransport)
 
 
 def get_default_factory() -> DefaultTransportFactory:
@@ -44,6 +46,8 @@ __all__ = [
     "Config",
     "Transport",
     "TransportFactory",
+    "AmazonDataZoneConfig",
+    "AmazonDataZoneTransport",
     "CompositeTransport",
     "ConsoleTransport",
     "FileTransport",

--- a/client/python/openlineage/client/transport/amazon_datazone.py
+++ b/client/python/openlineage/client/transport/amazon_datazone.py
@@ -1,0 +1,77 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from openlineage.client import event_v2
+from openlineage.client.run import RunEvent
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Config, Transport
+
+if TYPE_CHECKING:
+    from openlineage.client.client import Event
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class AmazonDataZoneConfig(Config):
+    domain_id: str
+    endpoint_override: str | None = None
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> AmazonDataZoneConfig:
+        if "domainId" not in params:
+            msg = "`domainId` key not passed to AmazonDataZoneConfig"
+            raise RuntimeError(msg)
+        return cls(domain_id=params["domainId"], endpoint_override=params.get("endpointOverride"))
+
+
+class AmazonDataZoneTransport(Transport):
+    kind = "amazon_datazone_api"
+    config_class = AmazonDataZoneConfig
+
+    def __init__(self, config: AmazonDataZoneConfig) -> None:
+        self.config = config
+        self.datazone = None
+
+        self._setup_datazone(self.config.endpoint_override)
+        log.debug(
+            "Constructing OpenLineage transport that will send events to Amazon DataZone domain `%s`.",
+            config.domain_id,
+        )
+
+    def emit(self, event: Event) -> None:
+        if not isinstance(event, (RunEvent, event_v2.RunEvent)):
+            # DataZone only supports RunEvent
+            log.warning("DataZone only supports RunEvent")
+            return
+        try:
+            response = self.datazone.post_lineage_event(  # type: ignore[attr-defined]
+                domainIdentifier=self.config.domain_id, event=Serde.to_json(event).encode("utf-8")
+            )
+            log.info(
+                "Successfully posted a LineageEvent: %s in Domain: %s", response["id"], response["domainId"]
+            )
+        except Exception as error:  # noqa: BLE001
+            msg = f"Failed to send lineage event to DataZone Domain {self.config.domain_id}: {event}"
+            raise RuntimeError(msg) from error
+
+    def _setup_datazone(self, endpoint_url: str | None = None) -> None:
+        try:
+            import boto3  # type: ignore[import-untyped]
+
+            self.datazone = boto3.client("datazone", endpoint_url=endpoint_url)
+        except (ImportError, ModuleNotFoundError):
+            log.exception(
+                "OpenLineage client could not import the boto3 module. "
+                "This could be due to boto3 not being installed or being corrupted. "
+                "DataZoneTransport requires boto3 to function properly. "
+                "Please ensure boto3 is installed correctly. "
+                "You can install or reinstall it via `pip install boto3`"
+            )
+            raise

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -38,6 +38,9 @@ optional-dependencies.msk-iam = [
   "aws-msk-iam-sasl-signer-python>=1.0.1",
   "confluent-kafka>=2.1.1",
 ]
+optional-dependencies.datazone = [
+  "boto3>=1.34.134"
+]
 optional-dependencies.test = [
   "covdefaults>=2.3",
   "pytest>=7.3.1",

--- a/client/python/tests/test_amazon_datazone.py
+++ b/client/python/tests/test_amazon_datazone.py
@@ -1,0 +1,123 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from openlineage.client import OpenLineageClient
+from openlineage.client.run import (
+    Dataset,
+    DatasetEvent,
+    Job,
+    JobEvent,
+    Run,
+    RunEvent,
+    RunState,
+)
+from openlineage.client.serde import Serde
+from openlineage.client.transport.amazon_datazone import AmazonDataZoneConfig, AmazonDataZoneTransport
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture()
+def domain_id() -> str:
+    return "dzd_a1b2c3d4e5f6g7"
+
+
+@pytest.fixture()
+def run_event() -> RunEvent:
+    return RunEvent(
+        eventType=RunState.START,
+        eventTime="2024-08-20T11:08:01.123456",
+        run=Run(runId="f8b61441-a9fb-4f65-a156-be466eb29832"),
+        job=Job(namespace="test-namespace", name="test-job"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+@pytest.fixture()
+def dataset_event() -> DatasetEvent:
+    return DatasetEvent(
+        eventTime="2024-08-20T11:08:01.123456",
+        dataset=Dataset(namespace="test-namespace", name="test-dataset"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+@pytest.fixture()
+def job_event() -> JobEvent:
+    return JobEvent(
+        eventTime="2024-08-20T11:08:01.123456",
+        job=Job(namespace="test-namespace", name="test-job"),
+        producer="prod",
+        schemaURL="schema",
+    )
+
+
+def test_datazone_config_raises_when_missing_domain_id() -> None:
+    with pytest.raises(TypeError):
+        AmazonDataZoneConfig()
+
+
+def test_client_with_amazon_datazone_transport_emits_run_event(
+    run_event: RunEvent, domain_id: str, mocker: MockerFixture
+) -> None:
+    mocker.patch("boto3.client")
+    config = AmazonDataZoneConfig(domain_id=domain_id)
+    transport = AmazonDataZoneTransport(config)
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(run_event)
+
+    transport.datazone.post_lineage_event.assert_called_once_with(
+        domainIdentifier=domain_id,
+        event=Serde.to_json(run_event).encode("utf-8"),
+    )
+
+
+def test_client_with_amazon_datazone_transport_skips_job_event(
+    job_event: JobEvent, mocker: MockerFixture
+) -> None:
+    mocker.patch("boto3.client")
+    config = AmazonDataZoneConfig(domain_id=domain_id)
+    transport = AmazonDataZoneTransport(config)
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(job_event)
+
+    transport.datazone.post_lineage_event.assert_not_called()
+
+
+def test_client_with_amazon_datazone_transport_skips_dataset_event(
+    dataset_event: DatasetEvent, mocker: MockerFixture
+) -> None:
+    mocker.patch("boto3.client")
+    config = AmazonDataZoneConfig(domain_id=domain_id)
+    transport = AmazonDataZoneTransport(config)
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(dataset_event)
+
+    transport.datazone.post_lineage_event.assert_not_called()
+
+
+def test_setup_datazone_raises_when_boto3_missing(mocker: MockerFixture) -> None:
+    mocker.patch("boto3.client", side_effect=ModuleNotFoundError("No module named 'boto3'"))
+    config = AmazonDataZoneConfig(domain_id=domain_id)
+
+    with pytest.raises(ModuleNotFoundError):
+        AmazonDataZoneTransport(config)
+
+
+def test_setup_datazone_raises_when_boto3_corrupted(mocker: MockerFixture) -> None:
+    mocker.patch("boto3.client", side_effect=ImportError("Cannot import 'boto3'"))
+    config = AmazonDataZoneConfig(domain_id=domain_id)
+
+    with pytest.raises(ImportError):
+        AmazonDataZoneTransport(config)

--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -924,6 +924,72 @@ OpenLineageClient client = OpenLineageClient.builder()
 </TabItem>
 </Tabs>
 
+### [DataZone Transport](https://github.com/OpenLineage/OpenLineage/blob/main/client/java/transports-datazone/src/main/java/io/openlineage/client/transports/datazone/AmazonDataZoneTransport.java)
+
+To use this transport in your project, you need to include `io.openlineage:transports-datazone` artifact in
+your build configuration. This is particularly important for environments like `Spark`, where this transport must be on
+the classpath for lineage events to be emitted correctly.
+
+#### Configuration
+
+- `type` - string, must be `"amazon_datazone_api"`. Required.
+- `domainId` - string, specifies the DataZone / SageMaker Unified Studio domain id. The lineage events will be then sent to the following domain. Required.
+- `endpointOverride` - string, overrides the default HTTP endpoint for Amazon DataZone client.
+  Default value will be set by AWS SDK to [following endpoints](https://docs.aws.amazon.com/general/latest/gr/datazone.html#datazone_region) based on the region.
+  Optional, default: None
+
+#### Behavior
+
+- Events are serialized to JSON, and then dispatched to the `DataZone` / `SageMaker Unified Studio` endpoint.
+
+#### Examples
+
+<Tabs groupId="integrations">
+<TabItem value="yaml" label="Yaml Config">
+
+```yaml
+transport:
+  type: amazon_datazone_api
+  domainId: dzd-domain-id
+```
+
+</TabItem>
+<TabItem value="spark" label="Spark Config">
+
+```ini
+spark.openlineage.transport.type=amazon_datazone_api
+spark.openlineage.transport.domainId=dzd-domain-id
+```
+
+</TabItem>
+<TabItem value="flink" label="Flink Config">
+
+```ini
+openlineage.transport.type=amazon_datazone_api
+openlineage.transport.domainId=dzd-domain-id
+```
+
+</TabItem>
+<TabItem value="java" label="Java Code">
+
+```java
+import io.openlineage.client.OpenLineageClient;
+import io.openlineage.client.transports.datazone.AmazonDataZoneTransportConfig;
+import io.openlineage.client.transports.datazone.AmazonDataZoneTransport;
+
+AmazonDataZoneTransportConfig datazoneConfig = new AmazonDataZoneTransportConfig();
+
+datazoneConfig.setDomainId("dzd-domain-id");
+
+OpenLineageClient client = OpenLineageClient.builder()
+        .transport(
+                new AmazonDataZoneTransport(datazoneConfig))
+        .build();
+```
+
+</TabItem>
+</Tabs>
+
 
 import S3Transport from './s3_transport.md';
 

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -722,6 +722,52 @@ client = OpenLineageClient()
 
 </Tabs>
 
+### Amazon DataZone
+
+The `AmazonDataZoneTransport` requires `boto3` package to be additionally installed. It can be done via `pip install openlineage-python[datazone]`. This transport will send event to DataZone / SageMaker Unified Studio domain.
+
+#### Configuration
+
+- `type` - string, must be `"amazon_datazone_api"`. Required.
+- `domainId` - string, specifies the DataZone / SageMaker Unified Studio domain id. The lineage events will be then sent to the following domain. Required.
+- `endpointOverride` - string, overrides the default HTTP endpoint for Amazon DataZone client.
+  Default value will be set by AWS SDK to [following endpoints](https://docs.aws.amazon.com/general/latest/gr/datazone.html#datazone_region) based on the region.
+  Optional, default: None
+
+#### Behavior
+
+- Events are serialized to JSON, and then dispatched to the `DataZone` / `SageMaker Unified Studio` endpoint.
+
+
+#### Examples
+
+<Tabs groupId="integrations">
+<TabItem value="yaml" label="Yaml Config">
+
+```yaml
+transport:
+  type: amazon_datazone_api
+  domainId: dzd-domain-id
+```
+
+</TabItem>
+<TabItem value="python" label="Python Code">
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport.amazon_datazone import AmazonDataZoneTransport, AmazonDataZoneConfig
+
+datazone_config = AmazonDataZoneConfig(
+  domainId="dzd-domain-id",
+)
+
+client = OpenLineageClient(transport=AmazonDataZoneTransport(datazone_config))
+```
+
+</TabItem>
+
+</Tabs>
+
 ### Custom Transport Type
 
 To implement a custom transport, follow the instructions in [`transport.py`](https://github.com/OpenLineage/OpenLineage/blob/main/client/python/openlineage/client/transport/transport.py).


### PR DESCRIPTION
### Problem

DataZone and SageMaker Unified Studio(SMUS) currently accepts OpenLineage events via the [PostLineageEvent API](https://docs.aws.amazon.com/datazone/latest/APIReference/API_PostLineageEvent.html). However, the existing OpenLineage framework does not have a transport that can directly send OpenLineage events to Amazon DataZone / SageMaker Unified Studio.


### Solution
Adding DataZone transport where OpenLineage events can be sent directly to DataZone / SageMaker Unified Studio.

The Java transport has been tested in the AWS Glue job / EMR / local pyspark. This was done by adding the following spark config. The lineage events were successfully emitted to Amazon DataZone / SMUS.
```
--conf spark.extraListeners=io.openlineage.spark.agent.OpenLineageSparkListener
--conf spark.openlineage.transport.type=amazon_datazone_api
--conf spark.openlineage.transport.domainId=dzd_domain_id
```

The Python transport has been tested in the Amazon Managed Workflows for Apache Airflow (MWAA) environment. This was done by loading the updated openlineage-python.whl package as a [custom dependency](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-import-plugins.html). The lineage events were successfully emitted to Amazon DataZone / SMUS.
```
transport:
  type: amazon_datazone_api
  domainId: dzd-domain-id
``` 

#### One-line summary:

Add Amazon DataZone transport

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project