### PR TITLE
more resiliency for missing dbt nodes

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -7,12 +7,14 @@ import subprocess
 import sys
 import time
 from collections import defaultdict
-from functools import cached_property
-from typing import Dict, Generator, List, Optional, TextIO
+from functools import cached_property, wraps
+from typing import Any, Dict, Generator, List, Optional, TextIO
 
 from openlineage.client.event_v2 import Dataset, RunEvent, RunState
 from openlineage.client.facet_v2 import (
-    data_quality_assertions_dataset,
+    data_quality_assertions_dataset as dq,
+)
+from openlineage.client.facet_v2 import (
     error_message_run,
     job_type_job,
     processing_engine_run,
@@ -48,6 +50,26 @@ from openlineage.common.utils import (
     get_from_nullable_chain,
     has_lines,
 )
+
+
+def handle_keyerror(func):
+    """
+    Handle KeyError exceptions when node_id was not found in the dbt manifest.
+    """
+
+    @wraps(func)
+    def wrapper(self, node_id: str, *args, **kwargs):
+        try:
+            return func(self, node_id, *args, **kwargs)
+        except KeyError:
+            self.logger.warning(
+                "Did not find node_id %s in the dbt manifest - did "
+                "the manifest change while the job was executing?",
+                node_id,
+            )
+            return None
+
+    return wrapper
 
 
 class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
@@ -127,6 +149,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             return self._compiled_manifest
         elif os.path.isfile(self.manifest_path):
             self._compiled_manifest = self.load_metadata(self.manifest_path, list(range(2, 13)), self.logger)
+            self._validate_manifest_integrity()
             return self._compiled_manifest
         else:
             return {}
@@ -292,7 +315,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             self.node_to_dataset(node=model_input, has_facets=True)
             for model_input in self._get_model_inputs(node_unique_id)
         ]
-        outputs = [self.node_to_output_dataset(node=self._get_model_node(node_unique_id), has_facets=True)]
+        outputs = []
+        if node := self._get_model_node(node_unique_id):
+            outputs = [self.node_to_output_dataset(node=node, has_facets=True)]
 
         return generate_run_event(
             event_type=RunState.START,
@@ -351,25 +376,25 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             self.node_to_dataset(node=model_input, has_facets=True)
             for model_input in self._get_model_inputs(node_unique_id)
         ]
-        outputs = [self.node_to_output_dataset(node=self._get_model_node(node_unique_id), has_facets=True)]
+        outputs = []
+        if node := self._get_model_node(node_unique_id):
+            outputs = [self.node_to_output_dataset(node=node, has_facets=True)]
+
         if resource_type == "test":
             success = node_status == "pass"
-            assertion = self._get_assertion(node_unique_id, success)
-            assertion_facet = data_quality_assertions_dataset.DataQualityAssertionsDatasetFacet(
-                assertions=[assertion]
-            )
-            attached_dataset = self._get_attached_dataset(node_unique_id)
-            inputs = []
-            if attached_dataset:
-                dataset_facets = attached_dataset.facets
-                dataset_facets["dataQualityAssertions"] = assertion_facet
-                inputs = [
-                    Dataset(
-                        name=attached_dataset.name,
-                        namespace=attached_dataset.namespace,
-                        facets=dataset_facets,
-                    )
-                ]
+            if assertion := self._get_assertion(node_unique_id, success):
+                assertion_facet = dq.DataQualityAssertionsDatasetFacet(assertions=[assertion])
+                inputs = []
+                if attached_dataset := self._get_attached_dataset(node_unique_id):
+                    dataset_facets = attached_dataset.facets
+                    dataset_facets["dataQualityAssertions"] = assertion_facet
+                    inputs = [
+                        Dataset(
+                            name=attached_dataset.name,
+                            namespace=attached_dataset.namespace,
+                            facets=dataset_facets,
+                        )
+                    ]
 
         return generate_run_event(
             event_type=event_type,
@@ -383,6 +408,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             outputs=outputs,
         )
 
+    @handle_keyerror
     def _get_attached_dataset(self, test_node_id: str) -> Optional[InputDataset]:
         """
         gets the input the data test is attached to.
@@ -397,10 +423,11 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             input_dataset = self.node_to_dataset(node=attached_model_node, has_facets=True)
         return input_dataset
 
-    def _get_assertion(self, node_id: str, success: bool) -> data_quality_assertions_dataset.Assertion:
+    @handle_keyerror
+    def _get_assertion(self, node_id: str, success: bool) -> Optional[dq.Assertion]:
         manifest_test_node = self.compiled_manifest["nodes"][node_id]
         name = manifest_test_node["test_metadata"]["name"]
-        return data_quality_assertions_dataset.Assertion(
+        return dq.Assertion(
             assertion=name,
             success=success,
             column=get_from_nullable_chain(manifest_test_node["test_metadata"], ["kwargs", "column_name"]),
@@ -715,7 +742,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         while self._dbt_log_file.readlines():
             pass
 
-    def _get_model_node(self, node_id) -> ModelNode:
+    @handle_keyerror
+    def _get_model_node(self, node_id) -> Optional[ModelNode]:
         """
         Builds a ModelNode of a given node_id
         """
@@ -731,19 +759,88 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         if node_id in self.node_id_to_inputs:
             return self.node_id_to_inputs[node_id]
 
-        input_node_ids = self.compiled_manifest["parent_map"][node_id]
-        inputs = [self._get_model_node(input_node_id) for input_node_id in input_node_ids]
-        self.node_id_to_inputs[node_id] = inputs
+        try:
+            input_node_ids = self.compiled_manifest["parent_map"][node_id]
+            inputs = [node for n in input_node_ids if (node := self._get_model_node(n)) is not None]
+            self.node_id_to_inputs[node_id] = inputs
+            return inputs
+        except KeyError:
+            self.logger.warning(
+                "Did not find node_id %s in the dbt manifest - did "
+                "the manifest change while the job was executing?",
+                node_id,
+            )
+        return []
 
-        return inputs
+    def _validate_manifest_integrity(self) -> dict[str, Any]:
+        """
+        Performs metadata integrity checks on the compiled manifest.
 
