### PR TITLE
spark: add new AlterTableCommandDatasetBuilder for spark40

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -37,6 +37,7 @@ import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputData
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.MergeRowsColumnLineageVisitor;
+import io.openlineage.spark40.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark40.agent.lifecycle.plan.StreamingDataSourceV2ScanRelationDatasetBuilder;
 import java.util.Collection;
 import java.util.List;
@@ -88,10 +89,8 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new DropTableDatasetBuilder(context))
-            .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context));
-    // .add(new AlterTableCommandDatasetBuilder(context); one of the classes no longer present for
-    // Spark 4
-    // TODO: https://github.com/OpenLineage/OpenLineage/issues/3884
+            .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
+            .add(new AlterTableCommandDatasetBuilder(context));
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -1,0 +1,111 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark40.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.plans.logical.AddColumns;
+import org.apache.spark.sql.catalyst.plans.logical.AlterTableCommand;
+import org.apache.spark.sql.catalyst.plans.logical.CommentOnTable;
+import org.apache.spark.sql.catalyst.plans.logical.DropColumns;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.RenameColumn;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceColumns;
+import org.apache.spark.sql.catalyst.plans.logical.SetTableLocation;
+import org.apache.spark.sql.catalyst.plans.logical.SetTableProperties;
+import org.apache.spark.sql.catalyst.plans.logical.UnsetTableProperties;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.StructType;
+
+@Slf4j
+public class AlterTableCommandDatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<LogicalPlan> {
+
+  public AlterTableCommandDatasetBuilder(@NonNull OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return x instanceof CommentOnTable
+        || x instanceof SetTableLocation
+        || x instanceof SetTableProperties
+        || x instanceof UnsetTableProperties
+        || x instanceof AddColumns
+        || x instanceof ReplaceColumns
+        || x instanceof DropColumns
+        || x instanceof RenameColumn;
+    // Note: AlterColumn removed for Spark 4.0 compatibility
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, LogicalPlan alterTableCommand) {
+    ResolvedTable resolvedTable = (ResolvedTable) ((AlterTableCommand) alterTableCommand).table();
+    Table table;
+    try {
+      // resolvedTable has only old metadata (before alter)
+      table = resolvedTable.catalog().loadTable(resolvedTable.identifier());
+    } catch (NoSuchTableException e) {
+      return Collections.emptyList();
+    }
+    TableCatalog tableCatalog = resolvedTable.catalog();
+    Map<String, String> tableProperties = table.properties();
+    Identifier identifier = resolvedTable.identifier();
+    StructType schema = table.schema();
+    OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange =
+        OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.ALTER;
+
+    Optional<DatasetIdentifier> di =
+        PlanUtils3.getDatasetIdentifier(context, tableCatalog, identifier, tableProperties);
+
+    if (!di.isPresent()) {
+      return Collections.emptyList();
+    }
+
+    OpenLineage openLineage = context.getOpenLineage();
+    DatasetCompositeFacetsBuilder builder = new DatasetCompositeFacetsBuilder(openLineage);
+    builder
+        .getFacets()
+        .schema(PlanUtils.schemaFacet(openLineage, schema))
+        .lifecycleStateChange(
+            openLineage.newLifecycleStateChangeDatasetFacet(lifecycleStateChange, null))
+        .dataSource(PlanUtils.datasourceFacet(openLineage, di.get().getNamespace()));
+
+    if (includeDatasetVersion(event)) {
+      Optional<String> datasetVersion =
+          CatalogUtils3.getDatasetVersion(
+              context, resolvedTable.catalog(), resolvedTable.identifier(), table.properties());
+      datasetVersion.ifPresent(
+          version ->
+              builder.getFacets().version(openLineage.newDatasetVersionDatasetFacet(version)));
+    }
+    return Collections.singletonList(outputDataset().getDataset(di.get(), builder));
+  }
+
+  @Override
+  public Optional<String> jobNameSuffix(LogicalPlan alterTableCommand) {
+    ResolvedTable resolvedTable = (ResolvedTable) ((AlterTableCommand) alterTableCommand).table();
+    return Optional.of(identToSuffix(resolvedTable.identifier()));
+  }
+}

--- a/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
+++ b/integration/spark/spark40/src/main/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilder.java
@@ -55,7 +55,7 @@ public class AlterTableCommandDatasetBuilder
         || x instanceof ReplaceColumns
         || x instanceof DropColumns
         || x instanceof RenameColumn;
-    // Note: AlterColumn removed for Spark 4.0 compatibility
+    // AlterColumn removed for Spark 4.0 compatibility
   }
 
   @Override

