### PR TITLE
[DBT] Add processing_engine facet

### DIFF
--- a/integration/common/tests/dbt/catalog/result.json
+++ b/integration/common/tests/dbt/catalog/result.json
@@ -29,6 +29,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/compiled_code/result.json
+++ b/integration/common/tests/dbt/compiled_code/result.json
@@ -43,6 +43,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -83,6 +88,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/duckdb/result.json
+++ b/integration/common/tests/dbt/duckdb/result.json
@@ -67,6 +67,11 @@
             "dbt_version": {
                 "version": "1.8.9"
             },
+			"processing_engine": {
+				"name": "dbt",
+				"version": "1.8.9",
+				"openlineageAdapterVersion": "{{ any(result) }}"
+			},
             "parent": {
                 "job": {
                     "name": "dbt-job-name",
@@ -144,6 +149,11 @@
             "dbt_version": {
                 "version": "1.8.9"
             },
+			"processing_engine": {
+				"name": "dbt",
+				"version": "1.8.9",
+				"openlineageAdapterVersion": "{{ any(result) }}"
+			},
             "parent": {
                 "job": {
                     "name": "dbt-job-name",

--- a/integration/common/tests/dbt/env_vars/result.json
+++ b/integration/common/tests/dbt/env_vars/result.json
@@ -29,6 +29,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -73,6 +73,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -118,6 +123,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -174,6 +184,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -100,11 +100,22 @@
 		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "{{ any(result) }}"}
+				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
 			},
 			"dbt_version": {
-				"version": "{{ any(result) }}"
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "0.21.0",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -147,10 +158,19 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "{{ any(result) }}"}
+				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
 			},
 			"dbt_version": {
-				"version": "{{ any(result) }}"
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+				"version": "0.21.0"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "0.21.0",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -198,7 +218,14 @@
 			"dbt_version": {
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-				"version": "{{ any(result) }}"
+				"version": "0.21.0"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "0.21.0",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -236,11 +263,22 @@
 		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
-				"run": {"runId": "{{ any(result) }}"}
+				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
 			},
 			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "0.21.0"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "0.21.0",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -326,11 +364,22 @@
 		"runId": "{{ any(result) }}",
 		"facets": {
 			"parent": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
 			},
 			"dbt_version": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "0.21.0"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "0.21.0",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/no_test_metadata/result.json
+++ b/integration/common/tests/dbt/no_test_metadata/result.json
@@ -11,6 +11,13 @@
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
@@ -94,6 +101,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -259,6 +273,13 @@
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
@@ -342,6 +363,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -436,6 +464,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -531,6 +566,13 @@
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
@@ -614,6 +656,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -779,6 +828,13 @@
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
@@ -862,6 +918,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
@@ -956,6 +1019,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 },
                 "parent": {
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/postgres/result.json
+++ b/integration/common/tests/dbt/postgres/result.json
@@ -19,6 +19,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -76,6 +83,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -135,6 +149,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -194,6 +215,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -327,6 +355,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -449,6 +484,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -506,6 +548,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -565,6 +614,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -624,6 +680,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},
@@ -757,6 +820,13 @@
 				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
 				"_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
 				"version": "1.3.1"
+			},
+			"processing_engine": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+				"name": "dbt",
+				"version": "1.3.1",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/profiles/result.json
+++ b/integration/common/tests/dbt/profiles/result.json
@@ -26,9 +26,14 @@
 				"job": {"name": "dbt-job-name", "namespace": "dbt"},
 				"run": {"runId": "{{ any(result) }}"}
 			},
-                "dbt_version": {
-                    "version": "{{ any(result) }}"
-                }
+			"dbt_version": {
+				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
+			}
 		}
 	},
 	"job": {

--- a/integration/common/tests/dbt/small/result.json
+++ b/integration/common/tests/dbt/small/result.json
@@ -28,6 +28,11 @@
 			},
 			"dbt_version": {
 				"version": "{{ any(result) }}"
+			},
+			"processing_engine": {
+				"name": "dbt",
+				"version": "{{ any(result) }}",
+				"openlineageAdapterVersion": "{{ any(result) }}"
 			}
 		}
 	},

--- a/integration/common/tests/dbt/snapshot/result.json
+++ b/integration/common/tests/dbt/snapshot/result.json
@@ -62,6 +62,13 @@
           "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
           "version": "{{ any(result) }}"
         },
