### PR TITLE
Add Github stars statistics to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ See [CONTRIBUTING.md](https://github.com/OpenLineage/OpenLineage/blob/main/CONTR
 
 If you discover a vulnerability in the project, please [open an issue](https://github.com/OpenLineage/OpenLineage/issues/new/choose) and attach the "security" label.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=OpenLineage/OpenLineage&type=Date)](https://www.star-history.com/#OpenLineage/OpenLineage&Date)
+
 ----
 SPDX-License-Identifier: Apache-2.0\
 Copyright 2018-2025 contributors to the OpenLineage project


### PR DESCRIPTION
### Problem

### Solution

Add a chart with Github repo stars history:
![изображение](https://github.com/user-attachments/assets/e4f0272d-42e8-489c-b96d-90fb44445138)
https://github.com/OpenLineage/OpenLineage/blob/22c92115467a2504ca6160d1ad7aec597c255b2d/README.md

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project