### PR TITLE
Website: add missing guidance to readme

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -45,7 +45,7 @@ If you are familiar with the GitHub pull request process, proposing a new blog p
 ### New talks for the Community page
 
 1. Fork this project.
-2. Add a talk photo or screenshot with the dimensions 1920 x 1080 px to `static/img`.
+2. Add a talk photo or screenshot in PNG format with the dimensions 1920 x 1080 px to `static/img`.
 3. Add an array to `static/talks/talkStrings.tsx`, using the filename of the photo for the image value. Note that the `video_url` is optional:
 
 ```tsx
@@ -68,7 +68,7 @@ If you are familiar with the GitHub pull request process, proposing a new blog p
 ### New meetup groups for the Community page
 
 1. Fork this project.
-2. Add a meetup photo or screenshot with the dimensions 1920 x 1080 px to `static/img`.
+2. Add a meetup photo or screenshot in PNG format with the dimensions 1920 x 1080 px to `static/img`.
 3. Add an array to `static/meetups/meetupStrings.tsx`, using the filename of the photo for the image value, like so:
 
 ```tsx


### PR DESCRIPTION
### Problem

Website readme is missing guidance on adding talks.

### Solution

This adds the guidance there.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project