### PR TITLE
dbt-ol should not error on job complete if there is no start event

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -148,7 +148,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
         if not self.received_dbt_command_completed:
             # We did not receive the CommandCompleted event, so we emit an abort event
-            yield self._get_dbt_command_abort_event()
+            ol_event = self._get_dbt_command_abort_event()
+            if ol_event:
+                yield ol_event
 
     def _parse_structured_log_event(self, line: str) -> Optional[RunEvent]:
         """
@@ -244,6 +246,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                 producer=self.producer,
             )
         }
+        if not self.dbt_run_metadata:
+            return None
         return generate_run_event(
             event_type=RunState.ABORT,
             event_time=datetime.datetime.now().isoformat(),  # Current time - no other data source


### PR DESCRIPTION
When `self.dbt_run_metadata` is not set, we should not try to generate abort event.
This also means we haven't send `START` event.