### PR TITLE
Website: restyle `cardMedia` on ecosystem page

### DIFF
--- a/website/src/pages/ecosystem.tsx
+++ b/website/src/pages/ecosystem.tsx
@@ -72,7 +72,7 @@ const LogoCard = (partner: Partner) => {
         >
           <CardActionArea sx={{ padding: 0 }}>
             <CardMedia
-              sx={{ minWidth: 340, minHeight: 170, padding: 0 }}
+              sx={{ width: 340, height: 170, padding: 0 }}
               component="img"
               src={require(`@site/static/img/${partner.image}`).default}
               title={partner.org}


### PR DESCRIPTION
### Problem

Due to flexible height and width styling on cards, incorrectly sized images resize cards, and consequently distort the grid, on the ecosystem page. 

### Solution

Replace the `minHeight` and `minWidth` styles on cards with stricter `height` and `width` properties. In the attached image, the Collibra image is incorrectly sized, but the card dims remain unchanged.

![Screenshot from 2025-05-31 14-39-45](https://github.com/user-attachments/assets/18384c0b-8918-4293-b819-f4ae33b256f0)

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project