### PR TITLE
feat: Add TransformTransport for Python Client

### DIFF
--- a/client/python/openlineage/client/transport/__init__.py
+++ b/client/python/openlineage/client/transport/__init__.py
@@ -10,6 +10,10 @@ from openlineage.client.transport.http import HttpConfig, HttpTransport
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 from openlineage.client.transport.msk_iam import MSKIAMConfig, MSKIAMTransport
 from openlineage.client.transport.noop import NoopTransport
+from openlineage.client.transport.transform.transform import (
+    TransformConfig,
+    TransformTransport,
+)
 from openlineage.client.transport.transport import Config, Transport, TransportFactory
 
 _factory = DefaultTransportFactory()
@@ -20,6 +24,7 @@ _factory.register_transport(MSKIAMTransport.kind, MSKIAMTransport)
 _factory.register_transport(ConsoleTransport.kind, ConsoleTransport)
 _factory.register_transport(NoopTransport.kind, NoopTransport)
 _factory.register_transport(FileTransport.kind, FileTransport)
+_factory.register_transport(TransformTransport.kind, TransformTransport)
 
 
 def get_default_factory() -> DefaultTransportFactory:
@@ -34,17 +39,21 @@ def register_transport(clazz: type[Transport]) -> type[Transport]:
 
 
 __all__ = [
+    "register_transport",
+    "get_default_factory",
     "Config",
+    "Transport",
     "TransportFactory",
+    "CompositeTransport",
+    "ConsoleTransport",
+    "FileTransport",
     "HttpConfig",
     "HttpTransport",
     "KafkaConfig",
     "KafkaTransport",
-    "MSKIAMTransport",
     "MSKIAMConfig",
-    "ConsoleTransport",
+    "MSKIAMTransport",
     "NoopTransport",
-    "Transport",
-    "register_transport",
-    "get_default_factory",
+    "TransformConfig",
+    "TransformTransport",
 ]

--- a/client/python/openlineage/client/transport/transform/__init__.py
+++ b/client/python/openlineage/client/transport/transform/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from openlineage.client.transport.transform.transform import (
+    EventTransformer,
+    TransformConfig,
+    TransformTransport,
+)
+from openlineage.client.transport.transform.transformers.job_namespace_replace_transformer import (
+    JobNamespaceReplaceTransformer,
+)
+
+__all__ = [
+    "EventTransformer",
+    "TransformConfig",
+    "TransformTransport",
+    "JobNamespaceReplaceTransformer",
+]

