### PR TITLE
Fix PMD pre-commit hook for Spark integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -193,7 +193,7 @@ repos:
         description: "Runs the PMD static code analyzer - Spark."
         language: script
         entry: .pre_commit/run-pmd.sh --java-version 17 --ruleset-file integration/spark/pmd-openlineage.xml
-        files: ^integration/flink/.*\.java$
+        files: ^integration/spark/.*\.java$
         exclude: ".*test.*"
         require_serial: true
       - id: spotless-client-java

--- a/integration/spark/vendor/gcp/src/main/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtils.java
+++ b/integration/spark/vendor/gcp/src/main/java/io/openlineage/spark/agent/vendor/gcp/util/GCPUtils.java
@@ -83,6 +83,8 @@ public class GCPUtils {
     return (sparkDistClasspath != null && sparkDistClasspath.contains(DATAPROC_CLASSPATH));
   }
 
+  // Remove suppression after PMD is updated to >=7.0.0
+  @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
   public static Map<String, Object> getDataprocRunFacetMap(SparkContext context) {
     Map<String, Object> dataprocProperties = new HashMap<>();
     ResourceType resource = identifyResource(context);
@@ -192,6 +194,8 @@ public class GCPUtils {
     return fetchGCPMetadata(CLUSTER_UUID_ENDPOINT, context);
   }
 
+  // Remove suppression after PMD is updated to >=7.0.0
+  @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
   private static Map<String, Object> createDataprocOriginMap(SparkContext context) {
     Map<String, Object> originProperties = new HashMap<>();
     String nameFormat = "";


### PR DESCRIPTION
### Problem

PMD pre-commit hook for Spark integration is configured to look for files in Flink integration

### Solution

Change the pre-commit config to look for files in Spark integration

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project