### PR TITLE
Java: Make UUIDUtils.generateStaticUUID random part more variative

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/UUIDUtils.java
@@ -72,8 +72,11 @@ public class UUIDUtils {
   @SneakyThrows
   public static UUID generateStaticUUID(Instant instant, byte[] data) {
     MessageDigest md = MessageDigest.getInstance("SHA-1");
-    byte[] hash = md.digest(data);
+    // if data is some static value, e.g. job name, mix it with instant to make it more random
+    md.update(instant.toString().getBytes("UTF-8"));
+    md.update(data);
 
+    byte[] hash = md.digest();
     long hasbMsb = 0;
     long hasbLsb = 0;
     for (int i = 0; i < 8; i++) hasbMsb = (hasbMsb << 8) | (hash[i] & 0xff);

--- a/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/UUIDUtilsTest.java
@@ -49,6 +49,18 @@ class UUIDUtilsTest {
   }
 
   @Test
+  void testGenerateNewUUIDPrefixDependsOnInstantMilliseconds() {
+    Instant instantMilliseconds = Instant.parse("2025-05-20T10:52:33.881000Z");
+    Instant instantMicroseconds = Instant.parse("2025-05-20T10:52:33.881863Z");
+
+    UUID uuid1 = UUIDUtils.generateNewUUID(instantMilliseconds);
+    UUID uuid2 = UUIDUtils.generateNewUUID(instantMicroseconds);
+
+    assertThat(uuid1.toString()).matches(s -> s.startsWith("0196ed52-e0d9-7"));
+    assertThat(uuid2.toString()).matches(s -> s.startsWith("0196ed52-e0d9-7"));
+  }
+
+  @Test
   void testGenerateStaticUUIDReturnsSameResultForSameInput() {
     Instant instant = Instant.now();
     byte[] data = "some".getBytes(UTF_8);
@@ -74,5 +86,43 @@ class UUIDUtilsTest {
     assertThat(uuid2.version()).isEqualTo(7);
     assertThat(uuid1).isNotEqualTo(uuid2);
     assertThat(uuid1).isLessThan(uuid2);
+
+    // both timestamp and random parts are different
+    assertThat(uuid1.getMostSignificantBits()).isNotEqualTo(uuid2.getMostSignificantBits());
+    assertThat(uuid1.getLeastSignificantBits()).isNotEqualTo(uuid2.getLeastSignificantBits());
+  }
+
+  @ParameterizedTest
+  @CsvSource({"some", "other"})
+  void testGenerateStaticUUIDResultPrefixDependsOnInstantMilliseconds(String data) {
+    Instant instantMilliseconds = Instant.parse("2025-05-20T10:52:33.881000Z");
+    Instant instantMicroseconds = Instant.parse("2025-05-20T10:52:33.881863Z");
+
+    UUID uuid1 = UUIDUtils.generateStaticUUID(instantMilliseconds, data.getBytes(UTF_8));
+    UUID uuid2 = UUIDUtils.generateStaticUUID(instantMicroseconds, data.getBytes(UTF_8));
+
+    assertThat(uuid1.toString()).matches(s -> s.startsWith("0196ed52-e0d9-7"));
+    assertThat(uuid2.toString()).matches(s -> s.startsWith("0196ed52-e0d9-7"));
+  }
+
+  @Test
+  void testGenerateStaticUUIDResultIsDifferentForDifferentData() {
+    Instant instant = Instant.now();
+
+    UUID uuid1 = UUIDUtils.generateStaticUUID(instant, "some".getBytes(UTF_8));
+    UUID uuid2 = UUIDUtils.generateStaticUUID(instant, "other".getBytes(UTF_8));
+
+    assertThat(uuid1.version()).isEqualTo(7);
+    assertThat(uuid2.version()).isEqualTo(7);
+    assertThat(uuid1).isNotEqualTo(uuid2);
+
+    // timestamp part is the same
+    assertThat(uuid1.getMostSignificantBits() & 0x0000L)
+        .isEqualTo(uuid2.getMostSignificantBits() & 0x0000L);
+
+    // random part is different
+    assertThat(uuid1.getMostSignificantBits() & 0xffffL)
+        .isNotEqualTo(uuid2.getMostSignificantBits() & 0xffffL);
+    assertThat(uuid1.getLeastSignificantBits()).isNotEqualTo(uuid2.getLeastSignificantBits());
   }
 }

--- a/client/python/tests/test_uuid.py
+++ b/client/python/tests/test_uuid.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from openlineage.client.uuid import generate_new_uuid, generate_static_uuid
@@ -30,6 +30,17 @@ def test_generate_new_uuid_result_is_increasing_with_instant_increment():
     assert result1 < result2
 
 
+def test_generate_new_uuid_returns_prefix_based_on_instant_milliseconds():
+    instant_milliseconds = datetime(2025, 5, 20, 10, 52, 33, 881000, tzinfo=timezone.utc)
+    instant_microseconds = datetime(2025, 5, 20, 10, 52, 33, 881863, tzinfo=timezone.utc)
+
+    uuid1 = generate_new_uuid(instant_milliseconds)
+    uuid2 = generate_new_uuid(instant_microseconds)
+
+    assert str(uuid1).startswith("0196ed52-e0d9-7")
+    assert str(uuid2).startswith("0196ed52-e0d9-7")
+
+
 def test_generate_static_uuid_returns_uuidv7():
     assert generate_static_uuid(datetime.now(), b"some").version == 7  # noqa: PLR2004
 
@@ -41,6 +52,24 @@ def test_generate_static_uuid_returns_same_result_for_same_input():
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        b"some",
+        b"other",
+    ],
+)
+def test_generate_static_uuid_result_prefix_depends_on_instant_milliseconds(data):
+    instant_milliseconds = datetime(2025, 5, 20, 10, 52, 33, 881000, tzinfo=timezone.utc)
+    instant_microseconds = datetime(2025, 5, 20, 10, 52, 33, 881863, tzinfo=timezone.utc)
+
+    uuid1 = generate_static_uuid(instant_milliseconds, data)
+    uuid2 = generate_static_uuid(instant_microseconds, data)
+
+    assert str(uuid1).startswith("0196ed52-e0d9-7")
+    assert str(uuid2).startswith("0196ed52-e0d9-7")
+
+
+@pytest.mark.parametrize(
     ("data1", "data2"),
     [
         (b"some", b"other"),
@@ -48,7 +77,26 @@ def test_generate_static_uuid_returns_same_result_for_same_input():
     ],
 )
 def test_generate_static_uuid_result_is_increasing_with_instant_increment(data1, data2):