--- a/client/python/openlineage/client/transport/transform/transform.py
+++ b/client/python/openlineage/client/transport/transform/transform.py
@@ -1,0 +1,141 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import copy
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any
+
+import attr
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transport import Config, Transport
+from openlineage.client.utils import get_only_specified_fields, import_from_string
+
+if TYPE_CHECKING:
+    from openlineage.client.client import Event
+
+log = logging.getLogger(__name__)
+
+
+class EventTransformer:
+    """Base class for transformers of OpenLineage events."""
+
+    def __init__(self, properties: dict[str, Any]) -> None:
+        """Initialize the transformer with a dictionary of properties.
+
+        These properties can be used by subclasses to configure the transformation behavior.
+        """
+        self.properties = properties
+
+    def transform(self, event: Event) -> Event | None:
+        """Transform an OpenLineage event.
+
+        Subclasses must override this method to apply specific transformations
+        to the given event.
+
+        Args:
+            event: The event to be transformed.
+
+        Returns:
+            The transformed event, or None to not emit the event.
+        """
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"<{self.__class__.__name__}({self.properties})>"
+
+
+@attr.s
+class TransformConfig(Config):
+    """Configuration class for transform transport.
+
+    Holds configuration details including inner transport settings, the name of the
+    transformer class to use, and optional transformer-specific properties.
+    """
+
+    transport: dict[str, Any] = attr.ib()
+    transformer_class: str = attr.ib()
+    transformer_properties: dict[str, Any] = attr.ib(default={})
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TransformConfig:
+        """Create a TransformConfig instance from a dictionary of parameters.
+
+        Validates that required fields (`transport` and `transformer_class`) are present
+        and filters out unspecified fields based on the class definition.
+
+        Args:
+            params: Dictionary containing configuration parameters.
+
+        Returns:
+            An instance of TransformConfig populated with the provided data.
+
+        Raises:
+            RuntimeError: If required keys (`transport` or `transformer_class`) are missing.
+        """
+        if "transport" not in params:
+            msg = "'transport' not passed to TransformConfig"
+            raise RuntimeError(msg)
+        if "transformer_class" not in params:
+            msg = "'transformer_class' not passed to TransformConfig"
+            raise RuntimeError(msg)
+        return cls(**get_only_specified_fields(cls, params))
+
+
+class TransformTransport(Transport):
+    """Transport that transforms events before emitting them.
+
+    This transport wraps another transport (defined in the configuration) and intercepts
+    events for transformation using a user-defined EventTransformer class. Events can be
+    modified or discarded prior to being sent.
+    """
+
+    kind = "transform"
+    config_class = TransformConfig
+
+    def __init__(self, config: TransformConfig) -> None:
+        """Initialize the TransformTransport with the given configuration.
+
+        Dynamically loads the transformer class specified in the config, validates it,
+        and initializes both the transformer and the inner transport.
+
+        Args:
+            config: Configuration object containing transport and transformer settings.
+
+        Raises:
+            TypeError: If the transformer is not a valid subclass of EventTransformer.
+        """
+        # Import within method to avoid circular import error
+        from openlineage.client.transport import get_default_factory
+
+        transformer_class = import_from_string(config.transformer_class)
+        if not inspect.isclass(transformer_class) or not issubclass(transformer_class, EventTransformer):
+            msg = f"Transformer `{transformer_class}` has to be class, and subclass of EventTransformer"
+            raise TypeError(msg)
+        self.transformer = transformer_class(properties=config.transformer_properties)
+        self.transport = get_default_factory().create(config.transport)
+
+    def emit(self, event: Event) -> Any:
+        """Transform and emit an OpenLineage event.
+
+        Applies the configured EventTransformer to the event. If the result is not `None`,
+        the transformed event is passed to the wrapped transport's `emit` method.
+
+        Args:
+            event: The OpenLineage event to be transformed and emitted.
+
+        Returns:
+            The result of the inner transport's emit call, or None if the event is dropped.
+        """
+        log.debug("Event before transformation: %s", Serde.to_json(event))
+        event = copy.deepcopy(event)  # Copy to make sure the transformer does not modify original event
+
+        log.debug("Transforming OpenLineage event with %s", self.transformer)
+        transformed = self.transformer.transform(event)
+        if transformed is None:
+            log.info("Transformed OpenLineage event is None. Skipping emission.")
+            return None
+
+        log.debug("Event after transformation: %s", Serde.to_json(transformed))
+        return self.transport.emit(transformed)

--- a/client/python/openlineage/client/transport/transform/transformers/__init__.py
+++ b/client/python/openlineage/client/transport/transform/transformers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0

--- a/client/python/openlineage/client/transport/transform/transformers/job_namespace_replace_transformer.py
+++ b/client/python/openlineage/client/transport/transform/transformers/job_namespace_replace_transformer.py
@@ -1,0 +1,44 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from openlineage.client import event_v2
+from openlineage.client.transport.transform.transform import EventTransformer
+
+if TYPE_CHECKING:
+    from openlineage.client.client import Event
+
+log = logging.getLogger(__name__)
+
+
+class JobNamespaceReplaceTransformer(EventTransformer):
+    """EventTransformer that replaces the Job namespace in OpenLineage events."""
+
+    def __init__(self, properties: dict[str, Any]) -> None:
+        if not properties.get("new_job_namespace"):
+            msg = f"`new_job_namespace` not passed to {self.__class__.__name__}"
+            raise RuntimeError(msg)
+        super().__init__(properties=properties)
+
+    def transform(self, event: Event) -> Event | None:
+        if not isinstance(event, (event_v2.RunEvent, event_v2.JobEvent)):  # These events have Job
+            log.warning(
+                "Unsupported type: expected `RunEvent` or `JobEvent`, got `%s`. Skipping transformation.",
+                type(event),
+            )
+            return event
+
+        new_namespace = self.properties["new_job_namespace"]
+        log.debug(
+            "Replacing current OpenLineage job namespace: `%s` with new: `%s` for single event.",
+            event.job.namespace,
+            new_namespace,
+        )
+
+        event.job.namespace = new_namespace
+
+        return event

