### PR TITLE
feat: Add continue_on_success and sorting transport in CompositeTransport

### DIFF
--- a/client/python/openlineage/client/__init__.py
+++ b/client/python/openlineage/client/__init__.py
@@ -8,7 +8,7 @@ from openlineage.client.client import OpenLineageClient, OpenLineageClientOption
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
-from openlineage.client.facet import set_producer as set_producer_v1
+    from openlineage.client.facet import set_producer as set_producer_v1
 from openlineage.client.facet_v2 import set_producer as set_producer_v2
 
 

--- a/client/python/openlineage/client/filter.py
+++ b/client/python/openlineage/client/filter.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import logging
 import re
 import typing
+import warnings
 
 import attr
 from openlineage.client.event_v2 import RunEvent as RunEvent_v2
-from openlineage.client.run import RunEvent
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from openlineage.client.run import RunEvent
 
 log = logging.getLogger(__name__)
 RunEventType = typing.Union[RunEvent, RunEvent_v2]

--- a/client/python/openlineage/client/run.py
+++ b/client/python/openlineage/client/run.py
@@ -7,8 +7,12 @@ from typing import Any, ClassVar, Optional
 
 import attr
 from dateutil import parser
-from openlineage.client.facet import NominalTimeRunFacet, ParentRunFacet
 from openlineage.client.utils import RedactMixin
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from openlineage.client.facet import NominalTimeRunFacet, ParentRunFacet
+
 
 warnings.warn(
     "This module is deprecated. Please use `openlineage.client.event_v2`.", DeprecationWarning, stacklevel=2

--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -51,6 +51,12 @@ class DefaultTransportFactory(TransportFactory):
             raise TypeError(msg) from None
 
         transport_name = config.pop("name", None)
+        transport_priority = config.pop("priority", 0)
+        try:
+            transport_priority = int(transport_priority)
+        except ValueError as e:
+            msg = f"Error casting priority `{transport_priority}` to int for transport `{transport_type}`"
+            raise ValueError(msg) from e
 
         transport_class_type_or_str = self.transports.get(transport_type, transport_type)
 
@@ -73,4 +79,6 @@ class DefaultTransportFactory(TransportFactory):
         transport: Transport = transport_class(config_class.from_dict(config))  # type: ignore[call-arg]
         if transport_name and not transport.name:
             transport.name = transport_name
+        if transport_priority and transport.priority == 0:
+            transport.priority = transport_priority
         return transport

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -41,6 +41,7 @@ class Config:
 class Transport:
     kind: str | None = None
     name: str | None = None
+    priority: int = 0
     config_class: type[Config] = Config
 
     def emit(self, event: Event) -> Any:
@@ -74,7 +75,7 @@ class Transport:
         return True
 
     def __str__(self) -> str:
-        return f"<{self.__class__.__name__}(name={self.name}, kind={self.kind})>"
+        return f"<{self.__class__.__name__}(name={self.name}, kind={self.kind}, priority={self.priority})>"
 
 
 class TransportFactory:

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -679,6 +679,30 @@ def test_async_transport_with_priority_overwrite() -> None:
     {
         "OPENLINEAGE_URL": "http://example.com",
         "OPENLINEAGE__TRANSPORT__TYPE": "composite",
+        "OPENLINEAGE__TRANSPORT__SORT_TRANSPORTS": "true",
+        "OPENLINEAGE__TRANSPORT__TRANSPORTS__ANOTHER__TYPE": "console",
+        "OPENLINEAGE__TRANSPORT__TRANSPORTS__ANOTHER__PRIORITY": "4",
+    },
+)
+def test_composite_transport_with_sorted_by_priority() -> None:
+    transport: CompositeTransport = OpenLineageClient().transport
+    expected_priority = 4
+    assert transport.kind == CompositeTransport.kind
+    assert transport.config.sort_transports is True
+    assert len(transport.transports) == 2  # noqa: PLR2004
+    assert transport.transports[0].kind == ConsoleTransport.kind
+    assert transport.transports[0].priority == expected_priority
+    assert transport.transports[0].name == "another"
+    assert transport.transports[1].kind == HttpTransport.kind
+    assert transport.transports[1].name == "default_http"
+    assert transport.transports[1].priority == 0
+
+
+@patch.dict(
+    os.environ,
+    {
+        "OPENLINEAGE_URL": "http://example.com",
+        "OPENLINEAGE__TRANSPORT__TYPE": "composite",
         "OPENLINEAGE__TRANSPORT__TRANSPORTS__DEFAULT_HTTP__TYPE": "console",
         "OPENLINEAGE__TRANSPORT__TRANSPORTS__ANOTHER__TYPE": "console",
     },

--- a/client/python/tests/test_composite.py
+++ b/client/python/tests/test_composite.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from openlineage.client.transport import ConsoleTransport
 from openlineage.client.transport.composite import CompositeConfig, CompositeTransport
 from openlineage.client.transport.transport import Transport
 
@@ -25,6 +26,8 @@ def test_composite_loads_full_config() -> None:
                 "console": {"type": "console"},
             },
             "continue_on_failure": False,
