### PR TITLE
Github: mark Hive PRs with proper label

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -26,9 +26,11 @@ labelPRBasedOnFilePath:
   area:integration/flink:
     - integration/flink/**/*
   area:integration/spark:
-    - integration/spark/**/*
+    - integration/spark*/**/*
   area:integration/sql:
     - integration/sql/**/*
+  area:integration/hive:
+    - integration/hive*/**/*
   area:proxy:
     - proxy/**/*
   area:spec:


### PR DESCRIPTION
### Problem

PRs changing new Hive integration don't have a label assigned, e.g. #3777
![изображение](https://github.com/user-attachments/assets/7e1ed959-9f6f-4785-be35-b5bb9cb3ac2a)

### Solution

Update boring-cyborg config to add `area:integration/hive` label on any Hive integration change. 

**Note:** this requires adding this label manually in Github interface.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project