### PR TITLE
add new symlink type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   *Support lineage extraction from `UnionRdd` and `NewHadoopRDD`, which makes dynamic frames docker based test passing.*
 * **Hive: Integration added.** [`#3555`](https://github.com/OpenLineage/OpenLineage/pull/3555) [@tnazarew](https://github.com/tnazarew) with [@ddebowczyk92](https://github.com/ddebowczyk92), [@jphalip](https://github.com/jphalip)
   *Added OpenLineage Hive integration*
+* **Java: Add Location Symlink type** [`#3717`](https://github.com/OpenLineage/OpenLineage/pull/3717) [@tnazarew](https://github.com/tnazarew)  
+  *Add new symlink type representing physical location of dataset*
 
 ## [1.33.0](https://github.com/OpenLineage/OpenLineage/compare/1.32.1...1.33.0) - 2025-05-19
 

--- a/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/DatasetIdentifier.java
@@ -16,7 +16,8 @@ public class DatasetIdentifier {
   List<Symlink> symlinks;
 
   public enum SymlinkType {
-    TABLE
+    TABLE,
+    LOCATION
   };
 
   public DatasetIdentifier(String name, String namespace) {

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
@@ -38,7 +38,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/transactions",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -170,7 +170,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/monthly_transaction_summary",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t3",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -66,7 +66,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -93,7 +93,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t2",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -268,7 +268,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -66,7 +66,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t2",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -173,7 +173,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
@@ -35,7 +35,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -82,7 +82,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t4",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -66,7 +66,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t3",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -174,7 +174,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t2",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -267,7 +267,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
@@ -35,7 +35,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -103,7 +103,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -107,7 +107,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t2",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -107,7 +107,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
@@ -35,7 +35,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -82,7 +82,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -100,7 +100,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -184,7 +184,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
@@ -43,7 +43,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -157,7 +157,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
@@ -35,7 +35,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -82,7 +82,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
@@ -35,7 +35,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -82,7 +82,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -120,7 +120,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -184,7 +184,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
@@ -43,7 +43,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -124,7 +124,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
@@ -43,7 +43,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -116,7 +116,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
@@ -43,7 +43,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -116,7 +116,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -111,7 +111,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -111,7 +111,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
@@ -39,7 +39,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t1",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -66,7 +66,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/t2",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -164,7 +164,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/xxx",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
@@ -43,7 +43,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/employees",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -74,7 +74,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/managers",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -105,7 +105,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/teams",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }
@@ -142,7 +142,7 @@
             {
               "namespace": "file",
               "name": "/opt/hive/data/warehouse/test.db/result_t",
-              "type": "TABLE"
+              "type": "LOCATION"
             }
           ]
         }

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/util/HiveUtils.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/util/HiveUtils.java
@@ -86,7 +86,7 @@ public class HiveUtils {
       DatasetIdentifier di =
           new DatasetIdentifier(table.getFullyQualifiedName(), table.getCatName());
       return di.withSymlink(
-          symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.TABLE);
+          symlink.getName(), symlink.getNamespace(), DatasetIdentifier.SymlinkType.LOCATION);
     }
     return new DatasetIdentifier(table.getFullyQualifiedName(), table.getCatName());
   }

--- a/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/integration/ColumnLevelLineageTests.java
+++ b/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/integration/ColumnLevelLineageTests.java
@@ -219,7 +219,7 @@ public class ColumnLevelLineageTests extends ContainerHiveTestBase {
                         assertThat(identifier.getNamespace()).isEqualTo("file");
                         assertThat(identifier.getName())
                             .isEqualTo("/opt/hive/data/warehouse/test.db/xxx");
-                        assertThat(identifier.getType()).isEqualTo("TABLE");
+                        assertThat(identifier.getType()).isEqualTo("LOCATION");
                       });
             });
   }

--- a/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/util/HiveUtilsTest.java
+++ b/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/util/HiveUtilsTest.java
@@ -61,6 +61,6 @@ public class HiveUtilsTest {
     DatasetIdentifier.Symlink symlink = datasetIdentifier.getSymlinks().get(0);
     assertThat(symlink.getName()).isEqualTo("/path/to/my/table");
     assertThat(symlink.getNamespace()).isEqualTo("file");
-    assertThat(symlink.getType().name()).isEqualTo("TABLE");
+    assertThat(symlink.getType().name()).isEqualTo("LOCATION");
   }
 }


### PR DESCRIPTION
### Problem

The symlinks created by java client could only have one type: `TABLE`, new type was needed for when the table is the dataset identifier, which is the case for Hive integration

### Solution

create new symlink type and use it in hive integration