### PR TITLE
[DBT] Document supported adapters

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -188,7 +188,8 @@ class DbtArtifactProcessor:
         if self.command not in ["run", "build", "test", "seed", "snapshot"]:
             if self.should_raise_on_unsupported_command:
                 raise UnsupportedDbtCommand(
-                    f"Not recognized run command " f"{self.command} - should be run, test, seed or build"
+                    f"Not recognized run command {self.command} - "
+                    "should be run, build, test, seed or snapshot"
                 )
             else:
                 return events
@@ -449,7 +450,7 @@ class DbtArtifactProcessor:
             )
         else:
             # Should not happen?
-            raise ValueError(f"Run status was {status}, " f"should be in ['success', 'skipped', 'error']")
+            raise ValueError(f"Run status was {status}, should be in ['success', 'skipped', 'error']")
 
     def node_to_dataset(
         self,
@@ -584,7 +585,7 @@ class DbtArtifactProcessor:
             self.adapter_type = Adapter[profile["type"].upper()]
         except KeyError:
             raise NotImplementedError(
-                f"Only {Adapter.adapters()} adapters are supported right now. " f"Passed {profile['type']}"
+                f"Only {Adapter.adapters()} adapters are supported right now. Passed {profile['type']}"
             )
 
     def extract_dataset_namespace(self, profile: Dict):
@@ -635,11 +636,11 @@ class DbtArtifactProcessor:
                 return f"spark://{profile['host']}{port}"
             else:
                 raise NotImplementedError(
-                    f"Connection method `{profile['method']}` is not " f"supported for spark adapter."
+                    f"Connection method `{profile['method']}` is not supported for spark adapter."
                 )
         else:
             raise NotImplementedError(
-                f"Only {Adapter.adapters()} adapters are supported right now. " f"Passed {profile['type']}"
+                f"Only {Adapter.adapters()} adapters are supported right now. Passed {profile['type']}"
             )
 
     def get_run(self, run_id: str) -> Run:

--- a/integration/dbt/README.md
+++ b/integration/dbt/README.md
@@ -14,7 +14,20 @@ Wrapper script for automatic metadata collection from dbt
 - [Python >= 3.8](https://www.python.org/downloads)
 - [dbt >= 0.20](https://www.getdbt.com/)
 
-Right now, `openlineage-dbt` only supports `bigquery`, `snowflake`, `spark`,`redshift`, `athena` and `glue` dbt adapters.
+Right now, `openlineage-dbt` supports only these dbt adapters:
+
+* `bigquery`
+* `snowflake`
+* `spark` (`thrift` and `odbc`, but not `local`)
+* `redshift`
+* `athena`
+* `glue`
+* `postgres`
+* `trino`
+* `databricks`
+* `sqlserver`
+* `dremio`
+* `duckdb`
 
 ## Installation
 
@@ -30,23 +43,24 @@ $ pip install .
 
 ## Configuration
 
+### Transport
 
-### `HTTP` Backend Environment Variables
+`openlineage-dbt` uses the OpenLineage Python client to push data to the OpenLineage backend, so any way of configuring Python client will work here as well:
 
-`openlineage-dbt` uses the OpenLineage client to push data to the OpenLineage backend.
+```ini
+OPENLINEAGE_URL=http://localhost:5000
+OPENLINEAGE_API_KEY=abc
+```
 
-The OpenLineage client depends on environment variables:
+dbt integration-specific environment variables:
 
-* `OPENLINEAGE_URL` - point to service which will consume OpenLineage events
-* `OPENLINEAGE_API_KEY` - set if consumer of OpenLineage events requires `Bearer` authentication key
 * `OPENLINEAGE_NAMESPACE` - set if you are using something other than the `default` namespace for job namespace.
-
 
 ### Logging
 
 In addition to conventional logging approaches, the OpenLineage dbt wrapper script provides an alternative way of configuring its logging behavior. By setting the `OPENLINEAGE_DBT_LOGGING` environment variable, you can establish the logging level for the `openlineage.dbt` and its child modules.
 
-You can also set log level of `dbtol` which is deprecated.
+You can also set log level of `dbtol` Python module but this is deprecated.
 
 ## Usage
 

--- a/website/docs/integrations/dbt.md
+++ b/website/docs/integrations/dbt.md
@@ -17,6 +17,21 @@ This integration is implemented as a wrapper script, `dbt-ol`, that calls `dbt` 
 
 ## Preparing a dbt project for OpenLineage
 
+Right now, `openlineage-dbt` supports only these dbt adapters:
+
+* `bigquery`
+* `snowflake`
+* `spark` (`thrift` and `odbc`, but not `local`)
+* `redshift`
+* `athena`
+* `glue`
+* `postgres`
+* `trino`
+* `databricks`
+* `sqlserver`
+* `dremio`
+* `duckdb`
+
 First, we need to install the integration:
 
 ```bash
@@ -34,6 +49,8 @@ Finally, we can optionally specify a namespace where the lineage events will be 
 ```bash
 OPENLINEAGE_NAMESPACE=dev
 ```
+
+More configuration parameters can be found in [Python client documentation](../client/python.md#configuration)
 
 ## Running dbt with OpenLineage
 


### PR DESCRIPTION
### Problem

### Solution

* List of supported dbt adapters was mentioned in integrations/dbt/README.md in Github. but not on website. Fixed
* README.md and documentation didn't mentioned how this integration could be configured. Fixed by providing a link to Python client documentation.
* Fixed a warning in integration about supported dbt commands

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project