### PR TITLE
[Spark] Close OpenLineageClient in onApplicationEnd

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -92,6 +92,14 @@ public class EventEmitter {
     }
   }
 
+  public void close() {
+    try {
+      client.close();
+    } catch (Exception e) {
+      log.error("Failed to close OpenLineage client", e);
+    }
+  }
+
   private static Optional<UUID> convertToUUID(String uuid) {
     try {
       return Optional.ofNullable(uuid).map(UUID::fromString);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/ContextFactory.java
@@ -144,6 +144,10 @@ public class ContextFactory {
             });
   }
 
+  public void close() {
+    openLineageEventEmitter.close();
+  }
+
   public static Optional<QueryExecution> executionFromCompleteEvent(
       SparkListenerSQLExecutionEnd event) {
     try {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkAgentTestExtension.java
@@ -30,7 +30,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.SparkSession$;
 import org.apache.spark.sql.catalog.Table;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -41,32 +40,18 @@ import org.slf4j.LoggerFactory;
 
 /** JUnit extension that sets up SparkSession for OpenLineage context. */
 public class SparkAgentTestExtension
-    implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, ParameterResolver {
+    implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
   public static final EventEmitter EVENT_EMITTER = mock(EventEmitter.class);
 
   @SuppressWarnings("PMD") // always point locally
   private static final String LOCAL_IP = "127.0.0.1";
 
   @Override
-  public void beforeAll(ExtensionContext context) throws Exception {
-    when(SparkAgentTestExtension.EVENT_EMITTER.getJobNamespace()).thenReturn("ns_name");
-    when(SparkAgentTestExtension.EVENT_EMITTER.getParentJobName())
-        .thenReturn(Optional.of("parent_name"));
-    when(SparkAgentTestExtension.EVENT_EMITTER.getParentJobNamespace())
-        .thenReturn(Optional.of("parent_namespace"));
-    when(SparkAgentTestExtension.EVENT_EMITTER.getParentRunId())
-        .thenReturn(Optional.of(UUID.fromString("8d99e33e-2a1c-4254-9600-18f23435fc3b")));
-    when(SparkAgentTestExtension.EVENT_EMITTER.getApplicationRunId())
-        .thenReturn(UUID.fromString("8d99e33e-bbbb-cccc-dddd-18f2343aaaaa"));
-    when(SparkAgentTestExtension.EVENT_EMITTER.getApplicationJobName()).thenReturn("test_rdd");
-
-    OpenLineageSparkListener.init(
+  public void beforeEach(ExtensionContext context) throws Exception {
+    OpenLineageSparkListener.overrideDefaultFactoryForTests(
         new StaticExecutionContextFactory(
             EVENT_EMITTER, new SimpleMeterRegistry(), new SparkOpenLineageConfig()));
-  }
 
-  @Override
-  public void beforeEach(ExtensionContext context) throws Exception {
     Mockito.reset(EVENT_EMITTER);
     JobMetricsHolder.getInstance().cleanUpAll();
     when(SparkAgentTestExtension.EVENT_EMITTER.getJobNamespace()).thenReturn("ns_name");
@@ -104,6 +89,8 @@ public class SparkAgentTestExtension
 
   @Override
   public void afterEach(ExtensionContext context) throws Exception {
+    OpenLineageSparkListener.resetDefaultFactoryForTests();
+
     try {
       ScalaConversionUtils.asJavaOptional(SparkSession.getActiveSession())
           .ifPresent(
@@ -164,6 +151,7 @@ public class SparkAgentTestExtension
   public static OpenLineageContext newContext(SparkSession sparkSession) {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
     SparkOpenLineageConfig config = new SparkOpenLineageConfig();
+
     return OpenLineageContext.builder()
         .sparkSession(sparkSession)
         .sparkContext(sparkSession.sparkContext())

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
@@ -89,8 +89,6 @@ public class SparkTestUtils {
     Path sparkSqlWarehouse =
         userDirPath.resolve("tmp").resolve("spark-sql-warehouse").resolve(testUuid.toString());
 
-    OpenLineageSparkListener.close();
-
     return SparkSession.builder()
         .appName(appName)
         .master("local[*]")


### PR DESCRIPTION
### Problem

Then Spark session is stopped, OpenLineage integration emits FINISHED event for application job, and that's all. But async/queue based transport require to call `.close()` to ensure that all events were send.

### Solution

* Make all OpenLineageSparkListener fields non-static. Leave only 2 fields which are mocked up in integration tests, and have to be set before new SparkListener object created.
* Remove `OpenLineageSparkListener.outputs` field - it is only initialized with empty map, but never filled up with data.
* `OpenLineageSparkListener.onApplicationEnd` now closes underlying OpenLineage client, which should trigger flushing of underlying transports (e.g. Kafka).

#### One-line summary:

[Spark] Close OpenLineageClient in onApplicationEnd

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project