### PR TITLE
fix: replace dbt deprecated configs in CI

### DIFF
--- a/integration/airflow/tests/integration/data/dbt/testproject/dbt_project.yml
+++ b/integration/airflow/tests/integration/data/dbt/testproject/dbt_project.yml
@@ -5,12 +5,12 @@ config-version: 2
 profile: "{{ env_var('DBT_PROFILE') }}"
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/build/dbt_project.yml
+++ b/integration/common/tests/dbt/build/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/catalog/dbt_project.yml
+++ b/integration/common/tests/dbt/catalog/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/env_vars/dbt_project.yml
+++ b/integration/common/tests/dbt/env_vars/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'redshift'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/fail/dbt_project.yml
+++ b/integration/common/tests/dbt/fail/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/large/dbt_project.yml
+++ b/integration/common/tests/dbt/large/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'snowflake'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/no_test_metadata/dbt_project.yml
+++ b/integration/common/tests/dbt/no_test_metadata/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'snowflake'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/profiles/dbt_project.yml
+++ b/integration/common/tests/dbt/profiles/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/small/dbt_project.yml
+++ b/integration/common/tests/dbt/small/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration/common/tests/dbt/test/dbt_project.yml
+++ b/integration/common/tests/dbt/test/dbt_project.yml
@@ -10,12 +10,12 @@ config-version: 2
 profile: 'bigquery'
 
 # These configurations specify where dbt should look for different types of files.
-# The `source-paths` config, for example, states that models in this project can be
+# The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 


### PR DESCRIPTION
### Problem

CI started to fail with deprecated dbt configs:
![image](https://github.com/user-attachments/assets/d47ba0d4-050d-4530-b9b4-fa4fdccfa35f)


### Solution
Replaced deprecated configs:
https://docs.getdbt.com/reference/deprecations#configsourcepathdeprecation
https://docs.getdbt.com/reference/deprecations#configdatapathdeprecation

#### One-line summary:
fix: replace dbt deprecated configs in CI

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project