### PR TITLE
[DBT] Use adapter rows_affected as outputStatistics

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -280,6 +280,7 @@ class DbtArtifactProcessor:
                     get_from_nullable_chain(context.catalog, ["nodes", run["unique_id"]]),
                 ),
                 has_facets=True,
+                adapter_response=run.get("adapter_response", None),
             )
 
             # Add column lineage if SQL is available
@@ -461,41 +462,71 @@ class DbtArtifactProcessor:
         namespace, name, facets, _ = self.extract_dataset_data(node, None, has_facets)
         return Dataset(name=name, namespace=namespace, facets=facets)
 
-    def node_to_output_dataset(self, node: ModelNode, has_facets: bool = False) -> OutputDataset:
+    def node_to_output_dataset(
+        self,
+        node: ModelNode,
+        has_facets: bool = False,
+        adapter_response: Optional[Dict] = None,
+    ) -> OutputDataset:
         namespace, name, facets, _ = self.extract_dataset_data(node, None, has_facets)
-        output_facets: Dict[str, OutputDatasetFacet] = {}
-        if has_facets and node.catalog_node:
-            bytes = get_from_multiple_chains(
-                node.catalog_node,
-                [
-                    ["stats", "num_bytes", "value"],  # bigquery
-                    ["stats", "bytes", "value"],  # snowflake
+        if not has_facets:
+            return OutputDataset(name=name, namespace=namespace, facets=facets)
+
+        row_count = 0
+        byte_count = 0
+        if node.catalog_node:
+            row_count = (
+                get_from_multiple_chains(
+                    node.catalog_node,
                     [
-                        "stats",
-                        "size",
-                        "value",
-                    ],  # redshift (Note: size = count of 1MB blocks)
-                ],
-            )
-            rows = get_from_multiple_chains(
-                node.catalog_node,
-                [
-                    ["stats", "num_rows", "value"],  # bigquery
-                    ["stats", "row_count", "value"],  # snowflake
-                    ["stats", "rows", "value"],  # redshift
-                ],
-            )
-
-            if bytes:
-                bytes = int(bytes) if self.adapter_type != Adapter.REDSHIFT else int(rows) * (2**20)
-            if rows:
-                rows = int(rows)
-
-                output_facets[
-                    "outputStatistics"
-                ] = output_statistics_output_dataset.OutputStatisticsOutputDatasetFacet(
-                    rowCount=rows, size=bytes
+                        ["stats", "num_rows", "value"],  # bigquery
+                        ["stats", "row_count", "value"],  # snowflake
+                        ["stats", "rows", "value"],  # redshift
+                    ],
                 )
+                or 0
+            )
+
+            byte_count = (
+                get_from_multiple_chains(
+                    node.catalog_node,
+                    [
+                        ["stats", "num_bytes", "value"],  # bigquery
+                        ["stats", "bytes", "value"],  # snowflake
+                    ],
+                )
+                or 0
+            )
+
+            if self.adapter_type == Adapter.REDSHIFT:
+                # size is the number of 1MB blocks
+                blocks_count = (
+                    get_from_multiple_chains(
+                        node.catalog_node,
+                        [
+                            ["stats", "size", "value"],
+                        ],
+                    )
+                    or 0
+                )
+                byte_count = byte_count or blocks_count * (2**20)
+
+        if adapter_response:
+            row_count = row_count or adapter_response.get("rows_affected", 0)
+            byte_count = byte_count or adapter_response.get("bytes_processed", 0)
+
+        row_count = int(row_count)
+        byte_count = int(byte_count)
+        if not row_count and not byte_count:
+            return OutputDataset(name=name, namespace=namespace, facets=facets)
+
+        output_facets: Dict[str, OutputDatasetFacet] = {}
+        output_facets[
+            "outputStatistics"
+        ] = output_statistics_output_dataset.OutputStatisticsOutputDatasetFacet(
+            rowCount=row_count if row_count > 0 else None,
+            size=byte_count if byte_count > 0 else None,
+        )
         return OutputDataset(name=name, namespace=namespace, facets=facets, outputFacets=output_facets)
 
     def _format_dataset_name(self, database: Optional[str], schema: Optional[str], table: str) -> str:

--- a/integration/common/tests/dbt/compiled_code/result.json
+++ b/integration/common/tests/dbt/compiled_code/result.json
@@ -74,6 +74,11 @@
 					"name": "id"
 				}]
 			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 2
+			}
 		}
 	}]
 }, {

--- a/integration/common/tests/dbt/fail/result.json
+++ b/integration/common/tests/dbt/fail/result.json
@@ -109,6 +109,13 @@
 					"name": "id"
 				}]
 			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+				"_schemaURL": "https://openlineage.io/spec/facets/1-0-2/OutputStatisticsOutputDatasetFacet.json#/$defs/OutputStatisticsOutputDatasetFacet",
+				"rowCount": 2
+			}
 		}
 	}]
 }, {

--- a/integration/common/tests/dbt/large/result.json
+++ b/integration/common/tests/dbt/large/result.json
@@ -146,6 +146,11 @@
 					"name": "status"
 				}]
 			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 1
+			}
 		}
 	}]
 }, {
@@ -202,7 +207,11 @@
 				}]
 			}
 		},
-		"outputFacets": {}
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 1
+			}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -253,6 +262,11 @@
 				"fields": [{
 					"name": "customer_id"
 				}]
+			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 1
 			}
 		}
 	}]
@@ -355,7 +369,11 @@
 				}]
 			}
 		},
-		"outputFacets": {}
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 1
+			}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",
@@ -472,6 +490,11 @@
 				}, {
 					"name": "total_order_amount"
 				}]
+			}
+		},
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 1
 			}
 		}
 	}]

--- a/integration/common/tests/dbt/postgres/result.json
+++ b/integration/common/tests/dbt/postgres/result.json
@@ -332,7 +332,11 @@
 				}]
 			}
 		},
-		"outputFacets": {}
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 100
+			}
+		}
 	}]
 }, {
 	"eventType": "START",
@@ -461,7 +465,11 @@
 				}]
 			}
 		},
-		"outputFacets": {}
+		"outputFacets": {
+			"outputStatistics": {
+				"rowCount": 99
+			}
+		}
 	}]
 }, {
 	"eventType": "COMPLETE",

--- a/integration/common/tests/dbt/spark/thrift/result.json
+++ b/integration/common/tests/dbt/spark/thrift/result.json
@@ -473,7 +473,11 @@
                 },
                 "name": "default.orders",
                 "namespace": "spark://localhost:10000",
-                "outputFacets": {}
+                "outputFacets": {
+                    "outputStatistics": {
+                        "size": 4722
+                    }
+                }
             }
         ],
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",


### PR DESCRIPTION
### Problem

Some adapters return number of rows affected by `INSERT`, `UPDATE`, `CREATE TABLE`, but openlineage-dbt integration doesn't use this field. Fixed.

### Solution

#### One-line summary:

[DBT] Use adapter's `rows_affected` in `outputStatistics` facet

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project