### PR TITLE
[Python] Do not use f-strings with logging module

### DIFF
--- a/integration/airflow/openlineage/airflow/adapter.py
+++ b/integration/airflow/openlineage/airflow/adapter.py
@@ -68,7 +68,7 @@ class OpenLineageAdapter:
         # Backcomp with Marquez integration
         marquez_url = os.getenv("MARQUEZ_URL")
         if marquez_url:
-            log.info(f"Sending lineage events to {marquez_url}")
+            log.info("Sending lineage events to %s", marquez_url)
             client = OpenLineageClient(
                 marquez_url,
                 OpenLineageClientOptions(api_key=os.environ["MARQUEZ_API_KEY"]),
@@ -113,7 +113,7 @@ class OpenLineageAdapter:
                 return self.client.emit(event)
         except Exception as e:
             Stats.incr("ol.emit.failed")
-            log.exception(f"Failed to emit OpenLineage event of id {event.run.runId}")
+            log.exception("Failed to emit OpenLineage event of id %s", event.run.runId)
             log.debug(e)
 
     def close(self, timeout: float = -1) -> bool:

--- a/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/athena_extractor.py
@@ -132,5 +132,5 @@ class AthenaExtractor(BaseExtractor):
             )
 
         except Exception as e:
-            self.log.error(f"Cannot retrieve table metadata from Athena.Client. {e}", exc_info=True)
+            self.log.error("Cannot retrieve table metadata from Athena.Client: %s", e, exc_info=True)
             return None

--- a/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/bigquery_extractor.py
@@ -27,14 +27,14 @@ class BigQueryExtractor(BaseExtractor):
         return None
 
     def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        self.log.debug(f"extract_on_complete({task_instance})")
+        self.log.debug("extract_on_complete(%s)", task_instance)
 
         try:
             bigquery_job_id = self._get_xcom_bigquery_job_id(task_instance)
             if bigquery_job_id is None:
                 raise Exception("Xcom could not resolve BigQuery job id. Job may have failed.")
         except Exception as e:
-            self.log.error(f"Cannot retrieve job details from BigQuery.Client. {e}", exc_info=True)
+            self.log.error("Cannot retrieve job details from BigQuery.Client: %s", e, exc_info=True)
             return TaskMetadata(
                 name=get_job_name(task=self.operator),
                 run_facets={
@@ -92,7 +92,7 @@ class BigQueryExtractor(BaseExtractor):
     def _get_xcom_bigquery_job_id(self, task_instance):
         bigquery_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="job_id")
 
-        self.log.debug(f"bigquery_job_id: {bigquery_job_id}")
+        self.log.debug("bigquery_job_id: %s", bigquery_job_id)
         return bigquery_job_id
 
     def _get_input_facets(self):

--- a/integration/airflow/openlineage/airflow/extractors/manager.py
+++ b/integration/airflow/openlineage/airflow/extractors/manager.py
@@ -36,13 +36,17 @@ class ExtractorManager:
             if task_uuid:
                 extractor.set_context("task_uuid", task_uuid)
             try:
-                self.log.debug(f"Using extractor {extractor.__class__.__name__} {task_info}")
+                self.log.debug(
+                    "Using extractor %s for task instance %s",
+                    extractor.__class__.__name__,
+                    task_info,
+                )
                 if complete:
                     task_metadata = extractor.extract_on_complete(task_instance)
                 else:
                     task_metadata = extractor.extract()
 
-                self.log.debug(f"Found task metadata for operation {task.task_id}: {task_metadata}")
+                self.log.debug("Found task metadata for operation %s: %s", task.task_id, task_metadata)
                 if task_metadata:
                     if (not task_metadata.inputs) and (not task_metadata.outputs):
                         inlets = task.get_inlet_defs()
@@ -59,14 +63,18 @@ class ExtractorManager:
                     )
                 else:
                     self.log.exception(
-                        f"Failed to extract metadata {e} {task_info}",
+                        "Failed to extract metadata from %s: %s",
+                        task_info,
+                        e,
                     )
             except Exception as e:
                 self.log.exception(
-                    f"Failed to extract metadata {e} {task_info}",
+                    "Failed to extract metadata from %s: %s",
+                    task_info,
+                    e,
                 )
         else:
