### PR TITLE
[Hive] Add docker-compose example for local testing

### DIFF
--- a/integration/hive-docker/README.md
+++ b/integration/hive-docker/README.md
@@ -6,12 +6,17 @@ OpenLineage Hive integration.
 
 ## Steps
 
-1. Login to `quay.io` using the following command: `docker login quay.io`
-2. Create a builder for the Docker images using the following
-   command: `docker buildx create --use --name openlineage-hive-builder --driver docker-container`
-3. Run the Gradle task to build and publish the Docker images: `./gradlew buildAllDockerImages`
+For building images locally:
 
-For testing you can use `./gradlew buildAllDockerImages -PskipPush=true` to only build locally for your system
+1. Create a builder for the Docker images using the following
+   command: `docker buildx create --use --name openlineage-hive-builder --driver docker-container`
+2. Run the Gradle task to build the Docker images: `./gradlew buildAllDockerImages -PskipPush=true`
+
+For pushing images:
+
+1. Create a builder for the Docker images using the following
+2. Login to `quay.io` using the following command: `docker login quay.io`
+3. Run the Gradle task to build and push the Docker images: `./gradlew buildAllDockerImages`
 
 ## manifest.json
 
@@ -38,3 +43,25 @@ mvn -q help:evaluate -Dexpression=tez.version -DforceStdout
 When the `buildAllDockerImages` task is run, the plugin reads this manifest file and for each
 object, it creates a Docker image with the specified Hive version. This allows you to easily build
 and publish Docker images for multiple versions of Hive to `quay.io/openlineage/hive`.
+
+
+## Starting Hive using docker-compose
+
+Just execute:
+
+```shell
+docker compose pull  # pull image from quay.io, can be skipped if image was build locally
+docker compose down -v  # important to clear metastore & warehouse
+docker compose up  # start container and show HiveServer2 logs
+```
+
+After HiveServer2 is started, connect using ``beeline`` cli or JDBC (e.g. DBBeaver):
+
+```shell
+docker exec -it hive-docker-hive-1 bash
+$ beeline -u "jdbc:hive2://localhost:10000"
+```
+
+Here you can run Hive queries. OpenLineage events will appear in HiveServer2 logs.
+
+Container also exposes web UI http://localhost:10002 where you can see status of sessions and queries.

--- a/integration/hive-docker/conf/hive-site.xml
+++ b/integration/hive-docker/conf/hive-site.xml
@@ -64,4 +64,28 @@
         <name>metastore.metastore.event.db.notification.api.auth</name>
         <value>false</value>
     </property>
+    <property>
+        <name>hive.aux.jars.path</name>
+        <value>/opt/hive/lib/openlineage/</value>
+    </property>
+    <property>
+        <name>hive.server2.session.hook</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
+    <property>
+        <name>hive.exec.post.hooks</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
+    <property>
+        <name>hive.exec.failure.hooks</name>
+        <value>io.openlineage.hive.hooks.HiveOpenLineageHook</value>
+    </property>
+    <property>
+        <name>hive.conf.validation</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>hive.openlineage.transport.type</name>
+        <value>console</value>
+    <property>
 </configuration>

--- a/integration/hive-docker/docker-compose.yml
+++ b/integration/hive-docker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  hive:
+    image: quay.io/openlineage/hive:${HIVE_VERSION:-3.1.3}
+    ports:
+      - 10000:10000
+      - 10002:10002
+    volumes:
+      - ./conf/:/opt/hive/conf/:ro
+      - ../hive/build/libs:/opt/hive/lib/openlineage/:ro
+    environment:
+      - SERVICE_NAME=hiveserver2


### PR DESCRIPTION
### Problem

### Solution

Added an example of `docker-compose.yml` for running Hive locally. This is quite useful for local testing of Hive integration.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project