### PR TITLE
[Hive] Add jobType facet

### DIFF
--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCaseInsensitivityComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.monthly_transaction_summary",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE monthly_transaction_summary\nAS\nSELECT\n    TRUNC(sUBMissionDAte, 'MM') AS MOnth,\n    transactionTYPe,\n    SUM(trANSactionamount) AS TotALAmount,\n    COUNT(*) AS transACTionCount\nFROM\n    tranSACTions\nGROUP BY\n    TRUNC(SUBMIssiondate, 'MM'),\n    tRANsacTIontype\nORDER BY\n    monTH,\n    transacTIONtype"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllComplexQueryCTEJoinsComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS \nWITH tmp as (SELECT * FROM t1 where b = '1'),\n     tmp2 as (SELECT * FROM t2 where c = 1),\n     tmp3 as (SELECT tmp.a, b, c from tmp join tmp2 on tmp.a = tmp2.a)\nSELECT tmp3.a as a, b, c, d FROM tmp3 join t3 on tmp3.a = t3.a order by d"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllCtasWithJoinsComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS\nWITH c AS (\n  SELECT b.name, a.id\n  FROM t1 a\n  JOIN t2 b\n    ON a.id = b.number\n)\nSELECT id * 10 as id, name FROM c"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllIfNotExists.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE IF NOT EXISTS xxx AS SELECT a FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllMultiInsertsComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "query.test.t2",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "WITH c AS (\n  SELECT a.id, b.name \n  FROM t3 a \n  JOIN t4 b \n    ON a.id = b.id\n)\nFROM c\nINSERT OVERWRITE TABLE t1\n  SELECT id * 10, name\nINSERT INTO TABLE t2\n  SELECT SUM(id), name\n  GROUP BY name"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllPartitionedTable.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT * FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSelectStar.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT * FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleInsertFromTable.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "query.test.t1",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "INSERT INTO t1 SELECT a, concat(b, 'x') FROM t2"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryExplode.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT a FROM (SELECT explode(split(a, ' ')) AS a FROM t1) subquery_alias"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryIndirect.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT a FROM t1 WHERE b > 1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMasking.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT \na as i, \na + 1 as t, \nsha1(string(a + 1)) as mt, \nsum(b) as a, \nsha1(string(sum(b))) as ma \nFROM t1 GROUP BY a"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryMultipleIndirect.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT a, c FROM t1 WHERE b > 1 GROUP BY a, c ORDER BY c"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyAggregation.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT count(a) AS a FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyIdentity.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT a FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryOnlyTransform.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT concat(a, 'test') AS a, a+b as b FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryPriorityDirect.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT a as i, a + 1 as t, sum(b) as a, 2 * sum(b) as ta, 2 * sum(b + 3) as tat FROM t1 GROUP BY a"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryRank.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS\nSELECT a, RANK() OVER (PARTITION BY b ORDER BY c) as rank FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedAggregate.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS\nSELECT sum(a) OVER (PARTITION BY b ORDER BY c) AS s FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWindowedTransformation.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS\nSELECT LAG(a, 3, 0) OVER (PARTITION BY b ORDER BY c) AS l FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithCaseWhenConditional.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT CASE WHEN b > 1 THEN a ELSE a + b END AS cond FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllSimpleQueryWithIfConditional.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS SELECT IF(b > 1, a, a + b) AS cond FROM t1"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/cllUnionComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.xxx",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "CREATE TABLE xxx AS\nSELECT a, b, 'table1' as source\nFROM t1\nUNION ALL\nSELECT a, c, 'table2' as source\nFROM t2"
       }

--- a/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
+++ b/integration/hive/hive-openlineage-hook/integrations/container/simpleCtasComplete.json
@@ -27,6 +27,11 @@
     "namespace": "default",
     "name": "createtable_as_select.test.result_t",
     "facets": {
+      "jobType": {
+        "integration": "HIVE",
+        "jobType": "QUERY",
+        "processingType": "BATCH"
+      },
       "sql": {
         "query": "create table result_t as\nselect\nteams.type,\nteams.building,\nmanagers.name as manager,\nemployees.name as employee\nfrom teams, managers, employees\nwhere teams.id = managers.team and teams.id = employees.team"
       }

--- a/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/hooks/Faceting.java
+++ b/integration/hive/hive-openlineage-hook/src/main/java/io/openlineage/hive/hooks/Faceting.java
@@ -292,8 +292,10 @@ public class Faceting {
     return schemaFacet;
   }
 
-  private static OpenLineage.ProcessingEngineRunFacet getProcessingEngineFacet(OpenLineage ol) {
-    return ol.newProcessingEngineRunFacetBuilder()
+  private static OpenLineage.ProcessingEngineRunFacet getProcessingEngineFacet(OpenLineageContext olContext) {
+    return olContext
+        .getOpenLineage()
+        .newProcessingEngineRunFacetBuilder()
         .name("hive")
         .version(HiveVersionInfo.getVersion())
         .openlineageAdapterVersion(Versions.getVersion())
@@ -339,7 +341,7 @@ public class Faceting {
             .runId(emitter.getRunId())
             .facets(
                 ol.newRunFacetsBuilder()
-                    .put("processing_engine", getProcessingEngineFacet(ol))
+                    .processing_engine(getProcessingEngineFacet(olContext))
                     .put("hive_query", getHiveQueryInfoFacet(olContext))
                     .put("hive_session", getHiveSessionInfoFacet(olContext))
                     .put("hive_properties", getHivePropertiesFacet(olContext))
@@ -357,7 +359,11 @@ public class Faceting {
                 .namespace(emitter.getJobNamespace())
                 .name(jobName)
                 // TODO: Add job facets
-                .facets(ol.newJobFacetsBuilder().put("sql", getSQLJobFacet(olContext)).build())
+                .facets(
+                    ol.newJobFacetsBuilder()
+                        .sql(getSQLJobFacet(olContext))
+                        .jobType(getJobTypeFacet(olContext))
+                        .build())
                 .build())
         .inputs(inputDatasets)
         .outputs(outputDatasets)
@@ -369,6 +375,16 @@ public class Faceting {
         .getOpenLineage()
         .newSQLJobFacetBuilder()
         .query(olContext.getHookContext().getQueryPlan().getQueryString())
+        .build();
+  }
+
+  private static OpenLineage.JobTypeJobFacet getJobTypeFacet(OpenLineageContext olContext) {
+    return olContext
+        .getOpenLineage()
+        .newJobTypeJobFacetBuilder()
+        .jobType("QUERY")
+        .processingType("BATCH")
+        .integration("HIVE")
         .build();
   }
 


### PR DESCRIPTION
### Problem

Hive integration currently misses `jobType` facet.

### Solution

#### One-line summary:

[Hive] Add jobType facet

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project