-            self.log.debug(f"Unable to find an extractor. {task_info}")
+            self.log.debug("Unable to find an extractor %s", task_info)
 
             # Only include the unkonwnSourceAttribute facet if there is no extractor
             task_metadata = TaskMetadata(
@@ -85,7 +93,7 @@ class ExtractorManager:
         if task.task_id in self.extractors:
             return self.extractors[task.task_id]
         extractor = self.task_to_extractor.get_extractor_class(get_operator_class(task))
-        self.log.debug(f"extractor for {task.__class__} is {extractor}")
+        self.log.debug("extractor for %s is %s", task.__class__, extractor)
         if extractor:
             self.extractors[task.task_id] = extractor(task)
             return self.extractors[task.task_id]

--- a/integration/airflow/openlineage/airflow/extractors/python_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/python_extractor.py
@@ -53,5 +53,5 @@ class PythonExtractor(BaseExtractor):
             # Trying to extract source code of builtin_function_or_method
             return str(callable)
         except OSError:
-            self.log.exception(f"Can't get source code facet of PythonOperator {self.operator.task_id}")
+            self.log.exception("Can't get source code facet of PythonOperator %s", self.operator.task_id)
         return None

--- a/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/redshift_data_extractor.py
@@ -19,20 +19,20 @@ class RedshiftDataExtractor(BaseExtractor):
         return None
 
     def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
-        self.log.debug(f"extract_on_complete({task_instance})")
+        self.log.debug("extract_on_complete(%s)", task_instance)
         job_facets = {"sql": sql_job.SQLJobFacet(self.operator.sql)}
 
-        self.log.debug(f"Sending SQL to parser: {self.operator.sql}")
+        self.log.debug("Sending SQL to parser: %s", self.operator.sql)
         sql_meta: Optional[SqlMeta] = parse(
             self.operator.sql, dialect=self.dialect, default_schema=self.default_schema
         )
-        self.log.debug(f"Got meta {sql_meta}")
+        self.log.debug("Got meta %s", sql_meta)
         try:
             redshift_job_id = self._get_xcom_redshift_job_id(task_instance)
             if redshift_job_id is None:
                 raise Exception("Xcom could not resolve Redshift job id. Job may have failed.")
         except Exception as e:
-            self.log.error(f"Cannot retrieve job details from {e}", exc_info=True)
+            self.log.exception("Cannot retrieve job details from Redshift: %s", e)
             return TaskMetadata(
                 name=get_job_name(task=self.operator),
                 run_facets={},
@@ -77,5 +77,5 @@ class RedshiftDataExtractor(BaseExtractor):
     def _get_xcom_redshift_job_id(self, task_instance):
         redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id)
 
-        self.log.debug(f"redshift job id: {redshift_job_id}")
+        self.log.debug("redshift job id: %s", redshift_job_id)
         return redshift_job_id

--- a/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
+++ b/integration/airflow/openlineage/airflow/extractors/sql_extractor.py
@@ -62,11 +62,11 @@ class SqlExtractor(BaseExtractor):
         run_facets: Dict = {}
 
         # (1) Parse sql statement to obtain input / output tables.
-        self.log.debug(f"Sending SQL to parser: {self.operator.sql}")
+        self.log.debug("Sending SQL to parser: %s", self.operator.sql)
         sql_meta: Optional[SqlMeta] = parse(
             self.operator.sql, dialect=self.dialect, default_schema=self.default_schema
         )
-        self.log.debug(f"Got meta {sql_meta}")
+        self.log.debug("Got meta: %s", sql_meta)
 
         if not sql_meta:
             return TaskMetadata(

--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -114,7 +114,7 @@ params = [
     stop_max_delay=1000 * 10 * 60,
 )
 def wait_for_dag(dag_id, airflow_db_conn, should_fail=False) -> bool:
-    log.info(f"Waiting for DAG '{dag_id}'...")
+    log.info("Waiting for DAG '%s'...", dag_id)
 
     cur = airflow_db_conn.cursor()
     cur.execute(
@@ -129,7 +129,7 @@ def wait_for_dag(dag_id, airflow_db_conn, should_fail=False) -> bool:
 
     cur.close()
 
-    log.info(f"DAG '{dag_id}' state set to '{state}'.")
+    log.info("DAG '%s' state set to '%s'.", dag_id, state)
     expected_state = "failed" if should_fail else "success"
     failing_state = "success" if should_fail else "failed"
     if state == failing_state:
@@ -209,13 +209,13 @@ def check_run_id_matches(actual_events: List[Dict]) -> bool:
         if event_type in [start, complete, fail]:
             event_tracker[event_run_id][event_type] += 1
         else:
-            log.info(f"Found unknown event_type: `{event_type}` for run_id: `{event_run_id}`")
+            log.info("Found unknown event_type %s for run_id %s", event_type, event_run_id)
             return False
 
     # Validate each run_id
     failed_runs = {}
     for run_id, events in event_tracker.items():
-        log.debug(f"{run_id} -> {events}")
+        log.debug("%s -> %s", run_id, events)
         if events["is_mapped"]:
             # Dynamic tasks will have the same run_id, so we can allow more than one start and complete
             if events[start] != (events[complete] + events[fail]):
@@ -241,14 +241,14 @@ def check_matches(expected_events, actual_events, check_duplicates: bool = None)
             # Try to find matching event by eventType and job name
             if expected["eventType"] == actual["eventType"] and expected_job_name == actual["job"]["name"]:
                 if is_compared and check_duplicates:
-                    log.info(f"found more than one event expected {expected}\n duplicate: {actual}")
+                    log.info("Found more than one event expected %s\n duplicate: %s", expected, actual)
                     return False
                 is_compared = True
                 if not match(expected, actual):
-                    log.info(f"failed to compare expected {expected}\nwith actual {actual}")
+                    log.info("Failed to compare expected %s\nwith actual %s", expected, actual)
                     return False
         if not is_compared:
-            log.info(f"not found event comparable to {expected['eventType']} " f"- {expected_job_name}")
+            log.info("Not found event comparable to %s - %s", expected["eventType"], expected_job_name)
             return False
     return True
 
@@ -259,12 +259,15 @@ def check_matches_ordered(expected_events, actual_events) -> bool:
         actual = actual_events[index]
         if expected["eventType"] == actual["eventType"] and expected["job"]["name"] == actual["job"]["name"]:
             if not match(expected, actual):
-                log.info(f"failed to compare expected {expected}\nwith actual {actual}")
+                log.info("Failed to compare expected %s\nwith actual %s", expected, actual)
                 return False
             break
         log.info(
-            f"Wrong order of events: expected {expected['eventType']} - "
-            f"{expected['job']['name']}\ngot {actual['eventType']} - {actual['job']['name']}"
+            "Wrong order of events:\nexpected %s - %s\ngot %s - %s",
+            expected["eventType"],
+            expected["job"]["name"],
+            actual["eventType"],
+            actual["job"]["name"],
         )
         return False
     return True
@@ -309,7 +312,7 @@ def airflow_db_conn():
 
 @pytest.mark.parametrize("dag_id, request_path, check_duplicates", params)
 def test_integration(dag_id, request_path, check_duplicates, airflow_db_conn):
-    log.info(f"Checking dag {dag_id}")
+    log.info("Checking dag %s", dag_id)
     # (1) Wait for DAG to complete
     result = wait_for_dag(dag_id, airflow_db_conn)
     assert result is True
@@ -327,7 +330,7 @@ def test_integration(dag_id, request_path, check_duplicates, airflow_db_conn):
 
     # (5) Verify events emitted
     assert check_matches(expected_events, actual_events, check_duplicates) is True
-    log.info(f"Events for dag {dag_id} verified!")
+    log.info("Events for dag %s verified!", dag_id)
 
 
 @pytest.mark.parametrize(
@@ -338,7 +341,7 @@ def test_integration(dag_id, request_path, check_duplicates, airflow_db_conn):
     ],
 )
 def test_failing_dag(dag_id, request_path, check_duplicates, airflow_db_conn):
-    log.info(f"Checking dag {dag_id}")
+    log.info("Checking dag %s", dag_id)
     # (1) Wait for DAG to complete
     result = wait_for_dag(dag_id, airflow_db_conn, should_fail=True)
     assert result is True
@@ -356,7 +359,7 @@ def test_failing_dag(dag_id, request_path, check_duplicates, airflow_db_conn):
 
     # (5) Verify events emitted
     assert check_matches(expected_events, actual_events, check_duplicates) is True
-    log.info(f"Events for dag {dag_id} verified!")
+    log.info("Events for dag %s verified!", dag_id)
 
 
 @pytest.mark.parametrize(
@@ -371,7 +374,7 @@ def test_failing_dag(dag_id, request_path, check_duplicates, airflow_db_conn):
     ],
 )
 def test_integration_ordered(dag_id, request_dir: str, skip_jobs: List[str], airflow_db_conn):
-    log.info(f"Checking dag {dag_id}")
+    log.info("Checking dag %s", dag_id)
     # (1) Wait for DAG to complete
     result = wait_for_dag(dag_id, airflow_db_conn)
     assert result is True
@@ -396,7 +399,7 @@ def test_integration_ordered(dag_id, request_dir: str, skip_jobs: List[str], air
 
     assert check_matches_ordered(expected_events, actual_events) is True
     assert check_event_time_ordered(actual_events) is True
-    log.info(f"Events for dag {dag_id} verified!")
+    log.info("Events for dag %s verified!", dag_id)
 
 
 @pytest.mark.parametrize(
@@ -409,7 +412,7 @@ def test_integration_ordered(dag_id, request_dir: str, skip_jobs: List[str], air
     ],
 )
 def test_airflow_run_facet(dag_id, request_path, airflow_db_conn):
-    log.info(f"Checking dag {dag_id} for AirflowRunFacet")
+    log.info("Checking dag %s for AirflowRunFacet", dag_id)
     result = wait_for_dag(dag_id, airflow_db_conn)
     assert result is True
 
@@ -423,7 +426,7 @@ def test_airflow_run_facet(dag_id, request_path, airflow_db_conn):
 def test_airflow_mapped_task_facet(airflow_db_conn):
     dag_id = "mapped_dag"
     task_id = "multiply"
-    log.info(f"Checking dag {dag_id} for AirflowMappedTaskRunFacet")
+    log.info("Checking dag %s for AirflowMappedTaskRunFacet", dag_id)
     result = wait_for_dag(dag_id, airflow_db_conn)
     assert result is True
 

--- a/integration/common/openlineage/common/sql/__init__.py
+++ b/integration/common/openlineage/common/sql/__init__.py
@@ -28,5 +28,5 @@ def parse(
         return parse_sql(sql, dialect=dialect, default_schema=default_schema)
     except BaseException as e:
         # PanicException is a BaseException https://pyo3.rs/main/doc/pyo3/panic/struct.panicexception
-        log.error(f"SQL parser failed: {e}")
+        log.exception("SQL parser failed: %s", e)
         return None

--- a/integration/common/openlineage/common/test.py
+++ b/integration/common/openlineage/common/test.py
@@ -88,25 +88,31 @@ def match(expected, result, ordered_list=False) -> bool:
         # Take a look only at keys present at expected dictionary
         for k, v in expected.items():
             if k not in result:
-                log.error(f"Key {k} not in received event {result}\nExpected {expected}")
+                log.error("Key %s not in received event %s\nExpected %s", k, result, expected)
                 return False
             if not match(v, result[k], ordered_list):
                 log.error(
-                    f"For key {k}, expected value {v} not equals received {result[k]}"
-                    f"\nExpected {expected}, request {result}"
+                    "For key %s, expected value %s not equals received %s\nExpected %s, request %s",
+                    k,
+                    v,
+                    result[k],
+                    expected,
+                    result,
                 )
                 return False
     elif isinstance(expected, list):
         if len(expected) != len(result):
-            log.error(f"Length does not match: expected {len(expected)} result: {len(result)}")
+            log.error("Length does not match: expected %s, got %s", len(expected), len(result))
             return False
 
         if ordered_list:
             for index, expected_elem, result_elem in zip(range(len(result)), expected, result):
                 if not match(expected_elem, result_elem, ordered_list):
                     log.error(
-                        f"Elements in list don't match at index {index} - "
-                        f"expected element={expected_elem} VS actual result = {result_elem}"
+                        "Elements in list don't match at index %s." "\nExpected: %s" "\nGot: %s",
+                        index,
+                        expected_elem,
+                        result_elem,
                     )
                     return False
 
@@ -125,22 +131,25 @@ def match(expected, result, ordered_list=False) -> bool:
                             result_name = env.from_string(y["name"]).render()
                             if expected_name == result_name:
                                 if not match(x, y, ordered_list):
-                                    log.error(f"List not matched {x} where {y}")
+                                    log.error("List not matched %s where %s", x, y)
                                     return False
                         matched = True
                         break
                     if not matched:
                         log.error(
-                            f"List not matched - no same stuff for {x} "
-                            f"in expected: {expected} result {result}"
+                            "List not matched - no same stuff for %s." "\nExpected: %s" "\nGot: %s",
+                            x,
+                            expected,
+                            result,
                         )
                         return False
                 else:
                     if not match(x, result[i], ordered_list):
                         log.error(
-                            f"List not matched at {i}\n"
-                            + f"  expected:\n{json.dumps(x)}\n"
-                            + f"  result: \n{json.dumps(result[i])}"
+                            "List not matched at %d." "\nExpected: %s" "\nGot: %s",
+                            i,
+                            json.dumps(x),
+                            json.dumps(result[i]),
                         )
                         return False
     elif isinstance(expected, str):
@@ -150,12 +159,12 @@ def match(expected, result, ordered_list=False) -> bool:
             rendered = env.from_string(expected).render(result=result)
             if rendered == "true" or rendered == result:
                 return True
-            log.error(f"Rendered value {rendered} does not equal 'true' or {result}")
+            log.error("Rendered value %s does not equal 'true' or %s", rendered, result)
             return False
         elif expected != result:
-            log.error(f"Expected value {expected} does not equal result {result}")
+            log.error("Expected value %s does not equal result %s", expected, result)
             return False
     elif expected != result:
-        log.error(f"Object of type {type(expected)}: {expected} does not match {result}")
+        log.error("Object of type %s: %s does not match %s", type(expected), expected, result)
         return False
     return True

--- a/integration/dagster/openlineage/dagster/adapter.py
+++ b/integration/dagster/openlineage/dagster/adapter.py
@@ -238,7 +238,7 @@ class OpenLineageAdapter:
 
     def _emit(self, event: RunEvent):
         self._client.emit(event)
-        log.debug(f"Successfully emitted OpenLineage run event: {event}")
+        log.debug("Successfully emitted OpenLineage run event: %s", event)
 
     @staticmethod
     def _build_run(


### PR DESCRIPTION
### Problem

Some logging integrations rely on unique log message + file:line location. For example, Sentry requires that to combine all the errors produced by the same logger call.

Using f-strings leads to producing unique log messages, which breaks this assumption.

### Solution

Replace `logger.log(f"Message {var}")` with `logger.log("Message %s", var)`

#### One-line summary:

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project