### PR TITLE
[Python] Implement KafkaTransport.wait_for_completion() and .close()

### DIFF
--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -22,7 +22,7 @@ from openlineage.client.serde import Serde
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 
 if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
+    from pytest_kafka_transport_mock import MockerFixture
 
 
 @pytest.fixture
@@ -142,7 +142,7 @@ def job_event_v2() -> JobEvent:
     )
 
 
-def test_kafka_loads_full_config() -> None:
+def test_kafka_transport_loads_full_config() -> None:
     config = KafkaConfig.from_dict(
         {
             "type": "kafka",
@@ -159,7 +159,7 @@ def test_kafka_loads_full_config() -> None:
     assert config.flush is False
 
 
-def test_kafka_loads_partial_config_with_defaults() -> None:
+def test_kafka_transport_loads_partial_config_with_defaults() -> None:
     config = KafkaConfig.from_dict(
         {
             "type": "kafka",
@@ -174,7 +174,7 @@ def test_kafka_loads_partial_config_with_defaults() -> None:
     assert config.flush is True
 
 
-def test_kafka_config_accepts_aliased_message_key() -> None:
+def test_kafka_transport_config_accepts_aliased_message_key() -> None:
     config = KafkaConfig.from_dict(
         {
             "type": "kafka",
@@ -190,7 +190,7 @@ def test_kafka_config_accepts_aliased_message_key() -> None:
     assert config.flush is True
 
 
-def test_kafka_load_config_fails_on_no_config() -> None:
+def test_kafka_transport_load_config_fails_on_no_config() -> None:
     with pytest.raises(TypeError):
         KafkaConfig.from_dict(
             {
@@ -200,7 +200,214 @@ def test_kafka_load_config_fails_on_no_config() -> None:
         )
 
 
-def test_client_with_kafka_transport_emits_run_event(
+def test_kafka_transport_emits_run_event(
+    run_event: RunEvent,
+    run_event_v2: event_v2.RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+
+    for event in [run_event, run_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="run:test-namespace/test-job",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_run_event_with_parent(
+    run_event_with_parent: RunEvent,
+    run_event_with_parent_v2: event_v2.RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+
+    for event in [run_event_with_parent, run_event_with_parent_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="run:parent-namespace/parent-job",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_run_event_with_root_parent(
+    run_event_with_root_parent_v2: event_v2.RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+    transport = KafkaTransport(config)
+
+    client = OpenLineageClient(transport=transport)
+
+    client.emit(run_event_with_root_parent_v2)
+    transport.producer.produce.assert_called_once_with(
+        topic="random-topic",
+        key="run:root-namespace/root-job",
+        value=Serde.to_json(run_event_with_root_parent_v2).encode("utf-8"),
+        on_delivery=ANY,
+    )
+    transport.producer.flush.assert_called_once()
+
+
+def test_kafka_transport_emits_run_event_with_explicit_message_key(
+    run_event: RunEvent,
+    run_event_v2: event_v2.RunEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+    )
+
+    for event in [run_event, run_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="explicit-key",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_job_event(
+    job_event: JobEvent,
+    job_event_v2: event_v2.JobEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+
+    for event in [job_event, job_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="job:test-namespace/test-job",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_job_event_with_explicit_message_key(
+    job_event: JobEvent,
+    job_event_v2: event_v2.JobEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+    )
+    for event in [job_event, job_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="explicit-key",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_dataset_event(
+    dataset_event: DatasetEvent,
+    dataset_event_v2: event_v2.DatasetEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+
+    for event in [dataset_event, dataset_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="dataset:test-namespace/test-dataset",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_dataset_event_explicit_message_key(
+    dataset_event: DatasetEvent,
+    dataset_event_v2: event_v2.DatasetEvent,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("confluent_kafka.Producer")
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+        messageKey="explicit-key",
+    )
+
+    for event in [dataset_event, dataset_event_v2]:
+        transport = KafkaTransport(config)
+
+        client = OpenLineageClient(transport=transport)
+
+        client.emit(event)
+        transport.producer.produce.assert_called_once_with(
+            topic="random-topic",
+            key="explicit-key",
+            value=Serde.to_json(event).encode("utf-8"),
+            on_delivery=ANY,
+        )
+        transport.producer.reset_mock()
+
+
+def test_kafka_transport_emits_run_event_with_flush(
     run_event: RunEvent,
     run_event_v2: event_v2.RunEvent,
     mocker: MockerFixture,
@@ -228,59 +435,7 @@ def test_client_with_kafka_transport_emits_run_event(
         transport.producer.reset_mock()
 
 
-def test_client_with_kafka_transport_emits_run_event_with_parent(
-    run_event_with_parent: RunEvent,
-    run_event_with_parent_v2: event_v2.RunEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        flush=True,
-    )
-
-    for event in [run_event_with_parent, run_event_with_parent_v2]:
-        transport = KafkaTransport(config)
-
-        client = OpenLineageClient(transport=transport)
-
-        client.emit(event)
-        transport.producer.produce.assert_called_once_with(
-            topic="random-topic",
-            key="run:parent-namespace/parent-job",
-            value=Serde.to_json(event).encode("utf-8"),
-            on_delivery=ANY,
-        )
-        transport.producer.flush.assert_called_once()
-        transport.producer.reset_mock()
-
-
-def test_client_with_kafka_transport_emits_run_event_with_root_parent(
-    run_event_with_root_parent_v2: event_v2.RunEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        flush=True,
-    )
-    transport = KafkaTransport(config)
-
-    client = OpenLineageClient(transport=transport)
-
-    client.emit(run_event_with_root_parent_v2)
-    transport.producer.produce.assert_called_once_with(
-        topic="random-topic",
-        key="run:root-namespace/root-job",
-        value=Serde.to_json(run_event_with_root_parent_v2).encode("utf-8"),
-        on_delivery=ANY,
-    )
-    transport.producer.flush.assert_called_once()
-
-
-def test_client_with_kafka_transport_emits_run_event_with_explicit_message_key(
+def test_kafka_transport_emits_run_event_without_flush(
     run_event: RunEvent,
     run_event_v2: event_v2.RunEvent,
     mocker: MockerFixture,
@@ -289,8 +444,7 @@ def test_client_with_kafka_transport_emits_run_event_with_explicit_message_key(
     config = KafkaConfig(
         config={"bootstrap.servers": "localhost:9092"},
         topic="random-topic",
-        messageKey="explicit-key",
-        flush=True,
+        flush=False,
     )
 
     for event in [run_event, run_event_v2]:
@@ -301,128 +455,15 @@ def test_client_with_kafka_transport_emits_run_event_with_explicit_message_key(
         client.emit(event)
         transport.producer.produce.assert_called_once_with(
             topic="random-topic",
-            key="explicit-key",
+            key="run:test-namespace/test-job",
             value=Serde.to_json(event).encode("utf-8"),
             on_delivery=ANY,
         )
-        transport.producer.flush.assert_called_once()
+        transport.producer.flush.assert_not_called()
         transport.producer.reset_mock()
 
 
-def test_client_with_kafka_transport_emits_job_event(
-    job_event: JobEvent,
-    job_event_v2: event_v2.JobEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        flush=True,
-    )
-
-    for event in [job_event, job_event_v2]:
-        transport = KafkaTransport(config)
-
-        client = OpenLineageClient(transport=transport)
-
-        client.emit(event)
-        transport.producer.produce.assert_called_once_with(
-            topic="random-topic",
-            key="job:test-namespace/test-job",
-            value=Serde.to_json(event).encode("utf-8"),
-            on_delivery=ANY,
-        )
-        transport.producer.flush.assert_called_once()
-        transport.producer.reset_mock()
-
-
-def test_client_with_kafka_transport_emits_job_event_with_explicit_message_key(
-    job_event: JobEvent,
-    job_event_v2: event_v2.JobEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        messageKey="explicit-key",
-        flush=True,
-    )
-    for event in [job_event, job_event_v2]:
-        transport = KafkaTransport(config)
-
-        client = OpenLineageClient(transport=transport)
-
-        client.emit(event)
-        transport.producer.produce.assert_called_once_with(
-            topic="random-topic",
-            key="explicit-key",
-            value=Serde.to_json(event).encode("utf-8"),
-            on_delivery=ANY,
-        )
-        transport.producer.flush.assert_called_once()
-        transport.producer.reset_mock()
-
-
-def test_client_with_kafka_transport_emits_dataset_event(
-    dataset_event: DatasetEvent,
-    dataset_event_v2: event_v2.DatasetEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        flush=True,
-    )
-
-    for event in [dataset_event, dataset_event_v2]:
-        transport = KafkaTransport(config)
-
-        client = OpenLineageClient(transport=transport)
-
-        client.emit(event)
-        transport.producer.produce.assert_called_once_with(
-            topic="random-topic",
-            key="dataset:test-namespace/test-dataset",
-            value=Serde.to_json(event).encode("utf-8"),
-            on_delivery=ANY,
-        )
-        transport.producer.flush.assert_called_once()
-        transport.producer.reset_mock()
-
-
-def test_client_with_kafka_transport_emits_dataset_event_explicit_message_key(
-    dataset_event: DatasetEvent,
-    dataset_event_v2: event_v2.DatasetEvent,
-    mocker: MockerFixture,
-) -> None:
-    mocker.patch("confluent_kafka.Producer")
-    config = KafkaConfig(
-        config={"bootstrap.servers": "localhost:9092"},
-        topic="random-topic",
-        messageKey="explicit-key",
-        flush=True,
-    )
-
-    for event in [dataset_event, dataset_event_v2]:
-        transport = KafkaTransport(config)
-
-        client = OpenLineageClient(transport=transport)
-
-        client.emit(event)
-        transport.producer.produce.assert_called_once_with(
-            topic="random-topic",
-            key="explicit-key",
-            value=Serde.to_json(event).encode("utf-8"),
-            on_delivery=ANY,
-        )
-        transport.producer.flush.assert_called_once()
-        transport.producer.reset_mock()
-
-
-def test_airflow_sqlalchemy_constructs_producer_each_call(
+def test_kafka_transport_airflow_sqlalchemy_constructs_producer_each_call(
     run_event: RunEvent,
     run_event_v2: event_v2.RunEvent,
     mocker: MockerFixture,
@@ -432,24 +473,32 @@ def test_airflow_sqlalchemy_constructs_producer_each_call(
         return_value=True,
     )
     mock = mocker.patch("confluent_kafka.Producer")
+    mock_producer = mock.return_value
+    mock_producer.flush.return_value = 0
 
     for event in [run_event, run_event_v2]:
         config = KafkaConfig(
             config={"bootstrap.servers": "localhost:9092"},
             topic="random-topic",
-            flush=True,
         )
         transport = KafkaTransport(config)
+        # producer wasn't created in constructor
+        assert transport.producer is None
 
         client = OpenLineageClient(transport=transport)
 
         client.emit(event)
         client.emit(event)
+
+        # producer was removed in .close(), and then created again
         mock.assert_has_calls([call(config.config), call(config.config)], any_order=True)
+        mock_producer.flush.assert_has_calls([call(timeout=-1), call(timeout=-1)], any_order=True)
+        assert transport.producer is None
+
         mock.reset_mock()
 
 
-def test_airflow_direct_constructs_producer_once(
+def test_kafka_transport_airflow_direct_constructs_producer_once(
     run_event: RunEvent,
     run_event_v2: event_v2.RunEvent,
     mocker: MockerFixture,
@@ -459,19 +508,45 @@ def test_airflow_direct_constructs_producer_once(
         return_value=False,
     )
     mock = mocker.patch("confluent_kafka.Producer")
+    mock.return_value.flush.return_value = 0
+
     config = KafkaConfig(
         config={"bootstrap.servers": "localhost:9092"},
         topic="random-topic",
-        flush=True,
     )
 
     for event in [run_event, run_event_v2]:
         transport = KafkaTransport(config)
+        producer1 = transport.producer
+        # producer is just created
+        assert producer1 is not None
 
         client = OpenLineageClient(transport=transport)
 
         client.emit(event)
         client.emit(event)
 
+        # producer is reused
         mock.assert_called_once_with(config.config)
         mock.reset_mock()
+
+        producer2 = transport.producer
+        assert producer2 is not None
+        assert producer1 is producer2
+
+
+def test_kafka_transport_close(mocker: MockerFixture) -> None:
+    mock = mocker.patch("confluent_kafka.Producer")
+    mock_producer = mock.return_value
+    mock_producer.flush.return_value = 0
+
+    config = KafkaConfig(
+        config={"bootstrap.servers": "localhost:9092"},
+        topic="random-topic",
+    )
+
+    transport = KafkaTransport(config)
+    transport.close()
+
+    mock_producer.flush.assert_called_once_with(timeout=-1)
+    assert transport.producer is None


### PR DESCRIPTION
### Problem

Related: #3771 and #3812.

### Solution

#3812 introduces new methods within Transport base class:
```python
class Transport:
  def wait_for_completion(self, timeout: float = -1): ...

  def close(self): ...
```

This PR brings implementation for KafkaTransport.

#### One-line summary:

[Python] Implement `KafkaTransport.wait_for_completion()` and `.close()` methods

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project