-    result1 = generate_static_uuid(datetime.now(), data1)
-    result2 = generate_static_uuid(datetime.now() + timedelta(seconds=0.001), data2)
+    instant = datetime.now()
+    result1 = generate_static_uuid(instant, data1)
+    result2 = generate_static_uuid(instant + timedelta(seconds=0.001), data2)
     assert result1 != result2
     assert result1 < result2
+
+    # both timestamp and random parts are different
+    assert result1.bytes != result2.bytes
+    assert result1.bytes_le != result2.bytes_le
+
+
+def test_generate_static_uuid_result_is_different_for_different_data():
+    timestamp = datetime.now()
+    result1 = generate_static_uuid(timestamp, b"some")
+    result2 = generate_static_uuid(timestamp, b"other")
+    assert result1 != result2
+
+    # timestamp part is the same
+    assert int.from_bytes(result1.bytes, "big") & 0x0000 == int.from_bytes(result2.bytes, "big") & 0x0000
+
+    # random part is different
+    assert int.from_bytes(result1.bytes, "big") & 0xFFFF != int.from_bytes(result2.bytes, "big") & 0xFFFF
+    assert result1.bytes_le != result2.bytes_le


### PR DESCRIPTION
### Problem

Python `generate_static_uuid` implementation returns different UUIDs for same user data because it concatenates data with timestamp, and then uses this to generate UUID random part.

Java `generateStaticUUID` algorithm was different - random UUID part was based on input data only. Because of this, calls like `generateStaticUUID(eventStartTime, jobName)` returned UUIDs which were not very variative (suffix was efficiently static).

### Solution

#### One-line summary:

Java: Make `UUIDUtils.generateStaticUUID` random part more variative by mixing timestamp with user input data

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project