### PR TITLE
[SPARK] Smart debug facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   *Added OpenLineage Hive integration*
 * **Java: Add Location Symlink type** [`#3717`](https://github.com/OpenLineage/OpenLineage/pull/3717) [@tnazarew](https://github.com/tnazarew)  
   *Add new symlink type representing physical location of dataset*
+* **Spark: Smart debug facet.** [`#3715`](https://github.com/OpenLineage/OpenLineage/pull/3715) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Automatically turn on debug facet in case of spark connector anomalies detected. See "Debugging" section in Spark integration docs for more details.*
+
 
 ## [1.33.0](https://github.com/OpenLineage/OpenLineage/compare/1.32.1...1.33.0) - 2025-05-19
 

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -45,8 +45,6 @@ public class ArgumentParser {
   public static final String SPARK_CONF_JOB_NAME_REPLACE_DOT_WITH_UNDERSCORE =
       "spark.openlineage.jobName.replaceDotWithUnderscore";
 
-  private static final String SPARK_CONF_DEBUG_FACET = "spark.openlineage.debugFacet";
-
   private static final String SPARK_TEST_EXTENSION_PROVIDER =
       "spark.openlineage.testExtensionProvider";
 
@@ -126,7 +124,6 @@ public class ArgumentParser {
     findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAMESPACE)
         .ifPresent(config::setParentJobNamespace);
     findSparkConfigKey(conf, SPARK_CONF_PARENT_RUN_ID).ifPresent(config::setParentRunId);
-    findSparkConfigKey(conf, SPARK_CONF_DEBUG_FACET).ifPresent(config::setDebugFacet);
     findSparkConfigKey(conf, SPARK_TEST_EXTENSION_PROVIDER)
         .ifPresent(config::setTestExtensionProvider);
     findSparkConfigKey(conf, SPARK_CONF_JOB_NAME_APPEND_DATASET_NAME)

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -86,8 +86,8 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                 .runEventBuilder(
                     openLineage
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(applicationStart.time()))
-                        .eventType(START))
+                        .eventTime(toZonedTime(applicationStart.time())))
+                .eventType(START)
                 .jobBuilder(getJobBuilder())
                 .jobFacetsBuilder(getJobFacetsBuilder())
                 .overwriteRunId(Optional.of(olContext.getApplicationUuid()))
@@ -117,8 +117,8 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(applicationEnd.time()))
-                        .eventType(COMPLETE))
+                        .eventTime(toZonedTime(applicationEnd.time())))
+                .eventType(COMPLETE)
                 .jobBuilder(getJobBuilder())
                 .jobFacetsBuilder(getJobFacetsBuilder())
                 .overwriteRunId(Optional.of(olContext.getApplicationUuid()))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -102,8 +102,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(startEvent.time()))
