### PR TITLE
nit: fix composite transport logging of multiple transports

### DIFF
--- a/client/python/openlineage/client/transport/composite.py
+++ b/client/python/openlineage/client/transport/composite.py
@@ -92,7 +92,7 @@ class CompositeTransport(Transport):
             raise ValueError(msg)
         log.debug(
             "Constructing OpenLineage composite transport with the following transports: %s",
-            self.transports,
+            [str(x) for x in self.transports],  # to use str and not repr
         )
 
     @cached_property
@@ -141,7 +141,10 @@ class CompositeTransport(Transport):
                     return
 
         if _success_count == 0:
-            msg = f"None of the transports successfully emitted the event: {self.transports}"
+            msg = (
+                f"None of the transports successfully emitted the event: "
+                f"{[str(x) for x in self.transports]}"  # to use str and not repr
+            )
             raise RuntimeError(msg)
 
         log.info(


### PR DESCRIPTION
Changed it recently, but it was not released. Forgot that str() called on list calls repr() on each list element and not str(). Adjusting it back to way it was before.