### PR TITLE
[website] Add Debezium job naming convention

### DIFF
--- a/website/docs/spec/naming.md
+++ b/website/docs/spec/naming.md
@@ -58,6 +58,7 @@ config. The job name is unique within its namespace.
 | Airflow task | `{dag_id}.{task_id}`          | `orders_etl.count_orders`                                    |
 | Spark job    | `{appName}.{command}.{table}` | `my_awesome_app.execute_insert_into_hive_table.mydb_mytable` |
 | SQL          | `{schema}.{table}`            | `gx.validate_datasets`                                       |
+| Debezium     | `{topic.prefix}.{taskId}`     | `inventory.0`                                                |
 
 ## Run Naming
 


### PR DESCRIPTION
### Problem

This just adds job naming for Debezium

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project