### PR TITLE
Spark - avoid WARN in DatasetVersionDatasetFacetUtils caused by unnecessary method calls

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DatasetFactory.java
@@ -17,6 +17,7 @@ import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombined
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.lifecycle.plan.BigQueryNodeOutputVisitor;
 import io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
+import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import java.net.URI;
@@ -57,6 +58,9 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
   abstract OpenLineage.Builder<D> datasetBuilder(
       String name, String namespace, DatasetFacets facets);
 
+  public abstract void buildVersionFacets(
+      DatasetCompositeFacetsBuilder facetsBuilder, String version);
+
   /**
    * Create a {@link DatasetFactory} that constructs only {@link OpenLineage.InputDataset}s.
    *
@@ -86,6 +90,11 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
             .namespace(namespaceResolver.resolve(namespace))
             .name(name)
             .facets(facets);
+      }
+
+      @Override
+      public void buildVersionFacets(DatasetCompositeFacetsBuilder facetsBuilder, String version) {
+        DatasetVersionUtils.buildVersionFacets(context, facetsBuilder, version);
       }
     };
   }
@@ -119,6 +128,11 @@ public abstract class DatasetFactory<D extends OpenLineage.Dataset> {
             .namespace(namespaceResolver.resolve(namespace))
             .name(name)
             .facets(facets);
+      }
+
+      @Override
+      public void buildVersionFacets(DatasetCompositeFacetsBuilder facetsBuilder, String version) {
+        DatasetVersionUtils.buildVersionOutputFacets(context, facetsBuilder, version);
       }
     };
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputOnEndDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputOnEndDatasetBuilder.java
@@ -54,7 +54,7 @@ public class DataSourceV2RelationInputOnEndDatasetBuilder
     DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
 
     // don't get dataset version on job end for inputs
-    return DataSourceV2RelationDatasetExtractor.extract(
+    return DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
         factory, context, relation, datasetFacetsBuilder);
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputOnStartDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputOnStartDatasetBuilder.java
@@ -6,13 +6,10 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -54,11 +51,7 @@ public class DataSourceV2RelationInputOnStartDatasetBuilder
 
   @Override
   public List<OpenLineage.InputDataset> apply(DataSourceV2Relation relation) {
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-
-    DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(context, relation)
-        .ifPresent(s -> DatasetVersionUtils.buildVersionFacets(context, datasetFacetsBuilder, s));
-    return DataSourceV2RelationDatasetExtractor.extract(
-        factory, context, relation, datasetFacetsBuilder);
+    return DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
+        factory, context, relation);
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationOutputDatasetBuilder.java
@@ -6,13 +6,10 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -52,15 +49,8 @@ public class DataSourceV2RelationOutputDatasetBuilder
       return getTableOutputs(relation);
     }
 
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-    if (includeDatasetVersion(event)) {
-      DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(context, relation)
-          .ifPresent(
-              s -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, s));
-    }
-
     return DataSourceV2RelationDatasetExtractor.extract(
-        factory, context, relation, datasetFacetsBuilder);
+        factory, context, relation, includeDatasetVersion(event));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilder.java
@@ -77,7 +77,7 @@ public final class DataSourceV2ScanRelationOnEndInputDatasetBuilder
                       }
                     }));
 
-    return DataSourceV2RelationDatasetExtractor.extract(
+    return DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
         factory, context, relation, datasetFacetsBuilder);
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnStartInputDatasetBuilder.java
@@ -6,13 +6,10 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage.InputDataset;
-import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanInputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
@@ -51,12 +48,8 @@ public final class DataSourceV2ScanRelationOnStartInputDatasetBuilder
     }
 
     DataSourceV2Relation relation = plan.relation();
-    DatasetCompositeFacetsBuilder datasetFacetsBuilder = factory.createCompositeFacetBuilder();
-
-    DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(context, relation)
-        .ifPresent(s -> DatasetVersionUtils.buildVersionFacets(context, datasetFacetsBuilder, s));
-    return DataSourceV2RelationDatasetExtractor.extract(
-        factory, context, relation, datasetFacetsBuilder);
+    return DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
+        factory, context, relation);
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -8,13 +8,11 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.IcebergHandler;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.List;
 import java.util.Optional;
 import lombok.NonNull;
@@ -89,14 +87,8 @@ public class TableContentChangeDatasetBuilder
         (table instanceof DataSourceV2ScanRelation)
             ? castToDataSourceV2Relation(x, table)
             : (DataSourceV2Relation) table;
-    if (includeDatasetVersion(event)) {
-      DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(context, returnTable)
-          .ifPresent(
-              s -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, s));
-    }
-
     return DataSourceV2RelationDatasetExtractor.extract(
-        outputDataset(), context, returnTable, datasetFacetsBuilder);
+        outputDataset(), context, returnTable, datasetFacetsBuilder, includeDatasetVersion(event));
   }
 
   private NamedRelation getNamedRelation(LogicalPlan x) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -32,15 +32,38 @@ import org.jetbrains.annotations.NotNull;
 public class DataSourceV2RelationDatasetExtractor {
 
   public static <D extends OpenLineage.Dataset> List<D> extract(
+      DatasetFactory<D> datasetFactory,
+      OpenLineageContext context,
+      DataSourceV2Relation relation,
+      boolean includeVersionFacet) {
+    return extract(
+        datasetFactory,
+        context,
+        relation,
+        datasetFactory.createCompositeFacetBuilder(),
+        includeVersionFacet);
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> extractIncludingVersionFacet(
       DatasetFactory<D> datasetFactory, OpenLineageContext context, DataSourceV2Relation relation) {
-    return extract(datasetFactory, context, relation, datasetFactory.createCompositeFacetBuilder());
+    return extract(
+        datasetFactory, context, relation, datasetFactory.createCompositeFacetBuilder(), true);
+  }
+
+  public static <D extends OpenLineage.Dataset> List<D> extractIncludingVersionFacet(
+      DatasetFactory<D> datasetFactory,
+      OpenLineageContext context,
+      DataSourceV2Relation relation,
+      DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
+    return extract(datasetFactory, context, relation, datasetFacetsBuilder, true);
   }
 
   public static <D extends OpenLineage.Dataset> List<D> extract(
       DatasetFactory<D> datasetFactory,
       OpenLineageContext context,
       DataSourceV2Relation relation,
-      DatasetCompositeFacetsBuilder datasetFacetsBuilder) {
+      DatasetCompositeFacetsBuilder datasetFacetsBuilder,
+      boolean includeVersionFacet) {
     OpenLineage openLineage = context.getOpenLineage();
     if (ExtensionDataSourceV2Utils.hasQueryExtensionLineage(relation)) {
       return getQueryDatasets(datasetFactory, relation);
@@ -53,6 +76,12 @@ public class DataSourceV2RelationDatasetExtractor {
                 ExtensionDataSourceV2Utils.loadBuilder(openLineage, datasetFacetsBuilder, relation);
               } else {
                 TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
+
+                if (includeVersionFacet && relation.identifier().isDefined()) {
+                  DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
+                          context, relation)
+                      .ifPresent(s -> datasetFactory.buildVersionFacets(datasetFacetsBuilder, s));
+                }
 
                 Map<String, String> tableProperties = relation.table().properties();
                 CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetOnEndBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetOnEndBuilderTest.java
@@ -73,7 +73,7 @@ class DataSourceV2RelationInputDatasetOnEndBuilderTest {
       try (MockedStatic facetUtilsMockedStatic =
           mockStatic(DatasetVersionDatasetFacetUtils.class)) {
         try (MockedStatic versionUtilsMockedStatic = mockStatic(DatasetVersionUtils.class)) {
-          when(DataSourceV2RelationDatasetExtractor.extract(
+          when(DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
                   factory, context, relation, datasetFacetsBuilder))
               .thenReturn(datasets);
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetOnStartBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2RelationInputDatasetOnStartBuilderTest.java
@@ -9,18 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.List;
-import java.util.Optional;
 import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
@@ -68,24 +64,10 @@ class DataSourceV2RelationInputDatasetOnStartBuilderTest {
 
     try (MockedStatic planUtils3MockedStatic =
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
-      try (MockedStatic facetUtilsMockedStatic =
-          mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        try (MockedStatic versionUtilsMockedStatic = mockStatic(DatasetVersionUtils.class)) {
-          when(DataSourceV2RelationDatasetExtractor.extract(
-                  factory, context, relation, datasetFacetsBuilder))
-              .thenReturn(datasets);
-
-          when(DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(
-                  context, relation))
-              .thenReturn(Optional.of("v2"));
-
-          Assertions.assertEquals(datasets, builder.apply(relation));
-
-          versionUtilsMockedStatic.verify(
-              () -> DatasetVersionUtils.buildVersionFacets(context, datasetFacetsBuilder, "v2"),
-              times(1));
-        }
-      }
+      when(DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
+              factory, context, relation))
+          .thenReturn(datasets);
+      Assertions.assertEquals(datasets, builder.apply(relation));
     }
   }
 }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/DataSourceV2ScanRelationOnEndInputDatasetBuilderTest.java
@@ -85,7 +85,7 @@ class DataSourceV2ScanRelationOnEndInputDatasetBuilderTest {
         mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
       try (MockedStatic<DatasetVersionUtils> facetUtilsMockedStatic =
           mockStatic(DatasetVersionUtils.class)) {
-        when(DataSourceV2RelationDatasetExtractor.extract(
+        when(DataSourceV2RelationDatasetExtractor.extractIncludingVersionFacet(
                 eq(factory), eq(context), eq(relation), any()))
             .thenReturn(datasets);
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.SneakyThrows;
 import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable;
 import org.apache.spark.sql.catalyst.plans.logical.InsertIntoStatement;
@@ -165,19 +164,14 @@ class TableContentChangeDatasetBuilderTest {
             .thenReturn(datasetVersionDatasetFacet);
 
         when(DataSourceV2RelationDatasetExtractor.extract(
-                any(), eq(openLineageContext), eq(dataSourceV2Relation), any()))
+                any(), eq(openLineageContext), eq(dataSourceV2Relation), any(), any(Boolean.class)))
             .thenReturn(Collections.singletonList(dataset));
-        when(CatalogUtils3.getDatasetVersion(any(), any(), any(), any()))
-            .thenReturn(Optional.of("v2"));
-        when(datasetFacetsBuilder.version(eq(datasetVersionDatasetFacet)))
-            .thenReturn(datasetFacetsBuilder);
 
         List<OpenLineage.OutputDataset> datasetList =
             builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L), logicalPlan);
 
         assertEquals(1, datasetList.size());
         assertEquals(dataset, datasetList.get(0));
-        Mockito.verify(datasetFacetsBuilder).version(eq(datasetVersionDatasetFacet));
 
         if (lifecycleStateChange != null) {
           Mockito.verify(datasetFacetsBuilder)

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/ReplaceIcebergDataDatasetBuilder.java
@@ -8,12 +8,10 @@ package io.openlineage.spark33.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
-import io.openlineage.spark.agent.util.DatasetVersionUtils;
 import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
-import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -70,14 +68,8 @@ public class ReplaceIcebergDataDatasetBuilder
                     OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE,
                     null));
 
-    if (includeDatasetVersion(event)) {
-      DatasetVersionDatasetFacetUtils.extractVersionFromDataSourceV2Relation(context, table)
-          .ifPresent(
-              s -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, s));
-    }
-
     return DataSourceV2RelationDatasetExtractor.extract(
-        datasetFactory, context, table, datasetFacetsBuilder);
+        datasetFactory, context, table, datasetFacetsBuilder, includeDatasetVersion(event));
   }
 
   @Override


### PR DESCRIPTION
Production workloads with bigqyery connector often produce significant amount of logs:
```
WARN DatasetVersionDatasetFacetUtils: Couldn't find identifier for dataset in plan
```

Although this is a valid warn, we should change the facet building method ordering: try extracting dataset version only when having a dataset identifier. In this case, we avoid calling a method that would result in `WARN` anyway. 