### PR TITLE
[Python] Remove transport.wait_for_completion()

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -192,17 +192,6 @@ class OpenLineageClient:
         """
         return self.transport.close(timeout)
 
-    def wait_for_completion(self, timeout: float = -1.0) -> bool:
-        """
-        Block until all events are processed or timeout is reached.
-        If the transport is fully synchronous, this method should be a no-op and return True.
-        Params:
-          timeout: Timeout in seconds. `-1` means to block until last event is processed, 0 means no timeout.
-        Returns:
-            bool: True if all events were processed, False if some events were not processed.
-        """
-        return self.transport.wait_for_completion(timeout)
-
     @property
     def config(self) -> OpenLineageConfig:
         """

--- a/client/python/openlineage/client/transport/async_http.py
+++ b/client/python/openlineage/client/transport/async_http.py
@@ -504,9 +504,16 @@ class AsyncHttpTransport(Transport):
         self.event_queue.put(request)
         log.debug("Queued event with event_id %s for async emission to %s", event_id, self.config.url)
 
-    def wait_for_completion(self, timeout: float = -1.0) -> bool:
-        # Block until all events are processed or timeout is reached.
-        # Special -1 value indicates that wait_for_completion will wait till all events are processed.
+    def wait_for_completion(self, timeout: float = -1) -> bool:
+        """
+        Block until all events are processed or timeout is reached.
+
+        Params:
+          timeout: Timeout in seconds. `-1` means to block until last event is processed, 0 means no timeout.
+
+        Returns:
+            bool: True if all events were processed, False if some events were not processed.
+        """
         log.debug("Waiting for events completion for %.3f seconds", timeout)
         start_time = time.time()
         while timeout < 0 or time.time() - start_time < timeout:

--- a/client/python/openlineage/client/transport/composite.py
+++ b/client/python/openlineage/client/transport/composite.py
@@ -152,11 +152,7 @@ class CompositeTransport(Transport):
         )
         return
 
-    def wait_for_completion(self, timeout: float = -1.0) -> bool:
-        # This can wait longer than timeout if multiple transports are slow, but acceptable
-        return all(transport.wait_for_completion(timeout) for transport in self.transports)
-
-    def close(self, timeout: float = -1.0) -> bool:
+    def close(self, timeout: float = -1) -> bool:
         result = True
         last_exception: Exception | None = None
         for transport in self.transports:

--- a/client/python/openlineage/client/transport/kafka.py
+++ b/client/python/openlineage/client/transport/kafka.py
@@ -166,13 +166,22 @@ class KafkaTransport(Transport):
             self.close()
 
     def wait_for_completion(self, timeout: float = -1) -> bool:
+        """
+        Block until all events are processed or timeout is reached.
+
+        Params:
+          timeout: Timeout in seconds. `-1` means to block until last event is processed, 0 means no timeout.
+
+        Returns:
+            bool: True if all events were processed, False if some events were not processed.
+        """
         if self.producer is None:
             return True
         messages_left: int = self.producer.flush(timeout=timeout)
-        log.debug("Amount of messages left in Kafka buffers after flush %d", messages_left)
+        log.debug("Amount of messages left in Kafka buffers after flush: %d", messages_left)
         return not messages_left
 
-    def close(self, timeout: float = -1.0) -> bool:
+    def close(self, timeout: float = -1) -> bool:
         all_processed = self.wait_for_completion(timeout)
         self.producer = None
         return all_processed

--- a/client/python/openlineage/client/transport/transform/transform.py
+++ b/client/python/openlineage/client/transport/transform/transform.py
@@ -143,8 +143,5 @@ class TransformTransport(Transport):
         log.debug("Event after transformation: %s", Serde.to_json(transformed))
         return self.transport.emit(transformed)
 
-    def wait_for_completion(self, timeout: float = -1) -> bool:
-        return self.transport.wait_for_completion(timeout)
-
     def close(self, timeout: float = -1) -> bool:
         return self.transport.close(timeout)