-                        .eventType(eventType))
+                        .eventTime(toZonedTime(startEvent.time())))
+                .eventType(eventType)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
@@ -149,8 +149,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(endEvent.time()))
-                        .eventType(eventType))
+                        .eventTime(toZonedTime(endEvent.time())))
+                .eventType(eventType)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
@@ -182,8 +182,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
-                        .eventType(RUNNING))
+                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC)))
+                .eventType(RUNNING)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
@@ -212,8 +212,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
-                        .eventType(RUNNING))
+                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC)))
+                .eventType(RUNNING)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
@@ -265,8 +265,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(jobStart.time()))
-                        .eventType(eventType))
+                        .eventTime(toZonedTime(jobStart.time())))
+                .eventType(eventType)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
@@ -314,8 +314,8 @@ class SparkSQLExecutionContext implements ExecutionContext {
                     olContext
                         .getOpenLineage()
                         .newRunEventBuilder()
-                        .eventTime(toZonedTime(jobEnd.time()))
-                        .eventType(eventType))
+                        .eventTime(toZonedTime(jobEnd.time())))
+                .eventType(eventType)
                 .jobBuilder(buildJob())
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -159,7 +159,6 @@ class SparkScalaContainerTest {
     addSparkConfig(
         sparkSubmitCommand,
         "spark.openlineage.transport.url=http://openlineageclient:1080/api/v1/namespaces/scala-test");
-    addSparkConfig(sparkSubmitCommand, "spark.openlineage.debugFacet=enabled");
     addSparkConfig(
         sparkSubmitCommand, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
     addSparkConfig(sparkSubmitCommand, "spark.sql.warehouse.dir=/tmp/warehouse");
@@ -276,7 +275,6 @@ class SparkScalaContainerTest {
     addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
     addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
     addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
     addSparkConfig(command, "spark.openlineage.facets.schema.disabled=true");
     addSparkConfig(command, "spark.openlineage.transport.type=file");
     addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");
@@ -510,7 +508,6 @@ class SparkScalaContainerTest {
     addSparkConfig(command, "spark.driver.extraJavaOptions=-Dderby.system.home=/tmp/derby");
     addSparkConfig(command, "spark.extraListeners=" + OpenLineageSparkListener.class.getName());
     addSparkConfig(command, "spark.jars.ivy=/tmp/.ivy2/");
-    addSparkConfig(command, "spark.openlineage.debugFacet=enabled");
     addSparkConfig(command, "spark.openlineage.facets.disabled=[spark_unknown]");
     addSparkConfig(command, "spark.openlineage.transport.type=file");
     addSparkConfig(command, "spark.openlineage.transport.location=/tmp/events.log");

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContextTest.java
@@ -28,6 +28,7 @@ import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.api.CustomFacetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
+import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import io.openlineage.spark.api.VisitedNodes;
 import java.util.Collections;
@@ -67,6 +68,7 @@ class SparkApplicationExecutionContextTest {
     when(olContext.getOpenLineage()).thenReturn(openLineage);
     when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
     when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
+    when(olContext.getLineageRunStatus()).thenReturn(new OpenLineageRunStatus());
     when(olContext.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     when(olContext.getVisitedNodes()).thenReturn(new VisitedNodes());
     when(olContext.getApplicationUuid())

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContextTest.java
@@ -24,6 +24,7 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.filters.EventFilterUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.OpenLineageEventHandlerFactory;
+import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import io.openlineage.spark.api.VisitedNodes;
 import java.util.Optional;
@@ -67,6 +68,9 @@ class SparkSQLExecutionContextTest {
   void setup(SparkSession spark) {
     when(olContext.getQueryExecution()).thenReturn(Optional.of(queryExecution));
     when(olContext.getSparkContext()).thenReturn(Optional.of(spark.sparkContext()));
+    when(olContext.getLineageRunStatus()).thenReturn(new OpenLineageRunStatus());
+    when(queryExecution.sparkPlan())
+        .thenReturn(mock(org.apache.spark.sql.execution.SparkPlan.class));
     when(queryExecution.sparkPlan().sparkContext()).thenReturn(spark.sparkContext());
     when(olContext.getOpenLineage()).thenReturn(openLineage);
     when(olContext.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/StaticExecutionContextFactory.java
@@ -17,6 +17,7 @@ import io.openlineage.spark.agent.OpenLineageSparkListener;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.util.TestOpenLineageEventHandlerFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
 import java.util.List;
@@ -86,6 +87,7 @@ public class StaticExecutionContextFactory extends ContextFactory {
     SparkOpenLineageConfig olConfig = new SparkOpenLineageConfig();
     olConfig.setOverriddenAppName("test_rdd");
     when(olContext.getOpenLineageConfig()).thenReturn(olConfig);
+    when(olContext.getLineageRunStatus()).thenReturn(new OpenLineageRunStatus());
     OpenLineageRunEventBuilder runEventBuilder =
         new OpenLineageRunEventBuilder(olContext, new TestOpenLineageEventHandlerFactory());
 

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_smart_debug.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_smart_debug.py
@@ -1,0 +1,25 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from pyspark.sql import SparkSession
+
+os.makedirs("/tmp/create_test", exist_ok=True)
+
+spark = (
+    SparkSession.builder.master("local")
+    .appName("Smart Debug Facet Test")
+    .config("spark.sql.warehouse.dir", "file:/tmp/create_test/")
+    .enableHiveSupport()
+    .getOrCreate()
+)
+
+# This should have an output dataset -> no smart debug facet
+spark.sql("CREATE TABLE test_table (a string, b string)")
+
+# This should have input dataset but no output dataset -> should smart debug facet
+spark.sql("SHOW TABLES")
+
+# This should outputs -> no smart debug facet
+spark.sql("INSERT INTO test_table VALUES ('1', '2')")

--- a/integration/spark/cli/spark-conf.yml
+++ b/integration/spark/cli/spark-conf.yml
@@ -4,5 +4,3 @@ scalaBinaryVersion: 2.12
 enableHiveSupport: true
 packages:
   - org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:1.5.2
-sparkConf:
-  spark.openlineage.debugFacet: enabled

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
@@ -6,9 +6,11 @@
 package io.openlineage.spark.agent.facets;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.micrometer.core.instrument.Tag;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.facets.serializer.DebugRunFacetSerializer;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -22,25 +24,32 @@ import lombok.Value;
  * integration and provide details on potential problems.
  */
 @Getter
+@JsonSerialize(using = DebugRunFacetSerializer.class)
 public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
   private final ClasspathDebugFacet classpath;
   private final SystemDebugFacet system;
   private final SparkConfigDebugFacet config;
   private final LogicalPlanDebugFacet logicalPlan;
   private final MetricsDebugFacet metrics;
+  private final List<String> logs;
+  private final int payloadSizeLimitInKilobytes;
 
   public DebugRunFacet(
       SparkConfigDebugFacet config,
       ClasspathDebugFacet classpath,
       SystemDebugFacet system,
       LogicalPlanDebugFacet logicalPlan,
-      MetricsDebugFacet metricsDebugFacet) {
+      MetricsDebugFacet metricsDebugFacet,
+      List<String> logs,
+      int payloadSizeLimitInKilobytes) {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
     this.config = config;
     this.classpath = classpath;
     this.system = system;
     this.logicalPlan = logicalPlan;
     this.metrics = metricsDebugFacet;
+    this.logs = logs;
+    this.payloadSizeLimitInKilobytes = payloadSizeLimitInKilobytes;
   }
 
   /** Entries from SparkConf that can be valuable for debugging. */

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializer.java
@@ -1,0 +1,97 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.spark.agent.facets.DebugRunFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.MetricsDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.SparkConfigDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.SystemDebugFacet;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Custom serializer to handle the serialization of the {@link DebugRunFacet} class. Implements a
+ * serialization limit which does not serialize a facet in case its size exceeds the limit.
+ */
+@Slf4j
+public class DebugRunFacetSerializer extends StdSerializer<DebugRunFacet> {
+
+  protected DebugRunFacetSerializer() {
+    super(DebugRunFacet.class);
+  }
+
+  @Override
+  public void serialize(
+      DebugRunFacet facet, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+      throws IOException {
+
+    int payloadSize =
+        OpenLineageClientUtils.toJson(new DebugRunFacetWithStandardSerializer(facet))
+                .getBytes(StandardCharsets.UTF_8)
+                .length
+            / 1024;
+
+    if (payloadSize > facet.getPayloadSizeLimitInKilobytes()) {
+      log.warn(
+          "DebugRunFacetSerializer skipping serialization of DebugRunFacet due to payload size: {} kilobytes",
+          payloadSize);
+
+      // replace debug facet with a simple JSON object indicating the reason for skipping
+      jsonGenerator.writeStartObject();
+      jsonGenerator.writeObjectField(
+          "logs",
+          Collections.singletonList(
+              String.format(
+                  "Skipping debug facet due to payload size: %d kilobytes", payloadSize)));
+      jsonGenerator.writeEndObject();
+
+      return;
+    }
+
+    jsonGenerator.writeStartObject();
+    jsonGenerator.writeObjectField("classpath", facet.getClasspath());
+    jsonGenerator.writeObjectField("system", facet.getSystem());
+    jsonGenerator.writeObjectField("config", facet.getConfig());
+    jsonGenerator.writeObjectField("logicalPlan", facet.getLogicalPlan());
+    jsonGenerator.writeObjectField("metrics", facet.getMetrics());
+    jsonGenerator.writeObjectField("logs", facet.getLogs());
+
+    jsonGenerator.writeEndObject();
+  }
+
+  /**
+   * A copy of the DebugRunFacet to be used for serialization with different serializer through the
+   * same ObjectMapper.
+   */
+  @Getter
+  private static class DebugRunFacetWithStandardSerializer {
+    private final ClasspathDebugFacet classpath;
+    private final SystemDebugFacet system;
+    private final SparkConfigDebugFacet config;
+    private final LogicalPlanDebugFacet logicalPlan;
+    private final MetricsDebugFacet metrics;
+    private final List<String> logs;
+
+    private DebugRunFacetWithStandardSerializer(DebugRunFacet facet) {
+      this.classpath = facet.getClasspath();
+      this.system = facet.getSystem();
+      this.config = facet.getConfig();
+      this.logicalPlan = facet.getLogicalPlan();
+      this.metrics = facet.getMetrics();
+      this.logs = facet.getLogs();
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventContext.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent.lifecycle;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.JobBuilder;
 import io.openlineage.client.OpenLineage.ParentRunFacet;
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.client.OpenLineage.RunEventBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +50,7 @@ public class OpenLineageRunEventContext {
   private Optional<Integer> jobId;
   private Optional<UUID> overwriteRunId;
   private SparkListenerEvent event;
+  private EventType eventType;
 
   public List<Object> loadNodes(Map<Integer, Stage> stageMap, Map<Integer, ActiveJob> jobMap) {
     List<Object> nodes = new ArrayList<>();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/FacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/FacetUtils.java
@@ -5,11 +5,18 @@
 
 package io.openlineage.spark.agent.util;
 
+import io.openlineage.client.OpenLineage.RunFacetsBuilder;
+import io.openlineage.spark.agent.facets.builder.DebugRunFacetBuilderDelegate;
+import io.openlineage.spark.api.DebugConfig;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class FacetUtils {
   public static boolean isFacetDisabled(OpenLineageContext context, String facetName) {
     return Optional.ofNullable(context)
@@ -19,5 +26,30 @@ public class FacetUtils {
             facetsConfig ->
                 Arrays.asList(facetsConfig.getEffectiveDisabledFacets()).contains(facetName))
         .orElse(SparkOpenLineageConfig.DISABLED_BY_DEFAULT.contains(facetName));
+  }
+
+  public static void attachSmartDebugFacet(
+      OpenLineageContext context, RunFacetsBuilder runFacetsBuilder) {
+    DebugConfig debugConfig = context.getOpenLineageConfig().getDebugConfig();
+    if (debugConfig == null) {
+      return;
+    }
+
+    boolean hasDetectedInputs = context.getLineageRunStatus().isDetectedInputs();
+    boolean hasDetectedOutputs = context.getLineageRunStatus().isDetectedOutputs();
+
+    if (!debugConfig.isSmartDebugActive(hasDetectedInputs, hasDetectedOutputs)) {
+      return;
+    }
+
+    List<String> logs = new LinkedList<>();
+    if (!hasDetectedInputs) {
+      logs.add("No input datasets detected");
+    }
+    if (!hasDetectedOutputs) {
+      logs.add("No output datasets detected");
+    }
+
+    runFacetsBuilder.put("debug", new DebugRunFacetBuilderDelegate(context).buildFacet(logs));
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DebugConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DebugConfig.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Slf4j
+public class DebugConfig {
+
+  public static String ANY_MISSING = "any-missing";
+  public static String OUTPUT_MISSING = "output-missing";
+
+  @JsonProperty("smart")
+  boolean smartEnabled;
+
+  @JsonProperty("smartMode")
+  String mode;
+
+  @JsonProperty("metricsDisabled")
+  boolean metricsDisabled;
+
+  @JsonProperty Integer payloadSizeLimitInKilobytes;
+
+  public boolean isSmartDebugActive(boolean hasDetectedInputs, boolean hasDetectedOutputs) {
+    if (!smartEnabled) {
+      return false;
+    }
+
+    if (ANY_MISSING.equalsIgnoreCase(mode)) {
+      return isAnyMissingActive(hasDetectedInputs, hasDetectedOutputs);
+    } else if (OUTPUT_MISSING.equalsIgnoreCase(mode)) {
+      return !hasDetectedOutputs;
+    } else {
+      if (mode != null && !mode.isEmpty()) {
+        log.warn("Unsupported smart mode: {}. Falling back to any-missing mode.", mode);
+      }
+      return isAnyMissingActive(hasDetectedInputs, hasDetectedOutputs);
+    }
+  }
+
+  private boolean isAnyMissingActive(boolean hasDetectedInputs, boolean hasDetectedOutputs) {
+    return (!hasDetectedInputs || !hasDetectedOutputs);
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageContext.java
@@ -303,6 +303,12 @@ public class OpenLineageContext {
    */
   @Getter final SparkOpenLineageExtensionVisitorWrapper sparkExtensionVisitorWrapper;
 
+  /**
+   * Status of the OpenLineage run, which can be used to indicate whether inputs or outputs were
+   * detected
+   */
+  @Builder.Default @Getter final OpenLineageRunStatus lineageRunStatus = new OpenLineageRunStatus();
+
   @Override
   public String toString() {
     return new StringJoiner(", ", OpenLineageContext.class.getSimpleName() + "[", "]")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageRunStatus.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/OpenLineageRunStatus.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.api;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Status of the OpenLineage run metadata, indicating whether inputs and outputs were detected. This
+ * is used to determine the quality of the lineage data collected during a Spark job run.
+ */
+@Getter
+@Setter
+public class OpenLineageRunStatus {
+  private boolean detectedInputs;
+  private boolean detectedOutputs;
+
+  public void capturedInputs(int datasetsCount) {
+    if (datasetsCount > 0) {
+      detectedInputs = true;
+    }
+  }
+
+  public void capturedOutputs(int datasetsCount) {
+    if (datasetsCount > 0) {
+      detectedOutputs = true;
+    }
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -42,7 +42,6 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
   private String rootParentJobNamespace;
   private String rootParentRunId;
   private String overriddenAppName;
-  @NonNull private String debugFacet;
   private String testExtensionProvider;
   private JobNameConfig jobName;
   private VendorsConfig vendors;
@@ -52,6 +51,9 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
 
   @JsonProperty("filter")
   private FilterConfig filterConfig;
+
+  @JsonProperty("debug")
+  private DebugConfig debugConfig;
 
   public SparkOpenLineageConfig(
       String namespace,

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializerTest.java
@@ -1,0 +1,71 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.facets.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineageClientUtils;
+import io.openlineage.spark.agent.facets.DebugRunFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.MetricsDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.SparkConfigDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.SystemDebugFacet;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class DebugRunFacetSerializerTest {
+
+  DebugRunFacet facet =
+      new DebugRunFacet(
+          SparkConfigDebugFacet.builder().catalogClass("someString").build(),
+          ClasspathDebugFacet.builder().build(),
+          SystemDebugFacet.builder().build(),
+          new LogicalPlanDebugFacet(Collections.emptyList()),
+          new MetricsDebugFacet(Collections.emptyList()),
+          Collections.emptyList(),
+          10);
+
+  @Test
+  void testSerializeWritesAllFields() {
+    String json = OpenLineageClientUtils.toJson(facet);
+    assertThat(json)
+        .containsIgnoringCase("\"classpath\"")
+        .containsIgnoringCase("\"system\"")
+        .containsIgnoringCase("\"config\"")
+        .containsIgnoringCase("\"logicalPlan\"")
+        .containsIgnoringCase("\"metrics\"")
+        .containsIgnoringCase("\"logs\"");
+  }
+
+  @Test
+  void testSerializeDoesNotExceedSizeLimit() {
+    char[] charArray = new char[20 * 1024];
+    Arrays.fill(charArray, 'a');
+    String largeString = new String(charArray); // 20KB string
+
+    facet =
+        new DebugRunFacet(
+            SparkConfigDebugFacet.builder().catalogClass(largeString).build(),
+            ClasspathDebugFacet.builder().build(),
+            SystemDebugFacet.builder().build(),
+            new LogicalPlanDebugFacet(Collections.emptyList()),
+            new MetricsDebugFacet(Collections.emptyList()),
+            Collections.emptyList(),
+            10);
+
+    String json = OpenLineageClientUtils.toJson(facet);
+    assertThat(json)
+        .isEqualTo("{\"logs\":[\"Skipping debug facet due to payload size: 20 kilobytes\"]}");
+  }
+
+  @Test
+  void testSerializeDoesNotWriteAllowedPayloadSize() {
+    String json = OpenLineageClientUtils.toJson(facet);
+    assertThat(json).doesNotContainIgnoringCase("\"payloadSizeLimitInKilobytes\"");
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/FacetUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/FacetUtilsTest.java
@@ -6,13 +6,26 @@
 package io.openlineage.spark.agent.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import io.openlineage.client.OpenLineage.RunFacetsBuilder;
 import io.openlineage.client.transports.FacetsConfig;
+import io.openlineage.spark.api.DebugConfig;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.OpenLineageRunStatus;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.Optional;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class FacetUtilsTest {
@@ -20,11 +33,18 @@ class FacetUtilsTest {
   public static final String SPARK_UNKNOWN_FACET_NAME = "spark_unknown";
   public static final String DEBUG_FACET_NAME = "debug";
 
+  OpenLineageContext olc = mock(OpenLineageContext.class, RETURNS_DEEP_STUBS);
+  SparkOpenLineageConfig solc = mock(SparkOpenLineageConfig.class);
+  OpenLineageRunStatus olcRunStatus = new OpenLineageRunStatus();
+
+  @BeforeEach
+  void setup() {
+    when(olc.getOpenLineageConfig()).thenReturn(solc);
+    when(olc.getLineageRunStatus()).thenReturn(olcRunStatus);
+  }
+
   @Test
   void testFacet() {
-    OpenLineageContext olc = mock(OpenLineageContext.class);
-    SparkOpenLineageConfig solc = mock(SparkOpenLineageConfig.class);
-    when(olc.getOpenLineageConfig()).thenReturn(solc);
     FacetsConfig facetsConfig = new FacetsConfig();
     when(solc.getFacetsConfig()).thenReturn(facetsConfig);
 
@@ -41,5 +61,45 @@ class FacetUtilsTest {
     assertThat(FacetUtils.isFacetDisabled(null, SPARK_UNKNOWN_FACET_NAME)).isTrue();
     assertThat(FacetUtils.isFacetDisabled(null, SPARK_LOGICAL_PLAN_FACET_NAME)).isTrue();
     assertThat(FacetUtils.isFacetDisabled(null, DEBUG_FACET_NAME)).isTrue();
+  }
+
+  @Test
+  void testAttachSmartDebugFacetWhenDebugConfigIsNull() {
+    RunFacetsBuilder runFacetsBuilder = mock(RunFacetsBuilder.class);
+    FacetUtils.attachSmartDebugFacet(olc, runFacetsBuilder);
+
+    verify(runFacetsBuilder, never()).put(any(), any());
+  }
+
+  @Test
+  void testAttachSmartDebugFacetWhenSmartDebugNotActive() {
+    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100));
+    when(olc.getSparkContext()).thenReturn(Optional.empty());
+    when(olc.getSparkSession()).thenReturn(Optional.empty());
+    when(olc.getLogicalPlan()).thenReturn(null);
+    RunFacetsBuilder runFacetsBuilder = mock(RunFacetsBuilder.class);
+
+    olcRunStatus.capturedInputs(1);
+    olcRunStatus.capturedOutputs(1);
+
+    FacetUtils.attachSmartDebugFacet(olc, runFacetsBuilder);
+    verify(runFacetsBuilder, never()).put(any(), any());
+  }
+
+  @Test
+  void testAttachSmartDebugFacetWhenSmartDebugActive() {
+    SparkContext sparkContext = mock(SparkContext.class);
+    SparkSession sparkSession = mock(SparkSession.class);
+    when(olc.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(olc.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(sparkSession.catalog()).thenReturn(null);
+    when(olc.getLogicalPlan()).thenReturn(null);
+    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100));
+    RunFacetsBuilder runFacetsBuilder = mock(RunFacetsBuilder.class);
+
+    FacetUtils.attachSmartDebugFacet(olc, runFacetsBuilder);
+
+    verify(runFacetsBuilder, times(1)).put(any(), any());
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/DebugConfigTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/DebugConfigTest.java
@@ -1,0 +1,68 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.spark.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DebugConfigTest {
+
+  DebugConfig debugConfig = new DebugConfig();
+
+  @Test
+  void testDebugConfigDisabled() {
+    debugConfig.setSmartEnabled(false);
+    assertThat(debugConfig.isSmartDebugActive(false, false)).isFalse();
+  }
+
+  @Test
+  void testDebugConfigEnabledForAnyMissing() {
+    debugConfig.setSmartEnabled(true);
+    debugConfig.setMode("any-missing");
+
+    // only input missing
+    assertThat(debugConfig.isSmartDebugActive(true, false)).isTrue();
+
+    // only output missing
+    assertThat(debugConfig.isSmartDebugActive(false, true)).isTrue();
+
+    assertThat(debugConfig.isSmartDebugActive(true, true)).isFalse();
+  }
+
+  @Test
+  void testDebugConfigEnabledForOutputMissing() {
+    debugConfig.setSmartEnabled(true);
+    debugConfig.setMode("output-missing");
+
+    // no output
+    assertThat(debugConfig.isSmartDebugActive(true, false)).isTrue();
+
+    // output detected
+    assertThat(debugConfig.isSmartDebugActive(false, true)).isFalse();
+    assertThat(debugConfig.isSmartDebugActive(true, true)).isFalse();
+  }
+
+  @Test
+  void testMissingOrUnsupportedSmartMode() {
+    debugConfig.setSmartEnabled(true);
+
+    // no mode set, should default to false
+    debugConfig.setMode(null);
+    assertThat(debugConfig.isSmartDebugActive(false, true)).isTrue();
+
+    // unsupported mode
+    debugConfig.setMode("unsupported-mode");
+    assertThat(debugConfig.isSmartDebugActive(false, true)).isTrue();
+  }
+
+  @Test
+  void testMetricsDisabled() {
+    assertThat(debugConfig.isMetricsDisabled()).isFalse();
+
+    debugConfig.setMetricsDisabled(true);
+    assertThat(debugConfig.isMetricsDisabled()).isTrue();
+  }
+}

--- a/website/docs/integrations/spark/debug_facet.md
+++ b/website/docs/integrations/spark/debug_facet.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 8
-title: Debug Facet
+title: Debugging with Debug Facet
 ---
 
 Whenever OpenLineage event is properly emitted, but its content is not as expected, debug facet is the easiest way to start
@@ -8,17 +8,11 @@ with and collect more insights about the problem.
 
 :::info
 As a name suggests, debug facet is not meant to be used in production by default. 
-However, it definitely makes sense to enable it ad-hoc when needed.
+However, it definitely makes sense to enable it ad-hoc when needed, or allow smart debug facet feature to turn it on automatically
+when it detects that OpenLineage event is not emitted properly.
 :::
 
-:::info
-`DebugFacet` is turned off by default. To enable it, set the following configuration has to be applied:
-```yaml
-spark.openlineage.facets.debug.disabled=false
-```
-:::
-
-## Facet content
+## Debug Facet's content
 
 `DebugFacet` contains following information:
 
@@ -26,5 +20,20 @@ spark.openlineage.facets.debug.disabled=false
 * Information about the system like: Spark deployment mode, Java version, Java vendor, OS name, OS version, timezone.
 * Metrics, which apart from being sent to Metric backend, can be filled within DebugFacet at the same time.
 * Shortened information about the LogicalPlan which contains tree structure as well class names of the nodes.
+* Logs: logs relating to OpenLineage Spark integration, which can be useful for debugging purposes.
 
 Please refer to `io.openlineage.spark.agent.facets.DebugRunFacet` source code to get more up-to-date information about the fields.
+
+### Debug facet configuration
+
+`DebugFacet` is turned off by default. To enable it, set the following configuration has to be applied:
+```yaml
+spark.openlineage.facets.debug.disabled=false
+```
+
+Additionally, following configuration entries are applicable:
+
+* `spark.openlineage.debug.smart=true` - Enables smart debug facet feature, which automatically turns on debug facet when OpenLineage event is not emitted properly. Disabled by default. For smart debug, the debug facet will be emitted only on `COMPLETE` when criteria depending on `smartMode` are met.
+* `spark.openlineage.debug.smartMode` - can be either `output-missing` to activate debug facet when outputs are missing or `any-missing` to activate when inputs or outputs are missing. Defaults to `any-missing`.
+* `spark.openlineage.debug.metricsDisabled` - By default Spark integration metrics are included in the debug facet. This can be useful for debugging how much time has the integration spent on each dataset builder. The representation of the metrics with tags within a JSON document can result in increased payload size, so it can be disabled by setting this configuration to `true`.
+* `spark.openlineage.debug.payloadSizeLimitInKilobytes=50` - Maximal size of the debug facet payload in kilobytes of JSON. If the payload exceeds this limit, it debug facet will contain only a single log message with the information about the exceeded size. Defaults to 100 kilobytes.


### PR DESCRIPTION
[https://github.com/OpenLineage/OpenLineage/issues/3711] Add the ability to automatically include debug facet, when no inputs and outputs datasets detected. This can be useful to assure lineage completeness. Please read the docs within the PR to get more details on the feature. 

Changes implemented: 
 * extend `OpenLineageContext` with `OpenLineageRunStatus` to store information whether any inputs/outputs have been collected through all the events for the given run. 
 * turn on `DebugFacet` on `COMPLETE` event when the configurable criteria are met: output dataset missing or any of the input/output is missing.
 * add `logs` field to debug facet determining if inputs or outputs are empty.
 * make sure `DebugFacet` json does not exceed 100KB, or other configurable value. 
 * In case the value is exceeded, replece debug facet with an empty facet and a single log message attached telling a debug facet size exceeded the limit. 
 * Add configuration entry to turn off metrics sent via debug facet. Metrics can be huge, bcz of metrics tags passed in JSON. 
 * Remove legacy `spark.openlineage.debugFacet` setting to turn on/off the debug facet.



