### PR TITLE
[Flink] Add processing_engine facet

### DIFF
--- a/integration/flink/flink1/src/test/resources/events/expected_cassandra.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_cassandra.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name": "flink_examples_cassandra"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs": [{
     "namespace": "cassandra://cassandra-cluster-prod:9042",
     "name": "flink.source_event"

--- a/integration/flink/flink1/src/test/resources/events/expected_failed.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_failed.json
@@ -5,10 +5,16 @@
     "name": "flink_failed_job"
   },
   "run" : {
+    "runId": "${json-unit.any-string}",
     "facets": {
       "errorMessage": {
         "message" : "Application Status: FAILED",
         "programmingLanguage": "JAVA"
+      },
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
       }
     }
   }

--- a/integration/flink/flink1/src/test/resources/events/expected_flink_conf.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_flink_conf.json
@@ -6,7 +6,14 @@
     "name": "flink_conf_job"
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "inputs": [
     {

--- a/integration/flink/flink1/src/test/resources/events/expected_iceberg.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_iceberg.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name": "flink_examples_iceberg"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs": [{
     "namespace": "file",
     "name": "/tmp/warehouse/db/source",

--- a/integration/flink/flink1/src/test/resources/events/expected_iceberg_source.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_iceberg_source.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name" : "flink_examples_iceberg_source"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs" : [ {
     "namespace" : "file",
     "name" : "/tmp/warehouse/db/source",

--- a/integration/flink/flink1/src/test/resources/events/expected_jdbc.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_jdbc.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name": "flink_examples_jdbc"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs": [{
     "namespace": "postgres://postgres:5432",
     "name": "postgres.source_event"

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka.json
@@ -13,7 +13,13 @@
     }
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {        "version": "${json-unit.regex}1.\\d+.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "inputs": [
     {

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_checkpoints.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_checkpoints.json
@@ -14,6 +14,11 @@
         "in-progress": "${json-unit.any-number}",
         "restored": "${json-unit.any-number}",
         "total": "${json-unit.any-number}"
+      },
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_generic_record.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_generic_record.json
@@ -6,7 +6,14 @@
     "name": "flink_source_with_generic_record"
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "inputs": [
     {

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_multi_topic_sink.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_multi_topic_sink.json
@@ -13,7 +13,14 @@
     }
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "outputs": [
     {

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -6,7 +6,14 @@
     "name": "flink_topic_pattern"
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "inputs": [
     {

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern_checkpoints.json
@@ -14,6 +14,11 @@
         "in-progress": "${json-unit.any-number}",
         "restored": "${json-unit.any-number}",
         "total": "${json-unit.any-number}"
+      },
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name": "flink_legacy_stateful"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs": [
     {
       "namespace": "kafka://kafka-cluster-prod:9092",

--- a/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
@@ -4,6 +4,16 @@
     "namespace" : "flink_job_namespace",
     "name": "flink_legacy_kafka_topic_pattern"
   },
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
+  },
   "inputs": [
     {
       "namespace": "kafka://kafka-cluster-prod:9092",

--- a/integration/flink/flink1/src/test/resources/events/expected_protobuf.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_protobuf.json
@@ -13,7 +13,14 @@
     }
   },
   "run": {
-    "runId": "${json-unit.any-string}"
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "inputs": [
     {

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/converter/LineageGraphConverter.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/converter/LineageGraphConverter.java
@@ -9,8 +9,10 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.client.Versions;
 import io.openlineage.flink.visitor.Flink2VisitorFactory;
 import java.time.ZonedDateTime;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.streaming.api.lineage.LineageGraph;
 
 public class LineageGraphConverter {
@@ -27,16 +29,28 @@ public class LineageGraphConverter {
   }
 
   public RunEvent convert(LineageGraph graph, EventType eventType) {
-    return context
-        .getOpenLineage()
+    OpenLineage openLineage = context.getOpenLineage();
+    return openLineage
         .newRunEventBuilder()
         .eventTime(ZonedDateTime.now())
         .eventType(eventType)
         .job(jobExtractor.extract(graph))
         .run(
-            context
-                .getOpenLineage()
-                .newRun(context.getRunUuid(), new OpenLineage.RunFacetsBuilder().build()))
+            openLineage
+                .newRunBuilder()
+                .runId(context.getRunUuid())
+                .facets(
+                    openLineage
+                        .newRunFacetsBuilder()
+                        .processing_engine(
+                            openLineage
+                                .newProcessingEngineRunFacetBuilder()
+                                .name("flink")
+                                .version(EnvironmentInformation.getVersion())
+                                .openlineageAdapterVersion(Versions.getVersion())
+                                .build())
+                        .build())
+                .build())
         .inputs(datasetExtractor.extractInputs(graph))
         .outputs(datasetExtractor.extractOutputs(graph))
         .build();

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -2,6 +2,14 @@
   "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
   "eventType": "START",
   "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}2\\.\\d+.*",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "job": {
     "namespace": "flink-jobs",

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern_checkpoint.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern_checkpoint.json
@@ -10,6 +10,11 @@
         "in-progress": "${json-unit.any-number}",
         "restored": "${json-unit.any-number}",
         "total": "${json-unit.any-number}"
+      },
+      "processing_engine": {
+        "version": "${json-unit.regex}2\\.\\d+.*",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
@@ -1,7 +1,15 @@
 {
   "schemaURL" : "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
   "eventType" : "START",
-  "run" : {
+  "run": {
+    "runId": "${json-unit.any-string}",
+    "facets": {
+      "processing_engine": {
+        "version": "${json-unit.regex}2\\.\\d+.*",
+        "name": "flink",
+        "openlineageAdapterVersion": "${json-unit.any-string}"
+      }
+    }
   },
   "job" : {
     "namespace" : "flink-jobs",


### PR DESCRIPTION
### Problem

Currently Flink integration doesn't produce standard facet `processing_engine` reported by all other integrations. Let's fix that.

### Solution

#### One-line summary:

Flink: Add `processing_engine` facet

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project