+            "continue_on_success": False,
+            "sort_transports": True,
         },
     )
 
@@ -34,6 +37,8 @@ def test_composite_loads_full_config() -> None:
     assert config.transports["kafka"]["flush"] is False
     assert config.transports["console"] == {"type": "console"}
     assert config.continue_on_failure is False
+    assert config.continue_on_success is False
+    assert config.sort_transports is True
 
 
 def test_composite_loads_partial_config_with_defaults() -> None:
@@ -58,6 +63,33 @@ def test_composite_loads_partial_config_with_defaults() -> None:
     assert config.transports[0]["flush"] is False
     assert config.transports[1] == {"type": "console"}
     assert config.continue_on_failure is True
+    assert config.continue_on_success is True
+    assert config.sort_transports is False
+
+
+@pytest.mark.parametrize("transports", [{}, []])
+def test_empty_transports(transports):
+    config = CompositeConfig(transports=transports, continue_on_failure=True, continue_on_success=True)
+    with pytest.raises(ValueError, match="CompositeTransport initialization failed: No transports found"):
+        CompositeTransport(config)
+
+
+@mock.patch("openlineage.client.transport.get_default_factory")
+def test_sort_transports(mock_factory):
+    mock_transport1 = ConsoleTransport(None)
+    mock_transport2 = ConsoleTransport(None)
+    mock_transport2.priority = 2
+    mock_transport3 = ConsoleTransport(None)
+    mock_transport3.priority = 3
+
+    # Configure mock factory
+    mock_factory.return_value.create.side_effect = [mock_transport1, mock_transport2, mock_transport3]
+
+    config = CompositeConfig(transports=[{}, {}, {}], sort_transports=True)
+    transport = CompositeTransport(config)
+
+    sorted_transports = [mock_transport3, mock_transport2, mock_transport1]
+    assert transport.transports == sorted_transports
 
 
 def test_composite_transport_create_transports():
@@ -138,6 +170,62 @@ def test_emit_failure_continue_on_failure(mock_factory):
 
     mock_transport1.emit.assert_called_once_with(event)
     mock_transport2.emit.assert_called_once_with(event)