--- a/client/python/tests/transform/__init__.py
+++ b/client/python/tests/transform/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0

--- a/client/python/tests/transform/test_transform.py
+++ b/client/python/tests/transform/test_transform.py
@@ -1,0 +1,384 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import datetime
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from openlineage.client import OpenLineageClient
+from openlineage.client.event_v2 import BaseEvent, Job, Run, RunEvent, RunState
+from openlineage.client.serde import Serde
+from openlineage.client.transport.transform import EventTransformer, TransformConfig, TransformTransport
+from openlineage.client.uuid import generate_new_uuid
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class NoopEventTransformer(EventTransformer):
+    def transform(self, event: BaseEvent) -> BaseEvent | None:
+        return event
+
+
+class AlwaysNoneEventTransformer(EventTransformer):
+    def transform(self, event: BaseEvent) -> BaseEvent | None:  # noqa: ARG002
+        return None
+
+
+class SampleEventTransformer(EventTransformer):
+    def transform(self, event: BaseEvent) -> BaseEvent | None:
+        event.job.namespace = "new_value"
+        return event
+
+
+class AlwaysFailingTransformer(EventTransformer):
+    def transform(self, event: BaseEvent) -> BaseEvent | None:  # noqa: ARG002
+        msg = "Failed transformation !"
+        raise ZeroDivisionError(msg)
+
+
+class NotEventTransformerBasedTransformer:
+    def transform(self, event: BaseEvent) -> BaseEvent | None:
+        return event
+
+
+def test_transform_config_from_dict_full_config() -> None:
+    transport_dict = {
+        "type": "http",
+        "url": "http://backend:5000",
+        "endpoint": "api/v1/lineage",
+        "verify": False,
+        "auth": {
+            "type": "api_key",
+            "api_key": "1500100900",
+        },
+        "compression": "gzip",
+        "retry": {
+            "total": 7,
+            "connect": 3,
+            "read": 2,
+            "status": 5,
+            "other": 1,
+            "allowed_methods": ["POST"],
+            "status_forcelist": [500, 502, 503, 504],
+            "backoff_factor": 0.5,
+            "raise_on_redirect": False,
+            "raise_on_status": False,
+        },
+    }
+    config = TransformConfig.from_dict(
+        {
+            "transport": transport_dict,
+            "transformer_class": "some.class.to.be.Imported",
+            "transformer_properties": {"first": "val", "second": "val2"},
+        }
+    )
+
+    assert config.transport == transport_dict
+    assert config.transformer_class == "some.class.to.be.Imported"
+    assert config.transformer_properties == {"first": "val", "second": "val2"}
+
+
+def test_transform_config_from_dict_minimal_config() -> None:
+    config = TransformConfig.from_dict(
+        {
+            "transport": {"type": "console"},
+            "transformer_class": "some.class.to.be.Imported",
+        }
+    )
+    assert config.transport == {"type": "console"}
+    assert config.transformer_class == "some.class.to.be.Imported"
+    assert config.transformer_properties == {}
+
+
+def test_transform_config_from_dict_missing_config() -> None:
+    with pytest.raises(RuntimeError):
+        TransformConfig.from_dict({"transport": {"type": "console"}})
+
+    with pytest.raises(RuntimeError):
+        TransformConfig.from_dict({"transformer_class": "some.class.to.be.Imported"})
+
+
+def test_base_event_transformer_saves_config():
+    config = {"first": "val", "second": "val2"}
+    obj = EventTransformer(properties=config)
+    assert obj.properties == config
+
+
+def test_base_event_transformer_requires_transform_method():
+    obj = EventTransformer(properties={})
+    with pytest.raises(NotImplementedError):
+        obj.transform(None)
+
+
+def test_base_event_transformer_str():
+    config = {"first": "val", "second": "val2"}
+    obj = NoopEventTransformer(properties=config)
+    obj_str = str(obj)
+    assert obj_str == "<NoopEventTransformer({'first': 'val', 'second': 'val2'})>"
+
+
+def test_client_with_transform_transport_emits(mocker: MockerFixture) -> None:
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.NoopEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.transport.session.post.assert_called_once_with(
+        url="http://backend:5000/api/v1/lineage",
+        data=Serde.to_json(event),
+        headers={"Content-Type": "application/json"},
+        timeout=5.0,
+        verify=True,
+    )
+
+
+def test_client_with_transform_transport_emits_modified_event(mocker: MockerFixture) -> None:
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.SampleEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    now = datetime.datetime.now().isoformat()
+    run_id = str(generate_new_uuid())
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+    modified_event = RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="new_value", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.transport.session.post.assert_called_once_with(
+        url="http://backend:5000/api/v1/lineage",
+        data=Serde.to_json(modified_event),
+        headers={"Content-Type": "application/json"},
+        timeout=5.0,
+        verify=True,
+    )
+
+    # Assert the original event is unchanged
+    assert event == RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+
+def test_client_with_transform_transport_skips_emission_when_transformed_event_is_none(
+    mocker: MockerFixture,
+) -> None:
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.AlwaysNoneEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+
+    transport.transport.session.post.assert_not_called()
+
+
+def test_client_with_transform_transport_emits_modified_deprecated_event(mocker: MockerFixture) -> None:
+    from openlineage.client.run import Job, Run, RunEvent, RunState
+
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.SampleEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    now = datetime.datetime.now().isoformat()
+    run_id = str(generate_new_uuid())
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+    modified_event = RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="new_value", name="test"),
+        producer="prod",
+    )
+
+    client.emit(event)
+    transport.transport.session.post.assert_called_once_with(
+        url="http://backend:5000/api/v1/lineage",
+        data=Serde.to_json(modified_event),
+        headers={"Content-Type": "application/json"},
+        timeout=5.0,
+        verify=True,
+    )
+
+    # Assert the original event is unchanged
+    assert event == RunEvent(
+        eventType=RunState.START,
+        eventTime=now,
+        run=Run(runId=run_id),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+
+@patch("requests.Session.post")
+@patch.dict(
+    os.environ,
+    {
+        "OPENLINEAGE__TRANSPORT__TYPE": "transform",
+        "OPENLINEAGE__TRANSPORT__TRANSFORMER_CLASS": "tests.transform.test_transform.NoopEventTransformer",
+        "OPENLINEAGE__TRANSPORT__TRANSPORT__TYPE": "http",
+        "OPENLINEAGE__TRANSPORT__TRANSPORT__URL": "http://example.com",
+        "OPENLINEAGE__TRANSPORT__TRANSPORT__CUSTOM_HEADERS__CUSTOM_HEADER": "FIRST",
+        "OPENLINEAGE__TRANSPORT__TRANSPORT__CUSTOM_HEADERS__ANOTHER_HEADER": "second",
+    },
+)
+def test_transform_transport_from_env_vars_emits(mock_post):
+    transport = OpenLineageClient().transport
+    mock_event = MagicMock()
+
+    with patch("openlineage.client.serde.Serde.to_json", return_value='{"mock": "event"}'), patch(
+        "gzip.compress", return_value=b"compressed_data"
+    ):
+        transport.emit(mock_event)
+
+    mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    headers = kwargs["headers"]
+
+    assert headers["custom_header"] == "FIRST"
+    assert headers["another_header"] == "second"
+
+
+def test_transform_transport_calls_transformer_and_inner_transport() -> None:
+    config = TransformConfig.from_dict(
+        {
+            "transport": {"type": "console"},
+            "transformer_class": "tests.transform.test_transform.AlwaysNoneEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    transport.transport = MagicMock()
+    transformer = MagicMock()
+    transformer.transform.return_value = {"transformed_event": "value"}
+    transport.transformer = transformer
+
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+    transport.emit(event)
+
+    transformer.transform.assert_called_once()
+    transport.transport.emit.assert_called_once_with({"transformed_event": "value"})
+
+
+def test_client_with_transform_transport_fails_initialization_if_transformer_is_not_proper_class() -> None:
+    config = TransformConfig.from_dict(
+        {
+            "transport": {"type": "console"},
+            "transformer_class": "tests.transform.test_transform.NotEventTransformerBasedTransformer",
+        }
+    )
+    with pytest.raises(TypeError):
+        TransformTransport(config)
+
+
+def test_client_with_transform_transport_fails_when_transform_fails(mocker: MockerFixture) -> None:
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.AlwaysFailingTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="http", name="test"),
+        producer="prod",
+    )
+
+    with pytest.raises(ZeroDivisionError):
+        client.emit(event)
+
+    transport.transport.session.post.assert_not_called()

--- a/client/python/tests/transform/transformers/__init__.py
+++ b/client/python/tests/transform/transformers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0

--- a/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
+++ b/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
@@ -1,0 +1,81 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+
+import pytest
+from openlineage.client.event_v2 import DatasetEvent, Job, JobEvent, Run, RunEvent, RunState
+from openlineage.client.generated.base import StaticDataset
+from openlineage.client.transport.transform.transformers.job_namespace_replace_transformer import (
+    JobNamespaceReplaceTransformer,
+)
+from openlineage.client.uuid import generate_new_uuid
+
+
+def test_transformer_requires_new_namespace():
+    JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_value"})
+
+    with pytest.raises(RuntimeError):
+        JobNamespaceReplaceTransformer(properties={})
+
+
+def test_transformer_early_exit_for_unsupported_event_type():
+    transformer = JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_value"})
+
+    unsupported_event = DatasetEvent(
+        eventTime=datetime.datetime.now().isoformat(),
+        producer="prod",
+        dataset=StaticDataset(namespace="namespace", name="name"),
+    )
+
+    result = transformer.transform(unsupported_event)
+
+    assert result is unsupported_event
+
+
+def test_transformer_replaces_namespace_for_run_event():
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_namespace"})
+    result = transformer.transform(event)
+
+    assert result.job.namespace == "new_namespace"
+
+
+def test_transformer_replaces_namespace_for_job_event():
+    event = JobEvent(
+        eventTime=datetime.datetime.now().isoformat(),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_namespace"})
+    result = transformer.transform(event)
+
+    assert result.job.namespace == "new_namespace"
+
+
+def test_transformer_does_not_modify_other_fields():
+    run_id = str(generate_new_uuid())
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime="2024-01-01T00:00:00Z",
+        run=Run(runId=run_id),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_namespace"})
+    transformed_event = transformer.transform(event)
+
+    assert transformed_event.job.namespace == "new_namespace"
+    assert transformed_event.job.name == "test"
+    assert transformed_event.run.runId == run_id
+    assert transformed_event.eventType == RunState.START
+    assert transformed_event.eventTime == "2024-01-01T00:00:00Z"
+    assert transformed_event.producer == "prod"


### PR DESCRIPTION
### Problem

The `TransformTransport` is designed to enable event manipulation before emitting the event. Together with `CompositeTransport`, it can be used to send different events into multiple backends.  I think is a very common use case when using multiple backends, f.e. Atlan requires namespace value to be set exactly as they need, and other backends may have similar requirements.

closes: #3597

### Solution

Similar to [Java implementation](https://github.com/OpenLineage/OpenLineage/pull/3301), this PR implements TransformTransport for Python client. It also implements some example Transformer - `JobNamespaceReplaceTransformer`, that will replace job namespace before emitting the event. We can add different transformers later if needed and the users are always free to provide their own custom transformer.

#### One-line summary:

feat: Add TransformTransport for Python Client

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project