### PR TITLE
spark: Broaden getIcebergTable exception catching to ensure columLineage facet is included

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 
@@ -269,12 +268,12 @@ public class IcebergHandler implements CatalogHandler {
         SparkSessionCatalog sparkCatalog = (SparkSessionCatalog) tableCatalog;
         return Optional.ofNullable(sparkCatalog.icebergCatalog().loadTable(tableIdentifier));
       }
-    } catch (NoSuchTableException e) {
-      // don't log stack trace for missing tables
-      log.warn("Failed to load table from catalog: {}", identifier);
-      return Optional.empty();
     } catch (ClassCastException e) {
       log.error("Failed to load table from catalog: {}", identifier, e);
+      return Optional.empty();
+    } catch (Exception e) {
+      // don't log stack trace for missing tables
+      log.warn("Failed to load table from catalog: {}", identifier);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
### Problem

Unhandled exceptions in `getIcebergTable` could abruptly terminate the method. This interruption in the OpenLineage event processing flow resulted in missing the `columnLineage` facet, as the process would fail before this information could be generated.

Closes: #3553

### Solution

The exception handling was broadened by changing the specific `catch` block to a more general `catch (Exception e)`. This ensures all exceptions encountered during table loading are caught. The method now consistently logs a warning and returns `Optional.empty()` upon any failure, preventing crashes and allowing the OpenLineage processing to proceed, thereby enabling the `columnLineage` facet to be included.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:
Broadened exception handling in the `getIcebergTable` method to prevent unhandled errors from disrupting OpenLineage facet generation, ensuring `columnLineage` is captured.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project