### PR TITLE
spark: implement support for WriteDelta, WriteIcebergDelta logical plan nodes

### DIFF
--- a/integration/spark/app/integrations/container/pysparkV2DeleteCowCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteCowCompleteEvent.json
@@ -1,0 +1,42 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_delete_cow"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/iceberg/default/tbl_delete_cow",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/iceberg",
+              "name": "default.tbl_delete_cow",
+              "type": "TABLE"
+            }
+          ]
+        },
+        "version": {}
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkV2DeleteCowStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteCowStartEvent.json
@@ -2,7 +2,7 @@
   "eventType": "START",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_delete"
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_delete_cow"
   },
   "inputs": [],
   "outputs": []

--- a/integration/spark/app/integrations/container/pysparkV2DeleteMorCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteMorCompleteEvent.json
@@ -1,0 +1,42 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_tbl_delete_mor"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/iceberg/default/tbl_delete_mor",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/iceberg",
+              "name": "default.tbl_delete_mor",
+              "type": "TABLE"
+            }
+          ]
+        },
+        "version": {}
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkV2DeleteMorStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2DeleteMorStartEvent.json
@@ -2,7 +2,7 @@
   "eventType": "START",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.atomic_create_table_as_select.default_tbl_update"
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_tbl_delete_mor"
   },
   "inputs": [],
   "outputs": []

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCowCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCowCompleteEvent.json
@@ -1,0 +1,69 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_events_cow"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/iceberg/default/events_cow",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "event_id",
+              "type": "long"
+            },
+            {
+              "name": "last_updated_at",
+              "type": "long"
+            }
+          ]
+        },
+        "version": {},
+        "columnLineage": {
+          "fields": {
+            "event_id": {
+              "inputFields": [
+                {
+                  "namespace": "file",
+                  "name": "/tmp/iceberg/default/events_cow",
+                  "field": "event_id"
+                },
+                {
+                  "namespace": "file",
+                  "name": "/tmp/iceberg/default/updates_cow",
+                  "field": "event_id"
+                }
+              ]
+            },
+            "last_updated_at": {
+              "inputFields": [
+                {
+                  "namespace": "file",
+                  "name": "/tmp/iceberg/default/updates_cow",
+                  "field": "updated_at"
+                }
+              ]
+            }
+          }
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/iceberg",
+              "name": "default.events_cow",
+              "type": "TABLE"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCowStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableCowStartEvent.json
@@ -1,14 +1,13 @@
 {
-  "eventType": "COMPLETE",
+  "eventType": "START",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.atomic_create_table_as_select.default_tbl_update"
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_events_cow"
   },
-  "inputs": [],
-  "outputs": [
+  "inputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default/tbl_update",
+      "name": "/tmp/iceberg/default/updates_cow",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -17,26 +16,27 @@
         "schema": {
           "fields": [
             {
-              "name": "a",
+              "name": "event_id",
               "type": "long"
             },
             {
-              "name": "b",
+              "name": "updated_at",
               "type": "long"
             }
           ]
         },
+        "version": {},
         "symlinks": {
           "identifiers": [
             {
               "namespace": "file:/tmp/iceberg",
-              "name": "default.tbl_update",
+              "name": "default.updates_cow",
               "type": "TABLE"
             }
           ]
-        },
-        "version": {}
+        }
       }
     }
-  ]
+  ],
+  "outputs": []
 }

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableMorCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableMorCompleteEvent.json
@@ -2,13 +2,13 @@
   "eventType": "COMPLETE",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.replace_data.spark_catalog_default_events"
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_events_mor"
   },
   "inputs": [],
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default/events",
+      "name": "/tmp/iceberg/default/events_mor",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -33,12 +33,12 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default/events",
+                  "name": "/tmp/iceberg/default/events_mor",
                   "field": "event_id"
                 },
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default/updates",
+                  "name": "/tmp/iceberg/default/updates_mor",
                   "field": "event_id"
                 }
               ]
@@ -47,7 +47,7 @@
               "inputFields": [
                 {
                   "namespace": "file",
-                  "name": "/tmp/iceberg/default/updates",
+                  "name": "/tmp/iceberg/default/updates_mor",
                   "field": "updated_at"
                 }
               ]
