### PR TITLE
Flink integration: Fixed a bug incorrectly loading configuration in Event Emitter

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageConfig.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * Configuration for {@link OpenLineageClient}.
@@ -29,6 +30,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class OpenLineageConfig<T extends OpenLineageConfig> implements MergeConfig<T> {
   @JsonProperty("transport")
   protected TransportConfig transportConfig;

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
@@ -48,6 +48,8 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
     this.context =
         OpenLineageContextFactory.fromConfig(FlinkConfigParser.parse(context.getConfiguration()))
             .build();
+    log.info(
+        "Creating OpenLineageJobStatusChangedListener with OpenLineageContext: {}", this.context);
 
     String jobsApiUrl =
         String.format(
@@ -206,7 +208,7 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
             .jobNamespace(jobNamespace)
             .flinkJobId(createdEvent.jobId())
             .build();
-    log.debug("JobIdentifier with jobId: {}", jobId.getFlinkJobId());
+    log.info("JobIdentifier with jobId: {}", jobId.getFlinkJobId());
     context.setJobId(jobId);
   }
 }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
@@ -17,13 +17,18 @@ import io.openlineage.flink.visitor.identifier.KafkaTopicListDatasetIdentifierVi
 import io.openlineage.flink.visitor.identifier.KafkaTopicPatternDatasetIdentifierVisitor;
 import java.util.Arrays;
 import java.util.Collection;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.core.execution.JobStatusChangedListener;
 import org.apache.flink.core.execution.JobStatusChangedListenerFactory;
 
+@Slf4j
 public class OpenLineageJobStatusChangedListenerFactory implements JobStatusChangedListenerFactory {
 
   @Override
   public JobStatusChangedListener createListener(Context context) {
+    log.info(
+        "Creating OpenLineageJobStatusChangedListener with Flink configuration: {}",
+        context.getConfiguration());
     return new OpenLineageJobStatusChangedListener(context, loadVisitorFactory());
   }
 

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/api/OpenLineageContext.java
@@ -18,6 +18,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.ToString;
 import org.apache.flink.api.common.JobID;
 
 /**
@@ -31,6 +32,7 @@ import org.apache.flink.api.common.JobID;
  */
 @Builder
 @Getter
+@ToString
 public class OpenLineageContext {
 
   @Builder.Default UUID runUuid = UUIDUtils.generateNewUUID();

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/EventEmitter.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/EventEmitter.java
@@ -10,7 +10,6 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
 import io.openlineage.client.OpenLineageClientException;
 import io.openlineage.client.OpenLineageConfig;
-import io.openlineage.client.transports.TransportFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -33,10 +32,7 @@ public class EventEmitter {
   public EventEmitter(OpenLineageConfig openLineageConfig) {
     if (openLineageConfig.getTransportConfig() != null) {
       // build emitter client based on flink configuration
-      this.client =
-          OpenLineageClient.builder()
-              .transport(new TransportFactory(openLineageConfig.getTransportConfig()).build())
-              .build();
+      this.client = Clients.newClient(openLineageConfig);
     } else {
       // build emitter default way - openlineage.yml file or system properties
       client = Clients.newClient();

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/config/FlinkOpenLineageConfig.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-@ToString
+@ToString(callSuper = true)
 public class FlinkOpenLineageConfig extends OpenLineageConfig<FlinkOpenLineageConfig> {
 
   private static final Integer DEFAULT_TRACKING_INTERVAL = 60;

--- a/integration/sql/README.md
+++ b/integration/sql/README.md
@@ -80,6 +80,24 @@ The interface can be manually tested by running the integration test from the `i
 ./src/test/integration/run_test.sh [sql]
 ```
 
+#### Java Versions
+Works on Java 17
+
+`./gradlew build` fails on Java 21
+
+#### Unit tests failing
+
+The build script doesn't execute unit tests.
+When running `./gradlew build`, two tests are failing: `returnedError()` and `returnedMultipleErrors()`.
+
+`./iface-java/scripts/build.sh` doesn't execute tests - it should, but since tests are failing, I'll wait for a decision
+on how to proceed.
+
+Changing 
+`"$ROOT"/gradlew -x javadoc publishToMavenLocal` 
+to 
+`"$ROOT"/gradlew test -x javadoc publishToMavenLocal` should fix the issue, but cannot be done until tests are fixed.
+
 #### Todo:
 * Support a larger part of the SQL language 
 * Python as a Cargo feature

--- a/integration/sql/README.md
+++ b/integration/sql/README.md
@@ -85,19 +85,6 @@ Works on Java 17
 
 `./gradlew build` fails on Java 21
 
-#### Unit tests failing
-
-The build script doesn't execute unit tests.
-When running `./gradlew build`, two tests are failing: `returnedError()` and `returnedMultipleErrors()`.
-
-`./iface-java/scripts/build.sh` doesn't execute tests - it should, but since tests are failing, I'll wait for a decision
-on how to proceed.
-
-Changing 
-`"$ROOT"/gradlew -x javadoc publishToMavenLocal` 
-to 
-`"$ROOT"/gradlew test -x javadoc publishToMavenLocal` should fix the issue, but cannot be done until tests are fixed.
-
 #### Todo:
 * Support a larger part of the SQL language 
 * Python as a Cargo feature


### PR DESCRIPTION
Incorrect configuration resulted in "disabled facets" feature not working (and probably others as well).

### Problem

openlineage-flink has a bug where in EventEmitter's constructor, the OpenLineageClient is built with only part of the OpenLineageContext. This is a fix, as well as some logging that would have helped in the diagnosis.

### Solution

Instead of only passing transport to the OpenLineageClient builder, we're now calling the Clients.newClient factory method, passing the whole configuration.

#### One-line summary:
Fixed incorrect EventEmitter constructor

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project