### PR TITLE
spark: Implement CatalogDatasetFacet for CatalogHandler

### DIFF
--- a/integration/spark/buildDependencies.sh
+++ b/integration/spark/buildDependencies.sh
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -x -e
-(cd ../../client/java && ./gradlew clean publishToMavenLocal -x test)
+(cd ../../client/java && ./gradlew generateCode publishToMavenLocal -x test --rerun-tasks)
 (cd ../spark-extension-interfaces && ./gradlew clean publishToMavenLocal -x test)
 (cd ../sql/iface-java && ./script/compile.sh && ./script/build.sh)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -32,7 +32,16 @@ public class AwsUtils {
                   getGlueCatalogId(sparkConf, hadoopConf)
                       .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
     } else {
-      return Optional.empty();
+      try {
+        return awsRegion()
+            .flatMap(
+                region ->
+                    getGlueCatalogId(sparkConf, hadoopConf)
+                        .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
+      } catch (Exception e) {
+        log.error("Failed to retrieve Glue", e);
+        return Optional.empty();
+      }
     }
   }
 

--- a/integration/spark/spark3/build.gradle
+++ b/integration/spark/spark3/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     testFixturesApi("org.mockito:mockito-core:${mockitoVersion}")
     testFixturesApi("org.mockito:mockito-inline:${mockitoVersion}")
     testFixturesApi("io.micrometer:micrometer-core:${micrometerVersion}")
+    testFixturesApi('org.xerial:sqlite-jdbc:3.49.1.0')
 
     // Scala 2.12
     scala212Implementation(project(path: ":shared", configuration: "scala212RuntimeElements"))