--- a/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
+++ b/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
@@ -33,11 +33,11 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
-import scala.Option;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import scala.Option;
 
 class AlterTableCommandDatasetBuilderTest {
 
@@ -91,7 +91,8 @@ class AlterTableCommandDatasetBuilderTest {
           .thenReturn(Optional.empty());
 
       List<OpenLineage.OutputDataset> outputDatasets =
-          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+          builder.apply(
+              new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
       assertEquals(0, outputDatasets.size());
     }
   }
@@ -106,7 +107,8 @@ class AlterTableCommandDatasetBuilderTest {
           .thenReturn(Optional.of(di));
 
       List<OpenLineage.OutputDataset> outputDatasets =
-          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+          builder.apply(
+              new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
 
       assertEquals(1, outputDatasets.size());
       assertEquals("table", outputDatasets.get(0).getName());
@@ -129,7 +131,8 @@ class AlterTableCommandDatasetBuilderTest {
             .thenReturn(Optional.of(di));
 
         List<OpenLineage.OutputDataset> outputDatasets =
-            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+            builder.apply(
+                new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
 
         assertEquals(1, outputDatasets.size());
         assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());

--- a/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
+++ b/integration/spark/spark40/src/test/java/io/openlineage/spark40/agent/lifecycle/plan/AlterTableCommandDatasetBuilderTest.java
@@ -1,0 +1,145 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark40.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
+import io.openlineage.spark3.agent.utils.PlanUtils3;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable;
+import org.apache.spark.sql.catalyst.plans.logical.CommentOnTable;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import scala.Option;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class AlterTableCommandDatasetBuilderTest {
+
+  OpenLineageContext openLineageContext =
+      OpenLineageContext.builder()
+          .sparkSession(mock(SparkSession.class))
+          .sparkContext(mock(SparkContext.class))
+          .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+          .meterRegistry(new SimpleMeterRegistry())
+          .openLineageConfig(new SparkOpenLineageConfig())
+          .build();
+
+  TableCatalog tableCatalog = mock(TableCatalog.class);
+  StructType schema = new StructType();
+  Table table = mock(Table.class);
+  Map<String, String> tableProperties = new HashMap<>();
+  DatasetIdentifier di = new DatasetIdentifier("table", "db");
+  Identifier identifier = mock(Identifier.class);
+  CommentOnTable alterTable = mock(CommentOnTable.class);
+
+  ResolvedTable resolvedTable = mock(ResolvedTable.class);
+
+  AlterTableCommandDatasetBuilder builder = new AlterTableCommandDatasetBuilder(openLineageContext);
+
+  @BeforeEach
+  public void setUp() {
+    when(alterTable.table()).thenReturn(resolvedTable);
+    when(resolvedTable.catalog()).thenReturn(tableCatalog);
+    when(resolvedTable.identifier()).thenReturn(identifier);
+    when(resolvedTable.table()).thenReturn(table);
+    when(resolvedTable.table().schema()).thenReturn(schema);
+    when(resolvedTable.table().properties()).thenReturn(tableProperties);
+  }
+
+  @Test
+  @SneakyThrows
+  void testApplyWhenTableNotFound() {
+    when(tableCatalog.loadTable(identifier)).thenThrow(mock(NoSuchTableException.class));
+    List<OpenLineage.OutputDataset> outputDatasets =
+        builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+    assertEquals(0, outputDatasets.size());
+  }
+
+  @Test
+  @SneakyThrows
+  void testApplyWhenNoDatasetIdentifier() {
+    when(tableCatalog.loadTable(identifier)).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.empty());
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+      assertEquals(0, outputDatasets.size());
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  void testApply() {
+    when(tableCatalog.loadTable(identifier)).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      when(PlanUtils3.getDatasetIdentifier(
+              openLineageContext, tableCatalog, identifier, tableProperties))
+          .thenReturn(Optional.of(di));
+
+      List<OpenLineage.OutputDataset> outputDatasets =
+          builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+
+      assertEquals(1, outputDatasets.size());
+      assertEquals("table", outputDatasets.get(0).getName());
+      assertEquals("db", outputDatasets.get(0).getNamespace());
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  void testApplyDatasetVersionIncluded() {
+    when(tableCatalog.loadTable(identifier)).thenReturn(table);
+    try (MockedStatic mocked = mockStatic(PlanUtils3.class)) {
+      try (MockedStatic mockCatalog = mockStatic(CatalogUtils3.class)) {
+        when(CatalogUtils3.getDatasetVersion(
+                openLineageContext, tableCatalog, identifier, tableProperties))
+            .thenReturn(Optional.of("v2"));
+
+        when(PlanUtils3.getDatasetIdentifier(
+                openLineageContext, tableCatalog, identifier, tableProperties))
+            .thenReturn(Optional.of(di));
+
+        List<OpenLineage.OutputDataset> outputDatasets =
+            builder.apply(new SparkListenerSQLExecutionEnd(1L, 1L, Option.<String>empty()), alterTable);
+
+        assertEquals(1, outputDatasets.size());
+        assertEquals("v2", outputDatasets.get(0).getFacets().getVersion().getDatasetVersion());
+      }
+    }
+  }
+
+  @Test
+  void testJobNameSuffix() {
+    when(resolvedTable.identifier()).thenReturn(Identifier.of(new String[] {"a", "b"}, "c"));
+    assertThat(builder.jobNameSuffix(alterTable).get()).isEqualTo("a_b_c");
+  }
+}

--- a/integration/spark/spark40/src/test/resources/io/openlineage/spark/agent/version.properties
+++ b/integration/spark/spark40/src/test/resources/io/openlineage/spark/agent/version.properties
@@ -1,0 +1,1 @@
+version 1.36.0-SNAPSHOT


### PR DESCRIPTION
### Problem

The `AlterColumn` class was removed in Spark 4, causing the existing Spark 3.2 implementation to fail.
Closes: #3884 

### Solution

#### One-line summary:

Fixes `AlterTableCommandDatasetBuilder` for spark40 compatibility by creating a new spark40-specific implementation that removes the dependency on the missing `AlterColumn` class.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project