### PR TITLE
[Flink] Do not hide OpenLineage config parsing errors

### DIFF
--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkConfigParser.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkConfigParser.java
@@ -60,7 +60,7 @@ public class FlinkConfigParser {
               OpenLineageClientUtils.loadOpenLineageConfigYaml(
                   new DefaultConfigPathProvider(), new TypeReference<FlinkOpenLineageConfig>() {}));
     } catch (OpenLineageClientException e) {
-      log.info("Couldn't log config from file, will read it from FlinkConf");
+      log.info("Couldn't log config from file, will read it from FlinkConf", e);
       configFromFile = Optional.empty();
     }
     return configFromFile;


### PR DESCRIPTION
### Problem

If Flink integration cannot parse `openlineage.yml` file (e.g. syntax error), the only log message the user see is `Couldn't log config from file, will read it from FlinkConf`, without any explanation.

### Solution

#### One-line summary:

Flink: Do not hide OpenLineage config parsing errors

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project