### PR TITLE
(python) fix tags config

### DIFF
--- a/client/python/openlineage/client/client.py
+++ b/client/python/openlineage/client/client.py
@@ -67,11 +67,9 @@ class OpenLineageConfig:
         if "filters" in params:
             config.filters = [FilterConfig(**filter_config) for filter_config in params["filters"]]
         if "tags" in params:
-            job_tags = params["tags"].get("job", {})
-            run_tags = params["tags"].get("run", {})
             config.tags = TagsConfig(
-                job=[TagsJobFacetFields(key, value, "USER") for (key, value) in job_tags.items()],
-                run=[TagsRunFacetFields(key, value, "USER") for (key, value) in run_tags.items()],
+                job=params["tags"].get("job", {}),
+                run=params["tags"].get("run", {}),
             )
         return config
 
@@ -452,14 +450,16 @@ class OpenLineageClient:
         """
         run_event_types = (RunEvent, event_v2.RunEvent)
         run_and_job_event_types = (RunEvent, event_v2.RunEvent, JobEvent, event_v2.JobEvent)
-        tags_job = self.config.tags.job
+        # tags_job = self.config.tags.job
+        tags_job = [TagsJobFacetFields(key, value, "USER") for (key, value) in self.config.tags.job.items()]
         if isinstance(event, run_and_job_event_types) and tags_job:
             # Ensure facets exists
             event.job.facets = {} if not event.job.facets else event.job.facets
             tags_facet = event.job.facets.get("tags", TagsJobFacet())
             event.job.facets["tags"] = self._update_tag_facet(tags_facet, tags_job)  # type: ignore [arg-type, assignment]
 
-        tags_run = self.config.tags.run
+        # tags_run = self.config.tags.run
+        tags_run = [TagsRunFacetFields(key, value, "USER") for (key, value) in self.config.tags.run.items()]
         if isinstance(event, run_event_types) and tags_run:
             # Ensure facets exists
             event.run.facets = {} if not event.run.facets else event.run.facets

--- a/client/python/openlineage/client/tags.py
+++ b/client/python/openlineage/client/tags.py
@@ -2,16 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import attr
-
-if TYPE_CHECKING:
-    from openlineage.client.generated.tags_job import TagsJobFacetFields
-    from openlineage.client.generated.tags_run import TagsRunFacetFields
 
 
 @attr.define
 class TagsConfig:
-    job: list[TagsJobFacetFields] = attr.field(factory=list)
-    run: list[TagsRunFacetFields] = attr.field(factory=list)
+    job: dict[str, str] = attr.field(factory=dict)
+    run: dict[str, str] = attr.field(factory=dict)

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -8,6 +8,7 @@ import re
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import attr
 import pytest
 from openlineage.client import event_v2
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions, OpenLineageConfig
@@ -415,6 +416,16 @@ def test_ol_config_from_dict():
     # Test with invalid data type
     with pytest.raises(TypeError):
         OpenLineageConfig.from_dict({"facets": "invalid_data"})
+
+
+def test_ol_config_from_the_same_dict():
+    config_dict = {
+        "transport": {"url": "http://localhost:5050"},
+        "facets": {"environment_variables": ["VAR1", "VAR2"]},
+        "filters": [{"type": "exact", "match": "job_name"}],
+    }
+    config = OpenLineageConfig.from_dict(config_dict)
+    assert OpenLineageConfig.from_dict(attr.asdict(config)) == config
 
 
 @patch("yaml.safe_load", return_value=None)


### PR DESCRIPTION
### Problem

TagsConfig should not have facets but data to create them in correct moment.
This also fixes behaviour when serialized config is used back again as `config` param.

### Solution

This commit fixes the TagsConfig class to use dictionaries for job and run tags instead of lists of TagsJobFacetFields and TagsRunFacetFields.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project