### PR TITLE
[Spark] Include spark_applicationDetails facet to all START events

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/OpenLineageSparkListenerTest.java
@@ -70,6 +70,7 @@ class OpenLineageSparkListenerTest {
   void setup() {
     when(sparkSession.sparkContext()).thenReturn(sparkContext);
     when(sparkContext.appName()).thenReturn("appName");
+    when(sparkContext.applicationId()).thenReturn("application_123_234");
     when(sparkContext.getConf()).thenReturn(new SparkConf());
     when(plan.sparkContext()).thenReturn(sparkContext);
     when(plan.nodeName()).thenReturn("execute");
@@ -176,9 +177,6 @@ class OpenLineageSparkListenerTest {
   void testSparkSQLEndGetsQueryExecutionFromEvent() {
     LogicalPlan query = UnresolvedRelation$.MODULE$.apply(TableIdentifier.apply("tableName"));
 
-    when(sparkSession.sparkContext()).thenReturn(sparkContext);
-    when(sparkContext.appName()).thenReturn("appName");
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
     when(qe.optimizedPlan())
         .thenReturn(
             new InsertIntoHadoopFsRelationCommand(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkGenericIntegrationTest.java
@@ -180,14 +180,10 @@ class SparkGenericIntegrationTest {
               return event.getJob().getFacets().getJobType() != null;
             });
 
-    // Only Spark application START events have spark_applicationDetails facet
+    // Only START events have spark_applicationDetails facet
     assertThat(
             events.stream()
-                .filter(
-                    event ->
-                        event.getEventType() == RunEvent.EventType.START
-                            && event.getJob().getFacets().getJobType().getJobType()
-                                == "APPLICATION")
+                .filter(event -> event.getEventType() == RunEvent.EventType.START)
                 .collect(Collectors.toList()))
         .allMatch(
             event -> {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilder.java
@@ -12,13 +12,16 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 
 /**
  * {@link CustomFacetBuilder} that adds the {@link SparkApplicationDetailsFacet} to a run. This
- * facet is generated for every {@link SparkListenerApplicationStart}.
+ * facet is generated for every {@link SparkListenerEvent}.
  */
 public class SparkApplicationDetailsFacetBuilder
-    extends CustomFacetBuilder<SparkListenerApplicationStart, SparkApplicationDetailsFacet> {
+    extends CustomFacetBuilder<SparkListenerEvent, SparkApplicationDetailsFacet> {
 
   private Optional<SparkContext> sparkContext;
 
@@ -28,8 +31,12 @@ public class SparkApplicationDetailsFacetBuilder
 
   @Override
   protected void build(
-      SparkListenerApplicationStart event,
-      BiConsumer<String, ? super SparkApplicationDetailsFacet> consumer) {
+      SparkListenerEvent event, BiConsumer<String, ? super SparkApplicationDetailsFacet> consumer) {
+    if (!(event instanceof SparkListenerApplicationStart
+        || event instanceof SparkListenerJobStart
+        || event instanceof SparkListenerSQLExecutionStart)) {
+      return;
+    }
     sparkContext.ifPresent(
         context ->
             consumer.accept("spark_applicationDetails", new SparkApplicationDetailsFacet(context)));

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/builder/SparkApplicationDetailsFacetBuilderTest.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import scala.Option;
@@ -59,8 +61,10 @@ class SparkApplicationDetailsFacetBuilderTest {
   }
 
   @Test
-  void testIsDefinedForSparkListenerApplicationStartEvent() {
+  void testIsDefinedForSparkListenerEvent() {
     assertThat(builder.isDefinedAt(mock(SparkListenerApplicationStart.class))).isTrue();
+    assertThat(builder.isDefinedAt(mock(SparkListenerSQLExecutionStart.class))).isTrue();
+    assertThat(builder.isDefinedAt(mock(SparkListenerJobStart.class))).isTrue();
   }
 
   @Test


### PR DESCRIPTION
### Problem

Partially solves #3846

`spark_applicationDetails` facet is included only to events emitted for `SparkListenerApplicationStart` event. But in some environment (e.g. `spark.master=yarn`) this event could be emitted without `sparkContext` being set, so facet was never included.

### Solution

#### One-line summary:

[Spark] Include `spark_applicationDetails` facet to all START events

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project