### PR TITLE
Shaded JNI

### DIFF
--- a/integration/sql/iface-java/src/lib.rs
+++ b/integration/sql/iface-java/src/lib.rs
@@ -30,7 +30,7 @@ trait AsJavaObject {
 
 impl AsJavaObject for rust_impl::SqlMeta {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/SqlMeta"
+        "shaded/io/openlineage/sql/SqlMeta"
     }
 
     fn ctor_signature() -> &'static str {
@@ -84,7 +84,7 @@ impl AsJavaObject for rust_impl::SqlMeta {
 
 impl AsJavaObject for rust_impl::QuoteStyle {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/QuoteStyle"
+        "shaded/io/openlineage/sql/QuoteStyle"
     }
 
     fn ctor_signature() -> &'static str {
@@ -115,11 +115,11 @@ impl AsJavaObject for rust_impl::QuoteStyle {
 
 impl AsJavaObject for rust_impl::DbTableMeta {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/DbTableMeta"
+        "shaded/io/openlineage/sql/DbTableMeta"
     }
 
     fn ctor_signature() -> &'static str {
-        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/openlineage/sql/QuoteStyle;)V"
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lshaded/io/openlineage/sql/QuoteStyle;)V"
     }
 
     fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
@@ -149,11 +149,11 @@ impl AsJavaObject for rust_impl::DbTableMeta {
 
 impl AsJavaObject for rust_impl::ColumnMeta {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/ColumnMeta"
+        "shaded/io/openlineage/sql/ColumnMeta"
     }
 
     fn ctor_signature() -> &'static str {
-        "(Lio/openlineage/sql/DbTableMeta;Ljava/lang/String;)V"
+        "(Lshaded/io/openlineage/sql/DbTableMeta;Ljava/lang/String;)V"
     }
 
     fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
@@ -169,11 +169,11 @@ impl AsJavaObject for rust_impl::ColumnMeta {
 
 impl AsJavaObject for rust_impl::ColumnLineage {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/ColumnLineage"
+        "shaded/io/openlineage/sql/ColumnLineage"
     }
 
     fn ctor_signature() -> &'static str {
-        "(Lio/openlineage/sql/ColumnMeta;Ljava/util/List;)V"
+        "(Lshaded/io/openlineage/sql/ColumnMeta;Ljava/util/List;)V"
     }
 
     fn ctor_arguments<'a>(&self, env: &'a JNIEnv) -> Result<Box<[JValue<'a>]>> {
@@ -201,7 +201,7 @@ impl AsJavaObject for rust_impl::ColumnLineage {
 
 impl AsJavaObject for rust_impl::ExtractionError {
     fn java_class_name() -> &'static str {
-        "io/openlineage/sql/ExtractionError"
+        "shaded/io/openlineage/sql/ExtractionError"
     }
 
     fn ctor_signature() -> &'static str {

--- a/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
+++ b/integration/sql/iface-java/src/main/java/io/openlineage/sql/OpenLineageSql.java
@@ -76,7 +76,7 @@ public final class OpenLineageSql {
   public static Optional<String> loadError = Optional.empty();
 
   private static void loadNativeLibrary(String libName) throws IOException {
-    String fullName = "io/openlineage/sql/" + libName;
+    String fullName = "shaded/io/openlineage/sql/" + libName;
 
     URL url = OpenLineageSql.class.getResource("/" + fullName);
     if (url == null) {


### PR DESCRIPTION
### Problem

Hardcoded JNI prevents shading.

### Solution

Testing hardcoding a new value 😄

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project