### PR TITLE
[Flink 1.x] Close OpenLineageClient in onJobExecuted

### DIFF
--- a/integration/flink/flink1/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
+++ b/integration/flink/flink1/src/main/java/io/openlineage/flink/visitor/lifecycle/FlinkExecutionContext.java
@@ -333,4 +333,8 @@ public class FlinkExecutionContext implements ExecutionContext {
         .flatMap(List::stream)
         .collect(Collectors.toList());
   }
+
+  public void close() {
+    olContext.getEventEmitter().close();
+  }
 }

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListener.java
@@ -129,6 +129,8 @@ public class OpenLineageJobStatusChangedListener implements JobStatusChangedList
 
   private void onDefaultJobExecutionStatusEvent(DefaultJobExecutionStatusEvent event) {
     if (context.getJobId() == null) {
+      // If jobId wasn't recorded, then there was no START event emitted.
+      // This means that current event is CANCELLED, so we should not emit anything.
       log.warn("JobId is not set, skipping event: {}", event);
       return;
     }

--- a/integration/flink/shared/src/main/java/io/openlineage/flink/client/EventEmitter.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/client/EventEmitter.java
@@ -47,6 +47,14 @@ public class EventEmitter {
     }
   }
 
+  public void close() {
+    try {
+      client.close();
+    } catch (Exception e) {
+      log.error("Failed to close OpenLineage client", e);
+    }
+  }
+
   private static URI getUri() {
     return URI.create(
         String.format(


### PR DESCRIPTION
### Problem

Then Flink job is stopped, OpenLineage integration emits FINISHED/FAILED event, and that's all. But async/queue based transport require to call `.close()` to ensure that all events were send.

### Solution

* Explicitly call `client.close()` after sending job FINISHED/FAILED events
* Update tests to check that `onJobCompleted`, `onJobFailed` are really called during `onJobExecuted`

This is only for Flink 1.x, as Flink 2.x JobStatusChangedListener can be run in session mode, so all jobs reuse the same OpenLineage client to send data. Also Flink JobStatusChangedListener interface doesn't have any `shutdown` or `close` methods we can override.

#### One-line summary:

[Flink 1.x] Close OpenLineageClient in onJobExecuted

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project