### PR TITLE
name threads used in Java client

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -38,6 +38,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -350,12 +352,44 @@ public final class OpenLineageClientUtils {
 
   public static ExecutorService getOrCreateExecutor() {
     if (EXECUTOR == null) {
-      EXECUTOR = Executors.newCachedThreadPool();
+      EXECUTOR = Executors.newCachedThreadPool(new ExecutorThreadFactory("openlineage-executor"));
+    }
+    return EXECUTOR;
+  }
+
+  public static ExecutorService getOrCreateExecutor(ThreadFactory threadFactory) {
+    if (EXECUTOR == null) {
+      EXECUTOR = Executors.newCachedThreadPool(threadFactory);
     }
     return EXECUTOR;
   }
 
   public static Optional<ExecutorService> getExecutor() {
     return Optional.ofNullable(EXECUTOR);
+  }
+
+  public static class ExecutorThreadFactory implements java.util.concurrent.ThreadFactory {
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+    private final String namePrefix;
+    private final ThreadGroup group;
+
+    /**
+     * Creates a ThreadFactory with the specified name prefix and daemon flag. Threads will be named
+     * as "{namePrefix}-{number}".
+     *
+     * @param namePrefix the prefix for thread names
+     */
+    public ExecutorThreadFactory(String namePrefix) {
+      this.group = Thread.currentThread().getThreadGroup();
+      this.namePrefix = namePrefix + "-";
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+      if (t.isDaemon()) t.setDaemon(false);
+      if (t.getPriority() != Thread.NORM_PRIORITY) t.setPriority(Thread.NORM_PRIORITY);
+      return t;
+    }
   }
 }

--- a/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
+++ b/client/java/src/main/java/io/openlineage/client/circuitBreaker/TaskQueueCircuitBreaker.java
@@ -7,6 +7,7 @@ package io.openlineage.client.circuitBreaker;
 
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.metrics.MicrometerProvider;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +49,12 @@ public class TaskQueueCircuitBreaker implements CircuitBreaker {
     eventQueue = new ArrayBlockingQueue<>(config.getQueueSize());
     eventProcessingExecutor =
         new ThreadPoolExecutor(
-            config.getThreadCount(), config.getThreadCount(), 60L, TimeUnit.SECONDS, eventQueue);
+            config.getThreadCount(),
+            config.getThreadCount(),
+            60L,
+            TimeUnit.SECONDS,
+            eventQueue,
+            new OpenLineageClientUtils.ExecutorThreadFactory("openlineage-taskqueue"));
   }
 
   @Override
@@ -77,7 +83,7 @@ public class TaskQueueCircuitBreaker implements CircuitBreaker {
           .ifPresent(
               m ->
                   log.info(
-                      "Openlineage async stats: dropped={}, timeout={}, queueDepth={}, failed={}",
+                      "OpenLineage async stats: dropped={}, timeout={}, queueDepth={}, failed={}",
                       m.counter(DROPPED_METRIC).count(),
                       m.counter(TIMED_OUT_METRIC).count(),
                       getPendingTasks(),


### PR DESCRIPTION
This helps with debugging thread dumps - for example, when application gets stuck, I want to know if stuck thread

```
"pool-35-thread-1" #109 prio=5 os_prio=0 cpu=307.27ms elapsed=573.64s tid=0x0000f6c71cc622e0 nid=0x177 waiting on condition  [0x0000f6c6f9c61000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.14/Native Method)
	- parking to wait for  <0x0000000607a52cb8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.14/LockSupport.java:341)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@17.0.14/AbstractQueuedSynchronizer.java:506)
	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.14/ForkJoinPool.java:3465)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.14/ForkJoinPool.java:3436)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@17.0.14/AbstractQueuedSynchronizer.java:1630)
	at java.util.concurrent.LinkedBlockingQueue.take(java.base@17.0.14/LinkedBlockingQueue.java:435)
	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@17.0.14/ThreadPoolExecutor.java:1062)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.14/ThreadPoolExecutor.java:1122)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.14/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.14/Thread.java:840)

   Locked ownable synchronizers:
	- None
```

comes from OpenLineage