### PR TITLE
[DOC] Fix the incorrect httpConfig header and timeout property values

### DIFF
--- a/website/docs/client/java/partials/java_transport.md
+++ b/website/docs/client/java/partials/java_transport.md
@@ -238,8 +238,8 @@ httpConfig.setUrl("http://localhost:5000");
 httpConfig.setEndpoint("/api/v1/lineage");
 httpConfig.setUrlParams(queryParams);
 httpConfig.setAuth(apiKeyTokenProvider);
-httpConfig.setTimeoutInMillis(headers);
-httpConfig.setHeaders(5000);
+httpConfig.setTimeoutInMillis(5000);
+httpConfig.setHeaders(headers);
 httpConfig.setCompression(HttpConfig.Compression.GZIP);
 
 OpenLineageClient client = OpenLineageClient.builder()


### PR DESCRIPTION
### Problem
 The values in the httpConfig property are incorrectly mapped in the Java client.

<img width="393" alt="image" src="https://github.com/user-attachments/assets/01498691-510e-4a96-a73f-552336d97133" />


### Solution
Update the httpConfig property in the Java client with the correct values.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project