### PR TITLE
[Airflow] Send pending events after Airflow DAG is finished

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -80,7 +80,7 @@ class OpenLineageAdapter:
     @property
     def client(self) -> OpenLineageClient:
         if not self._client:
-            self._client = OpenLineageAdapter.get_or_create_openlineage_client()
+            self._client = self.get_or_create_openlineage_client()
         return self._client
 
     @staticmethod
@@ -115,6 +115,11 @@ class OpenLineageAdapter:
             Stats.incr("ol.emit.failed")
             log.exception(f"Failed to emit OpenLineage event of id {event.run.runId}")
             log.debug(e)
+
+    def close(self, timeout: float = -1) -> bool:
+        if self._client:
+            return self._client.close(timeout)
+        return True
 
     def start_task(
         self,

--- a/integration/airflow/openlineage/airflow/listener.py
+++ b/integration/airflow/openlineage/airflow/listener.py
@@ -243,7 +243,11 @@ def on_starting(component):
 
 @hookimpl
 def before_stopping(component):
-    executor.shutdown(wait=False)
+    if executor:
+        # stom accepting new events
+        executor.shutdown(wait=False)
+    # block until all pending events are processed
+    adapter.close()
 
 
 @hookimpl

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -200,7 +200,7 @@ def consume_structured_logs(
         models=models,
         selector=model_selector,
     )
-    logger.info(f"dbt-ol will read logs from {processor.dbt_log_file_path}")
+    logger.info("dbt-ol will read logs from %s", processor.dbt_log_file_path)
     client = OpenLineageClient()
     emitted_events = 0
     try:
@@ -209,7 +209,7 @@ def consume_structured_logs(
                 client.emit(event)
                 emitted_events += 1
                 if emitted_events % 50 == 0:
-                    logger.debug(f"Processed {emitted_events} events")
+                    logger.debug("Processed %d events", emitted_events)
             except Exception as e:
                 logger.warning(
                     "OpenLineage client failed to emit event %s runId %s. Exception: %s",
@@ -218,8 +218,6 @@ def consume_structured_logs(
                     e,
                     exc_info=True,
                 )
-        # Will wait for async events to be sent if async config is enabled\
-        logger.debug("Waiting for events to be sent.")
     except UnsupportedDbtCommand as e:
         logger.error(e)
     except Exception:
@@ -228,7 +226,9 @@ def consume_structured_logs(
             "fail, however, data might not end up in your configured lineage backend."
         )
     finally:
-        client.close(timeout=30.0)
+        # Will wait for async events to be sent if async config is enabled
+        logger.debug("Waiting for events to be sent.")
+        client.close()
 
     logger.info("Emitted %d OpenLineage events", emitted_events)
     logger.info("Underlying dbt execution returned %d", processor.dbt_command_return_code)


### PR DESCRIPTION
### Problem

Related: #3771 and #3812.

### Solution

* Call `OpenLineageClient.close()` after DAG is finished.
* Remove timeout from dbt `client.close()` to wait until all events are send.

#### One-line summary:

[Airflow] Send pending events after Airflow DAG is finished

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project