### PR TITLE
add an option to override dbt job name

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/local.py
+++ b/integration/common/openlineage/common/provider/dbt/local.py
@@ -134,6 +134,10 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
 
         The construction of the job name adheres to the following rules:
 
+            - If there is user-defined OPENLINEAGE_DBT_JOB_NAME env var
+              or --openlineage-dbt-job-name command line flag, then
+              it uses the value as the job name.
+
             - If OPENLINEAGE_DBT_USE_EXTENDED_JOB_NAME is set to false/0
               (default), then the job name is in the format
               ``dbt-run-{project_name}``.
@@ -147,6 +151,8 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
         task. Feel free to open a PR/discussion if you think that this list of
         identifiers should be extended or modified.
         """
+        if self.openlineage_job_name:
+            return self.openlineage_job_name
 
         job_name = f"dbt-run-{self.project_name}"
         if not self._use_extended_job_name:

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -141,11 +141,13 @@ class DbtArtifactProcessor:
         logger: Optional[logging.Logger] = None,
         models: Optional[Sequence[str]] = None,
         selector: Optional[str] = None,
+        openlineage_job_name: Optional[str] = None,
     ):
         self.producer = producer
         self._dbt_run_metadata: Optional[ParentRunMetadata] = None
         self.logger = logger or logging.getLogger(f"{self.__class__.__module__}.{self.__class__.__name__}")
 
+        self.openlineage_job_name = openlineage_job_name
         self.job_namespace = job_namespace
         self.dataset_namespace = ""
         self.skip_errors = skip_errors

--- a/integration/common/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/openlineage/common/provider/dbt/utils.py
@@ -16,6 +16,7 @@ PRODUCER = f"https://github.com/OpenLineage/OpenLineage/tree/{__version__}/integ
 # for which command structured logs consumption is implemented
 HANDLED_COMMANDS = ["run", "seed", "snapshot", "test", "build"]
 CONSUME_STRUCTURED_LOGS_COMMAND_OPTION = "--consume-structured-logs"
+OPENLINEAGE_DBT_JOB_NAME_OPTION = "--openlineage-dbt-job-name"
 DBT_LOG_FILE_MAX_BYTES = str(5 * 1024 * 1024 * 1024)
 
 log = logging.getLogger(__name__)

--- a/integration/common/openlineage/common/utils.py
+++ b/integration/common/openlineage/common/utils.py
@@ -147,13 +147,27 @@ def has_command_line_option(command_line: List[str], command_option: str) -> boo
     return command_option in command_line
 
 
-def remove_command_line_option(command_line: List[str], command_option: str) -> List[str]:
+def remove_command_line_option(
+    command_line: List[str], command_option: str, remove_value: bool = False
+) -> List[str]:
     if not has_command_line_option(command_line, command_option):
         return command_line
 
     command_line = list(command_line)
     command_option_index = command_line.index(command_option)
+
+    # Remove the option itself
     command_line.pop(command_option_index)
+
+    # Optionally remove the value if requested and it exists
+    if (
+        remove_value
+        and command_option_index < len(command_line)
+        and not command_line[command_option_index].startswith("-")
+    ):
+        # Remove the value as well
+        command_line.pop(command_option_index)
+
     return command_line
 
 

--- a/integration/common/tests/dbt/test_dbt_local.py
+++ b/integration/common/tests/dbt/test_dbt_local.py
@@ -43,27 +43,28 @@ def serialize(inst, field, value):
 
 
 @pytest.mark.parametrize(
-    "path",
+    ("path", "job_name"),
     [
-        "tests/dbt/small",
-        "tests/dbt/large",
-        "tests/dbt/profiles",
-        "tests/dbt/catalog",
-        "tests/dbt/fail",
-        "tests/dbt/build",
-        "tests/dbt/compiled_code",
-        "tests/dbt/spark/thrift",
-        "tests/dbt/spark/odbc",
-        "tests/dbt/postgres",
-        "tests/dbt/snapshot",
-        "tests/dbt/duckdb",
+        ("tests/dbt/small", "dbt-job-name"),
+        ("tests/dbt/large", None),
+        ("tests/dbt/profiles", None),
+        ("tests/dbt/catalog", None),
+        ("tests/dbt/fail", None),
+        ("tests/dbt/build", None),
+        ("tests/dbt/compiled_code", None),
+        ("tests/dbt/spark/thrift", None),
+        ("tests/dbt/spark/odbc", "dbt-job-name"),
+        ("tests/dbt/postgres", None),
+        ("tests/dbt/snapshot", None),
+        ("tests/dbt/duckdb", None),
     ],
 )
-def test_dbt_parse_and_compare_event(path, parent_run_metadata):
+def test_dbt_parse_and_compare_event(path, job_name, parent_run_metadata):
     processor = DbtLocalArtifactProcessor(
         producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         job_namespace="job-namespace",
         project_dir=path,
+        openlineage_job_name=job_name,
     )
     processor.dbt_run_metadata = parent_run_metadata
     dbt_events = processor.parse()

--- a/integration/dbt/tests/integration/test_structured_logs.py
+++ b/integration/dbt/tests/integration/test_structured_logs.py
@@ -15,13 +15,22 @@ class TestStructuredLogs:
 
         # Run with structured logs mode using dbt-ol for a single model
         result = dbt_runner.run_dbt_ol_command(
-            ["--consume-structured-logs", "run", "--select", "stg_customers"]
+            [
+                "--consume-structured-logs",
+                "run",
+                "--select",
+                "stg_customers",
+                "--openlineage-dbt-job-name",
+                "structured-logs",
+            ]
         )
         assert result["success"], f"dbt-ol run with structured logs failed: {result['output']}"
 
         # Get events
         events = dbt_runner.get_events()
         print(f"Total events received: {len(events)}")
+
+        print(result["output"])
 
         # Should have at least 6 events
         assert len(events) >= 6, f"Expected at least 6 events, got {len(events)}"
@@ -60,6 +69,13 @@ class TestStructuredLogs:
 
         assert len(job_start_events) == 1, f"Expected 1 job START event, got {len(job_start_events)}"
         assert len(job_complete_events) == 1, f"Expected 1 job COMPLETE event, got {len(job_complete_events)}"
+
+        assert (
+            job_start_events[0]["job"]["name"] == "structured-logs"
+        ), "Expected job name to be structured-logs"
+        assert (
+            job_complete_events[0]["job"]["name"] == "structured-logs"
+        ), "Expected job name to be structured-logs"
 
         # Should have exactly 2 model-level events (START and COMPLETE)
         assert len(model_events) == 2, f"Expected 2 model events, got {len(model_events)}"

--- a/integration/dbt/tests/test_main.py
+++ b/integration/dbt/tests/test_main.py
@@ -56,6 +56,22 @@ def test_structured_logs(command_line: str, number_of_calls: int, monkeypatch):
             ],
             {"OPENLINEAGE_NAMESPACE": "dbt"},
             {
+                "args": [
+                    "dbt",
+                    "run",
+                    "--select",
+                    "orders",
+                    "--profiles-dir",
+                    "~/dbt/profiles-foo",
+                    "--project-dir",
+                    "~/dbt",
+                    "--target",
+                    "production",
+                    "--target-path",
+                    "dbt-target-1234",
+                    "--vars",
+                    '\'{"foo": "bar"}\'',
+                ],
                 "target": "production",
                 "project_dir": "~/dbt",
                 "profile_name": None,
@@ -112,4 +128,5 @@ def test_consume_structured_logs(command_line, os_envs, function_kwargs, monkeyp
         logger=mock.ANY,
         models=function_kwargs["models"],
         selector=function_kwargs["model_selector"],
+        openlineage_job_name=None,
     )

--- a/website/docs/integrations/dbt.md
+++ b/website/docs/integrations/dbt.md
@@ -51,6 +51,12 @@ Finally, we can optionally specify a namespace where the lineage events will be 
 OPENLINEAGE_NAMESPACE=dev
 ```
 
+You can also override the job name sent by dbt OpenLineage events by providing env variable
+```bash
+OPENLINEAGE_DBT_JOB_NAME=<your-job-name>
+```
+or passing `--openlineage-dbt-job-name <your-job-name>` in the dbt command line.
+
 More configuration parameters can be found in [Python client documentation](../client/python.md#configuration)
 
 ## Running dbt with OpenLineage


### PR DESCRIPTION
Currently, we use dbt project name as the name of the dbt job level event. We also have an option to use the selector as override. 

However, in many use cases, user defined name would be the best option, especially in the cases where the users run a lot of different subsets of models from single, large, dbt project - that have some business definition.