### PR TITLE
Spark - CLL performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+* **Spark: Improve performance of column level lineage** [`#3946`](https://github.com/OpenLineage/OpenLineage/pull/3946) [@pawel-big-lebowski](https://github.com/pawel-big-lebowski)  
+  *Limit memory consumption, provide limits for the amount of dependencies processed (1M) and input fields returned in the facet (100K). Turns on dataset lineage by default.*
+
 ## [1.36.0](https://github.com/OpenLineage/OpenLineage/compare/1.35.0...1.36.0) - 2025-07-22
 
 ### Added

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkContainerUtils.java
@@ -208,6 +208,7 @@ public class SparkContainerUtils {
     addSparkConfig(sparkConf, "spark.jars.ivy=/tmp/.ivy2/");
     addSparkConfig(sparkConf, "spark.openlineage.facets.spark.logicalPlan.disabled=false");
     addSparkConfig(sparkConf, "spark.openlineage.facets.spark_unknown.disabled=false");
+    addSparkConfig(sparkConf, "spark.openlineage.columnLineage.datasetLineageEnabled=false");
     addSparkConfig(
         sparkConf, "spark.openlineage.dataset.namespaceResolvers.kafka-cluster-prod.type=hostList");
     addSparkConfig(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/ColumnLevelLineageBuilder.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacetFields;
+import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacetFieldsAdditionalBuilder;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.client.OpenLineageClientUtils;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -39,6 +41,9 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class ColumnLevelLineageBuilder {
 
+  private static final Integer COMPUTED_DEPENDENCY_HARD_LIMIT = 1000000;
+  private static final Integer RETURNED_INPUT_FIELD_LIMIT = 100000;
+
   private Map<ExprId, Set<Dependency>> exprDependencies = new HashMap<>();
   private List<ExprId> datasetDependencies = new LinkedList<>();
   @Getter private Map<ExprId, Set<Input>> inputs = new HashMap<>();
@@ -46,6 +51,10 @@ public class ColumnLevelLineageBuilder {
   private Map<ColumnMeta, ExprId> externalExpressionMappings = new HashMap<>();
   private final OpenLineage.SchemaDatasetFacet schema;
   private final OpenLineageContext context;
+
+  private final Map<ExprId, Dependency> commonDependencies = new HashMap<>();
+
+  private int dependenciesAdded;
 
   public ColumnLevelLineageBuilder(
       @NonNull final OpenLineage.SchemaDatasetFacet schema,
@@ -87,16 +96,28 @@ public class ColumnLevelLineageBuilder {
    * @param inputExprId
    */
   public void addDependency(ExprId outputExprId, ExprId inputExprId) {
-    exprDependencies
-        .computeIfAbsent(outputExprId, k -> new HashSet<>())
-        .add(new Dependency(inputExprId, TransformationInfo.identity()));
+    addDependency(outputExprId, inputExprId, TransformationInfo.identity());
   }
 
   public void addDependency(
       ExprId outputExprId, ExprId inputExprId, TransformationInfo transformationInfo) {
-    exprDependencies
-        .computeIfAbsent(outputExprId, k -> new HashSet<>())
-        .add(new Dependency(inputExprId, transformationInfo));
+    if (dependenciesAdded > COMPUTED_DEPENDENCY_HARD_LIMIT) {
+      // do nothing -> hard limit of allowed dependencies reached
+      return;
+    }
+    dependenciesAdded++;
+
+    Dependency dependency = commonDependencies.get(inputExprId);
+
+    if (dependency != null && transformationInfo.equals(dependency.getTransformationInfo())) {
+      // no need to create new dependency object
+    } else {
+      // store dependency in common dependencies
+      dependency = new Dependency(inputExprId, transformationInfo);
+      commonDependencies.put(inputExprId, dependency);
+    }
+
+    exprDependencies.computeIfAbsent(outputExprId, k -> new HashSet<>()).add(dependency);
   }
 
   public void addDatasetDependency(ExprId outputExprId) {
@@ -162,9 +183,34 @@ public class ColumnLevelLineageBuilder {
     List<TransformedInput> datasetDependencyInputs =
         datasetLineageEnabled ? Collections.emptyList() : datasetDependencyInputs();
 
-    schema.getFields().stream()
-        .map(field -> Pair.of(field, getInputsUsedFor(field.getName())))
-        .filter(pair -> !pair.getRight().isEmpty())
+    if (dependenciesAdded >= COMPUTED_DEPENDENCY_HARD_LIMIT) {
+      log.warn(
+          "Field dependency amount exceeded allowed hard limit of {}. Returning empty column lineage.",
+          COMPUTED_DEPENDENCY_HARD_LIMIT);
+      return fieldsBuilder.build();
+    }
+
+    List<Pair<SchemaDatasetFacetFields, List<TransformedInput>>> collected =
+        schema.getFields().stream()
+            .map(field -> Pair.of(field, getInputsUsedFor(field.getName())))
+            .filter(pair -> !pair.getRight().isEmpty())
+            .collect(Collectors.toList());
+
+    Integer fieldsDependencies =
+        collected.stream().map(Pair::getRight).map(List::size).reduce(0, Integer::sum);
+
+    if (fieldsDependencies > RETURNED_INPUT_FIELD_LIMIT) {
+      // don't return input fields
+      log.warn(
+          "Amount of input fields exceeds {}. Returning empty column lineage.",
+          RETURNED_INPUT_FIELD_LIMIT);
+      return fieldsBuilder.build();
+    }
+
+    ColumnLineageDatasetFacetFieldsAdditionalBuilder additionalBuilder =
+        context.getOpenLineage().newColumnLineageDatasetFacetFieldsAdditionalBuilder();
+
+    collected.stream()
         .map(
             pair ->
                 Pair.of(pair.getLeft(), facetInputFields(pair.getRight(), datasetDependencyInputs)))
@@ -172,11 +218,7 @@ public class ColumnLevelLineageBuilder {
             pair ->
                 fieldsBuilder.put(
                     pair.getLeft().getName(),
-                    context
-                        .getOpenLineage()
-                        .newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(pair.getRight())
-                        .build()));
+                    additionalBuilder.inputFields(pair.getRight()).build()));
 
     return fieldsBuilder.build();
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/Dependency.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/column/Dependency.java
@@ -8,14 +8,13 @@ package io.openlineage.spark.agent.lifecycle.plan.column;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.spark.sql.catalyst.expressions.ExprId;
 
 @AllArgsConstructor
 class Dependency {
-  @Getter @Setter private ExprId exprId;
+  @Getter private ExprId exprId;
 
-  @Getter @Setter private TransformationInfo transformationInfo;
+  @Getter private TransformationInfo transformationInfo;
 
   @Override
   public String toString() {
@@ -44,8 +43,13 @@ class Dependency {
 
   public Dependency merge(Dependency dependency) {
     if (this.transformationInfo != null) {
-      return new Dependency(
-          dependency.exprId, this.transformationInfo.merge(dependency.getTransformationInfo()));
+      TransformationInfo merged = this.transformationInfo.merge(dependency.getTransformationInfo());
+      if (merged.equals(transformationInfo)) {
+        // exactly the same dependency would work
+        return dependency;
+      } else {
+        return new Dependency(dependency.exprId, merged);
+      }
     }
     return new Dependency(dependency.exprId, null);
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
@@ -20,7 +20,6 @@ public class ColumnLineageConfig {
    * represented as field dependencies. WARNING: This flag is temporary. It is going to default to
    * true in future versions and eventually removed.
    */
-  // TODO #3084: For the release 1.26.0 this flag should default to true
   // TODO #3084: Three releases later (1.29.0), this flag should be removed and the behavior should
   // reflect it set to true
   private boolean datasetLineageEnabled;

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
@@ -22,7 +22,7 @@ public class ColumnLineageConfig {
    */
   // TODO #3084: Three releases later (1.29.0), this flag should be removed and the behavior should
   // reflect it set to true
-  private boolean datasetLineageEnabled;
+  private Boolean datasetLineageEnabled;
 
   private Integer schemaSizeLimit;
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -131,7 +131,6 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     if (columnLineageConfig == null) {
       columnLineageConfig = new ColumnLineageConfig();
       // TODO #3084: For the release 1.26.0 this flag should default to true
-      columnLineageConfig.setDatasetLineageEnabled(false);
       columnLineageConfig.setSchemaSizeLimit(1_000);
       columnLineageConfig.setDatasetLineageEnabled(true);
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -133,6 +133,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       // TODO #3084: For the release 1.26.0 this flag should default to true
       columnLineageConfig.setDatasetLineageEnabled(false);
       columnLineageConfig.setSchemaSizeLimit(1_000);
+      columnLineageConfig.setDatasetLineageEnabled(true);
     }
     return columnLineageConfig;
   }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -62,10 +62,6 @@ public class ColumnLevelLineageUtils {
             .getOpenLineageConfig()
             .getColumnLineageConfig()
             .isDatasetLineageEnabled();
-    if (!datasetLineageEnabled) {
-      log.warn(
-          "DEPRECATION WARNING: The columnLineage.datasetLineageEnabled configuration is set to false. This flag will default to true in the future versions. To avoid this warning, explicitly set it to true. This warning will automatically be removed once the default is switched to true.");
-    }
     facetBuilder.fields(context.getBuilder().buildFields(datasetLineageEnabled));
     context
         .getBuilder()


### PR DESCRIPTION
 * Improvements on memory consumption: reuse objects
 * Provide hard limit on amount of input fields returned in the facet (100K)
 * Provide hard limit on amount of dependencies processed (1M) 