### PR TITLE
[Docs] Add documentation for some facets

### DIFF
--- a/spec/registry/core/registry.json
+++ b/spec/registry/core/registry.json
@@ -2,6 +2,7 @@
   "producer": {
     "root_doc_url": "https://github.com/OpenLineage/OpenLineage/tree/main/spec",
     "produced_facets": [
+      "ol:core:CatalogDatasetFacet.json",
       "ol:core:ColumnLineageDatasetFacet.json",
       "ol:core:DataQualityAssertionsDatasetFacet.json",
       "ol:core:DataQualityMetricsInputDatasetFacet.json",
@@ -10,6 +11,7 @@
       "ol:core:DatasourceDatasetFacet.json",
       "ol:core:DocumentationDatasetFacet.json",
       "ol:core:DocumentationJobFacet.json",
+      "ol:core:EnvironmentVariablesRunFacet.json",
       "ol:core:ErrorMessageRunFacet.json",
       "ol:core:ExternalQueryRunFacet.json",
       "ol:core:ExtractionErrorRunFacet.json",

--- a/spec/tests/DatasetTypeDatasetFacet/1.json
+++ b/spec/tests/DatasetTypeDatasetFacet/1.json
@@ -1,0 +1,8 @@
+{
+  "datasetType": {
+    "datasetType": "VIEW",
+    "subType": "MATERIALIZED",
+    "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetVersionDatasetFacet.json"
+  }
+}

--- a/website/docs/spec/facets/dataset-facets/catalog.md
+++ b/website/docs/spec/facets/dataset-facets/catalog.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 1
 ---
 
 # Catalog Dataset Facet

--- a/website/docs/spec/facets/dataset-facets/column_lineage_facet.md
+++ b/website/docs/spec/facets/dataset-facets/column_lineage_facet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Column Level Lineage Dataset Facet

--- a/website/docs/spec/facets/dataset-facets/data_quality_assertions.md
+++ b/website/docs/spec/facets/dataset-facets/data_quality_assertions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Data Quality Assertions Facet

--- a/website/docs/spec/facets/dataset-facets/data_source.md
+++ b/website/docs/spec/facets/dataset-facets/data_source.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Datasource Facet

--- a/website/docs/spec/facets/dataset-facets/documentation.md
+++ b/website/docs/spec/facets/dataset-facets/documentation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 4
 ---
 
 # Dataset Documentation Facet

--- a/website/docs/spec/facets/dataset-facets/lifecycle_state_change.md
+++ b/website/docs/spec/facets/dataset-facets/lifecycle_state_change.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Lifecycle State Change Facet

--- a/website/docs/spec/facets/dataset-facets/ownership.md
+++ b/website/docs/spec/facets/dataset-facets/ownership.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Ownership Dataset Facet

--- a/website/docs/spec/facets/dataset-facets/schema.md
+++ b/website/docs/spec/facets/dataset-facets/schema.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Schema Dataset Facet

--- a/website/docs/spec/facets/dataset-facets/storage.md
+++ b/website/docs/spec/facets/dataset-facets/storage.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Storage Facet

--- a/website/docs/spec/facets/dataset-facets/symlinks.md
+++ b/website/docs/spec/facets/dataset-facets/symlinks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Symlinks Facet

--- a/website/docs/spec/facets/dataset-facets/type.md
+++ b/website/docs/spec/facets/dataset-facets/type.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 11
+---
+
+# Dataset Type Facet
+
+The facet contains type of dataset within a database.
+
+Fields description:
+- `datasetType`: Dataset type, e.g. `TABLE`, `VIEW`, `TOPIC`, `MODEL`.
+- `subType`: sub-type within `datasetType`, e.g. `MATERIALIZED`, `EXTERNAL`.
+
+Example:
+
+```json
+{
+    ...
+    "inputs": {
+        "facets": {
+            "datasetType": {
+                "_producer": "https://some.producer.com/version/1.0",
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/DatasetTypeDatasetFacet.json",
+                "datasetType": "VIEW",
+                "subType": "MATERIALIZED"
+            }
+        }
+    }
+    ...
+}
+```
+The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-0/DatasetTypeDatasetFacet.json).

--- a/website/docs/spec/facets/dataset-facets/version_facet.md
+++ b/website/docs/spec/facets/dataset-facets/version_facet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 12
 ---
 
 # Version Facet

--- a/website/docs/spec/facets/job-facets/job-type.md
+++ b/website/docs/spec/facets/job-facets/job-type.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 2
 ---
 
 # Job type Job Facet

--- a/website/docs/spec/facets/job-facets/ownership.md
+++ b/website/docs/spec/facets/job-facets/ownership.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Ownership Job Facet

--- a/website/docs/spec/facets/job-facets/source-code-location.md
+++ b/website/docs/spec/facets/job-facets/source-code-location.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Source Code Location Facet

--- a/website/docs/spec/facets/job-facets/source-code.md
+++ b/website/docs/spec/facets/job-facets/source-code.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Source Code Facet

--- a/website/docs/spec/facets/job-facets/sql.md
+++ b/website/docs/spec/facets/job-facets/sql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 

--- a/website/docs/spec/facets/run-facets/environment_variables.md
+++ b/website/docs/spec/facets/run-facets/environment_variables.md
@@ -1,13 +1,41 @@
 ---
-sidebar_position: 6
+sidebar_position: 1
 ---
 
 # Environment Variables Run Facet
 The Environment Variables Run Facet provides detailed information about the environment variables that were set during the execution of a job. This facet is useful for capturing the runtime environment configuration, which can be used for categorizing and filtering jobs based on their environment settings.
 
-| Property              | Description                                                                 | Type   | Example                   | Required |
-|-----------------------|-----------------------------------------------------------------------------|--------|---------------------------|----------|
-| name                  | The name of the environment variable. This helps in identifying the specific environment variable used during the job run. | string | "JAVA_HOME"              | Yes      |
-| value                 | The value of the environment variable. This captures the actual value set for the environment variable during the job run. | string | "/usr/lib/jvm/java-11"   | Yes      |
+Fields:
+
+- `environmentVariables`: The environment variables for the run, collected by OpenLineage. Array of objects, the order doesn't matter:
+  - `name`: The name of the environment variable.
+  - `value`: The value of the environment variable.
+
+Example:
+
+```json
+{
+    ...
+    "run": {
+        "facets": {
+            "environmentVariables": {
+                "_producer": "https://some.producer.com/version/1.0",
+                "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/EnvironmentVariablesRunFacet.json",
+                "environmentVariables": [
+                    {
+                        "name": "JAVA_HOME",
+                        "value": "/usr/lib/jvm/java-11-openjdk"
+                    },
+                    {
+                        "name": "PATH",
+                        "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                    }
+                ]
+            }
+        }
+    }
+    ...
+}
+```
 
 The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-0/EnvironmentVariablesRunFacet.json).

