### PR TITLE
[Hive] Add hive_session facet

### DIFF
--- a/integration/hive/hive-openlineage-hook/build.gradle
+++ b/integration/hive/hive-openlineage-hook/build.gradle
@@ -47,6 +47,8 @@ dependencies {
         exclude group: 'org.apache.avro', module: 'avro'
     }
 
+    compileOnly("org.apache.hive:hive-service:${hiveVersion}");
+
     compileOnly("org.apache.hive:hive-exec:${hiveVersion}") {
         exclude group: 'org.pentaho', module: '*'
         exclude group: 'org.apache.hadoop', module: '*'

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "QUERY"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "QUERY"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
@@ -14,6 +14,11 @@
       "hive_query": {
         "queryId": "${json-unit.any-string}",
         "operationName": "CREATETABLE_AS_SELECT"
+      },
+      "hive_session": {
+        "sessionId": "${json-unit.any-string}",
+        "username": "hive",
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
@@ -18,7 +18,8 @@
       "hive_session": {
         "sessionId": "${json-unit.any-string}",
         "username": "hive",
-        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+        "clientIp": "${json-unit.regex}\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
+        "creationTime": "${json-unit.any-string}"
       }
     }
   },

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/api/OpenLineageContext.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/api/OpenLineageContext.java
@@ -12,10 +12,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
-import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
-import org.apache.hadoop.hive.ql.parse.SemanticAnalyzer;
 
 /**
  * Context holder with references to several required objects during construction of an OpenLineage
@@ -35,19 +34,9 @@ public class OpenLineageContext {
    */
   @NonNull OpenLineage openLineage;
 
-  SemanticAnalyzer semanticAnalyzer;
-
   @NonNull @Getter HiveOpenLineageConfig openLineageConfig;
 
