### PR TITLE
Flink integration: connector of type kafka-upsert wasn't identifying kafka topics correctly

### DIFF
--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KafkaTableLineageDatasetIdentifierVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/identifier/KafkaTableLineageDatasetIdentifierVisitor.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -21,7 +22,7 @@ import org.apache.flink.table.planner.lineage.TableLineageDataset;
 /** Class to extract dataset identifier from {@link TableLineageDataset} stored on Kafka. */
 @Slf4j
 public class KafkaTableLineageDatasetIdentifierVisitor implements DatasetIdentifierVisitor {
-  private static final String KAFKA_CONNECTOR = "kafka";
+  private static final Set<String> KAFKA_CONNECTORS = Set.of("kafka", "upsert-kafka");
   private static final String KAFKA_DATASET_PREFIX = "kafka://";
   private static final String COMMA = ",";
   private static final String SEMICOLON = ";";
@@ -49,7 +50,7 @@ public class KafkaTableLineageDatasetIdentifierVisitor implements DatasetIdentif
     }
 
     log.debug("Table options contains connector {}", options.get("connector"));
-    return KAFKA_CONNECTOR.equals(options.get("connector"));
+    return KAFKA_CONNECTORS.contains(options.get("connector"));
   }
 
   @Override

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KafkaTableLineageDatasetIdentifierVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/identifier/KafkaTableLineageDatasetIdentifierVisitorTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.planner.lineage.TableLineageDataset;
 import org.apache.flink.table.planner.lineage.TableLineageDatasetImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class KafkaTableLineageDatasetIdentifierVisitorTest {
   KafkaTableLineageDatasetIdentifierVisitor visitor =
@@ -69,13 +71,14 @@ class KafkaTableLineageDatasetIdentifierVisitorTest {
     assertThat(visitor.isDefinedAt(table)).isTrue();
   }
 
-  @Test
-  void testApply() {
+  @ParameterizedTest
+  @ValueSource(strings = {"kafka", "upsert-kafka"})
+  void testApply(String connectorName) {
     when(catalogBaseTable.getOptions())
         .thenReturn(
             Map.of(
                 "connector",
-                "kafka",
+                connectorName,
                 "properties.bootstrap.servers",
                 "localhost:1000,localhost:2000",
                 "topic",


### PR DESCRIPTION
### Problem

Openlineage-flink was resolving topics correctly for connector "kafka" but not for "upsert-kafka". This tiny fix solved the issue.

### Solution

Fix is tiny and the above problem statement solves this.

#### One-line summary:

Fix kafka dataset name resolution for "kafka-upsert" flink connector

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project