### PR TITLE
spark: Adjust tmp dir in integration tests

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkStreamingTest.java
@@ -148,11 +148,9 @@ class SparkStreamingTest {
     SparkSession spark =
         createSparkSession(server.getAddress().getPort(), "testKafkaSourceToKafkaSink");
 
-    String userDirProperty = System.getProperty("user.dir");
-    Path userDirPath = Paths.get(userDirProperty);
+    Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
 
-    Path checkpointsDir =
-        userDirPath.resolve("tmp").resolve("checkpoints").resolve(testUuid.toString());
+    Path checkpointsDir = tmpDir.resolve("checkpoints").resolve(testUuid.toString());
 
     Dataset<Row> sourceStream =
         readKafkaTopic(spark, kafkaContainer.sourceTopic, bootstrapServers)

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkTestUtils.java
@@ -81,13 +81,11 @@ public class SparkTestUtils {
   }
 
   static SparkSession createSparkSession(Integer httpServerPort, String appName) {
-    String userDirProperty = System.getProperty("user.dir");
-    Path userDirPath = Paths.get(userDirProperty);
+    Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
     UUID testUuid = UUID.randomUUID();
 
-    Path derbySystemHome = userDirPath.resolve("tmp").resolve("derby").resolve(testUuid.toString());
-    Path sparkSqlWarehouse =
-        userDirPath.resolve("tmp").resolve("spark-sql-warehouse").resolve(testUuid.toString());
+    Path derbySystemHome = tmpDir.resolve("derby").resolve(testUuid.toString());
+    Path sparkSqlWarehouse = tmpDir.resolve("spark-sql-warehouse").resolve(testUuid.toString());
 
     return SparkSession.builder()
         .appName(appName)


### PR DESCRIPTION
### Problem

Some of the Spark's integration tests are using the project directory for storing temporary files.
This results in creation of a `integrations/spark/app/tmp` directory (which is not in .gitignore) with multiple files in it during tests execution.

### Solution

Adjust integration tests to use the actual system temp dir.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project