### PR TITLE
[Python] Reuse requests.Session() in sync HttpTransport

### DIFF
--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -158,13 +158,11 @@ class HttpTransport(Transport):
                 raise ValueError(msg)
         self.url = url
         self.endpoint = config.endpoint
-        self.session = None
-        if config.session:
-            self.session = config.session
-            self._prepare_session(self.session)
         self.timeout = config.timeout
         self.verify = config.verify
         self.compression = config.compression
+        self._session: Session | None = None
+        self.session = config.session  # type: ignore[assignment]
 
     def emit(self, event: Event) -> Response:
         # If anyone overrides debuglevel manually, we can potentially leak secrets to logs.
@@ -173,28 +171,36 @@ class HttpTransport(Transport):
         http_client.HTTPConnection.debuglevel = 0
         body, headers = self._prepare_request(Serde.to_json(event))
 
-        if self.session:
-            resp = self.session.post(
-                url=urljoin(self.url, self.endpoint),
-                data=body,
-                headers=headers,
-                timeout=self.timeout,
-                verify=self.verify,
-            )
-        else:
-            with Session() as session:
-                self._prepare_session(session)
-                resp = session.post(
-                    url=urljoin(self.url, self.endpoint),
-                    data=body,
-                    headers=headers,
-                    timeout=self.timeout,
-                    verify=self.verify,
-                )
-            resp.close()
+        resp = self.session.post(
+            url=urljoin(self.url, self.endpoint),
+            data=body,
+            headers=headers,
+            timeout=self.timeout,
+            verify=self.verify,
+        )
+        resp.close()
         http_client.HTTPConnection.debuglevel = prev_debuglevel
         resp.raise_for_status()
         return resp
+
+    @property
+    def session(self) -> Session:
+        if not self._session:
+            self._session = Session()
+            self._prepare_session(self._session)
+        return self._session
+
+    @session.setter
+    def session(self, value: Session | None) -> None:
+        if value:
+            self._prepare_session(value)
+        self._session = value
+
+    def close(self, timeout: float = -1) -> bool:
+        if self._session:
+            self._session.close()
+            self._session = None
+        return True
 
     def _auth_headers(self, token_provider: TokenProvider) -> dict:  # type: ignore[type-arg]
         bearer = token_provider.get_bearer()

--- a/client/python/tests/conftest.py
+++ b/client/python/tests/conftest.py
@@ -349,8 +349,7 @@ def mock_http_session_class(mock_http_session):
 
     with patch("openlineage.client.transport.http.Session") as mock_session_class:
         # Configure the context manager
-        mock_session_class.return_value.__enter__.return_value = mock_client
-        mock_session_class.return_value.__exit__.return_value = None
+        mock_session_class.return_value = mock_client
         yield mock_session_class, mock_client, mock_response
 
 
@@ -361,6 +360,5 @@ def mock_async_http_client_class(mock_http_session):
 
     with patch("httpx.AsyncClient") as mock_client_class:
         # Configure the async context manager
-        mock_client_class.return_value.__aenter__.return_value = mock_client
-        mock_client_class.return_value.__aexit__.return_value = None
+        mock_client_class.return_value = mock_client
         yield mock_client_class, mock_client, mock_response

--- a/client/python/tests/test_facet_v2.py
+++ b/client/python/tests/test_facet_v2.py
@@ -49,15 +49,8 @@ def test_optional_attributed_not_validated():
     nominal_time_run.NominalTimeRunFacet(nominalStartTime="2020-12-17T03:00:00.001Z")
 
 
-@mock.patch("openlineage.client.transport.http.Session")
-def test_custom_facet(mock_client_class, test_producer) -> None:
-    # Mock the context manager and post method
-    mock_client = mock.MagicMock()
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 200
-    mock_client.post.return_value = mock_response
-    mock_client_class.return_value.__enter__.return_value = mock_client
-    mock_client_class.return_value.__exit__.return_value = None
+def test_custom_facet(mock_http_session_class, test_producer) -> None:
+    mock_session_class, mock_client, mock_response = mock_http_session_class
 
     client = OpenLineageClient(url="http://example.com")
 
@@ -114,15 +107,8 @@ def test_custom_facet(mock_client_class, test_producer) -> None:
     assert expected_event == event_sent
 
 
-@mock.patch("openlineage.client.transport.http.Session")
-def test_full_core_event_serializes_properly(mock_client_class) -> None:
-    # Mock the context manager and post method
-    mock_client = mock.MagicMock()
-    mock_response = mock.MagicMock()
-    mock_response.status_code = 200
-    mock_client.post.return_value = mock_response
-    mock_client_class.return_value.__enter__.return_value = mock_client
-    mock_client_class.return_value.__exit__.return_value = None
+def test_full_core_event_serializes_properly(mock_http_session_class) -> None:
+    mock_session_class, mock_client, mock_response = mock_http_session_class
 
     client = OpenLineageClient(url="http://example.com")
 


### PR DESCRIPTION
### Problem

For now, Python implementation of `HttpTransport` creates new `requests.Session()` fo every call. This is both slow and doesn't allow auth using session cookies.

### Solution

#### One-line summary:

[Python] Reuse `requests.Session()` in sync HttpTransport

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project