@@ -102,6 +103,7 @@ dependencies {
     testScala212Implementation("io.delta:delta-core_2.12:${deltaVersion}")
     testScala212Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:${icebergVersion}")
     testScala212Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
+    testScala212Implementation('org.xerial:sqlite-jdbc:3.49.1.0')
 
     testScala212Implementation("org.assertj:assertj-core:${assertjVersion}")
     testScala212Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
@@ -136,6 +138,7 @@ dependencies {
     testScala213Implementation("io.delta:delta-core_2.13:${deltaVersion}")
     testScala213Implementation("org.apache.iceberg:iceberg-spark-runtime-3.2_2.13:${icebergVersion}")
     testScala213Implementation("io.micrometer:micrometer-core:${micrometerVersion}")
+    testScala213Implementation('org.xerial:sqlite-jdbc:3.49.1.0')
 
     testScala213Implementation("org.assertj:assertj-core:${assertjVersion}")
     testScala213Implementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -124,6 +124,8 @@ public class CreateReplaceDatasetBuilder
 
     CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
         .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
+    CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
+        .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -6,9 +6,12 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.PlanUtils3;
 import java.util.Collections;
 import java.util.List;
@@ -48,12 +51,22 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
         PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
 
     if (di.isPresent()) {
-      return Collections.singletonList(
-          outputDataset()
-              .getDataset(
-                  di.get(),
-                  resolvedTable.schema(),
-                  OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP));
+      DatasetCompositeFacetsBuilder builder = outputDataset().createCompositeFacetBuilder();
+      CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
+          .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
+      builder
+          .getFacets()
+          .schema(PlanUtils.schemaFacet(context.getOpenLineage(), resolvedTable.schema()));
+      builder
+          .getFacets()
+          .lifecycleStateChange(
+              context
+                  .getOpenLineage()
+                  .newLifecycleStateChangeDatasetFacet(
+                      OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP,
+                      null));
+
+      return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
     } else {
       return Collections.emptyList();
     }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
@@ -29,6 +29,11 @@ public interface CatalogHandler {
     return Optional.empty();
   }
 
+  default Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    return Optional.empty();
+  }
+
   /** Try to find string that uniquely identifies version of a dataset. */
   default Optional<String> getDatasetVersion(
       TableCatalog catalog, Identifier identifier, Map<String, String> properties) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -100,6 +100,14 @@ public class CatalogUtils3 {
         : Optional.empty();
   }
 
+  public static Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      OpenLineageContext context, TableCatalog catalog, Map<String, String> properties) {
+    Optional<CatalogHandler> catalogHandler = getCatalogHandler(context, catalog);
+    return catalogHandler.isPresent()
+        ? catalogHandler.get().getCatalogDatasetFacet(catalog, properties)
+        : Optional.empty();
+  }
+
   public static Optional<String> getDatasetVersion(
       OpenLineageContext context,
       TableCatalog catalog,

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
@@ -10,6 +10,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 /**
  * The DatabricksDeltaHandler is intended to support Databricks' custom DeltaCatalog which has the
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
+  private static final String DELTA = "delta";
 
   public DatabricksDeltaHandler(OpenLineageContext context) {
     super(context, "com.databricks.sql.transaction.tahoe.catalog.DeltaCatalog");
@@ -30,11 +32,26 @@ public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
     return Optional.of(
         context
             .getOpenLineage()
-            .newStorageDatasetFacet("delta", "parquet")); // Delta is always parquet
+            .newStorageDatasetFacet(DELTA, "parquet")); // Delta is always parquet
+  }
+
+  @Override
+  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    OpenLineage.CatalogDatasetFacetBuilder builder =
+        context
+            .getOpenLineage()
+            .newCatalogDatasetFacetBuilder()
+            .name(tableCatalog.name())
+            .framework(DELTA)
+            .type(DELTA)
+            .source("spark");
+
+    return Optional.of(builder.build());
   }
 
   @Override
   public String getName() {
-    return "delta";
+    return DELTA;
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
@@ -10,6 +10,7 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 /**
  * The DatabricksUnityV2Handler is intended to support Databricks' custom Unity Catalog which has
@@ -31,6 +32,21 @@ public class DatabricksUnityV2Handler extends AbstractDatabricksHandler {
         context
             .getOpenLineage()
             .newStorageDatasetFacet("unity", "parquet")); // The default is parquet / delta
+  }
+
+  @Override
+  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    OpenLineage.CatalogDatasetFacetBuilder builder =
+        context
+            .getOpenLineage()
+            .newCatalogDatasetFacetBuilder()
+            .name(tableCatalog.name())
+            .framework("delta")
+            .type("unity")
+            .source("spark");
+
+    return Optional.of(builder.build());
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2;
 
 @Slf4j
 public class DeltaHandler implements CatalogHandler {
+  private static final String DELTA = "delta";
   private final OpenLineageContext context;
 
   public DeltaHandler(OpenLineageContext context) {
@@ -81,12 +82,31 @@ public class DeltaHandler implements CatalogHandler {
   }
 
   @Override
+  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    String name = tableCatalog.name();
+    if (name == null || name.isEmpty()) {
+      name = "spark_catalog"; // default
+    }
+    OpenLineage.CatalogDatasetFacetBuilder builder =
+        context
+            .getOpenLineage()
+            .newCatalogDatasetFacetBuilder()
+            .name(name)
+            .framework(DELTA)
+            .type(DELTA)
+            .source("spark");
+
+    return Optional.of(builder.build());
+  }
+
+  @Override
   public Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(
       Map<String, String> properties) {
     return Optional.of(
         context
             .getOpenLineage()
-            .newStorageDatasetFacet("delta", "parquet")); // Delta is always parquet
+            .newStorageDatasetFacet(DELTA, "parquet")); // Delta is always parquet
   }
 
   @SneakyThrows
@@ -136,6 +156,6 @@ public class DeltaHandler implements CatalogHandler {
 
   @Override
   public String getName() {
-    return "delta";
+    return DELTA;
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.jdbc.JdbcDatasetUtils;
@@ -12,9 +13,10 @@ import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -22,10 +24,13 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
 
+@Slf4j
 public class JdbcHandler implements CatalogHandler {
+  private final OpenLineageContext context;
   private final DatasetNamespaceCombinedResolver namespaceResolver;
 
   public JdbcHandler(OpenLineageContext context) {
+    this.context = context;
     namespaceResolver = new DatasetNamespaceCombinedResolver(context.getOpenLineageConfig());
   }
 
@@ -39,23 +44,57 @@ public class JdbcHandler implements CatalogHandler {
     return tableCatalog instanceof JDBCTableCatalog;
   }
 
-  @SneakyThrows
   @Override
   public DatasetIdentifier getDatasetIdentifier(
       SparkSession session,
       TableCatalog tableCatalog,
       Identifier identifier,
       Map<String, String> properties) {
-    JDBCTableCatalog catalog = (JDBCTableCatalog) tableCatalog;
-    JDBCOptions jdbcOptions = (JDBCOptions) FieldUtils.readField(catalog, "options", true);
+    Optional<JDBCOptions> jdbcOptions = getJdbcOptions(tableCatalog);
 
+    if (!jdbcOptions.isPresent()) {
+      throw new MissingDatasetIdentifierCatalogException(
+          "No jdbc options found for catalog " + tableCatalog.name());
+    }
+
+    JDBCOptions options = jdbcOptions.get();
     List<String> parts =
         Stream.concat(Arrays.stream(identifier.namespace()), Stream.of(identifier.name()))
             .collect(Collectors.toList());
 
     return namespaceResolver.resolve(
         JdbcDatasetUtils.getDatasetIdentifier(
-            jdbcOptions.url(), parts, jdbcOptions.asConnectionProperties()));
+            options.url(), parts, options.asConnectionProperties()));
+  }
+
+  @Override
+  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+      TableCatalog tableCatalog, Map<String, String> properties) {
+    Optional<JDBCOptions> options = getJdbcOptions(tableCatalog);
+
+    OpenLineage.CatalogDatasetFacetBuilder builder =
+        context
+            .getOpenLineage()
+            .newCatalogDatasetFacetBuilder()
+            .name(tableCatalog.name())
+            .framework("jdbc")
+            .type("jdbc")
+            .source("spark");
+
+    options.ifPresent(jdbcOptions -> builder.metadataUri(options.get().url()));
+
+    return Optional.of(builder.build());
+  }
+
+  private Optional<JDBCOptions> getJdbcOptions(TableCatalog tableCatalog) {
+    try {
+      JDBCTableCatalog catalog = (JDBCTableCatalog) tableCatalog;
+      JDBCOptions jdbcOptions = (JDBCOptions) FieldUtils.readField(catalog, "options", true);
+      return Optional.of(jdbcOptions);
+    } catch (IllegalAccessException e) {
+      log.warn("Failed to access JDBC Options", e);
+      return Optional.empty();
+    }
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -56,9 +56,13 @@ public class DataSourceV2RelationDatasetExtractor {
 
                 Map<String, String> tableProperties = relation.table().properties();
                 CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-                    .map(
+                    .ifPresent(
                         storageDatasetFacet ->
                             datasetFacetsBuilder.getFacets().storage(storageDatasetFacet));
+                CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
+                    .ifPresent(
+                        catalogDatasetFacet ->
+                            datasetFacetsBuilder.getFacets().catalog(catalogDatasetFacet));
               }
               datasetFacetsBuilder
                   .getFacets()

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -6,19 +6,25 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +78,27 @@ class JdbcHandlerTest {
 
     assertEquals("database.schema.table", datasetIdentifier.getName());
     assertEquals("postgres://postgreshost:5432", datasetIdentifier.getNamespace());
+  }
+
+  @Test
+  void testGetCatalogData() {
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+    JdbcHandler handler = new JdbcHandler(context);
+
+    String uri = "jdbc:sqlite::memory:";
+    JDBCTableCatalog tableCatalog = new JDBCTableCatalog();
+    tableCatalog.initialize(
+        "testCatalog", new CaseInsensitiveStringMap(Collections.singletonMap("url", uri)));
+
+    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+        handler.getCatalogDatasetFacet(tableCatalog, new HashMap<>());
+    assertTrue(catalogDatasetFacet.isPresent());
+
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+
+    assertEquals("testCatalog", facet.getName());
+    assertEquals("jdbc", facet.getType());
+    assertEquals(uri, facet.getMetadataUri());
+    assertEquals("jdbc", facet.getFramework());
   }
 }


### PR DESCRIPTION
This PR implements adding CatalogDatasetFacet for Spark `CatalogHandler` and few other places that are using `TableCatalog`:  `DropTableVisitor` and `CreateReplaceDatasetBuilder`.