### PR TITLE
[SPARK] Fixed the Argument Parser to correctly parse spark.openlineage.vendors.iceberg.metricsReporterDisabled

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -150,6 +150,20 @@ public class ArgumentParser {
       ObjectNode nodePointer = objectNode;
       String keyPath = c._1;
       String value = c._2;
+
+      if (keyPath.startsWith("vendors.")) {
+        ObjectNode vendorsNode;
+        if (objectNode.has("vendors")) {
+          vendorsNode = (ObjectNode) objectNode.get("vendors");
+        } else {
+          vendorsNode = objectMapper.createObjectNode();
+          objectNode.set("vendors", vendorsNode);
+        }
+        String vendorKey = keyPath.substring("vendors.".length());
+        vendorsNode.put(vendorKey, value);
+        continue;
+      }
+
       if (StringUtils.isNotBlank(value)) {
         List<String> pathKeys = getJsonPath(keyPath);
         List<String> nonLeafs = pathKeys.subList(0, pathKeys.size() - 1);


### PR DESCRIPTION
### Problem

Setting the Spark Config `spark.openlineage.vendors.iceberg.metricsReporterDisabled` was throwing an error.

### Solution

The `extractOpenLineageConfFromSparkConf` method has been updated to include special handling for keys prefixed with `vendors.`. The new logic now correctly strips only the `vendors.` prefix and treats the remainder of the string as a single key. This ensures the generated JSON structure aligns with the configuration model, allowing vendor properties to be set correctly.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Update Argument parser to conform to the defined `VendorsConfig`.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project