@@ -58,7 +58,7 @@
           "identifiers": [
             {
               "namespace": "file:/tmp/iceberg",
-              "name": "default.events",
+              "name": "default.events_mor",
               "type": "TABLE"
             }
           ]

--- a/integration/spark/app/integrations/container/pysparkV2MergeIntoTableMorStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2MergeIntoTableMorStartEvent.json
@@ -2,12 +2,12 @@
   "eventType": "START",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.replace_data.spark_catalog_default_events"
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_events_mor"
   },
   "inputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default/updates",
+      "name": "/tmp/iceberg/default/updates_mor",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -30,7 +30,7 @@
           "identifiers": [
             {
               "namespace": "file:/tmp/iceberg",
-              "name": "default.updates",
+              "name": "default.updates_mor",
               "type": "TABLE"
             }
           ]

--- a/integration/spark/app/integrations/container/pysparkV2UpdateCowCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateCowCompleteEvent.json
@@ -2,13 +2,13 @@
   "eventType": "COMPLETE",
   "job": {
     "namespace": "iceberg-namespace",
-    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_delete"
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_update_cow"
   },
   "inputs": [],
   "outputs": [
     {
       "namespace": "file",
-      "name": "/tmp/iceberg/default/tbl_delete",
+      "name": "/tmp/iceberg/default/tbl_update_cow",
       "facets": {
         "dataSource": {
           "name": "file",
@@ -30,7 +30,7 @@
           "identifiers": [
             {
               "namespace": "file:/tmp/iceberg",
-              "name": "default.tbl_delete",
+              "name": "default.tbl_update_cow",
               "type": "TABLE"
             }
           ]

--- a/integration/spark/app/integrations/container/pysparkV2UpdateCowStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateCowStartEvent.json
@@ -1,0 +1,9 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.replace_data.spark_catalog_default_tbl_update_cow"
+  },
+  "inputs": [],
+  "outputs": []
+}

--- a/integration/spark/app/integrations/container/pysparkV2UpdateMorCompleteEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateMorCompleteEvent.json
@@ -1,0 +1,42 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_tbl_update_mor"
+  },
+  "inputs": [],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/iceberg/default/tbl_update_mor",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/iceberg",
+              "name": "default.tbl_update_mor",
+              "type": "TABLE"
+            }
+          ]
+        },
+        "version": {}
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkV2UpdateMorStartEvent.json
+++ b/integration/spark/app/integrations/container/pysparkV2UpdateMorStartEvent.json
@@ -1,0 +1,9 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "iceberg-namespace",
+    "name": "iceberg_integration_test.write_delta.spark_catalog_default_tbl_update_mor"
+  },
+  "inputs": [],
+  "outputs": []
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -35,6 +35,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
@@ -95,6 +96,10 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));
+    }
+
+    if (WriteIcebergDeltaDatasetBuilder.hasClasses()) {
+      builder.add(new WriteIcebergDeltaDatasetBuilder(context));
     }
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -34,6 +34,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuil
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
@@ -92,6 +93,10 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));
+    }
+
+    if (WriteIcebergDeltaDatasetBuilder.hasClasses()) {
+      builder.add(new WriteIcebergDeltaDatasetBuilder(context));
     }
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -33,6 +33,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuild
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
@@ -94,6 +95,10 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));
+    }
+
+    if (WriteIcebergDeltaDatasetBuilder.hasClasses()) {
+      builder.add(new WriteIcebergDeltaDatasetBuilder(context));
     }
 
     if (DeltaUtils.hasMergeIntoCommandClass()) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -425,6 +425,12 @@ class SparkIcebergIntegrationTest {
     createTempDataset(2).createOrReplaceTempView("temp");
     spark.sql("CREATE TABLE iceberg_temp USING iceberg AS SELECT * FROM temp");
 
+    try {
+      Thread.sleep(2000); // To ensure all events are consumed
+    } catch (InterruptedException e) {
+      // ignore
+    }
+
     HttpRequest[] httpRequests =
         mockServer.retrieveRecordedRequests(request().withPath("/api/v1/lineage"));
     RunEvent event =

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
@@ -37,7 +37,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class SparkTestUtils {
   static final String SPARK_3_OR_ABOVE = "^[3-9].*";
-  static final String SPARK_VERSION = "spark.version";
+  public static final String SPARK_VERSION = "spark.version";
   static final String SPARK_3_3_AND_ABOVE = "^3.[3-5].*|^[4-9].*";
 
   @Getter

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilder.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression;
 import org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic;
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData;
 import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation;
 
@@ -48,6 +49,7 @@ public class TableContentChangeDatasetBuilder
         || (x instanceof DeleteFromTable)
         || (x instanceof UpdateTable)
         || (new IcebergHandler(context).hasClasses() && x instanceof ReplaceData)
+        || (new IcebergHandler(context).hasClasses() && x instanceof WriteDelta)
         || (x instanceof MergeIntoTable)
         || (x instanceof InsertIntoStatement);
   }
@@ -98,9 +100,9 @@ public class TableContentChangeDatasetBuilder
     } else if (x instanceof InsertIntoStatement) {
       return (NamedRelation) ((InsertIntoStatement) x).table();
     } else if (new IcebergHandler(context).hasClasses() && x instanceof ReplaceData) {
-      // DELETE FROM on ICEBERG HAS START ELEMENT WITH ReplaceData AND COMPLETE ONE WITH
-      // DeleteFromTable
       return ((ReplaceData) x).table();
+    } else if (new IcebergHandler(context).hasClasses() && x instanceof WriteDelta) {
+      return ((WriteDelta) x).table();
     } else if (x instanceof DeleteFromTable) {
       return (NamedRelation) ((DeleteFromTable) x).table();
     } else if (x instanceof UpdateTable) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/TableContentChangeDatasetBuilderTest.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression;
 import org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic;
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData;
 import org.apache.spark.sql.catalyst.plans.logical.UpdateTable;
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -115,6 +116,13 @@ class TableContentChangeDatasetBuilderTest {
   }
 
   @Test
