### PR TITLE
[Flink2] Update example app dependencies

### DIFF
--- a/integration/flink/examples/flink2-test-apps/build.gradle
+++ b/integration/flink/examples/flink2-test-apps/build.gradle
@@ -37,10 +37,8 @@ dependencies {
     testCompileOnly 'org.codehaus.groovy:groovy-all:3.0.20'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     implementation 'org.awaitility:awaitility:4.3.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
     implementation "com.typesafe:config:1.4.3"
 
-    implementation "io.openlineage:openlineage-flink:$project.version"
     implementation "org.apache.flink:flink-connector-kafka:4.0.0-2.0"
     implementation "org.apache.flink:flink-avro-confluent-registry:$flinkVersion"
     implementation "org.apache.flink:flink-avro:$flinkVersion"

--- a/integration/flink/flink1/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/flink1/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -283,7 +283,11 @@ public class FlinkContainerUtils {
 
   static String getOpenLineageJarPath() {
     return Arrays.stream((new File("build/libs")).listFiles())
-        .filter(file -> file.getName().startsWith("openlineage-flink"))
+        .filter(
+            file ->
+                file.getName().startsWith("openlineage-flink")
+                    && !file.getName().endsWith("-javadoc.jar")
+                    && !file.getName().endsWith("-sources.jar"))
         .map(file -> file.getPath())
         .findAny()
         .get();

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/FlinkContainerUtils.java
@@ -220,7 +220,11 @@ public class FlinkContainerUtils {
 
   static String getOpenLineageJarPath() {
     return Arrays.stream((new File("build/libs")).listFiles())
-        .filter(file -> file.getName().startsWith("openlineage-flink"))
+        .filter(
+            file ->
+                file.getName().startsWith("openlineage-flink")
+                    && !file.getName().endsWith("-javadoc.jar")
+                    && !file.getName().endsWith("-sources.jar"))
         .map(file -> file.getPath())
         .findAny()
         .get();


### PR DESCRIPTION
### Problem

`openlineage-flink` fat jar is already mounted to Flink's JobManager container, so it can be excluded from flink2-example-app dependencies. Same for http client, it is already part of fat jar, and it is already shaded to prevent interference with Flink dependencies:
https://github.com/OpenLineage/OpenLineage/blob/1.33.0/integration/flink/build.gradle#L225

### Solution

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project