### PR TITLE
[Spark] Fix missing table path in InsertIntoHadoopFsRelationCommand

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -66,7 +66,7 @@ public class InsertIntoHadoopFsRelationVisitor
     if (command.catalogTable().isDefined()) {
       return Optional.of(
           PathUtils.fromCatalogTable(
-              command.catalogTable().get(), context.getSparkSession().get()));
+              command.catalogTable().get(), context.getSparkSession().get(), command.outputPath()));
     }
     return Optional.of(PathUtils.fromPath(command.outputPath()));
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -38,7 +38,6 @@ public class PathUtils {
    * Create DatasetIdentifier from CatalogTable, using storage's locationURI if it exists. In other
    * way, use defaultTablePath.
    */
-  @SneakyThrows
   public static DatasetIdentifier fromCatalogTable(
       CatalogTable catalogTable, SparkSession sparkSession) {
     URI locationUri;
@@ -47,9 +46,23 @@ public class PathUtils {
     } else {
       locationUri = getDefaultLocationUri(sparkSession, catalogTable.identifier());
     }
-    DatasetIdentifier locationDataset = fromURI(locationUri);
-    // perform normalization
-    locationUri = FilesystemDatasetUtils.toLocation(locationDataset);
+    return fromCatalogTable(catalogTable, sparkSession, locationUri);
+  }
+
+  /** Create DatasetIdentifier from CatalogTable, using provided location. */
+  @SneakyThrows
+  public static DatasetIdentifier fromCatalogTable(
+      CatalogTable catalogTable, SparkSession sparkSession, Path location) {
+    return fromCatalogTable(catalogTable, sparkSession, location.toUri());
+  }
+
+  /** Create DatasetIdentifier from CatalogTable, using provided location. */
+  @SneakyThrows
+  public static DatasetIdentifier fromCatalogTable(
+      CatalogTable catalogTable, SparkSession sparkSession, URI location) {
+    // perform URL normalization
+    DatasetIdentifier locationDataset = fromURI(location);
+    URI locationUri = FilesystemDatasetUtils.toLocation(locationDataset);
 
     Optional<DatasetIdentifier> symlinkDataset = Optional.empty();
 


### PR DESCRIPTION
### Problem

Closes: #3558

### Solution

Use table path from `InsertIntoHadoopFsRelationCommand` instead of fetching it from CatalogTable.

#### One-line summary:

[Spark] Fix missing table path in InsertIntoHadoopFsRelationCommand

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project