--- a/website/docs/spec/facets/run-facets/error_message.md
+++ b/website/docs/spec/facets/run-facets/error_message.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 

--- a/website/docs/spec/facets/run-facets/external_query.md
+++ b/website/docs/spec/facets/run-facets/external_query.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 

--- a/website/docs/spec/facets/run-facets/extraction_error.md
+++ b/website/docs/spec/facets/run-facets/extraction_error.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 4
+---
+
+
+# Extraction Error Facet
+
+The facet reflects internal processing errors of OpenLineage. For example, it allows to distinguish SQL job that was parsed and found no datasets processed, from the one which cannot be parsed.
+
+Fields:
+- `totalTasks`: The number of distinguishable tasks in a run that were processed by OpenLineage, whether successfully or not. Those could be, for example, distinct SQL statements.
+- `failedTasks`: The number of distinguishable tasks in a run that were processed not successfully by OpenLineage. Those could be, for example, distinct SQL statements.
+- `errors`: Array of error objects:
+  - `taskNumber`: Order of task (counted from 0).
+  - `task`: Text representation of task that failed. This can be, for example, SQL statement that parser could not interpret.
+  - `errorMessage`: Text representation of extraction error message.
+  - `stackTrace`: Stack trace of extraction error message
+
+Example:
+
+```json
+{
+    ...
+    "run": {
+        "facets": {
+            "extractionError": {
+                "_producer": "https://some.producer.com/version/1.0",
+                "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/ExtractionErrorRunFacet.json",
+                "totalTasks": "2",
+                "failedTasks": "1",
+                "errors": [
+                    {
+                        "taskNumber": 0,
+                        "task": "DROP POLICY IF EXISTS name ON table_name",
+                        "errorMessage": "Expected TABLE, VIEW, INDEX, ROLE, SCHEMA, FUNCTION, STAGE or SEQUENCE after DROP, found: POLICY at Line: 1, Column 6",
+                        "stackTrace": null
+                    },
+                ]
+            }
+        }
+    }
+    ...
+}
+```
+
+The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-0/ExtractionErrorRunFacet.json)

--- a/website/docs/spec/facets/run-facets/nominal_time.md
+++ b/website/docs/spec/facets/run-facets/nominal_time.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 

--- a/website/docs/spec/facets/run-facets/parent_run.md
+++ b/website/docs/spec/facets/run-facets/parent_run.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 # Parent Run Facet

--- a/website/docs/spec/facets/run-facets/processing_engine.md
+++ b/website/docs/spec/facets/run-facets/processing_engine.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Processing Engine Run Facet

--- a/website/docs/spec/facets/run-facets/tag-facet.md
+++ b/website/docs/spec/facets/run-facets/tag-facet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Tags Run Facet


### PR DESCRIPTION
### Problem

- `DatasetTypeDatasetFacet` is a part of specification, but it is not mentioned in documentation.
- Same for `ExtractionErrorRunFacet`
- `EnvironmentVariablesRunFacet` example was different from others (table instead of json).
- Added missing facets in spec's `registry.json`
- Change sorting of facets in documenation.

### Solution

#### One-line summary:

[Docs] Add documentation for some facets

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project