### PR TITLE
[Python] Implement `TransformTransport.close`

### DIFF
--- a/client/python/openlineage/client/transport/transform/transform.py
+++ b/client/python/openlineage/client/transport/transform/transform.py
@@ -142,3 +142,9 @@ class TransformTransport(Transport):
             return None
         log.debug("Event after transformation: %s", Serde.to_json(transformed))
         return self.transport.emit(transformed)
+
+    def wait_for_completion(self, timeout: float = -1) -> bool:
+        return self.transport.wait_for_completion(timeout)
+
+    def close(self, timeout: float = -1) -> bool:
+        return self.transport.close(timeout)

--- a/client/python/tests/transform/test_transform.py
+++ b/client/python/tests/transform/test_transform.py
@@ -469,3 +469,21 @@ def test_client_with_transform_transport_fails_when_transform_fails(mocker: Mock
         client.emit(event)
 
     transport.transport.session.post.assert_not_called()
+
+
+def test_client_with_transform_transport_close(mocker: MockerFixture) -> None:
+    session = mocker.patch("requests.Session")
+    config = TransformConfig.from_dict(
+        {
+            "transport": {
+                "type": "http",
+                "url": "http://backend:5000",
+                "session": session,
+            },
+            "transformer_class": "tests.transform.test_transform.NoopEventTransformer",
+        }
+    )
+    transport = TransformTransport(config)
+
+    transport.close()
+    session.close.assert_called_once()


### PR DESCRIPTION
### Problem

`TransformTransport` doesn't pass `.close()` and `wait_for_completion()` to underlying transport.

### Solution

#### One-line summary:

[Python] Implement `TransformTransport.close` method

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project