### PR TITLE
[SPARK] Add schema size size limit for column level lineage processing

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/ColumnLineageConfig.java
@@ -24,4 +24,6 @@ public class ColumnLineageConfig {
   // TODO #3084: Three releases later (1.29.0), this flag should be removed and the behavior should
   // reflect it set to true
   private boolean datasetLineageEnabled;
+
+  private Integer schemaSizeLimit;
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -132,6 +132,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       columnLineageConfig = new ColumnLineageConfig();
       // TODO #3084: For the release 1.26.0 this flag should default to true
       columnLineageConfig.setDatasetLineageEnabled(false);
+      columnLineageConfig.setSchemaSizeLimit(1_000);
     }
     return columnLineageConfig;
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtilsTest.java
@@ -1,0 +1,119 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.column;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.ColumnLineageConfig;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ColumnLevelLineageUtilsTest {
+
+  private OpenLineageContext olContext;
+  private SparkOpenLineageConfig config;
+  private ColumnLineageConfig columnLineageConfig;
+  private OpenLineage.SchemaDatasetFacet schemaFacet;
+  private SparkListenerEvent event;
+  private QueryExecution queryExecution;
+
+  @BeforeEach
+  void setup() {
+    olContext = mock(OpenLineageContext.class);
+    config = mock(SparkOpenLineageConfig.class);
+    columnLineageConfig = mock(ColumnLineageConfig.class);
+    schemaFacet = mock(OpenLineage.SchemaDatasetFacet.class);
+    event = mock(SparkListenerEvent.class);
+    queryExecution = mock(QueryExecution.class);
+
+    when(olContext.getOpenLineageConfig()).thenReturn(config);
+    when(config.getColumnLineageConfig()).thenReturn(columnLineageConfig);
+    when(olContext.getQueryExecution()).thenReturn(Optional.of(queryExecution));
+    when(queryExecution.optimizedPlan()).thenReturn(mock(LogicalPlan.class));
+  }
+
+  @Test
+  void testReturnsEmptyWhenQueryExecutionNotPresent() {
+    when(olContext.getQueryExecution()).thenReturn(Optional.empty());
+
+    Optional<OpenLineage.ColumnLineageDatasetFacet> result =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(event, olContext, schemaFacet);
+
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void testReturnsEmptyWhenSchemaFacetIsNull() {
+    // When
+    Optional<OpenLineage.ColumnLineageDatasetFacet> result =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(event, olContext, null);
+
+    // Then
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void testReturnsEmptyWhenOptimizedPlanIsNull() {
+    when(queryExecution.optimizedPlan()).thenReturn(null);
+
+    // When
+    Optional<OpenLineage.ColumnLineageDatasetFacet> result =
+        ColumnLevelLineageUtils.buildColumnLineageDatasetFacet(event, olContext, schemaFacet);
+
+    // Then
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void testSchemaExceedsLimitLogic() {
+    // Given: different schema sizes and limits
+    when(columnLineageConfig.getSchemaSizeLimit()).thenReturn(100);
+
+    List<OpenLineage.SchemaDatasetFacetFields> smallFields = new ArrayList<>();
+    for (int i = 0; i < 50; i++) {
+      smallFields.add(mock(OpenLineage.SchemaDatasetFacetFields.class));
+    }
+    when(schemaFacet.getFields()).thenReturn(smallFields);
+
+    boolean smallSchemaExceedsLimit =
+        schemaFacet.getFields().size() > columnLineageConfig.getSchemaSizeLimit();
+    assertFalse(smallSchemaExceedsLimit, "Schema with 50 fields should not exceed limit of 100");
+
+    List<OpenLineage.SchemaDatasetFacetFields> boundaryFields = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      boundaryFields.add(mock(OpenLineage.SchemaDatasetFacetFields.class));
+    }
+    when(schemaFacet.getFields()).thenReturn(boundaryFields);
+
+    boolean boundarySchemaExceedsLimit =
+        schemaFacet.getFields().size() > columnLineageConfig.getSchemaSizeLimit();
+    assertFalse(
+        boundarySchemaExceedsLimit,
+        "Schema with exactly 100 fields should not exceed limit of 100");
+
+    List<OpenLineage.SchemaDatasetFacetFields> largeFields = new ArrayList<>();
+    for (int i = 0; i < 150; i++) {
+      largeFields.add(mock(OpenLineage.SchemaDatasetFacetFields.class));
+    }
+    when(schemaFacet.getFields()).thenReturn(largeFields);
+
+    boolean largeSchemaExceedsLimit =
+        schemaFacet.getFields().size() > columnLineageConfig.getSchemaSizeLimit();
+    assertTrue(largeSchemaExceedsLimit, "Schema with 150 fields should exceed limit of 100");
+  }
+}


### PR DESCRIPTION
### Problem

This PR addresses problem described in this discussion #3878. The idea here is to omit column level lineage processing if the output schema size exceeds the configurable limit (1000 rows by default)


> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project