+        "processing_engine": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+          "name": "dbt",
+          "version": "{{ any(result) }}",
+          "openlineageAdapterVersion": "{{ any(result) }}"
+        },
         "parent": {
           "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
           "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
@@ -139,6 +146,13 @@
           "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
           "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
           "version": "{{ any(result) }}"
+        },
+        "processing_engine": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+          "name": "dbt",
+          "version": "{{ any(result) }}",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         },
         "parent": {
           "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/spark/thrift/result.json
+++ b/integration/common/tests/dbt/spark/thrift/result.json
@@ -318,9 +318,20 @@
         "run": {
             "facets": {
                 "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.0.0"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.0.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {
                         "name": "dbt-job-name",
                         "namespace": "dbt"
@@ -469,9 +480,20 @@
         "run": {
             "facets": {
                 "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.0.0"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.0.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {
                         "name": "dbt-job-name",
                         "namespace": "dbt"
@@ -646,9 +668,20 @@
         "run": {
             "facets": {
                 "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "1.0.0"
                 },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.0.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {
                         "name": "dbt-job-name",
                         "namespace": "dbt"

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/MainReportVersion_OL.yaml
@@ -6,6 +6,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/NodeStart_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/SQLQuery_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -107,6 +117,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_CommandCompleted_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -38,6 +43,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_NodeFinished_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_SQLQueryStatus_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -107,6 +117,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_test_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/failed_test_NodeFinished_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -135,6 +145,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         },
         "errorMessage": {
           "message": "Got 78 results, configured to fail if != 0",

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/missing_command_completed_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/missing_command_completed_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -106,6 +116,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -163,6 +178,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -33,6 +38,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_with_parent_id_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_CommandCompleted_with_parent_id_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_NodeFinished_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -106,6 +116,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_SQLQueryStatus_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -107,6 +117,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -145,6 +160,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_test_NodeFinished_OL.yaml
+++ b/integration/common/tests/dbt/structured_logs/postgres/events/results/successful_test_NodeFinished_OL.yaml
@@ -7,6 +7,11 @@
       "facets": {
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -42,6 +47,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -135,6 +145,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/run/results/failed_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/run/results/failed_run_ol_events.json
@@ -6,6 +6,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -40,6 +45,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -184,6 +194,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -223,6 +238,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -262,6 +282,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -306,6 +331,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -348,6 +378,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -488,6 +523,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/postgres/run/results/successful_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/run/results/successful_run_ol_events.json
@@ -6,6 +6,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -40,6 +45,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -105,6 +115,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -142,6 +157,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -179,6 +199,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -216,6 +241,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -253,6 +283,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -290,6 +325,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -327,6 +367,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -364,6 +409,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -401,6 +451,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -438,6 +493,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -475,6 +535,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -512,6 +577,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -549,6 +619,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -614,6 +689,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -683,6 +763,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -720,6 +805,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -757,6 +847,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -794,6 +889,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -831,6 +931,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -868,6 +973,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -905,6 +1015,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -942,6 +1057,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -979,6 +1099,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1016,6 +1141,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1053,6 +1183,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1090,6 +1225,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1127,6 +1267,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1196,6 +1341,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1265,6 +1415,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1302,6 +1457,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1339,6 +1499,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1376,6 +1541,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1413,6 +1583,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1450,6 +1625,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1487,6 +1667,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1524,6 +1709,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1561,6 +1751,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1598,6 +1793,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1635,6 +1835,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1672,6 +1877,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1709,6 +1919,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1778,6 +1993,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1929,6 +2149,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -1966,6 +2191,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2003,6 +2233,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2040,6 +2275,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2077,6 +2317,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2114,6 +2359,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2151,6 +2401,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2188,6 +2443,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2225,6 +2485,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2262,6 +2527,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2299,6 +2569,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2336,6 +2611,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2373,6 +2653,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2524,6 +2809,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2667,6 +2957,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2704,6 +2999,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2741,6 +3041,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2778,6 +3083,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2815,6 +3125,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2852,6 +3167,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2889,6 +3209,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2926,6 +3251,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -2963,6 +3293,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -3000,6 +3335,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -3037,6 +3377,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -3074,6 +3419,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -3111,6 +3461,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -3245,6 +3600,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/snowflake/run/results/failed_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/run/results/failed_run_ol_events.json
@@ -6,6 +6,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -40,6 +45,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -183,6 +193,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -225,6 +240,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -267,6 +287,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -406,6 +431,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/structured_logs/snowflake/run/results/successful_run_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/snowflake/run/results/successful_run_ol_events.json
@@ -6,6 +6,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -40,6 +45,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -183,6 +193,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -220,6 +235,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -257,6 +277,11 @@
         },
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },
@@ -391,6 +416,11 @@
       "facets":{
         "dbt_version": {
           "version": "1.8.2"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "1.8.2",
+          "openlineageAdapterVersion": "{{ any(result) }}"
         }
       }
     },

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -141,11 +141,22 @@
         "run": {
             "facets": {
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
                 },
                 "dbt_version": {
-                    "version": "{{ any(result) }}"
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "0.21.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 }
             },
             "runId": "{{ any(result) }}"
@@ -185,11 +196,22 @@
         "run": {
             "facets": {
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "{{ any(result) }}"}
                 },
                 "dbt_version": {
-                    "version": "{{ any(result) }}"
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "0.21.0"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "0.21.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 }
             },
             "runId": "{{ any(result) }}"
@@ -241,6 +263,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "0.21.0"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "0.21.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 }
             },
             "runId": "f99310b4-339a-4381-ad3e-c1b95c24ff11"
@@ -307,6 +336,13 @@
                     "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
                     "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "0.21.0"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "0.21.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 }
             },
             "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2"
@@ -344,11 +380,22 @@
         "run": {
             "facets": {
                 "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
                     "job": {"name": "dbt-job-name", "namespace": "dbt"},
                     "run": {"runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"}
                 },
                 "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
                     "version": "0.21.0"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "0.21.0",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
                 }
             },
             "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3"


### PR DESCRIPTION
### Problem

Currently dbt integration uses custom facet `dbt_version` instead of standard facet `processing_engine` reported by all other integrations.

### Solution

#### One-line summary:

DBT: Add `processing_engine` facet

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project