### PR TITLE
nit: adjust log level when aliasing default_http transport

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -345,7 +345,7 @@ class OpenLineageClient:
                 k.startswith(f"OPENLINEAGE__TRANSPORT__TRANSPORTS__{default_transport_name}")
                 for k in os.environ
             ):
-                log.warning(
+                log.info(
                     "%s already found in environment variables, skipping aliasing OPENLINEAGE_URL",
                     default_transport_name,
                 )


### PR DESCRIPTION
Imho we should not log at warning level when aliasing openlineage_url is skipped, adjusted to info level.