--- a/client/python/openlineage/client/transport/transport.py
+++ b/client/python/openlineage/client/transport/transport.py
@@ -59,19 +59,6 @@ class Transport:
             bool: True if all events were processed before transport was closed,
                 False if some events were not processed.
         """
-        return self.wait_for_completion(timeout)
-
-    def wait_for_completion(self, timeout: float = -1) -> bool:
-        """
-        Block until all events are processed or timeout is reached.
-
-        Params:
-            timeout: Timeout in seconds. Negative value will block until last event is processed,
-            while 0 means it completes immediately.
-
-        Returns:
-            bool: True if all events were processed, False if some events were not processed.
-        """
         return True
 
     def __str__(self) -> str:

--- a/client/python/tests/test_async_http.py
+++ b/client/python/tests/test_async_http.py
@@ -25,11 +25,11 @@ from openlineage.client.uuid import generate_new_uuid
 
 
 @contextmanager
-def closing_immediately(resource):
+def closing_immediately(transport: AsyncHttpTransport):
     try:
-        yield resource
+        yield transport
     finally:
-        resource.close(timeout=0)
+        transport.close(timeout=0)
 
 
 class TestAsyncHttpConfig:

--- a/client/python/tests/test_composite.py
+++ b/client/python/tests/test_composite.py
@@ -245,60 +245,6 @@ def test_emit_raises_error_when_all_failed(mock_factory):
 
 
 @mock.patch("openlineage.client.transport.get_default_factory")
-def test_wait_for_completion_all_succeed(mock_factory):
-    mock_transport1 = MagicMock(spec=Transport)
-    mock_transport2 = MagicMock(spec=Transport)
-    mock_transport1.wait_for_completion.return_value = True
-    mock_transport2.wait_for_completion.return_value = True
-    mock_factory.return_value.create.side_effect = [mock_transport1, mock_transport2]
-
-    config = CompositeConfig(transports=[{}, {}])
-    transport = CompositeTransport(config)
-
-    result = transport.wait_for_completion(5.0)
-
-    assert result is True
-    mock_transport1.wait_for_completion.assert_called_once_with(5.0)
-    mock_transport2.wait_for_completion.assert_called_once_with(5.0)
-
-
-@mock.patch("openlineage.client.transport.get_default_factory")
-def test_wait_for_completion_one_fails(mock_factory):
-    mock_transport1 = MagicMock(spec=Transport)
-    mock_transport2 = MagicMock(spec=Transport)
-    mock_transport1.wait_for_completion.return_value = True
-    mock_transport2.wait_for_completion.return_value = False
-    mock_factory.return_value.create.side_effect = [mock_transport1, mock_transport2]
-
-    config = CompositeConfig(transports=[{}, {}])
-    transport = CompositeTransport(config)
-
-    result = transport.wait_for_completion(3.0)
-
-    assert result is False
-    mock_transport1.wait_for_completion.assert_called_once_with(3.0)
-    mock_transport2.wait_for_completion.assert_called_once_with(3.0)
-
-
-@mock.patch("openlineage.client.transport.get_default_factory")
-def test_wait_for_completion_default_timeout(mock_factory):
-    mock_transport1 = MagicMock(spec=Transport)
-    mock_transport2 = MagicMock(spec=Transport)
-    mock_transport1.wait_for_completion.return_value = True
-    mock_transport2.wait_for_completion.return_value = True
-    mock_factory.return_value.create.side_effect = [mock_transport1, mock_transport2]
-
-    config = CompositeConfig(transports=[{}, {}])
-    transport = CompositeTransport(config)
-
-    result = transport.wait_for_completion()
-
-    assert result is True
-    mock_transport1.wait_for_completion.assert_called_once_with(-1.0)
-    mock_transport2.wait_for_completion.assert_called_once_with(-1.0)
-
-
-@mock.patch("openlineage.client.transport.get_default_factory")
 def test_close_all_succeed(mock_factory):
     mock_transport1 = MagicMock(spec=Transport)
     mock_transport2 = MagicMock(spec=Transport)

--- a/client/python/tests/test_kafka.py
+++ b/client/python/tests/test_kafka.py
@@ -550,3 +550,11 @@ def test_kafka_transport_close(mocker: MockerFixture) -> None:
 
     mock_producer.flush.assert_called_once_with(timeout=-1)
     assert transport.producer is None
+
+    mock_producer.reset_mock()
+
+    transport = KafkaTransport(config)
+    transport.close(10)
+
+    mock_producer.flush.assert_called_once_with(timeout=10)
+    assert transport.producer is None

--- a/integration/dbt/openlineage/dbt/__init__.py
+++ b/integration/dbt/openlineage/dbt/__init__.py
@@ -228,7 +228,7 @@ def consume_structured_logs(
             "fail, however, data might not end up in your configured lineage backend."
         )
     finally:
-        client.close(timeout=30.0)
+        client.close()
 
     logger.info("Emitted %d OpenLineage events", emitted_events)
     logger.info("Underlying dbt execution returned %d", processor.dbt_command_return_code)
@@ -356,7 +356,7 @@ def consume_local_artifacts(
                 e,
                 exc_info=True,
             )
-    client.close(timeout=30.0)
+    client.close()
     logger.info("Emitted %d OpenLineage events", emitted_events)
     logger.info("Underlying dbt execution returned %d", return_code)
     return return_code

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -394,12 +394,12 @@ client.emit(start_event)      # Non-blocking
 client.emit(complete_event)   # Waits for START success, then sent
 
 # Wait for all events to complete
-client.wait_for_completion()
+client.transport.wait_for_completion()
 # Get processing statistics
 stats = client.transport.get_stats()
 print(f"Pending: {stats['pending']}, Success: {stats['success']}, Failed: {stats['failed']}")
 # Graceful shutdown
-client.close(timeout=5)
+client.close()
 ```
 </TabItem>
 


### PR DESCRIPTION
### Problem

Address comments from https://github.com/OpenLineage/OpenLineage/issues/3771#issuecomment-3026912591 and https://github.com/OpenLineage/OpenLineage/pull/3812#issuecomment-3026760075.

### Solution

* AsyncHttpTransport and KafkaTransport still have `.wait_for_completion(timeout=-1)` and `.close(timeout=-1)` methods as underlying implementation has proper support for them. Other transport types have only `.close()` which closes all user resources, if any.
* `OpenLineageClient` and `CompositeTransport`/`TransformTransport` have only `.close()` method implemented.

This reduces surface area of the client. Transports which uses client without `.flush()` method don't have to implement it.

Also this synchronizes behavior Python and Java client & transports, as Java has only `void close()`, and no `.waitForCompletion()` https://github.com/OpenLineage/OpenLineage/pull/3839.

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project