### PR TITLE
[Flink] Add facet with Flink jobId

### DIFF
--- a/integration/flink/flink1/src/test/java/io/openlineage/flink/JobListenerTest.java
+++ b/integration/flink/flink1/src/test/java/io/openlineage/flink/JobListenerTest.java
@@ -47,7 +47,7 @@ class JobListenerTest {
       JobIdentifier.builder()
           .jobNamespace("some-job-namespace")
           .jobName("some-job-name")
-          .flinkJobId(mock(JobID.class))
+          .flinkJobId(new JobID(1, 2))
           .build();
   List<Transformation<?>> transformations = new ArrayList<>();
   OpenLineageFlinkJobListener listener;
@@ -113,7 +113,7 @@ class JobListenerTest {
         JobIdentifier.builder()
             .jobNamespace(customNamespace)
             .jobName(customJobName)
-            .flinkJobId(mock(JobID.class))
+            .flinkJobId(new JobID(1, 2))
             .build();
 
     StreamExecutionEnvironment streamExecutionEnvironment =

--- a/integration/flink/flink1/src/test/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextTest.java
+++ b/integration/flink/flink1/src/test/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContextTest.java
@@ -37,7 +37,7 @@ public class FlinkExecutionContextTest {
       JobIdentifier.builder()
           .jobNamespace("jobNamespace")
           .jobName("jobName")
-          .flinkJobId(mock(JobID.class))
+          .flinkJobId(new JobID(1, 2))
           .build();
 
   @AfterEach

--- a/integration/flink/flink1/src/test/resources/events/expected_cassandra.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_cassandra.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_failed.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_failed.json
@@ -15,6 +15,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   }

--- a/integration/flink/flink1/src/test/resources/events/expected_flink_conf.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_flink_conf.json
@@ -12,6 +12,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_iceberg.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_iceberg.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_iceberg_source.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_iceberg_source.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_jdbc.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_jdbc.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka.json
@@ -15,9 +15,13 @@
   "run": {
     "runId": "${json-unit.any-string}",
     "facets": {
-      "processing_engine": {        "version": "${json-unit.regex}1.\\d+.\\d+",
+      "processing_engine": {
+        "version": "${json-unit.regex}1.\\d+.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_checkpoints.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_checkpoints.json
@@ -19,6 +19,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_generic_record.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_generic_record.json
@@ -12,6 +12,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_multi_topic_sink.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_multi_topic_sink.json
@@ -19,6 +19,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -12,6 +12,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_legacy_kafka_topic_pattern.json
@@ -11,6 +11,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink1/src/test/resources/events/expected_protobuf.json
+++ b/integration/flink/flink1/src/test/resources/events/expected_protobuf.json
@@ -19,6 +19,9 @@
         "version": "${json-unit.regex}1\\.\\d+\\.\\d+",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/converter/LineageGraphConverter.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/converter/LineageGraphConverter.java
@@ -10,6 +10,7 @@ import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.client.Versions;
+import io.openlineage.flink.facets.FlinkJobDetailsFacet;
 import io.openlineage.flink.visitor.Flink2VisitorFactory;
 import java.time.ZonedDateTime;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -49,10 +50,21 @@ public class LineageGraphConverter {
                                 .version(EnvironmentInformation.getVersion())
                                 .openlineageAdapterVersion(Versions.getVersion())
                                 .build())
+                        .put("flink_job", buildJobDetailsFacet())
                         .build())
                 .build())
         .inputs(datasetExtractor.extractInputs(graph))
         .outputs(datasetExtractor.extractOutputs(graph))
         .build();
+  }
+
+  private FlinkJobDetailsFacet buildJobDetailsFacet() {
+    OpenLineageContext.JobIdentifier jobId = context.getJobId();
+    if (jobId == null || jobId.getFlinkJobId() == null) {
+      return null;
+    }
+
+    String flinkJobId = jobId.getFlinkJobId().toString();
+    return new FlinkJobDetailsFacet(flinkJobId);
   }
 }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
@@ -18,6 +18,7 @@ import io.openlineage.flink.client.Versions;
 import io.openlineage.flink.config.FlinkConfigParser;
 import io.openlineage.flink.config.FlinkOpenLineageConfig;
 import io.openlineage.flink.converter.LineageGraphConverter;
+import io.openlineage.flink.facets.FlinkJobDetailsFacet;
 import io.openlineage.flink.tracker.OpenLineageContinousJobTracker;
 import io.openlineage.flink.util.JobStatusUtil;
 import io.openlineage.flink.visitor.Flink2VisitorFactory;
@@ -38,6 +39,7 @@ import org.apache.flink.streaming.runtime.execution.JobCreatedEvent;
 @Slf4j
 public class OpenLineageJobStatusChangedListener implements JobStatusChangedListener {
   public static final String DEFAULT_NAMESPACE = "flink-jobs";
+  public static final String FLINK_JOB_FACET_KEY = "flink_job";
   private final OpenLineageContext context;
   private final LineageGraphConverter graphConverter;
   private OpenLineageContinousJobTracker tracker;
@@ -112,6 +114,7 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
                             .newRunFacetsBuilder()
                             .processing_engine(buildProcessingEngineFacet(openLineage))
                             .put("checkpoints", checkpointFacet)
+                            .put(FLINK_JOB_FACET_KEY, buildJobDetailsFacet())
                             .build())
                     .build())
             .build();
@@ -140,6 +143,7 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
                         openLineage
                             .newRunFacetsBuilder()
                             .processing_engine(buildProcessingEngineFacet(openLineage))
+                            .put(FLINK_JOB_FACET_KEY, buildJobDetailsFacet())
                             .build())
                     .build())
             .build();
