### PR TITLE
chore: Use attr.define instead of attr.s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,19 @@ repos:
         entry: .pre_commit/check_version_update_path.sh
         files: new-version\.sh$|\.gradle$|gradle\.properties$|README\.md$|version\.properties$
         pass_filenames: false
+      - id: forbid-attr-s
+        name: Check for @attr.s
+        description: "Checks if @attr.s is used instead of desired @attr.define"
+        language: pygrep
+        entry: "@(attr\\.s|s)(\\s|\\n|\\()"
+        files: "\\.(py|md)$"
+        # Exclude tests directories and deprecated modules that can use @attr.s
+        exclude: |
+          (?x)^(
+            .*tests.* |
+            client/python/openlineage/client/facet\.py |
+            client/python/openlineage/client/run\.py
+          )$
       - id: prettier
         name: prettier
         description: ""

--- a/client/python/openlineage/client/facets.py
+++ b/client/python/openlineage/client/facets.py
@@ -5,6 +5,6 @@ from __future__ import annotations
 import attr
 
 
-@attr.s
+@attr.define
 class FacetsConfig:
-    environment_variables: list[str] = attr.ib(factory=list)
+    environment_variables: list[str] = attr.field(factory=list)

--- a/client/python/openlineage/client/filter.py
+++ b/client/python/openlineage/client/filter.py
@@ -14,11 +14,11 @@ log = logging.getLogger(__name__)
 RunEventType = typing.Union[RunEvent, RunEvent_v2]
 
 
-@attr.s
+@attr.define
 class FilterConfig:
-    type: str | None = attr.ib(default=None)
-    match: str | None = attr.ib(default=None)
-    regex: str | None = attr.ib(default=None)
+    type: str | None = None
+    match: str | None = None
+    regex: str | None = None
 
 
 class Filter:

--- a/client/python/openlineage/client/tags.py
+++ b/client/python/openlineage/client/tags.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from openlineage.client.generated.tags_run import TagsRunFacetFields
 
 
-@attr.s
+@attr.define
 class TagsConfig:
-    job: list[TagsJobFacetFields] = attr.ib(factory=list)
-    run: list[TagsRunFacetFields] = attr.ib(factory=list)
+    job: list[TagsJobFacetFields] = attr.field(factory=list)
+    run: list[TagsRunFacetFields] = attr.field(factory=list)

--- a/client/python/openlineage/client/transport/composite.py
+++ b/client/python/openlineage/client/transport/composite.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-@attr.s
+@attr.define
 class CompositeConfig(Config):
     """
     CompositeConfig is a configuration class for CompositeTransport.
@@ -36,8 +36,8 @@ class CompositeConfig(Config):
             transport will halt the emission process for subsequent transports.
     """
 
-    transports: list[dict[str, Any]] | dict[str, dict[str, Any]] = attr.ib()
-    continue_on_failure: bool = attr.ib(default=True)
+    transports: list[dict[str, Any]] | dict[str, dict[str, Any]]
+    continue_on_failure: bool = True
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> CompositeConfig:
@@ -86,6 +86,7 @@ class CompositeTransport(Transport):
             except Exception as e:  # noqa: BLE001
                 if self.config.continue_on_failure:
                     log.warning("Transport %s failed to emit event with error: %s", transport, e)
+                    log.debug("OpenLineage emission failure details:", exc_info=True)
                 else:
                     msg = f"Transport {transport} failed to emit event"
                     raise RuntimeError(msg) from e

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -76,23 +76,23 @@ def get_session() -> Session:
     return Session()
 
 
-@attr.s
+@attr.define
 class HttpConfig(Config):
-    url: str = attr.ib()
-    endpoint: str = attr.ib(default="api/v1/lineage")
-    timeout: float = attr.ib(default=5.0)
+    url: str
+    endpoint: str = "api/v1/lineage"
+    timeout: float = 5.0
     # check TLS certificates
-    verify: bool = attr.ib(default=True)
-    auth: TokenProvider = attr.ib(factory=lambda: TokenProvider({}))
-    compression: HttpCompression | None = attr.ib(default=None)
+    verify: bool = True
+    auth: TokenProvider = attr.field(factory=lambda: TokenProvider({}))
+    compression: HttpCompression | None = None
     # not set by TransportFactory
