### PR TITLE
fix: raise error if no events were emitted by composite transport

### DIFF
--- a/client/python/openlineage/client/transport/composite.py
+++ b/client/python/openlineage/client/transport/composite.py
@@ -32,8 +32,9 @@ class CompositeConfig(Config):
         continue_on_failure:
             If set to True, the CompositeTransport will attempt to emit the event using
             all configured transports, regardless of whether any previous transport
-            in the list failed to emit the event. If set to False, an error in one
-            transport will halt the emission process for subsequent transports.
+            in the list failed to emit the event. If none of the transports successfully emit
+            the event, an error will still be raised at the end to indicate that no events were emitted.
+            If set to False, an error in transport will halt the emission process for subsequent transports.
 
         continue_on_success:
             If True, the CompositeTransport will continue emitting events to all transports
@@ -91,7 +92,7 @@ class CompositeTransport(Transport):
             raise ValueError(msg)
         log.debug(
             "Constructing OpenLineage composite transport with the following transports: %s",
-            [str(x) for x in self.transports],
+            self.transports,
         )
 
     @cached_property
@@ -138,6 +139,10 @@ class CompositeTransport(Transport):
                         transport,
                     )
                     return
+
+        if _success_count == 0:
+            msg = f"None of the transports successfully emitted the event: {self.transports}"
+            raise RuntimeError(msg)
 
         log.info(
             "CompositeTransport: finished emitting OpenLineage events;"


### PR DESCRIPTION
### Problem

In other transports, if the event emission fails we raise an error and there is no way to prevent that. In CompositeTransport, user can configure to continue on failure, so that all the transports try to emit, but I think we should still raise an error, if none of them emits the event successfully.

### Solution

CompositeTransport will now raise error when all transports fail, regardless of `continue_on_failure` flag.

#### One-line summary:
fix: raise error if no events were emitted by composite transport

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project