### PR TITLE
fix: import from facet_v2 and event_v2 instead of directly from generated modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,21 @@ repos:
             client/python/openlineage/client/facet\.py |
             client/python/openlineage/client/run\.py
           )$
+      - id: check-python-generated-imports
+        name: Check python imports from generated modules
+        description: "Checks if objects are correctly imported in python from event_v2 and facet_v2 modules"
+        language: pygrep
+        entry: "from openlineage.client.generated"
+        files: "\\.py$"
+        # Exclude internal modules that must import this way
+        exclude: |
+          (?x)^(
+            client/python/openlineage/client/generated/.* |
+            client/python/openlineage/client/facet_v2\.py |
+            client/python/openlineage/client/event_v2\.py |
+            client/python/openlineage/client/generator/base\.py |
+            client/python/tests/generator/test_base\.py
+          )$
       - id: prettier
         name: prettier
         description: ""

--- a/client/python/openlineage/client/event_v2.py
+++ b/client/python/openlineage/client/event_v2.py
@@ -13,6 +13,7 @@ from openlineage.client.generated.base import (
     OutputDataset,
     Run,
     RunEvent,
+    StaticDataset,
     set_producer,
 )
 from openlineage.client.generated.base import (
@@ -31,5 +32,6 @@ __all__ = [
     "Run",
     "RunEvent",
     "RunState",
+    "StaticDataset",
     "set_producer",
 ]

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -12,13 +12,8 @@ import attr
 import pytest
 from openlineage.client import event_v2
 from openlineage.client.client import OpenLineageClient, OpenLineageClientOptions, OpenLineageConfig
+from openlineage.client.facet_v2 import environment_variables_run, tags_job, tags_run
 from openlineage.client.facets import FacetsConfig
-from openlineage.client.generated.environment_variables_run import (
-    EnvironmentVariable,
-    EnvironmentVariablesRunFacet,
-)
-from openlineage.client.generated.tags_job import TagsJobFacet, TagsJobFacetFields
-from openlineage.client.generated.tags_run import TagsRunFacet, TagsRunFacetFields
 from openlineage.client.run import (
     SCHEMA_URL,
     Dataset,
@@ -520,8 +515,10 @@ def test_add_environment_facets():
     modified_event = client.add_environment_facets(event)
 
     assert "environmentVariables" in modified_event.run.facets
-    assert modified_event.run.facets["environmentVariables"] == EnvironmentVariablesRunFacet(
-        [EnvironmentVariable(name="ENV_VAR_1", value="value1")]
+    assert modified_event.run.facets[
+        "environmentVariables"
+    ] == environment_variables_run.EnvironmentVariablesRunFacet(
+        [environment_variables_run.EnvironmentVariable(name="ENV_VAR_1", value="value1")]
     )
 
     event2 = event_v2.RunEvent(
@@ -536,8 +533,10 @@ def test_add_environment_facets():
     modified_event2 = client.add_environment_facets(event2)
 
     assert "environmentVariables" in modified_event2.run.facets
-    assert modified_event2.run.facets["environmentVariables"] == EnvironmentVariablesRunFacet(
-        [EnvironmentVariable(name="ENV_VAR_1", value="value1")]
+    assert modified_event2.run.facets[
+        "environmentVariables"
+    ] == environment_variables_run.EnvironmentVariablesRunFacet(
+        [environment_variables_run.EnvironmentVariable(name="ENV_VAR_1", value="value1")]
     )
 
 
@@ -776,7 +775,9 @@ def test_add_environment_facets_with_custom_env_var(mock_resolve_transport) -> N
     client.emit(event)
     assert mock_transport.emit.call_args[0][0].run.facets[
         "environmentVariables"
-    ] == EnvironmentVariablesRunFacet([EnvironmentVariable(name="CUSTOM_ENV_VAR", value="custom_value")])
+    ] == environment_variables_run.EnvironmentVariablesRunFacet(
+        [environment_variables_run.EnvironmentVariable(name="CUSTOM_ENV_VAR", value="custom_value")]
+    )
 
     mock_transport.emit.reset_mock()
     assert mock_transport.emit.call_args is None
@@ -791,7 +792,9 @@ def test_add_environment_facets_with_custom_env_var(mock_resolve_transport) -> N
     client.emit(event2)
     assert mock_transport.emit.call_args[0][0].run.facets[
         "environmentVariables"
-    ] == EnvironmentVariablesRunFacet([EnvironmentVariable(name="CUSTOM_ENV_VAR", value="custom_value")])
+    ] == environment_variables_run.EnvironmentVariablesRunFacet(
+        [environment_variables_run.EnvironmentVariable(name="CUSTOM_ENV_VAR", value="custom_value")]
+    )
 
 
 @patch.dict(
@@ -1109,8 +1112,8 @@ def test_client_creates_new_job_tag_facet(transport, run_event_multi):
     }
 
     tags = [
-        TagsJobFacetFields("environment", "PRODUCTION", "USER"),
-        TagsJobFacetFields("pipeline", "SALES", "USER"),
+        tags_job.TagsJobFacetFields("environment", "PRODUCTION", "USER"),
+        tags_job.TagsJobFacetFields("pipeline", "SALES", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1129,15 +1132,15 @@ def test_client_updates_existing_job_tags_facet(transport, run_event_multi):
     }
 
     existing_tags = [
-        TagsJobFacetFields("environment", "STAGING", "USER"),
-        TagsJobFacetFields("foo", "bar", "USER"),
+        tags_job.TagsJobFacetFields("environment", "STAGING", "USER"),
+        tags_job.TagsJobFacetFields("foo", "bar", "USER"),
     ]
-    run_event_multi.job.facets["tags"] = TagsJobFacet(tags=existing_tags)
+    run_event_multi.job.facets["tags"] = tags_job.TagsJobFacet(tags=existing_tags)
 
     tags = [
-        TagsJobFacetFields("foo", "bar", "USER"),
-        TagsJobFacetFields("environment", "PRODUCTION", "USER"),
-        TagsJobFacetFields("pipeline", "SALES", "USER"),
+        tags_job.TagsJobFacetFields("foo", "bar", "USER"),
+        tags_job.TagsJobFacetFields("environment", "PRODUCTION", "USER"),
+        tags_job.TagsJobFacetFields("pipeline", "SALES", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1156,8 +1159,8 @@ def test_client_creates_new_run_tags_facet(transport, run_event_multi):
     }
 
     tags = [
-        TagsRunFacetFields("environment", "PRODUCTION", "USER"),
-        TagsRunFacetFields("pipeline", "SALES", "USER"),
+        tags_run.TagsRunFacetFields("environment", "PRODUCTION", "USER"),
+        tags_run.TagsRunFacetFields("pipeline", "SALES", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1176,16 +1179,16 @@ def test_client_updates_existing_run_tags_facet(transport, run_event_multi):
     }
 
     existing_tags = [
-        TagsRunFacetFields("ENVIRONMENT", "STAGING", "USER"),
-        TagsRunFacetFields("foo", "bar", "USER"),
+        tags_run.TagsRunFacetFields("ENVIRONMENT", "STAGING", "USER"),
+        tags_run.TagsRunFacetFields("foo", "bar", "USER"),
     ]
-    run_event_multi.run.facets["tags"] = TagsRunFacet(tags=existing_tags)
+    run_event_multi.run.facets["tags"] = tags_run.TagsRunFacet(tags=existing_tags)
 
     # One existing tag (not updated), one existing tag (updated), one new tag from the user
     tags = [
-        TagsRunFacetFields("foo", "bar", "USER"),
-        TagsRunFacetFields("ENVIRONMENT", "PRODUCTION", "USER"),
-        TagsRunFacetFields("pipeline", "SALES", "USER"),
+        tags_run.TagsRunFacetFields("foo", "bar", "USER"),
+        tags_run.TagsRunFacetFields("ENVIRONMENT", "PRODUCTION", "USER"),
+        tags_run.TagsRunFacetFields("pipeline", "SALES", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1204,15 +1207,15 @@ def test_client_keeps_key_case_for_existing_tags(transport, run_event_multi):
     }
 
     tags = [
-        TagsRunFacetFields("environment", "STAGING", "USER"),
-        TagsRunFacetFields("PIPELINE", "FINANCE", "USER"),
+        tags_run.TagsRunFacetFields("environment", "STAGING", "USER"),
+        tags_run.TagsRunFacetFields("PIPELINE", "FINANCE", "USER"),
     ]
 
-    run_event_multi.run.facets["tags"] = TagsRunFacet(tags=tags)
+    run_event_multi.run.facets["tags"] = tags_run.TagsRunFacet(tags=tags)
 
     tags = [
-        TagsRunFacetFields("environment", "PRODUCTION", "USER"),
-        TagsRunFacetFields("PIPELINE", "SALES", "USER"),
+        tags_run.TagsRunFacetFields("environment", "PRODUCTION", "USER"),
+        tags_run.TagsRunFacetFields("PIPELINE", "SALES", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1235,8 +1238,8 @@ def test_client_creates_tag_facets_for_job_events(transport, job_event_multi):
     }
 
     tags = [
-        TagsJobFacetFields("environment", "production", "USER"),
-        TagsJobFacetFields("pipeline", "sales", "USER"),
+        tags_job.TagsJobFacetFields("environment", "production", "USER"),
+        tags_job.TagsJobFacetFields("pipeline", "sales", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):
@@ -1260,8 +1263,8 @@ def test_client_does_not_update_run_tags_for_job_events(transport, job_event_mul
     }
 
     tags = [
-        TagsJobFacetFields("environment", "production", "USER"),
-        TagsJobFacetFields("pipeline", "sales", "USER"),
+        tags_job.TagsJobFacetFields("environment", "production", "USER"),
+        tags_job.TagsJobFacetFields("pipeline", "sales", "USER"),
     ]
 
     with patch.dict(os.environ, tag_environment_variables):

--- a/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
+++ b/client/python/tests/transform/transformers/test_job_namespace_replace_transformer.py
@@ -3,9 +3,8 @@
 import datetime
 
 import pytest
-from openlineage.client.event_v2 import DatasetEvent, Job, JobEvent, Run, RunEvent, RunState
+from openlineage.client.event_v2 import DatasetEvent, Job, JobEvent, Run, RunEvent, RunState, StaticDataset
 from openlineage.client.facet_v2 import parent_run
-from openlineage.client.generated.base import StaticDataset
 from openlineage.client.transport.transform.transformers.job_namespace_replace_transformer import (
     JobNamespaceReplaceTransformer,
 )

--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -20,13 +20,13 @@ from openlineage.client.facet_v2 import (
     data_quality_assertions_dataset,
     datasource_dataset,
     documentation_dataset,
+    external_query_run,
     job_type_job,
     output_statistics_output_dataset,
     processing_engine_run,
     schema_dataset,
     sql_job,
 )
-from openlineage.client.generated.external_query_run import ExternalQueryRunFacet
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet, ParentRunMetadata
 from openlineage.common.provider.dbt.utils import __version__ as openlineage_version
@@ -723,7 +723,7 @@ class DbtArtifactProcessor:
             run_facets["parent"] = self._dbt_run_metadata.to_openlineage()
 
         if query_id:
-            run_facets["externalQuery"] = ExternalQueryRunFacet(
+            run_facets["externalQuery"] = external_query_run.ExternalQueryRunFacet(
                 externalQueryId=query_id, source=self.dataset_namespace
             )
 

--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -16,11 +16,11 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.facet_v2 import (
     error_message_run,
+    external_query_run,
     job_type_job,
     processing_engine_run,
     sql_job,
 )
-from openlineage.client.generated import external_query_run
 from openlineage.client.run import InputDataset
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet, ParentRunMetadata

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -3,8 +3,7 @@
 
 
 import pytest
-from openlineage.client.facet_v2 import processing_engine_run
-from openlineage.client.generated.external_query_run import ExternalQueryRunFacet
+from openlineage.client.facet_v2 import external_query_run, processing_engine_run
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import DbtRunRunFacet, DbtVersionRunFacet
 from openlineage.common.provider.dbt.processor import Adapter, DbtArtifactProcessor
@@ -76,7 +75,9 @@ def test_get_query_id(
             version=DBT_VERSION,
             openlineageAdapterVersion=openlineage_version,
         ),
-        "externalQuery": ExternalQueryRunFacet(externalQueryId=QUERY_ID, source=dataset_namespace),
+        "externalQuery": external_query_run.ExternalQueryRunFacet(
+            externalQueryId=QUERY_ID, source=dataset_namespace
+        ),
     }
 
 


### PR DESCRIPTION
### Problem

We expose facet_v2 and event_v2 publicly, so we should use those modules internally as well.

### Solution

Changed those few imports that were directly importing `from openlineage.client.generated` in python. Added pre-commit to automatically look for those imports and fail.

#### One-line summary:
fix: Import from facet_v2 and event_v2 instead of directly from generated modules

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project