-  @NonNull String openlineageHiveIntegrationVersion;
-
-  @NonNull String queryString;
-
-  @NonNull String queryId;
-
-  @NonNull String operationName;
-
-  @NonNull Configuration hadoopConf;
+  @NonNull HookContext hookContext;
 
   @NonNull Set<ReadEntity> readEntities;
 

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/EventEmitter.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/EventEmitter.java
@@ -26,7 +26,7 @@ public class EventEmitter implements AutoCloseable {
   private final String jobNamespace;
 
   public EventEmitter(OpenLineageContext olContext) {
-    Configuration conf = olContext.getHadoopConf();
+    Configuration conf = olContext.getHookContext().getConf();
     this.client = Clients.newClient(olContext.getOpenLineageConfig());
     this.runId = generateNewUUID();
     this.jobNamespace = conf.get(HiveOpenLineageConfigParser.NAMESPACE_KEY, "default");
@@ -43,8 +43,8 @@ public class EventEmitter implements AutoCloseable {
     }
   }
 
-  public static String getJobName(OpenLineageContext hookContext) {
-    return hookContext.getOperationName();
+  public static String getJobName(OpenLineageContext olContext) {
+    return olContext.getHookContext().getOperationName();
   }
 
   @Override

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfigParser.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/client/HiveOpenLineageConfigParser.java
@@ -29,6 +29,7 @@ public class HiveOpenLineageConfigParser {
           Arrays.asList("transport.properties.", "transport.urlParams.", "transport.headers."));
   public static final String NAMESPACE_KEY = CONF_PREFIX + "namespace";
   public static final String JOB_NAME_KEY = CONF_PREFIX + "job.name";
+  public static final String DATASET_LINEAGE_ENABLED_KEY = CONF_PREFIX + "datasetLineageEnabled";
 
   private static final ObjectMapper JSON = new ObjectMapper();
 

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/facets/HiveSessionInfoFacet.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/facets/HiveSessionInfoFacet.java
@@ -1,0 +1,45 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+package io.openlineage.hive.facets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.hive.client.Versions;
+import lombok.Getter;
+
+/**
+ * Captures information related to the Hive session, ich cannot be changed after session was
+ * created.
+ */
+@Getter
+public class HiveSessionInfoFacet extends OpenLineage.DefaultRunFacet {
+  @JsonProperty("username")
+  private String username;
+
+  @JsonProperty("clientIp")
+  private String clientIp;
+
+  @JsonProperty("sessionId")
+  private String sessionId;
+
+  public HiveSessionInfoFacet() {
+    super(Versions.OPEN_LINEAGE_PRODUCER_URI);
+  }
+
+  public HiveSessionInfoFacet setUsername(String username) {
+    this.username = username;
+    return this;
+  }
+
+  public HiveSessionInfoFacet setClientIp(String clientIp) {
+    this.clientIp = clientIp;
+    return this;
+  }
+
+  public HiveSessionInfoFacet setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+    return this;
+  }
+}

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/facets/HiveSessionInfoFacet.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/facets/HiveSessionInfoFacet.java
@@ -7,6 +7,7 @@ package io.openlineage.hive.facets;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.hive.client.Versions;
+import java.time.ZonedDateTime;
 import lombok.Getter;
 
 /**
@@ -24,6 +25,9 @@ public class HiveSessionInfoFacet extends OpenLineage.DefaultRunFacet {
   @JsonProperty("sessionId")
   private String sessionId;
 
+  @JsonProperty("creationTime")
+  private ZonedDateTime creationTime;
+
   public HiveSessionInfoFacet() {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
   }
@@ -40,6 +44,11 @@ public class HiveSessionInfoFacet extends OpenLineage.DefaultRunFacet {
 
   public HiveSessionInfoFacet setSessionId(String sessionId) {
     this.sessionId = sessionId;
+    return this;
+  }
+
+  public HiveSessionInfoFacet setCreationTime(ZonedDateTime creationTime) {
+    this.creationTime = creationTime;
     return this;
   }
 }

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/hooks/HiveOpenLineageHook.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/hooks/HiveOpenLineageHook.java
@@ -11,11 +11,13 @@ import io.openlineage.hive.api.OpenLineageContext;
 import io.openlineage.hive.client.EventEmitter;
 import io.openlineage.hive.client.HiveOpenLineageConfigParser;
 import io.openlineage.hive.client.Versions;
+import java.lang.reflect.Field;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.hooks.Entity;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
@@ -24,9 +26,14 @@ import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hive.service.cli.HiveSQLException;
+import org.apache.hive.service.cli.session.HiveSession;
+import org.apache.hive.service.cli.session.HiveSessionHook;
+import org.apache.hive.service.cli.session.HiveSessionHookContext;
+import org.apache.hive.service.cli.session.HiveSessionHookContextImpl;
 
 @Slf4j
-public class HiveOpenLineageHook implements ExecuteWithHookContext {
+public class HiveOpenLineageHook implements ExecuteWithHookContext, HiveSessionHook {
 
   private static final Set<HiveOperation> SUPPORTED_OPERATIONS = new HashSet<>();
   private static final Set<HookContext.HookType> SUPPORTED_HOOK_TYPES = new HashSet<>();
@@ -60,6 +67,25 @@ public class HiveOpenLineageHook implements ExecuteWithHookContext {
       }
     }
     return validOutputs;
+  }
+
+  // This method exists only to record session creation timestamp.
+  // See https://github.com/OpenLineage/OpenLineage/issues/3784
+  @Override
+  public void run(HiveSessionHookContext sessionHookContext) throws HiveSQLException {
+    try {
+      HiveConf conf = sessionHookContext.getSessionConf();
+      if (sessionHookContext instanceof HiveSessionHookContextImpl) {
+        HiveSessionHookContextImpl hiveSessionHookContext =
+            (HiveSessionHookContextImpl) sessionHookContext;
+        Field f = hiveSessionHookContext.getClass().getDeclaredField("hiveSession");
+        f.setAccessible(true);
+        HiveSession hiveSession = (HiveSession) f.get(hiveSessionHookContext);
+        conf.setLong("hive.session.creationTimestamp", hiveSession.getCreationTime());
+      }
+    } catch (Exception e) {
+      log.error("Error occurred while recording session creation timestamp:", e);
+    }
   }
 
   @Override

--- a/integration/hive/hive-openlineage-hook/src/test/resources/hive-site.xml
+++ b/integration/hive/hive-openlineage-hook/src/test/resources/hive-site.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-        <property>
-            <name>hive.compactor.worker.threads</name>
-            <value>1</value>
-        </property>
+    <property>
+        <name>hive.compactor.worker.threads</name>
+        <value>1</value>
+    </property>
     <property>
         <name>hive.server2.enable.doAs</name>
         <value>false</value>
@@ -49,7 +49,16 @@
         <value>false</value>
     </property>
     <property>
+        <!-- required only to capture session creation time, can be omitted -->
+        <name>hive.server2.session.hook</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
+    <property>
         <name>hive.exec.post.hooks</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
+    <property>
+        <name>hive.exec.failure.hooks</name>
         <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
     </property>
 <!--    <property>-->

--- a/website/docs/integrations/hive/configuration/configuration.md
+++ b/website/docs/integrations/hive/configuration/configuration.md
@@ -26,6 +26,7 @@ SELECT ...
 
 
 #### Using `--hiveconf` options with the CLI
+
 Executing hive query from CLI you can set configuration with `--hiveconf`
 ```bash
 hive \
@@ -44,9 +45,9 @@ In case of using the Hive integration on [Google Cloud Dataproc](https://cloud.g
 ```shell
 gcloud dataproc jobs submit hive \
     --cluster <cluster_name> \
-    --region <region> \
+    --region "<region>" \
     --properties "hive.openlineage.job.name=monthly_transaction_summary_job" \
-    --execute <query_string>
+    --execute "<query_string>"
 ```
 :::
 
@@ -56,6 +57,11 @@ gcloud dataproc jobs submit hive \
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     ...
+    <property>
+        <!-- required only to capture session creation time, can be omitted -->
+        <name>hive.server2.session.hook</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
     <property>
         <name>hive.exec.post.hooks</name>
         <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>

--- a/website/docs/integrations/hive/installation.md
+++ b/website/docs/integrations/hive/installation.md
@@ -55,7 +55,9 @@ gcloud dataproc clusters create <cluster_name> \
   --scopes cloud-platform \
   --initialization-actions gs://<your_bucket>/path/to/initialization_script.sh \
   --metadata "jar-urls=gs://<your_bucket>/path/to/openlineage-hive.jar" \
+  --properties "hive:hive.server2.session.hook=io.openlineage.hive.hooks.HiveOpenLineageHook" \
   --properties "hive:hive.exec.post.hooks=io.openlineage.hive.hooks.HiveOpenLineageHook" \
+  --properties "hive:hive.exec.failure.hooks=io.openlineage.hive.hooks.HiveOpenLineageHook" \
   --properties "hive:hive.conf.validation=false" \
   --properties "hive:hive.openlineage.namespace=mynamespace" \
   --properties "hive:hive.openlineage.transport.type=gcplineage" \


### PR DESCRIPTION
### Problem

Closes: #3784

Hive integration doesn't include `sessionId`, so it is impossible to determine if queries were emitted within same Hive connection or different ones. There is also no information about user created this Hive session.

### Solution

Added `hive_session` facet with `username`, `clientIP`, `sessionId` and `creationTime` fields. #3784 describes why this is a facet within query run event, and not some kind of parent run event.

`creationTime` is a bit special - `HookContext` and any nested fields doesn't include this field at all, so I have to implement `hive.server2.session.hook` to capture it. If this hook is disabled, then creation time is not recorded.

As now OpenLineageContext has `hookContext` field, there is no need to pass around properties based on its content (like `queryString`, `operationName`, `semanticAnalyzer`). So I've refactored this part a bit.

#### One-line summary:

[Hive] Add hive_session facet

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project