### PR TITLE
[SPARK] Support additional to Catalog facets

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/DropTableVisitor.java
@@ -53,7 +53,9 @@ public class DropTableVisitor extends QueryPlanVisitor<DropTable, OpenLineage.Ou
     if (di.isPresent()) {
       DatasetCompositeFacetsBuilder builder = outputDataset().createCompositeFacetBuilder();
       CatalogUtils3.getCatalogDatasetFacet(context, tableCatalog, tableProperties)
-          .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
+          .ifPresent(
+              catalogDatasetFacet ->
+                  builder.getFacets().catalog(catalogDatasetFacet.getCatalogDatasetFacet()));
       builder
           .getFacets()
           .schema(PlanUtils.schemaFacet(context.getOpenLineage(), resolvedTable.schema()));

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogHandler.java
@@ -7,13 +7,36 @@ package io.openlineage.spark3.agent.lifecycle.plan.catalog;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import lombok.Getter;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 public interface CatalogHandler {
+
+  @Getter
+  class CatalogWithAdditionalFacets {
+
+    private final OpenLineage.CatalogDatasetFacet catalogDatasetFacet;
+    private final Map<String, OpenLineage.DatasetFacet> additionalFacets = new HashMap<>();
+
+    private CatalogWithAdditionalFacets(OpenLineage.CatalogDatasetFacet catalogDatasetFacet) {
+      this.catalogDatasetFacet = catalogDatasetFacet;
+    }
+
+    public void addFacet(String key, OpenLineage.DatasetFacet facet) {
+      additionalFacets.put(key, facet);
+    }
+
+    public static CatalogWithAdditionalFacets of(
+        OpenLineage.CatalogDatasetFacet catalogDatasetFacet) {
+      return new CatalogWithAdditionalFacets(catalogDatasetFacet);
+    }
+  }
+
   boolean hasClasses();
 
   boolean isClass(TableCatalog tableCatalog);
@@ -29,7 +52,7 @@ public interface CatalogHandler {
     return Optional.empty();
   }
 
-  default Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  default Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     return Optional.empty();
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/CatalogUtils3.java
@@ -101,7 +101,13 @@ public class CatalogUtils3 {
     CatalogUtils3.getStorageDatasetFacet(context, catalog, properties)
         .map(storageDatasetFacet -> builder.getFacets().storage(storageDatasetFacet));
     CatalogUtils3.getCatalogDatasetFacet(context, catalog, properties)
-        .ifPresent(catalogDatasetFacet -> builder.getFacets().catalog(catalogDatasetFacet));
+        .ifPresent(
+            catalogDatasetFacet -> {
+              builder.getFacets().catalog(catalogDatasetFacet.getCatalogDatasetFacet());
+              catalogDatasetFacet
+                  .getAdditionalFacets()
+                  .forEach((k, v) -> builder.getFacets().put(k, v));
+            });
   }
 
   public static Optional<OpenLineage.StorageDatasetFacet> getStorageDatasetFacet(
@@ -112,7 +118,7 @@ public class CatalogUtils3 {
         : Optional.empty();
   }
 
-  public static Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public static Optional<CatalogHandler.CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       OpenLineageContext context, TableCatalog catalog, Map<String, String> properties) {
     Optional<CatalogHandler> catalogHandler = getCatalogHandler(context, catalog);
     return catalogHandler.isPresent()

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksDeltaHandler.java
@@ -36,7 +36,7 @@ public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
   }
 
   @Override
-  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     OpenLineage.CatalogDatasetFacetBuilder builder =
         context
@@ -47,7 +47,7 @@ public class DatabricksDeltaHandler extends AbstractDatabricksHandler {
             .type(DELTA)
             .source("spark");
 
-    return Optional.of(builder.build());
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DatabricksUnityV2Handler.java
@@ -35,7 +35,7 @@ public class DatabricksUnityV2Handler extends AbstractDatabricksHandler {
   }
 
   @Override
-  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     OpenLineage.CatalogDatasetFacetBuilder builder =
         context
@@ -46,7 +46,7 @@ public class DatabricksUnityV2Handler extends AbstractDatabricksHandler {
             .type("unity")
             .source("spark");
 
-    return Optional.of(builder.build());
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandler.java
@@ -82,7 +82,7 @@ public class DeltaHandler implements CatalogHandler {
   }
 
   @Override
-  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     String name = tableCatalog.name();
     if (name == null || name.isEmpty()) {
@@ -97,7 +97,7 @@ public class DeltaHandler implements CatalogHandler {
             .type(DELTA)
             .source("spark");
 
-    return Optional.of(builder.build());
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandler.java
@@ -71,7 +71,7 @@ public class IcebergHandler implements CatalogHandler {
   }
 
   @Override
-  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     Optional<Map<String, String>> catalogConf =
         context
@@ -106,7 +106,7 @@ public class IcebergHandler implements CatalogHandler {
       builder.metadataUri(catalogUri);
     }
 
-    return Optional.of(builder.build());
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandler.java
@@ -68,7 +68,7 @@ public class JdbcHandler implements CatalogHandler {
   }
 
   @Override
-  public Optional<OpenLineage.CatalogDatasetFacet> getCatalogDatasetFacet(
+  public Optional<CatalogWithAdditionalFacets> getCatalogDatasetFacet(
       TableCatalog tableCatalog, Map<String, String> properties) {
     Optional<JDBCOptions> options = getJdbcOptions(tableCatalog);
 
@@ -83,7 +83,7 @@ public class JdbcHandler implements CatalogHandler {
 
     options.ifPresent(jdbcOptions -> builder.metadataUri(options.get().url()));
 
-    return Optional.of(builder.build());
+    return Optional.of(CatalogWithAdditionalFacets.of(builder.build()));
   }
 
   private Optional<JDBCOptions> getJdbcOptions(TableCatalog tableCatalog) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/DeltaHandlerTest.java
@@ -222,11 +222,11 @@ class DeltaHandlerTest {
     when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
     when(deltaCatalog.name()).thenReturn("name");
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         deltaHandler.getCatalogDatasetFacet(deltaCatalog, Collections.emptyMap());
     assertThat(catalogDatasetFacet.isPresent()).isTrue();
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
     assertThat(facet.getName()).isEqualTo("name");
     assertThat(facet.getFramework()).isEqualTo("delta");
     assertThat(facet.getType()).isEqualTo("delta");

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -438,11 +438,11 @@ class IcebergHandlerTest {
                 "spark.sql.catalog.test.warehouse",
                 "hdfs://namenode:9000/path/to/warehouse"));
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
     assertTrue(catalogDatasetFacet.isPresent());
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
 
     assertEquals("test", facet.getName());
     assertEquals("hadoop", facet.getType());
@@ -460,11 +460,11 @@ class IcebergHandlerTest {
     when(sparkCatalog.name()).thenReturn("test");
     when(runtimeConfig.getAll()).thenReturn(new Map.Map1("spark.sql.catalog.test.type", "hadoop"));
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
     assertTrue(catalogDatasetFacet.isPresent());
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
 
     assertEquals("test", facet.getName());
     assertEquals("hadoop", facet.getType());
@@ -488,11 +488,11 @@ class IcebergHandlerTest {
                 "spark.sql.catalog.test.warehouse",
                 "s3://bucket/path/to/iceberg/warehouse"));
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
     assertTrue(catalogDatasetFacet.isPresent());
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
 
     assertEquals("test", facet.getName());
     assertEquals("jdbc", facet.getType());
@@ -518,11 +518,11 @@ class IcebergHandlerTest {
                 "spark.sql.catalog.bq_metastore_catalog.warehouse",
                 "gcs://bucket/path/to/iceberg/warehouse"));
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
     assertTrue(catalogDatasetFacet.isPresent());
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
 
     assertEquals("bq_metastore_catalog", facet.getName());
     assertEquals("bigquerymetastore", facet.getType());

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/JdbcHandlerTest.java
@@ -90,11 +90,11 @@ class JdbcHandlerTest {
     tableCatalog.initialize(
         "testCatalog", new CaseInsensitiveStringMap(Collections.singletonMap("url", uri)));
 
-    Optional<OpenLineage.CatalogDatasetFacet> catalogDatasetFacet =
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
         handler.getCatalogDatasetFacet(tableCatalog, new HashMap<>());
     assertTrue(catalogDatasetFacet.isPresent());
 
-    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get();
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
 
     assertEquals("testCatalog", facet.getName());
     assertEquals("jdbc", facet.getType());


### PR DESCRIPTION
### Problem
When using certain catalog implementations, there may be a need to provide additional, catalog-specific information that does not fit into the existing CatalogDatasetFacet definition. This PR addresses that limitation.

### Solution
This PR introduces an internal structure that allows users to create and attach additional catalog-specific dataset facets while visiting catalog-relevant LogicalPlan nodes. This eliminates the need for visiting those nodes separately.

> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project