### PR TITLE
retry exception on empty row

### DIFF
--- a/integration/airflow/tests/integration/test_integration.py
+++ b/integration/airflow/tests/integration/test_integration.py
@@ -131,7 +131,7 @@ def wait_for_dag(dag_id, airflow_db_conn, should_fail=False) -> bool:
     )
     row = cur.fetchone()
     if not row:
-        raise TypeError("Query returned empty result. DAG run not found.")
+        raise RetryException("Query returned empty result. DAG run not found.")
     dag_id, state = row
 
     cur.close()


### PR DESCRIPTION
If the row does not exist, means the dag did not start yet - do not fail then.