### PR TITLE
Python: Change gzip compression level in HttpTransport

### DIFF
--- a/client/python/openlineage/client/transport/async_http.py
+++ b/client/python/openlineage/client/transport/async_http.py
@@ -606,7 +606,9 @@ class AsyncHttpTransport(Transport):
         }
         if self.config.compression == HttpCompression.GZIP:
             headers["Content-Encoding"] = "gzip"
-            return gzip.compress(event.encode("utf-8")), headers
+            # levels higher than 3 are twice as slow:
+            # https://github.com/python/cpython/issues/91349#issuecomment-2737161048
+            return gzip.compress(event.encode("utf-8"), compresslevel=3), headers
 
         return event, headers
 

--- a/client/python/openlineage/client/transport/http.py
+++ b/client/python/openlineage/client/transport/http.py
@@ -226,6 +226,8 @@ class HttpTransport(Transport):
         }
         if self.compression == HttpCompression.GZIP:
             headers["Content-Encoding"] = "gzip"
-            return gzip.compress(event_str.encode("utf-8")), headers
+            # levels higher than 3 are twice as slow:
+            # https://github.com/python/cpython/issues/91349#issuecomment-2737161048
+            return gzip.compress(event_str.encode("utf-8"), compresslevel=3), headers
 
         return event_str, headers


### PR DESCRIPTION
### Problem

By default, Python's `gzip` module uses compressionlevel=9 which is very slow, and gives almost zero benefit. Python 3.15 changed default level from 9 to 6:
https://github.com/python/cpython/pull/131470

But according to this benchmark, level=1 already gives 22.5% of original content size, level=3 gives 21.8%, and levels higher than 3 gives additional 1-2% but twice as slow:
https://github.com/python/cpython/issues/91349#issuecomment-2737161048

My local benchmarks on a small set of Spark OL events:
```
gzip level=0 19181B->19204B in 22.396us 816.78 MB/s 100.12% size
gzip level=1 19181B->1937B in 82.601us 221.45 MB/s 10.10% size
gzip level=2 19181B->1817B in 84.314us 216.96 MB/s 9.47% size
gzip level=3 19181B->1722B in 83.877us 218.09 MB/s 8.98% size
gzip level=4 19181B->1712B in 156.018us 117.25 MB/s 8.93% size
gzip level=5 19181B->1615B in 205.281us 89.11 MB/s 8.42% size
gzip level=6 19181B->1539B in 201.254us 90.89 MB/s 8.02% size
gzip level=7 19181B->1539B in 201.740us 90.67 MB/s 8.02% size
gzip level=8 19181B->1522B in 231.234us 79.11 MB/s 7.93% size
gzip level=9 19181B->1520B in 231.193us 79.12 MB/s 7.92% size
```

### Solution

Alter HttpTransport/AsyncHttpTransport to use gzip with compressionlevel=3 instead of 9.

#### One-line summary:

Python: Change gzip compression level in HttpTransport

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project