+
+
+@pytest.mark.parametrize(
+    ("continue_on_failure", "continue_on_success", "expected_calls", "should_raise"),
+    [
+        # 1) continue_on_failure=True, continue_on_success=True
+        # Should emit to all transports even if one fails, never raises
+        (True, True, [True, True, True], False),
+        # 2) continue_on_failure=True, continue_on_success=False
+        # Should emit until first success, ignore failures before that, never raises
+        (True, False, [True, True, False], False),
+        # 3) continue_on_failure=False, continue_on_success=True
+        # Should raise on first failure immediately
+        (False, True, [True, False, False], True),
+        # 4) continue_on_failure=False, continue_on_success=False
+        # Should stop on first success or failure; raises only if first emit fails
+        (False, False, [True, False, False], True),
+    ],
+)
+@mock.patch("openlineage.client.transport.get_default_factory")
+def test_emit_continue_combinations(
+    mock_factory, continue_on_failure, continue_on_success, expected_calls, should_raise
+):
+    # Setup transports: three transports with first failing, second succeeding
+    mock_transport1 = MagicMock(spec=Transport)
+    mock_transport2 = MagicMock(spec=Transport)
+    mock_transport3 = MagicMock(spec=Transport)
+
+    mock_transport1.emit.side_effect = Exception("First transport fails")
+    mock_transport2.emit.side_effect = None
+    mock_transport3.emit.side_effect = None
+
+    # Configure mock factory
+    mock_factory.return_value.create.side_effect = [mock_transport1, mock_transport2, mock_transport3]
+
+    config = CompositeConfig(
+        transports=[{}, {}, {}],  # mocked anyway
+        continue_on_failure=continue_on_failure,
+        continue_on_success=continue_on_success,
+    )
+    transport = CompositeTransport(config)
+    event = MagicMock()
+
+    if should_raise:
+        with pytest.raises(RuntimeError):
+            transport.emit(event)
+    else:
+        transport.emit(event)
+
+    mock_emits = [mock_transport1.emit, mock_transport2.emit, mock_transport3.emit]
+    for i, expected_success in enumerate(expected_calls):
+        mock_emit = mock_emits[i]
+        if expected_success:
+            mock_emit.assert_called_once_with(event)
+        else:
+            mock_emit.assert_not_called()
 
 
 @mock.patch("openlineage.client.transport.get_default_factory")
@@ -278,27 +366,3 @@ def test_close_default_timeout(mock_factory):
     assert result is True
     mock_transport1.close.assert_called_once_with(-1.0)
     mock_transport2.close.assert_called_once_with(-1.0)
-
-
-@mock.patch("openlineage.client.transport.get_default_factory")
-def test_close_empty_transports(mock_factory):
-    mock_factory.return_value.create.side_effect = []
-
-    config = CompositeConfig(transports=[])
-    transport = CompositeTransport(config)
-
-    result = transport.close(5.0)
-
-    assert result is True
-
-
-@mock.patch("openlineage.client.transport.get_default_factory")
-def test_wait_for_completion_empty_transports(mock_factory):
-    mock_factory.return_value.create.side_effect = []
-
-    config = CompositeConfig(transports=[])
-    transport = CompositeTransport(config)
-
-    result = transport.wait_for_completion(5.0)
-
-    assert result is True


### PR DESCRIPTION
### Problem
There was no mechanism to control the behavior of continuing emission after a successful transport. In case users wanted to only deliver to a single backend, but have an option to "fallback" to another one, when first emission failed, it was hard to do.

Also, the current implementation of reading config from env variables uses a default descending alphabetical sorting of variable names. This sorting behavior is not clearly documented, which can cause confusion on which transport will emit first when defined as separate env variables. 


### Solution

- Introduced the `continue_on_success` attribute to the `CompositeConfig` class. This flag, when set to `True`, ensures that events continue to be emitted to all transports even after a successful emission to one of them. If set to `False`, it stops further emission once the first successful transport is encountered.
- Added an option to sort transports in composite transport, by newly added transport's `priority` field. Priority defaults to 0 and can be passed in transport's config. The higher priority, the earlier the transport will try to emit event. This allows the user to control the sorting behavior, even when env variables are used to define transports.

Using those two solutions together, you can achieve almost any logic.

Also, when running tests with pytest some deprecation warnings were raised from two deprecated modules that we still use internally to keep compatibility, moved them under warning silencer.

#### One-line summary:
Added `continue_on_success` for fallback behavior and clarified sorting mechanism for transport configurations in CompositeTransport.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project