### PR TITLE
feat: Add parent run facet modification to JobNamespaceReplaceTransformer

### DIFF
--- a/client/python/openlineage/client/transport/transform/transformers/job_namespace_replace_transformer.py
+++ b/client/python/openlineage/client/transport/transform/transformers/job_namespace_replace_transformer.py
@@ -11,6 +11,7 @@ from openlineage.client.transport.transform.transform import EventTransformer
 
 if TYPE_CHECKING:
     from openlineage.client.client import Event
+    from openlineage.client.facet_v2 import parent_run
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,8 @@ class JobNamespaceReplaceTransformer(EventTransformer):
         if not properties.get("new_job_namespace"):
             msg = f"`new_job_namespace` not passed to {self.__class__.__name__}"
             raise RuntimeError(msg)
+        self.new_job_namespace = properties["new_job_namespace"]
+        self.include_parent_facet = str(properties.get("include_parent_facet", "true")).lower() == "true"
         super().__init__(properties=properties)
 
     def transform(self, event: Event) -> Event | None:
@@ -32,13 +35,40 @@ class JobNamespaceReplaceTransformer(EventTransformer):
             )
             return event
 
-        new_namespace = self.properties["new_job_namespace"]
         log.debug(
-            "Replacing current OpenLineage job namespace: `%s` with new: `%s` for single event.",
+            "Replacing OpenLineage job namespace: `%s` with: `%s` for single event.",
             event.job.namespace,
-            new_namespace,
+            self.new_job_namespace,
         )
+        event.job.namespace = self.new_job_namespace
 
-        event.job.namespace = new_namespace
+        if not self.include_parent_facet:
+            log.debug("Set `include_parent_facet` to True to include replacement in ParentRunFacet.")
+            return event
+
+        if not isinstance(event, event_v2.RunEvent):
+            log.debug("Only `RunEvent` can have ParentRunFacet, skipping replacement in ParentRunFacet.")
+            return event
+
+        if not event.run.facets or not event.run.facets.get("parent"):
+            log.debug("Parent run facet not found, skipping replacement in ParentRunFacet.")
+            return event
+
+        # Mypy sees RunFacet, but we assume ParentRunFacet, so we ignore the check.
+        parent_facet: parent_run.ParentRunFacet = event.run.facets["parent"]  # type: ignore[assignment]
+        log.debug(
+            "Replacing parent OpenLineage job namespace: `%s` with: `%s` for single event.",
+            parent_facet.job.namespace,
+            self.new_job_namespace,
+        )
+        parent_facet.job.namespace = self.new_job_namespace
+
+        if parent_facet.root:
+            log.debug(
+                "Replacing root OpenLineage job namespace: `%s` with: `%s` for single event.",
+                parent_facet.root.job.namespace,
+                self.new_job_namespace,
+            )
+            parent_facet.root.job.namespace = self.new_job_namespace
 
         return event

--- a/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
+++ b/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
@@ -4,6 +4,7 @@ import datetime
 
 import pytest
 from openlineage.client.event_v2 import DatasetEvent, Job, JobEvent, Run, RunEvent, RunState