-    session: Session | None = attr.ib(default=None)
+    session: Session | None = None
     # not set by TransportFactory
-    adapter: HTTPAdapter | None = attr.ib(default=None)
+    adapter: HTTPAdapter | None = None
     # custom headers support
-    custom_headers: dict[str, str] = attr.ib(factory=dict)
+    custom_headers: dict[str, str] = attr.field(factory=dict)
     # retry settings
-    retry: dict[str, Any] = attr.ib(
+    retry: dict[str, Any] = attr.field(
         default={
             "total": 5,
             "read": 5,

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -24,21 +24,21 @@ log = logging.getLogger(__name__)
 _T = TypeVar("_T", bound="KafkaConfig")
 
 
-@attr.s
+@attr.define
 class KafkaConfig(Config):
     # Kafka producer config
     # https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#kafka-client-configuration
-    config: dict[str, str] = attr.ib()
+    config: dict[str, str]
 
     # Topic on which we should send messages
-    topic: str = attr.ib()
+    topic: str
 
     # Explicit key for Kafka producer
-    messageKey: str | None = attr.ib(default=None)  # noqa: N815
+    messageKey: str | None = None  # noqa: N815
 
     # Set to true if Kafka should flush after each event. The process that emits can be killed in
     # some cases - for example in Airflow integration, so flushing is desirable there.
-    flush: bool = attr.ib(default=True)
+    flush: bool = True
 
     @classmethod
     def from_dict(cls: type[_T], params: dict[str, Any]) -> _T:

--- a/client/python/openlineage/client/transport/msk_iam.py
+++ b/client/python/openlineage/client/transport/msk_iam.py
@@ -32,15 +32,15 @@ def _detect_running_region() -> None | str:
     return None
 
 
-@attr.s
+@attr.define
 class MSKIAMConfig(KafkaConfig):
     # MSK producer config
     # https://github.com/aws/aws-msk-iam-sasl-signer-python
 
-    region: str = attr.ib(default=None)
-    aws_profile: None | str = attr.ib(default=None)
-    role_arn: None | str = attr.ib(default=None)
-    aws_debug_creds: bool = attr.ib(default=False)
+    region: str | None = None
+    aws_profile: None | str = None
+    role_arn: None | str = None
+    aws_debug_creds: bool = False
 
 
 def _oauth_cb(config: MSKIAMConfig, *_: Any) -> tuple[str, float]:

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 _T = TypeVar("_T", bound="Config")
 
 
-@attr.s
+@attr.define
 class Config:
     @classmethod
     def from_dict(cls: type[_T], params: dict[str, Any]) -> _T:  # noqa: ARG003

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -103,25 +103,25 @@ def test_schema_field_default() -> None:
     )
 
 
-@attr.s
+@attr.define
 class NestedObject:
-    value: int | None = attr.ib(default=None)
+    value: int | None = None
 
 
-@attr.s
+@attr.define
 class NestingObject:
-    nested: list[NestedObject] = attr.ib()
-    optional: int | None = attr.ib(default=None)
+    nested: list[NestedObject]
+    optional: int | None = None
 
 
-@attr.s
+@attr.define
 class ListOfStrings:
-    values: list[str] = attr.ib()
+    values: list[str]
 
 
-@attr.s
+@attr.define
 class NestedListOfStrings:
-    nested: list[ListOfStrings] = attr.ib()
+    nested: list[ListOfStrings]
 
 
 def test_serde_list_of_strings() -> None:

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 from openlineage.client.client import OpenLineageClient
 from openlineage.client.facet import (
+    BaseFacet,
     ColumnLineageDatasetFacet,
     ColumnLineageDatasetFacetFieldsAdditional,
     ColumnLineageDatasetFacetFieldsAdditionalInputFields,
@@ -27,6 +28,7 @@ from openlineage.client.facet import (
     SymlinksDatasetFacetIdentifiers,
 )
 from openlineage.client.run import SCHEMA_URL, Dataset, Job, Run, RunEvent, RunState
+from openlineage.client.serde import Serde
 
 
 @pytest.fixture()
@@ -465,3 +467,19 @@ def test_job_type_job_facet(event: dict[str, Any]) -> None:
     expected_event["job"]["facets"]["jobType"] = job_type_facet
 
     assert expected_event == event_sent
+
+
+def test_facet_copy_serialization_base_facet():
+    facet = BaseFacet()
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_parent_run_facet():
+    facet = OwnershipJobFacet(
+        owners=[
+            OwnershipJobFacetOwners("some-owner", "some-owner-type"),
+        ],
+    )
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)

--- a/integration/airflow/openlineage/airflow/extractors/base.py
+++ b/integration/airflow/openlineage/airflow/extractors/base.py
@@ -12,21 +12,21 @@ from openlineage.client.event_v2 import Dataset
 from openlineage.client.facet_v2 import BaseFacet
 
 
-@attr.s
+@attr.define
 class OperatorLineage:
-    inputs: List[Dataset] = attr.ib(factory=list)
-    outputs: List[Dataset] = attr.ib(factory=list)
-    run_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
-    job_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
+    inputs: List[Dataset] = attr.field(factory=list)
+    outputs: List[Dataset] = attr.field(factory=list)
+    run_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
+    job_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
 
 
-@attr.s
+@attr.define
 class TaskMetadata:
     name: str = attr.ib()  # deprecated
-    inputs: List[Dataset] = attr.ib(factory=list)
-    outputs: List[Dataset] = attr.ib(factory=list)
-    run_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
-    job_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
+    inputs: List[Dataset] = attr.field(factory=list)
+    outputs: List[Dataset] = attr.field(factory=list)
+    run_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
+    job_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
 
 
 class BaseExtractor(ABC, LoggingMixin):

--- a/integration/airflow/openlineage/airflow/facets.py
+++ b/integration/airflow/openlineage/airflow/facets.py
@@ -11,12 +11,12 @@ from openlineage.client.utils import RedactMixin
 from airflow.version import version as AIRFLOW_VERSION
 
 
-@attr.s
+@attr.define
 class AirflowVersionRunFacet(BaseFacet):
-    operator: str = attr.ib()
-    taskInfo: Dict[str, object] = attr.ib()
-    airflowVersion: str = attr.ib()
-    openlineageAirflowVersion: str = attr.ib()
+    operator: str
+    taskInfo: Dict[str, object]
+    airflowVersion: str
+    openlineageAirflowVersion: str
 
     _additional_skip_redact: ClassVar[List[str]] = [
         "operator",
@@ -36,17 +36,17 @@ class AirflowVersionRunFacet(BaseFacet):
         )
 
 
-@attr.s
+@attr.define
 class AirflowRunArgsRunFacet(BaseFacet):
-    externalTrigger: bool = attr.ib(default=False)
+    externalTrigger: bool = False
 
     _additional_skip_redact: ClassVar[List[str]] = ["externalTrigger"]
 
 
-@attr.s
+@attr.define
 class AirflowMappedTaskRunFacet(BaseFacet):
-    mapIndex: int = attr.ib()
-    operatorClass: str = attr.ib()
+    mapIndex: int
+    operatorClass: str
 
     _additional_skip_redact: ClassVar[List[str]] = ["operatorClass"]
 
@@ -61,37 +61,37 @@ class AirflowMappedTaskRunFacet(BaseFacet):
         )
 
 
-@attr.s
+@attr.define
 class AirflowRunFacet(BaseFacet):
     """
     Composite Airflow run facet.
     """
 
-    dag: Dict = attr.ib()
-    dagRun: Dict = attr.ib()
-    task: Dict = attr.ib()
-    taskInstance: Dict = attr.ib()
-    taskUuid: str = attr.ib()
+    dag: Dict
+    dagRun: Dict
+    task: Dict
+    taskInstance: Dict
+    taskUuid: str
 
 
-@attr.s
+@attr.define
 class UnknownOperatorInstance(RedactMixin):
     """
     Describes an unknown operator - specifies the (class) name of the operator
     and its properties
     """
 
-    name: str = attr.ib()
-    properties: Dict[str, object] = attr.ib()
-    type: str = attr.ib(default="operator")
+    name: str
+    properties: Dict[str, object]
+    type: str = "operator"
 
     _skip_redact: ClassVar[List[str]] = ["name", "type"]
 
 
-@attr.s
+@attr.define
 class UnknownOperatorAttributeRunFacet(BaseFacet):
     """
     RunFacet that describes unknown operators in an Airflow DAG
     """
 
-    unknownItems: List[UnknownOperatorInstance] = attr.ib()
+    unknownItems: List[UnknownOperatorInstance]

--- a/integration/airflow/tests/extractors/test_default_extractor.py
+++ b/integration/airflow/tests/extractors/test_default_extractor.py
@@ -29,9 +29,9 @@ RUN_FACETS = {
 JOB_FACETS = {"sql": sql_job.SQLJobFacet(query="SELECT * FROM inputtable")}
 
 
-@attr.s
+@attr.define
 class CompleteRunFacet(BaseFacet):
-    finished: bool = attr.ib(default=False)
+    finished: bool = False
 
 
 FINISHED_FACETS = {"complete": CompleteRunFacet(True)}

--- a/integration/airflow/tests/integration/tests/airflow/dags/default.py
+++ b/integration/airflow/tests/integration/tests/airflow/dags/default.py
@@ -23,9 +23,9 @@ RUN_FACETS = {
 JOB_FACETS = {"sql": sql_job.SQLJobFacet(query="SELECT * FROM inputtable")}
 
 
-@attr.s
+@attr.define
 class CompleteRunFacet(BaseFacet):
-    finished: bool = attr.ib()
+    finished: bool
 
 
 class ExampleOperator(BaseOperator):

--- a/integration/airflow/tests/test_facets.py
+++ b/integration/airflow/tests/test_facets.py
@@ -1,0 +1,59 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+from openlineage.airflow.facets import (
+    AirflowMappedTaskRunFacet,
+    AirflowRunArgsRunFacet,
+    AirflowRunFacet,
+    AirflowVersionRunFacet,
+    UnknownOperatorAttributeRunFacet,
+    UnknownOperatorInstance,
+)
+from openlineage.client.serde import Serde
+
+
+def test_facet_copy_serialization_airflow_version_run_facet():
+    facet = AirflowVersionRunFacet(
+        operator="operator",
+        taskInfo={"task": "info"},
+        airflowVersion="airflowVersion",
+        openlineageAirflowVersion="openlineageAirflowVersion",
+        producer="producer",
+    )
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_airflow_run_args_run_facet():
+    facet = AirflowRunArgsRunFacet(externalTrigger=True, producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_airflow_mapped_task_run_facet():
+    facet = AirflowMappedTaskRunFacet(mapIndex=1, operatorClass="operatorClass", producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_airflow_run_facet():
+    facet = AirflowRunFacet(
+        dag={"dag": ""},
+        dagRun={"dagrun": ""},
+        taskInstance={"taskInstance": ""},
+        task={"task": ""},
+        taskUuid="taskUuid",
+        producer="producer",
+    )
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_unknown_operator_attribute_run_facet():
+    facet = UnknownOperatorAttributeRunFacet(
+        unknownItems=[UnknownOperatorInstance(name="name", properties={"properties": ""}, type="type")]
+    )
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)

--- a/integration/common/openlineage/common/provider/bigquery.py
+++ b/integration/common/openlineage/common/provider/bigquery.py
@@ -33,7 +33,7 @@ def get_bq_client():
     return Client
 
 
-@attr.s
+@attr.define
 class BigQueryErrorRunFacet(BaseFacet):
     """
     Represents errors that can happen during execution of BigqueryExtractor
@@ -41,15 +41,15 @@ class BigQueryErrorRunFacet(BaseFacet):
     :param parserError: represents errors that happened during parsing SQL provided to bigquery
     """
 
-    clientError: str = attr.ib(default=None)
-    parserError: str = attr.ib(default=None)
+    clientError: Optional[str] = None
+    parserError: Optional[str] = None
 
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "bq-error-run-facet.json"
 
 
-@attr.s
+@attr.define
 class BigQueryJobRunFacet(BaseFacet):
     """
     Facet that represents relevant statistics of bigquery run.
@@ -59,16 +59,16 @@ class BigQueryJobRunFacet(BaseFacet):
     :param properties: full property tree of bigquery run.
     """
 
-    cached: bool = attr.ib()
-    billedBytes: Optional[int] = attr.ib(default=None)
-    properties: Optional[str] = attr.ib(default=None)
+    cached: bool
+    billedBytes: Optional[int] = None
+    properties: Optional[str] = None
 
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "bq-statistics-run-facet.json"
 
 
-@attr.s
+@attr.define
 class BigQueryStatisticsDatasetFacet(BaseFacet):
     """
     Facet that represents statistics of output dataset resulting from bigquery run.
@@ -76,8 +76,8 @@ class BigQueryStatisticsDatasetFacet(BaseFacet):
     :param size: size of output dataset in bytes.
     """
 
-    rowCount: int = attr.ib()
-    size: int = attr.ib()
+    rowCount: int
+    size: int
 
     def to_openlineage(self) -> output_statistics_output_dataset.OutputStatisticsOutputDatasetFacet:
         return output_statistics_output_dataset.OutputStatisticsOutputDatasetFacet(
@@ -89,12 +89,12 @@ class BigQueryStatisticsDatasetFacet(BaseFacet):
         return GITHUB_LOCATION + "bq-statistics-dataset-facet.json"
 
 
-@attr.s
+@attr.define
 class BigQueryFacets:
-    run_facets: Dict[str, BaseFacet] = attr.ib()
-    inputs: List[Dataset] = attr.ib()
-    outputs: List[Dataset] = attr.ib()
-    _output: Optional[Dataset] = attr.ib(default=None)
+    run_facets: Dict[str, BaseFacet]
+    inputs: List[Dataset]
+    outputs: List[Dataset]
+    _output: Optional[Dataset] = None
 
     @property
     def output(self) -> Optional[Dataset]:

--- a/integration/common/openlineage/common/provider/dbt/facets.py
+++ b/integration/common/openlineage/common/provider/dbt/facets.py
@@ -11,14 +11,14 @@ from openlineage.client.facet_v2 import (
 from openlineage.common.schema import GITHUB_LOCATION
 
 
-@attr.s
+@attr.define
 class ParentRunMetadata:
-    run_id: str = attr.ib()
-    job_name: str = attr.ib()
-    job_namespace: str = attr.ib()
-    root_parent_job_name: Optional[str] = attr.ib(default=None)
-    root_parent_job_namespace: Optional[str] = attr.ib(default=None)
-    root_parent_run_id: Optional[str] = attr.ib(default=None)
+    run_id: str
+    job_name: str
+    job_namespace: str
+    root_parent_job_name: Optional[str] = None
+    root_parent_job_namespace: Optional[str] = None
+    root_parent_run_id: Optional[str] = None
 
     def to_openlineage(self) -> parent_run.ParentRunFacet:
         root = None
@@ -37,18 +37,18 @@ class ParentRunMetadata:
         )
 
 
-@attr.s
+@attr.define
 class DbtVersionRunFacet(BaseFacet):
-    version: str = attr.ib()
+    version: str
 
     @staticmethod
     def _get_schema() -> str:
         return GITHUB_LOCATION + "dbt-version-run-facet.json"
 
 
-@attr.s
+@attr.define
 class DbtRunRunFacet(BaseFacet):
-    invocation_id: str = attr.ib()
+    invocation_id: str
 
     @staticmethod
     def _get_schema() -> str:

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -69,36 +69,36 @@ class UnsupportedDbtCommand(Exception):
     pass
 
 
-@attr.s
+@attr.define
 class ModelNode:
-    metadata_node: Dict = attr.ib()
-    catalog_node: Optional[Dict] = attr.ib(default=None)
+    metadata_node: Dict
+    catalog_node: Optional[Dict] = None
 
 
-@attr.s
+@attr.define
 class DbtRun:
-    started_at: str = attr.ib()
-    completed_at: str = attr.ib()
-    status: str = attr.ib()
-    inputs: List[Dataset] = attr.ib()
-    output: Optional[Dataset] = attr.ib()
-    job_name: str = attr.ib()
-    namespace: str = attr.ib()
-    run_id: str = attr.ib(factory=lambda: str(generate_new_uuid()))
+    started_at: str
+    completed_at: str
+    status: str
+    inputs: List[Dataset]
+    output: Optional[Dataset]
+    job_name: str
+    namespace: str
+    run_id: str = attr.field(factory=lambda: str(generate_new_uuid()))
 
 
-@attr.s
+@attr.define
 class DbtRunResult:
-    start: RunEvent = attr.ib()
-    complete: Optional[RunEvent] = attr.ib(default=None)
-    fail: Optional[RunEvent] = attr.ib(default=None)
+    start: RunEvent
+    complete: Optional[RunEvent] = None
+    fail: Optional[RunEvent] = None
 
 
-@attr.s
+@attr.define
 class DbtEvents:
-    starts: List[RunEvent] = attr.ib(factory=list)
-    completes: List[RunEvent] = attr.ib(factory=list)
-    fails: List[RunEvent] = attr.ib(factory=list)
+    starts: List[RunEvent] = attr.field(factory=list)
+    completes: List[RunEvent] = attr.field(factory=list)
+    fails: List[RunEvent] = attr.field(factory=list)
 
     def events(self):
         return self.starts + self.completes + self.fails
@@ -121,11 +121,11 @@ class DbtEvents:
         raise NotImplementedError
 
 
-@attr.s
+@attr.define
 class DbtRunContext:
-    manifest: Dict = attr.ib()
-    run_results: Dict = attr.ib()
-    catalog: Optional[Dict] = attr.ib(default=None)
+    manifest: Dict
+    run_results: Dict
+    catalog: Optional[Dict] = None
 
 
 class DbtArtifactProcessor:

--- a/integration/common/openlineage/common/provider/great_expectations/facets.py
+++ b/integration/common/openlineage/common/provider/great_expectations/facets.py
@@ -14,38 +14,38 @@ from great_expectations.core.batch import BatchDefinition, BatchMarkers
 from great_expectations.core.id_dict import BatchKwargs, BatchSpec
 
 
-@attr.s
+@attr.define
 class GreatExpectationsRunFacet(BaseFacet):
     """
     Custom facet which describes the instance of GreatExpectations and the suite configuration
     """
 
-    great_expectations_version = attr.ib()
-    expectation_suite_name: str = attr.ib()
-    run_id: Dict = attr.ib()  # type: ignore
-    expectation_suite_meta: Dict = attr.ib()
-    validation_time: str = attr.ib()
-    batch_spec: Optional[BatchSpec] = attr.ib(default=None)
-    batch_markers: Optional[BatchMarkers] = attr.ib(default=None)
-    batch_kwargs: Optional[BatchKwargs] = attr.ib(default=None)
-    active_batch_definition: Union[None, IDDict, BatchDefinition] = attr.ib(default=None)
-    batch_parameters = attr.ib(default=None)
-    checkpoint_name: Optional[str] = attr.ib(default=None)
-    validation_id: Optional[str] = attr.ib(default=None)
-    checkpoint_id: Optional[str] = attr.ib(default=None)
+    great_expectations_version = attr.field()
+    expectation_suite_name: str = attr.field()
+    run_id: Dict = attr.field()  # type: ignore
+    expectation_suite_meta: Dict = attr.field()
+    validation_time: str = attr.field()
+    batch_spec: Optional[BatchSpec] = attr.field(default=None)
+    batch_markers: Optional[BatchMarkers] = attr.field(default=None)
+    batch_kwargs: Optional[BatchKwargs] = attr.field(default=None)
+    active_batch_definition: Union[None, IDDict, BatchDefinition] = attr.field(default=None)
+    batch_parameters = attr.field(default=None)
+    checkpoint_name: Optional[str] = attr.field(default=None)
+    validation_id: Optional[str] = attr.field(default=None)
+    checkpoint_id: Optional[str] = attr.field(default=None)
 
     @staticmethod
     def _get_schema() -> str:
         return "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/common/provider/ge-run-facet.json"
 
 
-@attr.s
+@attr.define
 class GreatExpectationsAssertionsDatasetFacet(BaseFacet):
     """
     This facet represents passed/failed status of asserted expectations on dataset
     """
 
-    assertions: List[GreatExpectationsAssertion] = attr.ib()
+    assertions: List[GreatExpectationsAssertion]
 
     @staticmethod
     def _get_schema() -> str:

--- a/integration/common/openlineage/common/provider/great_expectations/results.py
+++ b/integration/common/openlineage/common/provider/great_expectations/results.py
@@ -9,22 +9,22 @@ from openlineage.common.utils import get_from_nullable_chain
 from great_expectations.core import ExpectationValidationResult
 
 
-@attr.s
+@attr.define
 class ExpectationsParserResult:
     """
     Internal class to represent actual expectation values, per table and optionally per column
     """
 
-    facet_key: str = attr.ib()
-    value: Any = attr.ib()
-    column_id: Optional[str] = attr.ib(default=None)
+    facet_key: str
+    value: Any
+    column_id: Optional[str] = None
 
 
-@attr.s
+@attr.define
 class GreatExpectationsAssertion:
-    expectationType: str = attr.ib()
-    success: bool = attr.ib()
-    column: Optional[str] = attr.ib(default=None)
+    expectationType: str
+    success: bool
+    column: Optional[str] = None
 
 
 class ExpectationsParser:

--- a/integration/common/openlineage/common/provider/redshift_data.py
+++ b/integration/common/openlineage/common/provider/redshift_data.py
@@ -16,11 +16,11 @@ from openlineage.common.models import DbColumn, DbTableSchema
 from openlineage.common.sql import DbTableMeta
 
 
-@attr.s
+@attr.define
 class RedshiftFacets:
-    run_facets: Dict[str, BaseFacet] = attr.ib()
-    inputs: List[Dataset] = attr.ib()
-    output: List[Dataset] = attr.ib()
+    run_facets: Dict[str, BaseFacet]
+    inputs: List[Dataset]
+    output: List[Dataset]
 
 
 class RedshiftDataDatasetsProvider:

--- a/integration/common/tests/bigquery/test_bigquery.py
+++ b/integration/common/tests/bigquery/test_bigquery.py
@@ -1,14 +1,17 @@
 # Copyright 2018-2025 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import json
 from unittest.mock import MagicMock
 
 import pytest
 from openlineage.client.facet_v2 import external_query_run
+from openlineage.client.serde import Serde
 from openlineage.common.dataset import Dataset, Field, Source
 from openlineage.common.provider.bigquery import (
     BigQueryDatasetsProvider,
+    BigQueryErrorRunFacet,
     BigQueryJobRunFacet,
     BigQueryStatisticsDatasetFacet,
 )
@@ -224,3 +227,21 @@ def test_get_statistics_dataset_facet_with_stats():
     result = BigQueryDatasetsProvider._get_statistics_dataset_facet(properties)
     assert result.rowCount == 123
     assert result.size == 321
+
+
+def test_facet_copy_serialization_bq_job_run_facet():
+    facet = BigQueryJobRunFacet(cached=True, billedBytes=123, properties="properties", producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_bq_stats_dataset_facet():
+    facet = BigQueryStatisticsDatasetFacet(rowCount=123, size=321, producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_bq_error_run_facet():
+    facet = BigQueryErrorRunFacet(clientError="clientError", parserError="parserError", producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)

--- a/integration/common/tests/dbt/test_facets.py
+++ b/integration/common/tests/dbt/test_facets.py
@@ -1,0 +1,19 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+from openlineage.client.serde import Serde
+from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet
+
+
+def test_facet_copy_serialization_dbt_version_run_facet():
+    facet = DbtVersionRunFacet(version="version", producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)
+
+
+def test_facet_copy_serialization_dbt_run_run_facet():
+    facet = DbtRunRunFacet(invocation_id="invocation_id", producer="producer")
+    facet_copy = copy.deepcopy(facet)
+    assert Serde.to_json(facet) == Serde.to_json(facet_copy)

--- a/integration/dagster/openlineage/dagster/cursor.py
+++ b/integration/dagster/openlineage/dagster/cursor.py
@@ -9,23 +9,23 @@ import cattr
 from openlineage.client.run import InputDataset, OutputDataset
 
 
-@attr.s
+@attr.define
 class RunningStep:
-    step_run_id: str = attr.ib()
-    input_datasets: List[InputDataset] = attr.ib(factory=list)
-    output_datasets: List[OutputDataset] = attr.ib(factory=list)
+    step_run_id: str
+    input_datasets: List[InputDataset] = attr.field(factory=list)
+    output_datasets: List[OutputDataset] = attr.field(factory=list)
 
 
-@attr.s
+@attr.define
 class RunningPipeline:
-    running_steps: Dict[str, RunningStep] = attr.ib(factory=dict)
-    repository_name: Optional[str] = attr.ib(default=None)
+    running_steps: Dict[str, RunningStep] = attr.field(factory=dict)
+    repository_name: Optional[str] = None
 
 
-@attr.s
+@attr.define
 class OpenLineageCursor:
-    last_storage_id: int = attr.ib()
-    running_pipelines: Dict[str, RunningPipeline] = attr.ib(factory=dict)
+    last_storage_id: int
+    running_pipelines: Dict[str, RunningPipeline] = attr.field(factory=dict)
 
     def to_json(self):
         return json.dumps(attr.asdict(self))

--- a/website/docs/integrations/airflow/extractors/custom-extractors.md
+++ b/website/docs/integrations/airflow/extractors/custom-extractors.md
@@ -42,13 +42,13 @@ sets on it's own properties. Good example is `SnowflakeOperator` that sets `quer
 Both methods return `TaskMetadata` structure:
 
 ```python
-@attr.s
+@attr.define
 class TaskMetadata:
     name: str = attr.ib()  # deprecated
-    inputs: List[Dataset] = attr.ib(factory=list)
-    outputs: List[Dataset] = attr.ib(factory=list)
-    run_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
-    job_facets: Dict[str, BaseFacet] = attr.ib(factory=dict)
+    inputs: List[Dataset] = attr.field(factory=list)
+    outputs: List[Dataset] = attr.field(factory=list)
+    run_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
+    job_facets: Dict[str, BaseFacet] = attr.field(factory=dict)
 ```
 
 Inputs and outputs are lists of plain [OpenLineage datasets](../../../client/python.md) 

--- a/website/docs/spec/facets/custom-facets.md
+++ b/website/docs/spec/facets/custom-facets.md
@@ -165,11 +165,11 @@ def job(job_name, sql, location):
         )
     return Job(namespace=namespace, name=job_name, facets=facets)
 
-@attr.s
+@attr.define
 class MyFacet(BaseFacet):
-    name: str = attr.ib()
-    age: str = attr.ib()
-    email: str = attr.ib()
+    name: str
+    age: str
+    email: str
     _additional_skip_redact: List[str] = ['name', 'age', 'email']
     def __init__(self, name, age, email):
         super().__init__()
@@ -349,11 +349,11 @@ for event in events:
 As you can see in the source code, there is a class called `MyFacet` which extends from the `BaseFacet` of OpenLineage, having three attributes of `name`, `age`, and `email`.
 
 ```python
-@attr.s
+@attr.define
 class MyFacet(BaseFacet):
-    name: str = attr.ib()
-    age: str = attr.ib()
-    email: str = attr.ib()
+    name: str
+    age: str
+    email: str
     _additional_skip_redact: List[str] = ['name', 'age', 'email']
     def __init__(self, name, age, email):
         super().__init__()
@@ -509,11 +509,11 @@ OpenLineage backend should be able to store this information when submitted, and
 You might have noticed the schema URL is actually that of `BaseFacet`. By default, if the facet class did not specify its own schema URL, that value would be that of BaseFacet. From the view of OpenLineage specification, this is legal. However, if you have your own JSON spec defined, and has it publically accessible, you can specify it by overriding the `_get_schema` function as such:
 
 ```python
-@attr.s
+@attr.define
 class MyFacet(BaseFacet):
-    name: str = attr.ib()
-    age: str = attr.ib()
-    email: str = attr.ib()
+    name: str
+    age: str
+    email: str
     _additional_skip_redact: List[str] = ['name', 'age', 'email']
     def __init__(self, name, age, email):
         super().__init__()


### PR DESCRIPTION
### Problem

When facets are inheriting from BaseFacet V2, that is using @attr.define, but the child facet definition is made using @attr.s, after copying the child facet the attributes are not present in the copy. This can be an issue, as in the TransformTransport, we are copying the event before transformation. I've looked through the codebase, and only some DBT and Airflow Facets are defined in this `mixed` way. It's probably an issue about the slots and get/set state auto generation in attrs.

### Solution

There is no easier solution that simply not mixing the attr decorators. I've tried also copying the object in a generic way, that would handle that mix, but ended up in rabbit hole, creating more and more complex solution. I think the good approach here is to keep the facets that we own tidy and not mixed up and not try to solve all the possible combinations. I think also the TransformTransport is the only one using copy, so the impact is relatively low. Copying works fine for v1 classes and v2 classes, it's only the mixing on inheritance that's causing the problem, so there is no need to clean up all the classes or use attr.define everywhere for now.

EDIT: After review, we replaced @attr.s with @attr.define in the entire codebase and added a pre-commit to check that.

#### One-line summary:
chore: Use attr.define instead of attr.s

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project