### PR TITLE
DBT: Generate new runId for each start event

### DIFF
--- a/integration/dagster/tests/conftest.py
+++ b/integration/dagster/tests/conftest.py
@@ -164,8 +164,8 @@ class DagsterRunLatestProvider(DagsterRunProvider):
 def make_test_event_log_record(
     event_type: Optional[DagsterEventType] = None,
     pipeline_name: str = "a_job",
-    pipeline_run_id: str = str(generate_new_uuid()),
-    timestamp: float = time.time(),
+    pipeline_run_id: Optional[str] = None,
+    timestamp: Optional[float] = None,
     step_key: Optional[str] = None,
     storage_id: int = 1,
 ):
@@ -173,8 +173,8 @@ def make_test_event_log_record(
         None,
         "debug",
         "user_msg",
-        pipeline_run_id,
-        timestamp,
+        pipeline_run_id or str(generate_new_uuid()),
+        timestamp or time.time(),
         step_key,
         pipeline_name,
         _make_dagster_event(event_type, pipeline_name, step_key) if event_type else None,

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -47,13 +47,16 @@ def dbt_run_event(
     state: RunState,
     job_name: str,
     job_namespace: str,
-    run_id: str = str(generate_new_uuid()),
+    run_id: Optional[str] = None,
     parent: Optional[ParentRunMetadata] = None,
 ) -> RunEvent:
     return RunEvent(
         eventType=state,
         eventTime=datetime.now(timezone.utc).isoformat(),
-        run=Run(runId=run_id, facets={"parent": parent.to_openlineage()} if parent else {}),
+        run=Run(
+            runId=run_id or str(generate_new_uuid()),
+            facets={"parent": parent.to_openlineage()} if parent else {},
+        ),
         job=Job(
             namespace=parent.job_namespace if parent else job_namespace,
             name=job_name,


### PR DESCRIPTION
### Problem

In Python, default arguments like:
```python
def func(arg = "something"):
  ...
```

are effectively static values. Using some function result as a default value, like:
```python
def func(arg = generate_default_value()):
  ...
```
Will call `generate_default_value()` only once, while .py file is parsed and evaluated, not at each call of `func()`.

This pattern should be replaced with a guard like:
```python
def func(arg = None):
  arg = arg or generate_default_value()
  ...
```

### Solution

Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

DBT: Generate new runId for each start event

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project