+from openlineage.client.facet_v2 import parent_run
 from openlineage.client.generated.base import StaticDataset
 from openlineage.client.transport.transform.transformers.job_namespace_replace_transformer import (
     JobNamespaceReplaceTransformer,
@@ -65,7 +66,7 @@ def test_transformer_does_not_modify_other_fields():
     event = RunEvent(
         eventType=RunState.START,
         eventTime="2024-01-01T00:00:00Z",
-        run=Run(runId=run_id),
+        run=Run(runId=run_id, facets={"a": "b"}),
         job=Job(namespace="old_namespace", name="test"),
         producer="prod",
     )
@@ -76,6 +77,108 @@ def test_transformer_does_not_modify_other_fields():
     assert transformed_event.job.namespace == "new_namespace"
     assert transformed_event.job.name == "test"
     assert transformed_event.run.runId == run_id
+    assert transformed_event.run.facets == {"a": "b"}
     assert transformed_event.eventType == RunState.START
     assert transformed_event.eventTime == "2024-01-01T00:00:00Z"
     assert transformed_event.producer == "prod"
+
+
+def test_transformer_include_parent_default_value():
+    transformer = JobNamespaceReplaceTransformer(properties={"new_job_namespace": "new_namespace"})
+    assert transformer.include_parent_facet is True
+    assert transformer.new_job_namespace == "new_namespace"
+
+
+def test_transformer_with_include_parent_true_and_parent_run_facet_absent():
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(
+        properties={"new_job_namespace": "new_namespace", "include_parent_facet": True}
+    )
+    result = transformer.transform(event)
+
+    assert result.job.namespace == "new_namespace"
+
+
+def test_transformer_with_include_parent_true_and_parent_run_facet_present():
+    run_id = str(generate_new_uuid())
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(
+            runId=run_id,
+            facets={
+                "parent": parent_run.ParentRunFacet(
+                    run=parent_run.Run(run_id),
+                    job=parent_run.Job(namespace="parent_job_namespace", name="parent_job_name"),
+                    root=parent_run.Root(
+                        run=parent_run.RootRun(run_id),
+                        job=parent_run.RootJob(namespace="root_job_namespace", name="root_job_name"),
+                    ),
+                )
+            },
+        ),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(
+        properties={"new_job_namespace": "new_namespace", "include_parent_facet": True}
+    )
+    result = transformer.transform(event)
+
+    assert result.job.namespace == "new_namespace"
+    assert result.run.facets["parent"] == parent_run.ParentRunFacet(
+        run=parent_run.Run(run_id),
+        job=parent_run.Job(namespace="new_namespace", name="parent_job_name"),  # Changed
+        root=parent_run.Root(
+            run=parent_run.RootRun(run_id),
+            job=parent_run.RootJob(namespace="new_namespace", name="root_job_name"),  # Changed
+        ),
+    )
+
+
+def test_transformer_with_include_parent_false_and_parent_run_facet_present():
+    run_id = str(generate_new_uuid())
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(
+            runId=run_id,
+            facets={
+                "parent": parent_run.ParentRunFacet(
+                    run=parent_run.Run(run_id),
+                    job=parent_run.Job(namespace="parent_job_namespace", name="parent_job_name"),
+                    root=parent_run.Root(
+                        run=parent_run.RootRun(run_id),
+                        job=parent_run.RootJob(namespace="root_job_namespace", name="root_job_name"),
+                    ),
+                )
+            },
+        ),
+        job=Job(namespace="old_namespace", name="test"),
+        producer="prod",
+    )
+
+    transformer = JobNamespaceReplaceTransformer(
+        properties={"new_job_namespace": "new_namespace", "include_parent_facet": False}
+    )
+    result = transformer.transform(event)
+
+    assert result.job.namespace == "new_namespace"
+    assert result.run.facets["parent"].job.namespace == "parent_job_namespace"  # Unchanged
+    assert result.run.facets["parent"].root.job.namespace == "root_job_namespace"  # Unchanged
+    assert result.run.facets["parent"] == parent_run.ParentRunFacet(
+        run=parent_run.Run(run_id),
+        job=parent_run.Job(namespace="parent_job_namespace", name="parent_job_name"),  # Unchanged
+        root=parent_run.Root(
+            run=parent_run.RootRun(run_id),
+            job=parent_run.RootJob(namespace="root_job_namespace", name="root_job_name"),  # Unchanged
+        ),
+    )


### PR DESCRIPTION
### Problem

This supplements a sample Transformer added in #3697 with ability to also modify job namespace included in parent run facet. 

### Solution

#### One-line summary:
feat: Add parent run facet modification to JobNamespaceReplaceTransformer

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project