+  void testApplyForWriteDelta() {
+    WriteDelta logicalPlan = mock(WriteDelta.class);
+    when(logicalPlan.table()).thenReturn(dataSourceV2Relation);
+    verify(logicalPlan, null);
+  }
+
+  @Test
   void testApplyForMergeIntoTable() {
     MergeIntoTable logicalPlan = mock(MergeIntoTable.class);
     when(logicalPlan.targetTable()).thenReturn(dataSourceV2Relation);
@@ -137,6 +145,7 @@ class TableContentChangeDatasetBuilderTest {
     assertTrue(builder.isDefinedAtLogicalPlan(mock(DeleteFromTable.class)));
     assertTrue(builder.isDefinedAtLogicalPlan(mock(UpdateTable.class)));
     assertTrue(builder.isDefinedAtLogicalPlan(mock(ReplaceData.class)));
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(WriteDelta.class)));
     assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
   }
 

--- a/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitor.java
+++ b/integration/spark/spark32/src/main/java/io/openlineage/spark32/agent/lifecycle/plan/column/MergeIntoIceberg013ColumnLineageVisitor.java
@@ -15,10 +15,13 @@ import io.openlineage.spark3.agent.lifecycle.plan.column.OutputFieldsCollector;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows;
 import org.apache.spark.sql.catalyst.plans.logical.Project;
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData;
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta;
 
 @Slf4j
 public class MergeIntoIceberg013ColumnLineageVisitor implements ColumnLevelLineageVisitor {
@@ -29,7 +32,8 @@ public class MergeIntoIceberg013ColumnLineageVisitor implements ColumnLevelLinea
   }
 
   public static boolean hasClasses() {
-    return ReflectionUtils.hasClass("org.apache.spark.sql.catalyst.plans.logical.ReplaceData");
+    return ReflectionUtils.hasClass("org.apache.spark.sql.catalyst.plans.logical.ReplaceData")
+        && ReflectionUtils.hasClass("org.apache.spark.sql.catalyst.plans.logical.WriteDelta");
   }
 
   @Override
@@ -38,12 +42,19 @@ public class MergeIntoIceberg013ColumnLineageVisitor implements ColumnLevelLinea
       InputFieldsCollector.collect(context, ((ReplaceData) node).child());
       InputFieldsCollector.collect(context, (LogicalPlan) ((ReplaceData) node).table());
     }