@@ -150,7 +154,7 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
     }
   }
 
-  RunEventBuilder commonEventBuilder() {
+  private RunEventBuilder commonEventBuilder() {
     return context
         .getOpenLineage()
         .newRunEventBuilder()
@@ -173,7 +177,17 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
         .build();
   }
 
-  void loadJobId(JobCreatedEvent createdEvent) {
+  private FlinkJobDetailsFacet buildJobDetailsFacet() {
+    JobIdentifier jobId = context.getJobId();
+    if (jobId == null || jobId.getFlinkJobId() == null) {
+      return null;
+    }
+
+    String flinkJobId = jobId.getFlinkJobId().toString();
+    return new FlinkJobDetailsFacet(flinkJobId);
+  }
+
+  private void loadJobId(JobCreatedEvent createdEvent) {
     String jobName =
         Optional.ofNullable(context.getConfig())
             .map(FlinkOpenLineageConfig::getJobConfig)

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerTest.java
@@ -174,7 +174,7 @@ class OpenLineageJobStatusChangedListenerTest {
     // emit complete event
     DefaultJobExecutionStatusEvent statusEvent =
         new DefaultJobExecutionStatusEvent(
-            mock(JobID.class),
+            new JobID(1, 2),
             "jobName",
             JobStatus.RUNNING,
             JobStatus.FINISHED,
@@ -213,11 +213,7 @@ class OpenLineageJobStatusChangedListenerTest {
     // emit fail event
     DefaultJobExecutionStatusEvent statusEvent =
         new DefaultJobExecutionStatusEvent(
-            mock(JobID.class),
-            "jobName",
-            JobStatus.RUNNING,
-            JobStatus.FAILED,
-            mock(Throwable.class));
+            new JobID(1, 2), "jobName", JobStatus.RUNNING, JobStatus.FAILED, mock(Throwable.class));
     listener.onEvent(statusEvent);
 
     List<RunEvent> eventsEmitted =

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern.json
@@ -8,6 +8,9 @@
         "version": "${json-unit.regex}2\\.\\d+.*",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern_checkpoint.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_kafka_topic_pattern_checkpoint.json
@@ -15,6 +15,9 @@
         "version": "${json-unit.regex}2\\.\\d+.*",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
+++ b/integration/flink/flink2/src/test/resources/events/expected_sql_kafka.json
@@ -8,6 +8,9 @@
         "version": "${json-unit.regex}2\\.\\d+.*",
         "name": "flink",
         "openlineageAdapterVersion": "${json-unit.any-string}"
+      },
+      "flink_job": {
+        "jobId": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -64,6 +64,6 @@ public class OpenLineageContext {
     private String jobNamespace;
 
     /** Assigned during the event emitted. */
-    @Setter private JobID flinkJobId;
+    private JobID flinkJobId;
   }
 }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/facets/FlinkJobDetailsFacet.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/facets/FlinkJobDetailsFacet.java
@@ -1,0 +1,25 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.facets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.flink.client.Versions;
+import lombok.Getter;
+import lombok.NonNull;
+
+/** Captures information related to the Apache Flink job. */
+@Getter
+public class FlinkJobDetailsFacet extends OpenLineage.DefaultRunFacet {
+  @JsonProperty("jobId")
+  @NonNull
+  private String jobId;
+
+  public FlinkJobDetailsFacet(@NonNull String jobId) {
+    super(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    this.jobId = jobId;
+  }
+}


### PR DESCRIPTION
### Problem

Closes: #3635

### Solution

#### One-line summary:

[Flink] Add `flink_job` facet with `jobId` field

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project