### PR TITLE
fix: fail fast and reduce timeout for airflow tests

### DIFF
--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - airflow_worker
       - airflow_triggerer
       - backend
-    entrypoint: ["/wait-for-it.sh", "backend:5000", "--", "python", '-m', 'pytest', 'test_integration.py']
+    entrypoint: ["/wait-for-it.sh", "backend:5000", "--", "python", '-m', 'pytest', '-x', 'test_integration.py']
 
   airflow_scheduler:
     <<: *airflow-base


### PR DESCRIPTION
Lately, the Airflow tests have been quite flaky. I’m not entirely sure why, and I haven’t had much time to investigate, probably some CircleCI issues, as restart usually fixes it. The main issue is that CI runs can take 3-4 hours to fail, while successful runs complete in under 10 minutes.

To help with this, I first fixed the retry logic. Previously, the system would wait 10 minutes before retrying, even when an exception was raised (since exceptions are used to trigger retries). I’ve updated it to only retry on a specific retryException, and to fail immediately for other types of exceptions. I also reduced the timeout per test to 5 minutes, since they typically finish in about 3 minutes anyway. With over 20 tests, waiting 10 minutes for each one doesn’t make sense and just clogs up the CI pipeline.

Additionally, I added the -x flag to pytest, which stops the test run after the first DAG failure. I know this isn’t ideal in all cases - when we’re actively making changes, it’s useful to see all failing tests at once. However, these failures are almost always caused by flakiness or transient issues, not by actual code changes. Retrying the whole pipeline usually resolves them, so failing fast helps save time. For contributors making intentional changes, they can still run the full integration suite locally to catch multiple failures. That said, I understand this could be a topic for discussion, and I’m not set on it. If you think we should take a different approach, I’m open to changing it.