+    if (node instanceof WriteDelta) {
+      InputFieldsCollector.collect(context, ((WriteDelta) node).child());
+      InputFieldsCollector.collect(context, (LogicalPlan) ((WriteDelta) node).table());
+    }
   }
 
   @Override
   public void collectOutputs(ColumnLevelLineageContext context, LogicalPlan node) {
     if (node instanceof ReplaceData) {
       OutputFieldsCollector.collect(context, (LogicalPlan) ((ReplaceData) node).table());
+    }
+    if (node instanceof WriteDelta) {
+      OutputFieldsCollector.collect(context, (LogicalPlan) ((WriteDelta) node).table());
     }
   }
 
@@ -52,7 +63,6 @@ public class MergeIntoIceberg013ColumnLineageVisitor implements ColumnLevelLinea
     if (node instanceof ReplaceData) {
       ReplaceData replaceIcebergData = (ReplaceData) node;
       NamedRelation namedRelation = replaceIcebergData.table();
-
       LogicalPlan query = replaceIcebergData.query();
 
       if (query instanceof Project) {
@@ -72,6 +82,42 @@ public class MergeIntoIceberg013ColumnLineageVisitor implements ColumnLevelLinea
                   queryOutputs.get(i).exprId());
         }
       }
+    }
+
+    if (node instanceof WriteDelta) {
+      WriteDelta writeIcebergDelta = (WriteDelta) node;
+      NamedRelation namedRelation = writeIcebergDelta.table();
+      LogicalPlan query = writeIcebergDelta.query();
+      LogicalPlan originalQuery = query;
+
+      log.debug("Query is a {}", query);
+
+      while (query.children().length() > 0) {
+        if (query instanceof MergeRows) {
+          List<Attribute> inputs = ScalaConversionUtils.fromSeq(originalQuery.output());
+          List<Attribute> outputs =
+              ScalaConversionUtils.fromSeq(((LogicalPlan) namedRelation).output());
+
+          for (int i = 0; i < outputs.size(); i++) {
+            if (log.isDebugEnabled()) {
+              log.debug(
+                  "Adding dependency: {}, {}", outputs.get(i).exprId(), inputs.get(i + 1).exprId());
+            }
+            context.getBuilder().addDependency(outputs.get(i).exprId(), inputs.get(i + 1).exprId());
+          }
+          break;
+        } else {
+          query = query.children().apply(0);
+        }
+      }
+
+      // RebalancePartitions rp = (RebalancePartitions) writeIcebergDelta.query() ;
+      // log.debug("RP output {}", rp.output());
+
+      // MergeRows mr = (MergeRows) rp.child();
+      // log.debug("MR output {}", mr.output());
+
+      // log.debug("Projections: {}", writeIcebergDelta.projections());
     }
   }
 }

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteIcebergDeltaDatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteIcebergDeltaDatasetBuilder.java
@@ -1,0 +1,83 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.OutputDataset;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.WriteIcebergDelta;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+
+@Slf4j
+public class WriteIcebergDeltaDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public WriteIcebergDeltaDatasetBuilder(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  public static boolean hasClasses() {
+    try {
+      WriteIcebergDeltaDatasetBuilder.class
+          .getClassLoader()
+          .loadClass("org.apache.spark.sql.catalyst.plans.logical.WriteIcebergDelta");
+      return true;
+    } catch (Exception e) {
+      // swallow- we don't care
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof WriteIcebergDelta);
+  }
+
+  @Override
+  public List<OpenLineage.OutputDataset> apply(SparkListenerEvent event, LogicalPlan plan) {
+    WriteIcebergDelta replace = (WriteIcebergDelta) plan;
+
+    if (!(replace.table() instanceof DataSourceV2Relation)) {
+      return Collections.emptyList();
+    }
+    DatasetFactory<OutputDataset> datasetFactory = outputDataset();
+    DataSourceV2Relation table = (DataSourceV2Relation) replace.table();
+
+    final DatasetCompositeFacetsBuilder datasetFacetsBuilder =
+        datasetFactory.createCompositeFacetBuilder();
+    datasetFacetsBuilder
+        .getFacets()
+        .lifecycleStateChange(
+            context
+                .getOpenLineage()
+                .newLifecycleStateChangeDatasetFacet(
+                    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE,
+                    null));
+
+    return DataSourceV2RelationDatasetExtractor.extract(
+        datasetFactory, context, table, datasetFacetsBuilder, includeDatasetVersion(event));
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan plan) {
+    if (!(plan instanceof WriteIcebergDelta)) {
+      return Optional.empty();
+    }
+    WriteIcebergDelta replace = (WriteIcebergDelta) plan;
+    return Optional.ofNullable(replace.table()).map(NamedRelation::name);
+  }
+}

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteIcebergDeltaDatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteIcebergDeltaDatasetBuilderTest.java
@@ -1,0 +1,116 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import static io.openlineage.client.OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.OVERWRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.utils.DataSourceV2RelationDatasetExtractor;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.WriteIcebergDelta;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class WriteIcebergDeltaDatasetBuilderTest {
+
+  OpenLineage openLineage = mock(OpenLineage.class);
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(mock(SparkSession.class))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(openLineage)
+          .meterRegistry(new SimpleMeterRegistry())
+          .openLineageConfig(new SparkOpenLineageConfig())
+          .build();
+
+  WriteIcebergDeltaDatasetBuilder builder = new WriteIcebergDeltaDatasetBuilder(openLineageContext);
+
+  WriteIcebergDelta plan = mock(WriteIcebergDelta.class);
+  SparkListenerEvent event = mock(SparkListenerSQLExecutionEnd.class);
+
+  @Test
+  void testIsDefinedAtLogicalPlan() {
+    assertTrue(builder.isDefinedAtLogicalPlan(mock(WriteIcebergDelta.class)));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testApplyWhenNoDataSourceV2RelationTable() {
+    when(plan.table()).thenReturn(mock(NamedRelation.class));
+    assertEquals(0, builder.apply(event, plan).size());
+  }
+
+  @Test
+  void testApply() {
+    DataSourceV2Relation table = mock(DataSourceV2Relation.class);
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+    DatasetCompositeFacetsBuilder compositeFacetsBuilder =
+        mock(DatasetCompositeFacetsBuilder.class);
+    DatasetFacetsBuilder facetsBuilder = mock(DatasetFacetsBuilder.class);
+
+    when(compositeFacetsBuilder.getFacets()).thenReturn(facetsBuilder);
+
+    when(plan.table()).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(DataSourceV2RelationDatasetExtractor.class)) {
+      try (MockedStatic mockedDatasetFactory = mockStatic(DatasetFactory.class)) {
+        when(DataSourceV2RelationDatasetExtractor.extract(
+                any(DatasetFactory.class),
+                eq(openLineageContext),
+                eq(table),
+                any(),
+                any(Boolean.class)))
+            .thenReturn(Arrays.asList(expectedDataset));
+
+        DatasetFactory datasetFactory = mock(DatasetFactory.class);
+        when(DatasetFactory.output(openLineageContext)).thenReturn(datasetFactory);
+        when(datasetFactory.createCompositeFacetBuilder()).thenReturn(compositeFacetsBuilder);
+
+        List<OpenLineage.OutputDataset> datasets = builder.apply(event, plan);
+
+        assertEquals(1, datasets.size());
+        assertEquals(expectedDataset, datasets.get(0));
+
+        verify(facetsBuilder)
+            .lifecycleStateChange(openLineage.newLifecycleStateChangeDatasetFacet(OVERWRITE, null));
+      }
+    }
+  }
+
+  @Test
+  void testJobNameSuffix() {
+    assertThat(builder.jobNameSuffix(mock(LogicalPlan.class))).isEmpty();
+
+    WriteIcebergDelta WriteIcebergDelta = mock(WriteIcebergDelta.class);
+    NamedRelation namedRelation = mock(NamedRelation.class);
+    when(WriteIcebergDelta.table()).thenReturn(namedRelation);
+    when(namedRelation.name()).thenReturn("table");
+    assertThat(builder.jobNameSuffix(WriteIcebergDelta).get()).isEqualTo("table");
+  }
+}


### PR DESCRIPTION
### Problem

No output facets are generated when UPDATE, DELETE and MERGE operations are performed on Iceberg tables.

Closes: #3831

### Solution

I added visitors for two more logical plan nodes: WriteDelta and ReplaceData. The first is used for V2 sources when Spark performs row-level updates (including deletes and merges), the second is used when Spark performs row-level deletes.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Implement support for WriteDelta and ReplaceData logical plan nodes.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project