### PR TITLE
Add memory info to debug facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   *Fix failing tests for Spark 4.0. Make delta integration tests pass with Delta 4.0 on Spark 4.*
 * **Spark: bump minor versions 3.4.3 -> 3.4.4, 3.5.4 -> 3.5.6.** [`#3907`](https://github.com/OpenLineage/OpenLineage/pull/3907) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
   *Bump tested Spark versions.*
+* **Spark: Add memory info to debug facet.** [`#3914`](https://github.com/OpenLineage/OpenLineage/pull/3914) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Extend DebugFacet with additional information on Spark's driver memory configuration and current memory usage.*
 
 ### Changed
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/DebugRunFacet.java
@@ -31,6 +31,7 @@ public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
   private final SparkConfigDebugFacet config;
   private final LogicalPlanDebugFacet logicalPlan;
   private final MetricsDebugFacet metrics;
+  private final MemoryDebugFacet memory;
   private final List<String> logs;
   private final int payloadSizeLimitInKilobytes;
 
@@ -40,6 +41,7 @@ public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
       SystemDebugFacet system,
       LogicalPlanDebugFacet logicalPlan,
       MetricsDebugFacet metricsDebugFacet,
+      MemoryDebugFacet memory,
       List<String> logs,
       int payloadSizeLimitInKilobytes) {
     super(Versions.OPEN_LINEAGE_PRODUCER_URI);
@@ -48,6 +50,7 @@ public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
     this.system = system;
     this.logicalPlan = logicalPlan;
     this.metrics = metricsDebugFacet;
+    this.memory = memory;
     this.logs = logs;
     this.payloadSizeLimitInKilobytes = payloadSizeLimitInKilobytes;
   }
@@ -133,6 +136,18 @@ public class DebugRunFacet extends OpenLineage.DefaultRunFacet {
     String id;
     String desc;
     List<String> children;
+  }
+
+  @Value
+  @Builder
+  public static class MemoryDebugFacet {
+    String sparkConfDriverMemory;
+    String sparkConfDriverMemoryOverhead;
+    String sparkConfDriverMinMemoryOverhead;
+    String sparkConfDriverMemoryOverheadFactor;
+    long freeMemory;
+    long totalMemory;
+    long maxMemory;
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/DebugRunFacetBuilderDelegate.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.spark.agent.facets.builder;
 
+import io.openlineage.client.utils.RuntimeUtils;
 import io.openlineage.spark.agent.facets.DebugRunFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugClassDetails;
 import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugClassDetails.ClasspathDebugClassDetailsBuilder;
@@ -12,6 +13,7 @@ import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanNode;
 import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanNode.LogicalPlanNodeBuilder;
+import io.openlineage.spark.agent.facets.DebugRunFacet.MemoryDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.MetricsDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.MetricsNode;
 import io.openlineage.spark.agent.facets.DebugRunFacet.SparkConfigDebugFacet;
@@ -64,6 +66,7 @@ public class DebugRunFacetBuilderDelegate {
         buildSystemDebugFacet(),
         buildLogicalPlanDebugFacet(),
         buildMetricsDebugFacet(),
+        buildMemoryDebugFacet(),
         logs,
         payloadSizeLimitInKilobytes);
   }
@@ -241,5 +244,18 @@ public class DebugRunFacetBuilderDelegate {
       builder.isOnClasspath(false);
     }
     return builder.build();
+  }
+
+  private MemoryDebugFacet buildMemoryDebugFacet() {
+    return MemoryDebugFacet.builder()
+        .sparkConfDriverMemory(getSparkConfOrNull("spark.driver.memory"))
+        .sparkConfDriverMemoryOverhead(getSparkConfOrNull("spark.driver.memoryOverhead"))
+        .sparkConfDriverMinMemoryOverhead(getSparkConfOrNull("spark.driver.minMemoryOverhead"))
+        .sparkConfDriverMemoryOverheadFactor(
+            getSparkConfOrNull("spark.driver.memoryOverheadFactor"))
+        .freeMemory(RuntimeUtils.freeMemory() / (1024 * 1024))
+        .maxMemory(RuntimeUtils.maxMemory() / (1024 * 1024))
+        .totalMemory(RuntimeUtils.totalMemory() / (1024 * 1024))
+        .build();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventTimeoutExecutor.java
@@ -150,7 +150,7 @@ public class OpenLineageRunEventTimeoutExecutor {
       debugFacet.getLogs().add(message);
     } else {
       DebugRunFacet debugFacet =
-          new DebugRunFacet(null, null, null, null, null, Arrays.asList(message), 100);
+          new DebugRunFacet(null, null, null, null, null, null, Arrays.asList(message), 100);
       runFacets.getAdditionalProperties().put("debug", debugFacet);
     }
   }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/facets/serializer/DebugRunFacetSerializerTest.java
@@ -11,6 +11,7 @@ import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.spark.agent.facets.DebugRunFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.ClasspathDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.LogicalPlanDebugFacet;
+import io.openlineage.spark.agent.facets.DebugRunFacet.MemoryDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.MetricsDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.SparkConfigDebugFacet;
 import io.openlineage.spark.agent.facets.DebugRunFacet.SystemDebugFacet;
@@ -27,6 +28,7 @@ class DebugRunFacetSerializerTest {
           SystemDebugFacet.builder().build(),
           new LogicalPlanDebugFacet(Collections.emptyList()),
           new MetricsDebugFacet(Collections.emptyList()),
+          MemoryDebugFacet.builder().build(),
           Collections.emptyList(),
           10);
 
@@ -55,6 +57,7 @@ class DebugRunFacetSerializerTest {
             SystemDebugFacet.builder().build(),
             new LogicalPlanDebugFacet(Collections.emptyList()),
             new MetricsDebugFacet(Collections.emptyList()),
+            MemoryDebugFacet.builder().build(),
             Collections.emptyList(),
             10);
 

--- a/website/docs/integrations/spark/debug_facet.md
+++ b/website/docs/integrations/spark/debug_facet.md
@@ -20,6 +20,7 @@ when it detects that OpenLineage event is not emitted properly.
 * Information about the system like: Spark deployment mode, Java version, Java vendor, OS name, OS version, timezone.
 * Metrics, which apart from being sent to Metric backend, can be filled within DebugFacet at the same time.
 * Shortened information about the LogicalPlan which contains tree structure as well class names of the nodes.
+* Memory information including Spark's driver memory configuration and memory usage (free and total memory).
 * Logs: logs relating to OpenLineage Spark integration, which can be useful for debugging purposes.
 
 Please refer to `io.openlineage.spark.agent.facets.DebugRunFacet` source code to get more up-to-date information about the fields.


### PR DESCRIPTION
Extend DebugFacet with additional information on Spark's driver memory configuration and current memory usage. 