-    def _get_model_output(self, node_id) -> ModelNode:
-        if node_id in self.node_id_to_output:
-            return self.node_id_to_output[node_id]
-        model_node = self._get_model_node(node_id)
-        self.node_id_to_output[node_id] = model_node
+        Validates that all nodes referenced in parent_map exist in the manifest's
+        node definitions (either in 'nodes' or 'sources' sections).
 
-        return model_node
+        Returns:
+            dict: Validation results containing:
+                - 'is_valid': bool indicating if manifest is valid
+                - 'missing_nodes': list of node IDs that are missing
+                - 'missing_parents': list of parent node IDs that are missing
+                - 'missing_children': list of child node IDs that are missing
+                - 'total_missing': total count of missing nodes
+                - 'parent_map_size': total number of entries in parent_map
+                - 'available_nodes': total number of available nodes (nodes + sources)
+        """
+        if not self._compiled_manifest:
+            return {
+                "is_valid": True,
+                "missing_nodes": [],
+                "missing_parents": [],
+                "missing_children": [],
+                "total_missing": 0,
+                "parent_map_size": 0,
+                "available_nodes": 0,
+            }
+
+        parent_map = self._compiled_manifest.get("parent_map", {})
+        all_nodes = {**self._compiled_manifest.get("nodes", {}), **self._compiled_manifest.get("sources", {})}
+
+        missing_nodes = []
+        missing_parents = []
+        missing_children = []
+
+        for parent_node_id, child_node_ids in parent_map.items():
+            # Check that the parent node exists
+            if parent_node_id not in all_nodes:
+                missing_nodes.append(parent_node_id)
+                missing_parents.append(parent_node_id)
+
+            # Check that all child nodes exist
+            for child_node_id in child_node_ids:
+                if child_node_id not in all_nodes:
+                    missing_nodes.append(child_node_id)
+                    missing_children.append(child_node_id)
+
+        # Remove duplicates while preserving order
+        missing_nodes = list(dict.fromkeys(missing_nodes))
+        missing_parents = list(dict.fromkeys(missing_parents))
+        missing_children = list(dict.fromkeys(missing_children))
+
+        if missing_nodes:
+            self.logger.warning(
+                "Manifest integrity check failed: Found %d nodes in parent_map that don't exist "
+                "in manifest node definitions: %s",
+                len(missing_nodes),
+                missing_nodes[:10],  # Log first 10 to avoid overwhelming logs
+            )
+
+        return {
+            "is_valid": len(missing_nodes) == 0,
+            "missing_nodes": missing_nodes,
+            "missing_parents": missing_parents,
+            "missing_children": missing_children,
+            "total_missing": len(missing_nodes),
+            "parent_map_size": len(parent_map),
+            "available_nodes": len(all_nodes),
+        }
 
     def get_dbt_metadata(
         self,

--- a/integration/common/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/openlineage/common/provider/dbt/utils.py
@@ -103,6 +103,14 @@ def get_dbt_log_path(command: List[str]) -> str:
     return os.path.join(log_dirname, "dbt.log")
 
 
+def is_random_logfile(command: List[str]) -> bool:
+    from_command = parse_single_arg(command, ["--log-path"], default=None)
+    from_env_var = os.getenv("DBT_LOG_PATH")
+    if from_env_var or from_command:
+        return False
+    return True
+
+
 def generate_random_log_file_name() -> str:
     random_uuid = str(uuid.uuid4())
     log_directory_name = f"dbt-logs-{random_uuid}"

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -186,7 +186,6 @@ def consume_structured_logs(
         "This wrapper is using --consume-structured-logs: will send OpenLineage "
         "events while the models are executing."
     )
-    dbt_integration_return_code = 0
     job_namespace = os.environ.get("OPENLINEAGE_NAMESPACE", "dbt")
     dbt_command_line = remove_command_line_option(sys.argv, CONSUME_STRUCTURED_LOGS_COMMAND_OPTION)
     dbt_command_line = ["dbt"] + dbt_command_line[1:]
@@ -223,13 +222,17 @@ def consume_structured_logs(
         logger.debug("Waiting for events to be sent.")
     except UnsupportedDbtCommand as e:
         logger.error(e)
-        dbt_integration_return_code = 1
+    except Exception:
+        logger.exception(
+            "OpenLineage failed to process dbt execution. This does not make dbt execution "
+            "fail, however, data might not end up in your configured lineage backend."
+        )
     finally:
         client.close(timeout=30.0)
 
     logger.info("Emitted %d OpenLineage events", emitted_events)
     logger.info("Underlying dbt execution returned %d", processor.dbt_command_return_code)
-    return processor.dbt_command_return_code or dbt_integration_return_code
+    return processor.dbt_command_return_code
 
 
 def consume_local_artifacts(


### PR DESCRIPTION
There is an intermittent issue in an environment where the dbt manifest gets somehow corrupted or out of sync with currently running job and has missing dbt nodes. It causes the dbt integration to fail with KeyError.

This has a negative impact on the underlying job execution - so we can't really "fix" it, but we should still emit the events about the job - even if the inputs/outputs are incomplete, we still can capture the error.

Additionally, we add "manifest integrity validation" mechanism, where on start we check if the manifest is healthy, and log the results if it's not. This allows users to have upfront information about that type of error.