### PR TITLE
[Java] Cover OpenLineageClient.close() with tests

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClient.java
@@ -153,19 +153,26 @@ public final class OpenLineageClient implements AutoCloseable {
             "openlineage.emit.time", "openlineage.transport", transport.getClass().getName());
   }
 
+  /** Shutdown the underlying transport, waiting for all events to complete. */
+  @Override
+  public void close() throws Exception {
+    try {
+      transport.close();
+    } catch (Exception e) {
+      throw new OpenLineageClientException("Failed to close transport " + transport, e);
+    } finally {
+      circuitBreaker.ifPresent(CircuitBreaker::close);
+      meterRegistry.close();
+      OpenLineageClientUtils.getExecutor().ifPresent(ExecutorService::shutdown);
+    }
+  }
+
   /**
    * @return an new {@link OpenLineageClient.Builder} object for building {@link
    *     OpenLineageClient}s.
    */
   public static Builder builder() {
     return new Builder();
-  }
-
-  @Override
-  public void close() throws Exception {
-    transport.close();
-    meterRegistry.close();
-    OpenLineageClientUtils.getExecutor().ifPresent(ExecutorService::shutdown);
   }
 
   /**

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -349,7 +349,7 @@ public final class OpenLineageClientUtils {
   }
 
   public static ExecutorService getOrCreateExecutor() {
-    if (EXECUTOR == null) {
+    if (EXECUTOR == null || EXECUTOR.isShutdown()) {
       EXECUTOR = Executors.newCachedThreadPool();
     }
     return EXECUTOR;


### PR DESCRIPTION
### Problem

### Solution

Cover `OpenLineageClient.close()` with unit tests. Also change logic a bit:
* I f transport fails to close, do not left `circuitBreaker`, `meterRegistry` and default ExecutorService unclosed.
* Shared `ExecutorService` can be shut down safely, and next instance of `OpenLineageClient` will use a new one.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project