### PR TITLE
[SPARK] Fix missing output's dataset catalog facet when running CTAS queries on Iceberg tables

### DIFF
--- a/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2AppendDataCompleteEvent.json
@@ -40,6 +40,13 @@
             }
           }
         },
+        "catalog": {
+          "framework": "iceberg",
+          "type": "hadoop",
+          "name": "spark_catalog",
+          "warehouseUri": "/tmp/iceberg",
+          "source": "spark"
+        },
         "symlinks": {
           "identifiers": [
             {

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableAsSelectCompleteEvent.json
@@ -26,6 +26,13 @@
             }
           ]
         },
+        "catalog": {
+          "framework": "iceberg",
+          "type": "hadoop",
+          "name": "spark_catalog",
+          "warehouseUri": "/tmp/iceberg",
+          "source": "spark"
+        },
         "symlinks": {
           "identifiers": [
             {

--- a/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2CreateTableCompleteEvent.json
@@ -26,6 +26,13 @@
             }
           ]
         },
+        "catalog": {
+          "framework": "iceberg",
+          "type": "hadoop",
+          "name": "spark_catalog",
+          "warehouseUri": "/tmp/iceberg",
+          "source": "spark"
+        },
         "symlinks": {
           "identifiers": [
             {

--- a/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2OverwriteByExpressionCompleteEvent.json
@@ -25,6 +25,13 @@
             }
           ]
         },
+        "catalog": {
+          "framework": "iceberg",
+          "type": "hadoop",
+          "name": "spark_catalog",
+          "warehouseUri": "/tmp/iceberg",
+          "source": "spark"
+        },
         "symlinks": {
           "identifiers": [
             {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -121,11 +121,7 @@ public class CreateReplaceDatasetBuilder
       datasetVersion.ifPresent(
           version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
     }
-
-    CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
-    CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
-        .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
+    CatalogUtils3.addStorageAndCatalogFacets(context, tableCatalog, tableProperties, builder);
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
@@ -90,6 +91,17 @@ public class CatalogUtils3 {
                     String.format(
                         "Cannot extract dataset from relation=%s relationClass=%s",
                         relation.simpleString(5), relation.getClass().getCanonicalName())));
+  }
+
+  public static void addStorageAndCatalogFacets(
+      OpenLineageContext context,
+      TableCatalog catalog,
+      Map<String, String> properties,
+      DatasetCompositeFacetsBuilder builder) {
+    CatalogUtils3.getStorageDatasetFacet(context, catalog, properties)
+        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
+    CatalogUtils3.getCatalogDatasetFacet(context, catalog, properties)
+        .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
   }
 
   public static Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/DataSourceV2RelationDatasetExtractor.java
@@ -55,14 +55,8 @@ public class DataSourceV2RelationDatasetExtractor {
                 TableCatalog tableCatalog = (TableCatalog) relation.catalog().get();
 
                 Map<String, String> tableProperties = relation.table().properties();
-                CatalogUtils3.getStorageDatasetFacet(context, tableCatalog, tableProperties)
-                    .ifPresent(
-                        storageDatasetFacet ->
-                            datasetFacetsBuilder.getFacets().storage(storageDatasetFacet));
-                CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
-                    .ifPresent(
-                        catalogDatasetFacet ->
-                            datasetFacetsBuilder.getFacets().catalog(catalogDatasetFacet));
+                CatalogUtils3.addStorageAndCatalogFacets(
+                    context, tableCatalog, tableProperties, datasetFacetsBuilder);
               }
               datasetFacetsBuilder
                   .getFacets()

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -168,9 +168,7 @@ public class CreateReplaceDatasetBuilder
           .ifPresent(
               version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
     }
-
-    CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
-        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
+    CatalogUtils3.addStorageAndCatalogFacets(context, catalog, tableProperties, builder);
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceOutputDatasetBuilder.java
@@ -178,8 +178,7 @@ public class CreateReplaceOutputDatasetBuilder
           version -> DatasetVersionUtils.buildVersionOutputFacets(context, builder, version));
     }
 
-    CatalogUtils3.getStorageDatasetFacet(context, catalog, tableProperties)
-        .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
+    CatalogUtils3.addStorageAndCatalogFacets(context, catalog, tableProperties, builder);
     return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
   }
 


### PR DESCRIPTION


Closes: #3833


> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project