### PR TITLE
Extract lineage for AWS dynamic frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.33.0...HEAD)
 
+### Added
+
+* **Spark: Support dynamic frames.** [`#3691`](https://github.com/OpenLineage/OpenLineage/pull/3691) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Support lineage extraction from `UnionRdd` and `NewHadoopRDD`, which makes dynamic frames docker based test passing.*
+
 ## [1.33.0](https://github.com/OpenLineage/OpenLineage/compare/1.32.1...1.33.0) - 2025-05-19
 
 ### Added

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
@@ -1,0 +1,137 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_LOG4J2_PROPERTIES_PATH;
+import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_LOG4J_PROPERTIES_PATH;
+import static io.openlineage.spark.agent.SparkContainerProperties.CONTAINER_SPARK_JARS_DIR;
+import static io.openlineage.spark.agent.SparkContainerProperties.HOST_ADDITIONAL_JARS_DIR;
+import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LIB_DIR;
+import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J2_PROPERTIES_PATH;
+import static io.openlineage.spark.agent.SparkContainerProperties.HOST_LOG4J_PROPERTIES_PATH;
+import static io.openlineage.spark.agent.SparkContainerProperties.HOST_RESOURCES_DIR;
+import static io.openlineage.spark.agent.SparkContainerProperties.SPARK_DOCKER_IMAGE;
+import static io.openlineage.spark.agent.SparkContainerUtils.SPARK_DOCKER_CONTAINER_WAIT_MESSAGE;
+import static io.openlineage.spark.agent.SparkContainerUtils.mountFiles;
+import static io.openlineage.spark.agent.SparkContainerUtils.mountPath;
+import static io.openlineage.spark.agent.SparkTestUtils.SPARK_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.model.HttpRequest.request;
+
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.client.OpenLineageClientUtils;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Tag("integration-test")
+@Testcontainers
+@Slf4j
+@EnabledIfSystemProperty(named = SPARK_VERSION, matches = "([34].*)") // Spark version >= 3.*
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class AwsDynamicFrameIntegrationTest {
+
+  public static final String SPARK_DOCKER_IMAGE = "amazon/aws-glue-libs:5";
+
+  private static final Network network = Network.newNetwork();
+
+  @Container
+  private static final MockServerContainer mockServerContainer =
+      SparkContainerUtils.makeMockServerContainer(network);
+
+  private static MockServerClient mockServerClient;
+
+  @BeforeAll
+  public static void setupMockServer() {
+    mockServerClient =
+        new MockServerClient(mockServerContainer.getHost(), mockServerContainer.getServerPort());
+
+    mockServerClient
+        .when(request("/api/v1/lineage"))
+        .respond(org.mockserver.model.HttpResponse.response().withStatusCode(201));
+
+    Awaitility.await().until(mockServerContainer::isRunning);
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    mockServerContainer.stop();
+    network.close();
+  }
+
+  @Test
+  @SneakyThrows
+  @EnabledIfSystemProperty(named = "scala.binary.version", matches = "2\\.12")
+  void testDynamicFrame() {
+    StringBuilder command = new StringBuilder("spark-submit");
+    command
+        .append(" --conf ")
+        .append("spark.openlineage.transport.type=http")
+        .append(" --conf ")
+        .append("spark.openlineage.transport.url=http://openlineageclient:1080")
+        .append(" --conf ")
+        .append("spark.openlineage.facets.debug.disabled=false")
+        .append(" --conf ")
+        .append("spark.extraListeners=")
+        .append(OpenLineageSparkListener.class.getName())
+        .append(" --files ")
+        .append(CONTAINER_LOG4J_PROPERTIES_PATH)
+        .append(" /opt/spark_scripts/dynamic_frame.py")
+        .append(" -Dlog4j.configuration=log4j.properties");
+
+    log.info(command.toString());
+    GenericContainer container =
+        new GenericContainer<>(DockerImageName.parse(SPARK_DOCKER_IMAGE))
+            .withNetwork(network)
+            .withNetworkAliases("spark")
+            .withLogConsumer(SparkContainerUtils::consumeOutput)
+            .waitingFor(Wait.forLogMessage(SPARK_DOCKER_CONTAINER_WAIT_MESSAGE, 1))
+            .dependsOn(mockServerContainer)
+            .withCommand(command.toString());
+
+    final Path buildDir = Paths.get(System.getProperty("build.dir")).toAbsolutePath();
+    mountPath(container, HOST_RESOURCES_DIR.resolve("test_data"), Paths.get("/test_data"));
+    mountFiles(
+        container, HOST_RESOURCES_DIR.resolve("spark_scripts"), Paths.get("/opt/spark_scripts"));
+    Path targetDir = Paths.get("/opt/spark/jars/");
+    mountFiles(container, buildDir.resolve("libs"), targetDir);
+    mountPath(container, HOST_LOG4J_PROPERTIES_PATH, CONTAINER_LOG4J_PROPERTIES_PATH);
+    mountPath(container, HOST_LOG4J2_PROPERTIES_PATH, CONTAINER_LOG4J2_PROPERTIES_PATH);
+    mountFiles(container, HOST_ADDITIONAL_JARS_DIR, CONTAINER_SPARK_JARS_DIR);
+    mountFiles(container, HOST_LIB_DIR, targetDir);
+
+    container.start();
+
+    List<RunEvent> events =
+        Arrays.stream(
+                mockServerClient.retrieveRecordedRequests(request().withPath("/api/v1/lineage")))
+            .map(r -> OpenLineageClientUtils.runEventFromJson(r.getBodyAsString()))
+            .collect(Collectors.toList());
+
+    assertThat(events.stream().flatMap(e -> e.getInputs().stream()).collect(Collectors.toList()))
+        .isNotEmpty();
+    assertThat(events.stream().flatMap(e -> e.getOutputs().stream()).collect(Collectors.toList()))
+        .isNotEmpty();
+  }
+}

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -79,7 +79,7 @@ public class SparkContainerUtils {
     return container;
   }
 
-  static void mountPath(GenericContainer<?> container, Path sourcePath, Path targetPath) {
+  public static void mountPath(GenericContainer<?> container, Path sourcePath, Path targetPath) {
     if (log.isDebugEnabled()) {
       log.debug(
           "[image={}]: Mount volume '{}:{}'",
@@ -91,7 +91,7 @@ public class SparkContainerUtils {
   }
 
   @SneakyThrows
-  static void mountFiles(GenericContainer<?> container, Path sourceDir, Path targetDir) {
+  public static void mountFiles(GenericContainer<?> container, Path sourceDir, Path targetDir) {
     if (!Files.exists(sourceDir)) {
       log.warn("Source directory {} does not exist, skipping mount", sourceDir);
       return;

--- a/integration/spark/app/src/test/resources/spark_scripts/dynamic_frame.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/dynamic_frame.py
@@ -1,0 +1,34 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+
+# Create GlueContext
+sc = SparkContext.getOrCreate()
+glueContext = GlueContext(sc)
+
+print("Config OL: ", sc.getConf().getAll())
+
+
+# Create DynamicFrame from Glue Data Catalog
+data = glueContext.create_dynamic_frame.from_options(
+    "s3",
+    {"paths": ["/test_data/dynamic_data.json"]},
+    "json",
+    {"withHeader": False, "multiline": False},
+)
+
+# from os import system
+#
+# system("cat /test_data/dynamic_data.json")
+
+# Create filtered DynamicFrame with custom lambda
+# to filter records by Provider State and Provider City
+filtered = data.filter(f=lambda x: x["name"] in ["Sally"] and x["location"]["state"] in ["WY"])
+
+# filter.save()
+
+# Compare record counts
+print("Unfiltered record count: ", data.count())
+print("Filtered record count:  ", filtered.count())

--- a/integration/spark/app/src/test/resources/test_data/dynamic_data.json
+++ b/integration/spark/app/src/test/resources/test_data/dynamic_data.json
@@ -1,0 +1,5 @@
+{"name": "Sally", "age": 23, "location": {"state": "WY", "county": "Fremont"}, "friends": []}
+{"name": "Varun", "age": 34, "location": {"state": "NE", "county": "Douglas"}, "friends": [{"name": "Arjun", "age": 3}]}
+{"name": "George", "age": 52, "location": {"state": "NY"}, "friends": [{"name": "Fred"}, {"name": "Amy", "age": 15}]}
+{"name": "Haruki", "age": 21, "location": {"state": "AK", "county": "Denali"}}
+{"name": "Sheila", "age": 63, "friends": [{"name": "Nancy", "age": 22}]}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -258,7 +258,7 @@ public class PlanUtils {
         return p;
       }
     } catch (IOException e) {
-      log.warn("Unable to get file system for path ", e);
+      log.warn("Unable to get file system for path: {}", e.getMessage());
       return p;
     }
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.util;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -14,11 +15,14 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapreduce.Job;
 import org.apache.spark.package$;
 import org.apache.spark.rdd.HadoopRDD;
 import org.apache.spark.rdd.MapPartitionsRDD;
+import org.apache.spark.rdd.NewHadoopRDD;
 import org.apache.spark.rdd.ParallelCollectionRDD;
 import org.apache.spark.rdd.RDD;
+import org.apache.spark.rdd.UnionRDD;
 import org.apache.spark.sql.execution.datasources.FilePartition;
 import org.apache.spark.sql.execution.datasources.FileScanRDD;
 import scala.Tuple2;
@@ -34,12 +38,28 @@ public class RddPathUtils {
             new HadoopRDDExtractor(),
             new FileScanRDDExtractor(),
             new MapPartitionsRDDExtractor(),
+            new UnionRddExctractor(),
+            new NewHadoopRDDExtractor(),
             new ParallelCollectionRDDExtractor())
         .filter(e -> e.isDefinedAt(rdd))
         .findFirst()
         .orElse(new UnknownRDDExtractor())
         .extract(rdd)
         .filter(p -> p != null);
+  }
+
+  static class UnionRddExctractor implements RddPathExtractor<RDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof UnionRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(RDD rdd) {
+      return ScalaConversionUtils.<RDD>fromSeq(((UnionRDD) rdd).rdds()).stream()
+          .map(RDD.class::cast)
+          .flatMap(r -> findRDDPaths((RDD) r));
+    }
   }
 
   static class UnknownRDDExtractor implements RddPathExtractor<RDD> {
@@ -71,6 +91,27 @@ public class RddPathUtils {
         log.debug("Hadoop RDD job conf {}", rdd.getJobConf());
       }
       return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
+    }
+  }
+
+  static class NewHadoopRDDExtractor implements RddPathExtractor<NewHadoopRDD> {
+    @Override
+    public boolean isDefinedAt(Object rdd) {
+      return rdd instanceof NewHadoopRDD;
+    }
+
+    @Override
+    public Stream<Path> extract(NewHadoopRDD rdd) {
+      try {
+        org.apache.hadoop.fs.Path[] inputPaths =
+            org.apache.hadoop.mapreduce.lib.input.FileInputFormat.getInputPaths(
+                new Job(((NewHadoopRDD<?, ?>) rdd).getConf()));
+
+        return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, rdd.getConf()));
+      } catch (IOException e) {
+        log.error("Openlineage spark agent could not get input paths", e);
+      }
+      return Stream.empty();
     }
   }
 


### PR DESCRIPTION
Currently dynamic frames in Spark are not supported. 
This is due to `RDDPathUtils` missing the support for `UnionRdd` and `NewHadoopRDD`. 

This PR adds:
 *  integration test based on glue `amazon/aws-glue-libs:5` glue docker image. Test used to fail without added rdd extractors
 * Extractors for `UnionRdd` and `NewHadoopRDD` together covered with unit-tests