### PR TITLE
docs: Fix composite transport python docs on continue_on_failure

### DIFF
--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -464,13 +464,13 @@ The `CompositeTransport` is designed to combine multiple transports, allowing ev
 
 - `type` - string, must be "composite". Required.
 - `transports` - a list or a map of transport configurations. Required.
-- `continue_on_failure` - boolean flag, determines if the process should continue even when one of the transports fails. Default is `false`.
+- `continue_on_failure` - boolean flag, determines if the process should continue even when one of the transports fails. Default is `true`.
 
 #### Behavior
 
 - The configured transports will be initialized and used in sequence to emit OpenLineage events.
 - If `continue_on_failure` is set to `false`, a failure in one transport will stop the event emission process, and an exception will be raised.
-- If `continue_on_failure` is `true`, the failure will be logged, but the remaining transports will still attempt to send the event.
+- If `continue_on_failure` is `true`, the failure will be logged and the process will continue allowing the remaining transports to still send the event.
 
 #### Notes for Multiple Transports
 The composite transport can be used with any OpenLineage transport (e.g. `HttpTransport`, `KafkaTransport`, etc).
@@ -492,7 +492,7 @@ Transport names are not required for basic functionality. Their primary purpose 
 ```yaml
 transport:
   type: composite
-  continueOnFailure: true
+  continue_on_failure: true
   transports:
     - type: http
       url: http://example.com/api
@@ -508,7 +508,7 @@ transport:
 ```yaml
 transport:
   type: composite
-  continueOnFailure: true
+  continue_on_failure: true
   transports:
     my_http:
       type: http
@@ -529,6 +529,7 @@ from openlineage.client.transport.composite import CompositeTransport, Composite
 config = CompositeConfig.from_dict(
         {
             "type": "composite",
+            "continue_on_failure": True,
             "transports": [
                 {
                     "type": "kafka",


### PR DESCRIPTION
### Problem

Composite transport docs were wrong, `continue_on_failure` default value is True, not False.

### Solution

Change default value in the docs, also adjusted yaml examples as they were not working properly.

#### One-line summary:
docs: fix default value of `continue_on_failure` for CompositeTransport in python docs

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project