### PR TITLE
feat: add Jackson Blackbird module for JSON performance optimization

### DIFF
--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${jacksonVersion}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.module:jackson-module-blackbird:${jacksonVersion}"
     implementation 'org.apache.commons:commons-lang3:3.18.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
     implementation 'commons-logging:commons-logging:1.3.5'

--- a/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/OpenLineageClientUtils.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import io.openlineage.client.OpenLineage.RunEvent;
 import io.openlineage.client.utils.OpenLineageEnvParser;
 import java.io.ByteArrayInputStream;
@@ -85,6 +86,7 @@ public final class OpenLineageClientUtils {
    */
   public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {
     final ObjectMapper mapper = new ObjectMapper(jsonFactory);
+    mapper.registerModule(new BlackbirdModule());
     mapper.registerModule(new Jdk8Module());
     mapper.registerModule(new JavaTimeModule());
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);


### PR DESCRIPTION
Replace reflection-based accessors with LambdaMetafactory-generated ones to reduce overhead and speed up JSON serialization/deserialization in io.openlineage.client.OpenLineageClientUtils.java

Changes:
- Add jackson-module-blackbird dependency
- Register BlackbirdModule with ObjectMapper

## Problem

JSON serialization/deserialization in OpenLineage client currently relies on reflection-based property access, which introduces significant performance overhead. This is particularly noticeable in high-throughput scenarios where OpenLineage events are frequently serialized and deserialized.

The reflection-based approach creates bottlenecks by:
- Using slow reflection calls for property access
- Generating excessive garbage collection pressure
- Limiting JIT compiler optimizations

## Solution

This change integrates Jackson's Blackbird module, which replaces reflection-based property accessors with LambdaMetafactory-generated ones. The Blackbird module generates lightweight accessor classes at runtime using `invokedynamic` and method handles, providing near-native performance for JSON operations.

**Key changes:**
- Added `jackson-module-blackbird` dependency to the project
- Modified `OpenLineageClientUtils.java` to register `BlackbirdModule` with the `ObjectMapper`
- Maintained full backward compatibility - no API changes required

This is a **backwards-compatible** change that requires no schema modifications or client code updates.

#### One-line summary:
Integrate Jackson Blackbird module to replace reflection-based JSON accessors with LambdaMetafactory-generated ones for improved serialization performance

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project