### PR TITLE
feat: Add default tags with OL client version

### DIFF
--- a/client/python/tests/example_full_event.json
+++ b/client/python/tests/example_full_event.json
@@ -20,6 +20,17 @@
           "namespace": "my-scheduler-namespace",
           "name": "myjob.mytask"
         }
+      },
+      "tags": {
+        "_producer": "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client",
+        "_schemaURL": "http://test.schema.url",
+        "tags": [
+          {
+            "key": "openlineage_client_version",
+            "value": "1.30.0",
+            "source": "OPENLINEAGE_CLIENT"
+          }
+        ]
       }
     }
   },

--- a/client/python/tests/test_facet.py
+++ b/client/python/tests/test_facet.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import copy
 import json
 from typing import Any
+from unittest import mock
 
 import pytest
 from openlineage.client.client import OpenLineageClient
+from openlineage.client.constants import __version__ as OPENLINEAGE_CLIENT_VERSION
 from openlineage.client.facet import (
     BaseFacet,
     ColumnLineageDatasetFacet,
@@ -42,7 +44,19 @@ def event() -> dict[str, Any]:
         },
         "run": {
             "runId": "69f4acab-b87d-4fc0-b27b-8ea950370ff3",
-            "facets": {},
+            "facets": {
+                "tags": {
+                    "_producer": mock.ANY,
+                    "_schemaURL": mock.ANY,
+                    "tags": [
+                        {
+                            "key": "openlineage_client_version",
+                            "value": OPENLINEAGE_CLIENT_VERSION,
+                            "source": "OPENLINEAGE_CLIENT",
+                        }
+                    ],
+                }
+            },
         },
         "inputs": [],
         "outputs": [

--- a/client/python/tests/test_facet_v2.py
+++ b/client/python/tests/test_facet_v2.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from attr import asdict, define
 from openlineage.client.client import OpenLineageClient
+from openlineage.client.constants import __version__ as OPENLINEAGE_CLIENT_VERSION
 from openlineage.client.event_v2 import (
     BaseEvent,
     InputDataset,
@@ -49,9 +50,10 @@ def test_optional_attributed_not_validated():
     nominal_time_run.NominalTimeRunFacet(nominalStartTime="2020-12-17T03:00:00.001Z")
 
 
-def test_custom_facet(mock_http_session_class, test_producer) -> None:
+@mock.patch.object(OpenLineageClient, "_run_tags", new_callable=mock.PropertyMock)
+def test_custom_facet(mock_run_tags, mock_http_session_class, test_producer) -> None:
     mock_session_class, mock_client, mock_response = mock_http_session_class
-
+    mock_run_tags.return_value = []
     client = OpenLineageClient(url="http://example.com")
 
     @define
@@ -208,6 +210,7 @@ def test_full_core_event_serializes_properly(mock_http_session_class) -> None:
     with open(os.path.join(dirpath, "example_full_event.json")) as f:
         expected_event = json.load(f)
 
+    expected_event["run"]["facets"]["tags"]["tags"][0]["value"] = OPENLINEAGE_CLIENT_VERSION
     assert expected_event == event_sent
 
 

--- a/client/python/tests/test_http.py
+++ b/client/python/tests/test_http.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import gzip
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from openlineage.client import OpenLineageClient
@@ -353,8 +353,12 @@ class TestHttpMock:
         call_args = mock_client.post.call_args
         assert call_args.kwargs["url"] == "http://backend:5000/custom/lineage"
 
-    def test_client_with_http_transport_emits_with_gzip_compression(self, mock_http_session_class):
+    @patch.object(OpenLineageClient, "_run_tags", new_callable=PropertyMock)
+    def test_client_with_http_transport_emits_with_gzip_compression(
+        self, mock_run_tags, mock_http_session_class
+    ):
         mock_session_class, mock_client, mock_response = mock_http_session_class
+        mock_run_tags.return_value = []
 
         config = HttpConfig.from_dict(
             {

--- a/client/python/tests/transform/test_transform.py
+++ b/client/python/tests/transform/test_transform.py
@@ -6,7 +6,7 @@ import datetime
 import os
 import warnings
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import attr
 import pytest
@@ -157,7 +157,9 @@ def test_client_with_transform_transport_emits(mocker: MockerFixture) -> None:
     )
 
 
-def test_client_with_transform_transport_emits_modified_event(mocker: MockerFixture) -> None:
+@patch.object(OpenLineageClient, "_run_tags", new_callable=PropertyMock)
+def test_client_with_transform_transport_emits_modified_event(mock_run_tags, mocker: MockerFixture) -> None:
+    mock_run_tags.return_value = []
     session = mocker.patch("requests.Session")
     config = TransformConfig.from_dict(
         {
@@ -208,7 +210,9 @@ def test_client_with_transform_transport_emits_modified_event(mocker: MockerFixt
     )
 
 
+@patch.object(OpenLineageClient, "_run_tags", new_callable=PropertyMock)
 def test_client_with_transform_transport_emits_modified_event_with_older_facets(
+    mock_run_tags,
     mocker: MockerFixture,
 ) -> None:
     with warnings.catch_warnings():
@@ -219,6 +223,7 @@ def test_client_with_transform_transport_emits_modified_event_with_older_facets(
         class SomeOldRunFacet(OldBaseFacet):
             version: str = attr.ib()
 
+    mock_run_tags.return_value = []
     session = mocker.patch("requests.Session")
     config = TransformConfig.from_dict(
         {
@@ -322,9 +327,13 @@ def test_client_with_transform_transport_skips_emission_when_transformed_event_i
     transport.transport.session.post.assert_not_called()
 
 
-def test_client_with_transform_transport_emits_modified_deprecated_event(mocker: MockerFixture) -> None:
+@patch.object(OpenLineageClient, "_run_tags", new_callable=PropertyMock)
+def test_client_with_transform_transport_emits_modified_deprecated_event(
+    mock_run_tags, mocker: MockerFixture
+) -> None:
     from openlineage.client.run import Job, Run, RunEvent, RunState
 
+    mock_run_tags.return_value = []
     session = mocker.patch("requests.Session")
     config = TransformConfig.from_dict(
         {


### PR DESCRIPTION
Solving the problem described in #3969, in a better way, without introducing new facet.

I also moved the injection of env vars and tags (so all the pre-emit operations) to before we log the event on debug level, so that the debug is more accurate and contains the actual event emitted later on.

Example tag:
```
      "tags": {
        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.38.0/client/python",
        "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/TagsRunFacet.json#/$defs/TagsRunFacet",
        "tags": [
          {
            "key": "openlineage_client_version",
            "source": "OPENLINEAGE_CLIENT",
            "value": "1.38.0"
          }
        ]
      }
```

Not sure how we should name the `key` and the `source`, I proposed the one above. If you have any better ideas lmk.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project