### PR TITLE
spark: fix LogicalRelation constructor compatibility for Spark 4

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KustoRelationVisitorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.LogicalRelationFactory;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -32,7 +33,6 @@ import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -103,8 +103,6 @@ class TestKustoRelationVisitor extends KustoRelationVisitor {
   }
 }
 
-// This test is disabled for Spark 4.x versions, as the LogicalPlan constructor has changed
-@DisabledIfSystemProperty(named = "spark.version", matches = "([4].*)")
 class KustoRelationVisitorTest {
   private static final String FIELD_NAME = "name";
   SparkSession session = mock(SparkSession.class);
@@ -130,19 +128,20 @@ class KustoRelationVisitorTest {
 
     // Instantiate a MockKustoRelation
     LogicalRelation lr =
-        new LogicalRelation(
-            new MockKustoRelation(inputQuery, url, database),
-            ScalaConversionUtils.fromList(
-                Collections.singletonList(
-                    new AttributeReference(
-                        FIELD_NAME,
-                        StringType$.MODULE$,
-                        false,
-                        null,
-                        ExprId.apply(1L),
-                        ScalaConversionUtils.<String>asScalaSeqEmpty()))),
-            Option.empty(),
-            false);
+        LogicalRelationFactory.create(
+                new MockKustoRelation(inputQuery, url, database),
+                ScalaConversionUtils.fromList(
+                    Collections.singletonList(
+                        new AttributeReference(
+                            FIELD_NAME,
+                            StringType$.MODULE$,
+                            false,
+                            null,
+                            ExprId.apply(1L),
+                            ScalaConversionUtils.<String>asScalaSeqEmpty()))),
+                Option.empty(),
+                false)
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
 
     TestKustoRelationVisitor visitor =
         new TestKustoRelationVisitor(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/SQLDWDatabricksVisitorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.SparkAgentTestExtension;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.LogicalRelationFactory;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -30,7 +31,6 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import scala.Option;
@@ -120,9 +120,6 @@ class TestSqlDWDatabricksVisitor extends SqlDWDatabricksVisitor {
   }
 }
 
-@EnabledIfSystemProperty(
-    named = "spark.version",
-    matches = "([3].*)") // doesn't work for Spark 4 which has different LogicalRelation constructor
 class SQLDWDatabricksVisitorTest {
   private static final String FIELD_NAME = "name";
   SparkSession session = mock(SparkSession.class);
@@ -150,19 +147,20 @@ class SQLDWDatabricksVisitorTest {
 
     // Instantiate a MockSQLDWRelation
     LogicalRelation lr =
-        new LogicalRelation(
-            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            ScalaConversionUtils.fromList(
-                Collections.singletonList(
-                    new AttributeReference(
-                        FIELD_NAME,
-                        StringType$.MODULE$,
-                        false,
-                        null,
-                        ExprId.apply(1L),
-                        ScalaConversionUtils.asScalaSeqEmpty()))),
-            Option.empty(),
-            false);
+        LogicalRelationFactory.create(
+                new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+                ScalaConversionUtils.fromList(
+                    Collections.singletonList(
+                        new AttributeReference(
+                            FIELD_NAME,
+                            StringType$.MODULE$,
+                            false,
+                            null,
+                            ExprId.apply(1L),
+                            ScalaConversionUtils.asScalaSeqEmpty()))),
+                Option.empty(),
+                false)
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
@@ -191,19 +189,20 @@ class SQLDWDatabricksVisitorTest {
 
     // Instantiate a MockSQLDWRelation
     LogicalRelation lr =
-        new LogicalRelation(
-            new MockSpark2SqlDWBaseRelation(inputName, inputJdbcUrl),
-            ScalaConversionUtils.fromList(
-                Collections.singletonList(
-                    new AttributeReference(
-                        FIELD_NAME,
-                        StringType$.MODULE$,
-                        false,
-                        null,
-                        ExprId.apply(1L),
-                        ScalaConversionUtils.asScalaSeqEmpty()))),
-            Option.empty(),
-            false);
+        LogicalRelationFactory.create(
+                new MockSpark2SqlDWBaseRelation(inputName, inputJdbcUrl),
+                ScalaConversionUtils.fromList(
+                    Collections.singletonList(
+                        new AttributeReference(
+                            FIELD_NAME,
+                            StringType$.MODULE$,
+                            false,
+                            null,
+                            ExprId.apply(1L),
+                            ScalaConversionUtils.asScalaSeqEmpty()))),
+                Option.empty(),
+                false)
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
@@ -226,19 +225,20 @@ class SQLDWDatabricksVisitorTest {
 
     // Instantiate a MockSQLDWRelation
     LogicalRelation lr =
-        new LogicalRelation(
-            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            ScalaConversionUtils.fromList(
-                Collections.singletonList(
-                    new AttributeReference(
-                        FIELD_NAME,
-                        StringType$.MODULE$,
-                        false,
-                        null,
-                        ExprId.apply(1L),
-                        ScalaConversionUtils.asScalaSeqEmpty()))),
-            Option.empty(),
-            false);
+        LogicalRelationFactory.create(
+                new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+                ScalaConversionUtils.fromList(
+                    Collections.singletonList(
+                        new AttributeReference(
+                            FIELD_NAME,
+                            StringType$.MODULE$,
+                            false,
+                            null,
+                            ExprId.apply(1L),
+                            ScalaConversionUtils.asScalaSeqEmpty()))),
+                Option.empty(),
+                false)
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(
@@ -258,19 +258,20 @@ class SQLDWDatabricksVisitorTest {
 
     // Instantiate a MockSQLDWRelation
     LogicalRelation lr =
-        new LogicalRelation(
-            new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
-            ScalaConversionUtils.fromList(
-                Collections.singletonList(
-                    new AttributeReference(
-                        FIELD_NAME,
-                        StringType$.MODULE$,
-                        false,
-                        null,
-                        ExprId.apply(1L),
-                        ScalaConversionUtils.asScalaSeqEmpty()))),
-            Option.empty(),
-            false);
+        LogicalRelationFactory.create(
+                new MockSqlDWBaseRelation(inputName, inputJdbcUrl),
+                ScalaConversionUtils.fromList(
+                    Collections.singletonList(
+                        new AttributeReference(
+                            FIELD_NAME,
+                            StringType$.MODULE$,
+                            false,
+                            null,
+                            ExprId.apply(1L),
+                            ScalaConversionUtils.asScalaSeqEmpty()))),
+                Option.empty(),
+                false)
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
 
     TestSqlDWDatabricksVisitor visitor =
         new TestSqlDWDatabricksVisitor(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java
@@ -16,6 +16,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.jdbc.JdbcDatasetUtils;
 import io.openlineage.spark.agent.util.DatasetFacetsUtils;
+import io.openlineage.spark.agent.util.LogicalRelationFactory;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
@@ -184,11 +185,12 @@ public class SaveIntoDataSourceCommandVisitor
       throw ex;
     }
     LogicalRelation logicalRelation =
-        new LogicalRelation(
-            relation,
-            ScalaConversionUtils.asScalaSeqEmpty(),
-            Option.empty(),
-            command.isStreaming());
+        LogicalRelationFactory.create(
+                relation,
+                ScalaConversionUtils.asScalaSeqEmpty(),
+                Option.empty(),
+                command.isStreaming())
+            .orElseThrow(() -> new RuntimeException("Failed to create LogicalRelation"));
     return delegate(
             context.getOutputDatasetQueryPlanVisitors(), context.getOutputDatasetBuilders(), event)
         .applyOrElse(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/LogicalRelationFactory.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/LogicalRelationFactory.java
@@ -1,0 +1,101 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.sources.BaseRelation;
+import scala.Option;
+import scala.collection.Seq;
+
+@Slf4j
+public class LogicalRelationFactory {
+
+  private static final Class<?> LOGICAL_RELATION_CLASS = LogicalRelation.class;
+  private static volatile Constructor<?> cachedConstructor;
+
+  /**
+   * Creates LogicalRelation using reflection to handle version differences between Spark 3.x and
+   * 4.x. Spark 4.x added an additional stream parameter to the constructor.
+   *
+   * @param relation The BaseRelation
+   * @param attributes Sequence of AttributeReference
+   * @param catalogTable Optional CatalogTable
+   * @param isStreaming Boolean indicating if this is a streaming relation
+   * @return Optional LogicalRelation instance, empty if creation fails
+   */
+  public static Optional<LogicalRelation> create(
+      BaseRelation relation,
+      Seq<AttributeReference> attributes,
+      Option<?> catalogTable,
+      boolean isStreaming) {
+
+    try {
+      Constructor<?> constructor = getLogicalRelationConstructor();
+
+      if (constructor.getParameterCount() == 4) {
+        // Spark 3.x constructor
+        return Optional.of(
+            (LogicalRelation)
+                constructor.newInstance(relation, attributes, catalogTable, isStreaming));
+      } else if (constructor.getParameterCount() == 5) {
+        // Spark 4.x constructor with additional stream parameter
+        return Optional.of(
+            (LogicalRelation)
+                constructor.newInstance(
+                    relation, attributes, catalogTable, isStreaming, Option.empty()));
+      }
+
+      log.warn(
+          "Unexpected LogicalRelation constructor parameter count: {}",
+          constructor.getParameterCount());
+      return Optional.empty();
+
+    } catch (Exception e) {
+      log.warn("Failed to create LogicalRelation using reflection", e);
+      return Optional.empty();
+    }
+  }
+
+  private static Constructor<?> getLogicalRelationConstructor() throws Exception {
+    if (cachedConstructor != null) {
+      return cachedConstructor;
+    }
+
+    synchronized (LogicalRelationFactory.class) {
+      if (cachedConstructor != null) {
+        return cachedConstructor;
+      }
+
+      // Try Spark 4.x constructor first (5 parameters)
+      try {
+        cachedConstructor =
+            LOGICAL_RELATION_CLASS.getConstructor(
+                BaseRelation.class,
+                Seq.class,
+                Option.class,
+                boolean.class,
+                Option.class // stream parameter
+                );
+        log.debug("Using Spark 4.x LogicalRelation constructor (5 parameters)");
+        return cachedConstructor;
+      } catch (NoSuchMethodException ignored) {
+        // Fall back to Spark 3.x constructor
+      }
+
+      // Try Spark 3.x constructor (4 parameters)
+      cachedConstructor =
+          LOGICAL_RELATION_CLASS.getConstructor(
+              BaseRelation.class, Seq.class, Option.class, boolean.class);
+      log.debug("Using Spark 3.x LogicalRelation constructor (4 parameters)");
+
+      return cachedConstructor;
+    }
+  }
+}


### PR DESCRIPTION
### Problem

Spark 4 introduced changes to the `LogicalRelation` constructor signature, causing test failures and requiring version-specific exclusions.
Closes: #3885 

### Solution

Create a `LogicalRelationFactory` utility class that uses reflection to automatically detect and call the appropriate constructor based on the available Spark version.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project