### PR TITLE
Python: add fsspec support for FileTransport.

### DIFF
--- a/client/python/openlineage/client/transport/file.py
+++ b/client/python/openlineage/client/transport/file.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 import io
 import logging
 from dataclasses import dataclass
@@ -11,17 +12,49 @@ from typing import TYPE_CHECKING, Any
 
 from openlineage.client.serde import Serde
 from openlineage.client.transport.transport import Config, Transport
+from openlineage.client.utils import import_from_string
 
 if TYPE_CHECKING:
     from openlineage.client.client import Event
 
 log = logging.getLogger(__name__)
 
+# Try to import fsspec for file-like transport support
+try:
+    import fsspec  # type: ignore[import-untyped]
+
+    FSSPEC_AVAILABLE = True
+except ImportError:
+    FSSPEC_AVAILABLE = False
+    fsspec = None
+
 
 @dataclass
 class FileConfig(Config):
+    """Configuration for file-based OpenLineage event transport.
+
+    Supports local files and remote filesystems via fsspec (optional dependency).
+    The transport auto-detects protocols from URL schemes (s3://, gs://, etc.).
+
+    Attributes:
+        log_file_path (str): Path to the log file. Can be local or URL with protocol.
+        append (bool): Whether to append to existing file (default: False, creates timestamped files).
+        storage_options (dict): Options passed to the filesystem (e.g., credentials).
+        filesystem (str): Optional filesystem provider specification:
+            - Class path (e.g., "s3fs.S3FileSystem")
+            - Factory function path (e.g., "mymodule.get_filesystem")
+            - Instance attribute path (e.g., "mymodule.fs_instance")
+        fs_kwargs (dict): Keyword arguments for constructing/calling the filesystem provider.
+    """
+
     log_file_path: str
     append: bool = False
+    storage_options: dict[str, Any] | None = None
+    # Unified: explicit filesystem provider (class, callable factory, or instance attribute),
+    # dotted import path
+    filesystem: str | None = None
+    # Keyword arguments for constructing/calling the filesystem provider
+    fs_kwargs: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, params: dict[str, Any]) -> FileConfig:
@@ -29,33 +62,122 @@ class FileConfig(Config):
             msg = "`log_file_path` key not passed to FileConfig"
             raise RuntimeError(msg)
 
-        return cls(log_file_path=params["log_file_path"], append=params.get("append", False))
+        return cls(
+            log_file_path=params["log_file_path"],
+            append=params.get("append", False),
+            storage_options=params.get("storage_options"),
+            filesystem=params.get("filesystem"),
+            fs_kwargs=params.get("fs_kwargs"),
+        )
 
 
 class FileTransport(Transport):
+    """File-based transport for OpenLineage events.
+
+    Writes events to local or remote files. Supports automatic protocol detection
+    for remote filesystems via fsspec (s3://, gs://, az://, etc.).
+
+    Three filesystem configuration approaches:
+    1. Auto-detection: Specify only log_file_path with protocol URL
+    2. Explicit filesystem: Use 'filesystem' parameter with class/factory/instance
+    3. Storage options: Use 'storage_options' for credentials and configuration
+    """
+
     kind = "file"
     config_class = FileConfig
 
     def __init__(self, config: FileConfig) -> None:
         self.config = config
+        self._validate_config()
+        self._fs = self._create_filesystem()
         log.debug(
             "Constructing OpenLineage transport that will send events "
             "to file(s) using the following config: %s",
             self.config,
         )
 
-    def emit(self, event: Event) -> None:
+    def _validate_config(self) -> None:
+        """Validate configuration and check fsspec availability if needed."""
+        # Check if fsspec features are requested but not available
+        if self.config.filesystem and not FSSPEC_AVAILABLE:
+            msg = (
+                "An explicit filesystem was requested but fsspec is not available. "
+                "Please install fsspec to use remote filesystems."
+            )
+            raise RuntimeError(msg)
+
+        # Warn about conflicting configurations
+        if self.config.filesystem and self.config.storage_options:
+            log.warning("'storage_options' ignored when using explicit filesystem. Use fs_kwargs instead.")
+
+    def _create_filesystem(self) -> Any | None:
+        """Create and return an fsspec filesystem instance if configured, else None."""
+        if not FSSPEC_AVAILABLE:
+            return None
+        if self.config.filesystem:
+            target = import_from_string(self.config.filesystem)
+            kwargs = self.config.fs_kwargs or {}
+            # If it's a class, instantiate. If it's a callable factory, call it. If it's an instance, use it.
+            if inspect.isclass(target):
+                fs = target(**kwargs)
+            elif callable(target):
+                fs = target(**kwargs)
+            else:
+                fs = target
+            if not hasattr(fs, "open"):
+                raise RuntimeError(
+                    f"'{self.config.filesystem}' did not produce a filesystem implementing an 'open' method"
+                )
+            return fs
+        # Fall back to protocol-based lazy opening (handled in _open_file)
+        return None
+
+    def _get_file_path(self) -> str:
+        """Get the file path, adding timestamp if not in append mode."""
         if self.config.append:
-            log_file_path = self.config.log_file_path
+            return self.config.log_file_path
         else:
             time_str = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
-            log_file_path = f"{self.config.log_file_path}-{time_str}.json"
+            return f"{self.config.log_file_path}-{time_str}.json"
+
+    def _open_file(self, file_path: str, mode: str) -> Any:
+        """Open a file-like handle using the chosen mechanism.
+
+        - If an explicit filesystem instance is configured, use its .open.
+        - Else if fsspec is available, try fsspec.open with auto-detection from URL.
+        - Else use built-in open for local filesystem.
+        """
+        if self._fs is not None:
+            return self._fs.open(file_path, mode)
+
+        if FSSPEC_AVAILABLE:
+            storage_options = self.config.storage_options or {}
+            try:
+                # Let fsspec auto-detect protocol from URL (e.g., s3://, gs://, etc.)
+                return fsspec.open(file_path, mode=mode, **storage_options)
+            except (ValueError, ImportError) as e:
+                # If fsspec can't handle the URL (e.g., local path with no protocol),
+                # fall back to built-in open
+                log.debug(
+                    "fsspec could not handle path '%s', falling back to built-in open: %s", file_path, e
+                )
+
+        return open(file_path, mode)
+
+    def emit(self, event: Event) -> None:
+        log_file_path = self._get_file_path()
+        mode = "a" if self.config.append else "w"
 
         log.debug("Openlineage event will be emitted to file: `%s`", log_file_path)
+
         try:
-            with open(log_file_path, "a" if self.config.append else "w") as log_file_handle:
-                log_file_handle.write(Serde.to_json(event) + "\n")
+            with self._open_file(log_file_path, mode) as f:
+                f.write(Serde.to_json(event) + "\n")
         except (PermissionError, io.UnsupportedOperation) as error:
             # If we lack write permissions or file is opened in wrong mode
             msg = f"Log file `{log_file_path}` is not writeable"
+            raise RuntimeError(msg) from error
+        except Exception as error:
+            # Handle fsspec-specific errors or other filesystem errors
+            msg = f"Failed to write to log file `{log_file_path}`: {error}"
             raise RuntimeError(msg) from error

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -43,6 +43,9 @@ optional-dependencies.msk-iam = [
 optional-dependencies.datazone = [
   "boto3>=1.34.134"
 ]
+optional-dependencies.fsspec = [
+  "fsspec>=2023.1.0"
+]
 optional-dependencies.test = [
   "covdefaults>=2.3",
   "pytest>=7.3.1",

--- a/client/python/tests/test_file.py
+++ b/client/python/tests/test_file.py
@@ -218,3 +218,363 @@ def test_file_config_append_mode_does_not_modify_file_if_exists(append) -> None:
     assert file_content == "test content"
 
     os.remove(file_path)
+
+
+# ======== FSSpec Tests ========
+
+
+class MockFileSystem:
+    """Mock filesystem for testing fsspec functionality."""
+
+    def __init__(self, **kwargs):
+        self.storage_options = kwargs
+        self._files = {}
+        self._open_calls = []
+
+    def open(self, path, mode="r", **kwargs):
+        """Mock open method that tracks calls and returns a file-like object."""
+        self._open_calls.append((path, mode, kwargs))
+        if mode.startswith("w"):
+            # For write mode, return a mock file that tracks writes
+            return MockFile(path, mode, self._files)
+        elif mode.startswith("a"):
+            # For append mode, return a mock file that tracks appends
+            return MockFile(path, mode, self._files)
+        else:
+            # For read mode, return content if exists
+            if path in self._files:
+                return MockFile(path, mode, self._files, initial_content=self._files[path])
+            else:
+                raise FileNotFoundError(f"File {path} not found")
+
+
+class MockFile:
+    """Mock file-like object for testing."""
+
+    def __init__(self, path, mode, files_dict, initial_content=""):
+        self.path = path
+        self.mode = mode
+        self._files = files_dict
+        self._content = initial_content
+        self._closed = False
+
+    def write(self, content):
+        """Write content to the mock file."""
+        if self._closed:
+            raise ValueError("I/O operation on closed file")
+        if self.mode.startswith("a"):
+            self._files[self.path] = self._files.get(self.path, "") + content
+        else:
+            self._files[self.path] = content
+
+    def read(self):
+        """Read content from the mock file."""
+        if self._closed:
+            raise ValueError("I/O operation on closed file")
+        return self._files.get(self.path, "")
+
+    def close(self):
+        """Close the mock file."""
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+def test_file_config_from_dict_with_fsspec_options():
+    """Test FileConfig creation with fsspec-related options."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    # Test with storage_options only
+    config = FileConfig.from_dict(
+        params={
+            "log_file_path": file_path,
+            "append": True,
+            "storage_options": {"key": "value", "endpoint_url": "https://minio:9000"},
+        }
+    )
+
+    assert config.log_file_path == file_path
+    assert config.append is True
+    assert config.storage_options == {"key": "value", "endpoint_url": "https://minio:9000"}
+    assert config.filesystem is None
+    assert config.fs_kwargs is None
+
+
+def test_file_config_from_dict_with_filesystem():
+    """Test FileConfig creation with explicit filesystem configuration."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    # Test with filesystem and fs_kwargs
+    config = FileConfig.from_dict(
+        params={
+            "log_file_path": file_path,
+            "filesystem": "tests.test_file.MockFileSystem",
+            "fs_kwargs": {"endpoint_url": "https://minio:9000", "region": "us-east-1"},
+        }
+    )
+
+    assert config.log_file_path == file_path
+    assert config.append is False  # default
+    assert config.storage_options is None
+    assert config.filesystem == "tests.test_file.MockFileSystem"
+    assert config.fs_kwargs == {"endpoint_url": "https://minio:9000", "region": "us-east-1"}
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", False)
+def test_file_transport_raises_error_when_fsspec_not_available_with_filesystem():
+    """Test that FileTransport raises error when fsspec is not available but filesystem is specified."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(log_file_path=file_path, filesystem="tests.test_file.MockFileSystem")
+
+    with pytest.raises(RuntimeError):
+        FileTransport(config)
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_creates_filesystem_from_class():
+    """Test that FileTransport can create filesystem from a class."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(
+        log_file_path=file_path,
+        filesystem="tests.test_file.MockFileSystem",
+        fs_kwargs={"test_arg": "test_value"},
+    )
+
+    transport = FileTransport(config)
+    assert transport._fs is not None
+    assert isinstance(transport._fs, MockFileSystem)
+    assert transport._fs.storage_options == {"test_arg": "test_value"}
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_creates_filesystem_from_callable():
+    """Test that FileTransport can create filesystem from a callable factory."""
+
+    def mock_filesystem_factory(**kwargs):
+        return MockFileSystem(**kwargs)
+
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    # We'll mock the import_from_string to return our factory function
+    with mock.patch(
+        "openlineage.client.transport.file.import_from_string", return_value=mock_filesystem_factory
+    ):
+        config = FileConfig(
+            log_file_path=file_path,
+            filesystem="some.factory.function",
+            fs_kwargs={"factory_arg": "factory_value"},
+        )
+
+        transport = FileTransport(config)
+        assert transport._fs is not None
+        assert isinstance(transport._fs, MockFileSystem)
+        assert transport._fs.storage_options == {"factory_arg": "factory_value"}
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_uses_existing_filesystem_instance():
+    """Test that FileTransport can use an existing filesystem instance."""
+    mock_fs = MockFileSystem(existing="instance")
+
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    # Mock import_from_string to return the instance directly
+    with mock.patch("openlineage.client.transport.file.import_from_string", return_value=mock_fs):
+        config = FileConfig(
+            log_file_path=file_path, filesystem="some.existing.instance", fs_kwargs={"should": "be_ignored"}
+        )
+
+        transport = FileTransport(config)
+        assert transport._fs is mock_fs
+        assert transport._fs.storage_options == {"existing": "instance"}
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_raises_error_for_invalid_filesystem():
+    """Test that FileTransport raises error when filesystem doesn't have open method."""
+
+    class InvalidFileSystem:
+        """Filesystem without open method."""
+
+        pass
+
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    with mock.patch("openlineage.client.transport.file.import_from_string", return_value=InvalidFileSystem):
+        config = FileConfig(log_file_path=file_path, filesystem="some.invalid.filesystem")
+
+        with pytest.raises(RuntimeError, match="did not produce a filesystem implementing an 'open' method"):
+            FileTransport(config)
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_emit_with_explicit_filesystem():
+    """Test that FileTransport.emit works with explicit filesystem."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(log_file_path=file_path, filesystem="tests.test_file.MockFileSystem", append=True)
+
+    transport = FileTransport(config)
+
+    event = RunEvent(
+        eventType=RunState.START,
+        eventTime=datetime.datetime.now().isoformat(),
+        run=Run(runId=str(generate_new_uuid())),
+        job=Job(namespace="file", name="test"),
+        producer="prod",
+    )
+
+    transport.emit(event)
+
+    # Verify that the mock filesystem was used
+    mock_fs = transport._fs
+    assert len(mock_fs._open_calls) == 1
+    assert mock_fs._open_calls[0][0] == file_path  # path
+    assert mock_fs._open_calls[0][1] == "a"  # mode (append)
+
+    # Verify that content was written
+    assert file_path in mock_fs._files
+    written_content = mock_fs._files[file_path]
+    assert "START" in written_content
+    assert "file" in written_content  # namespace
+    assert "test" in written_content  # job name
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_emit_handles_fsspec_errors():
+    """Test that FileTransport.emit handles fsspec-specific errors properly."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    # Create a filesystem that raises an error on open
+    class ErrorFileSystem:
+        def open(self, path, mode="r", **kwargs):
+            raise OSError("Network connection failed")
+
+    with mock.patch("openlineage.client.transport.file.import_from_string", return_value=ErrorFileSystem):
+        config = FileConfig(log_file_path=file_path, filesystem="some.error.filesystem")
+
+        transport = FileTransport(config)
+
+        event = RunEvent(
+            eventType=RunState.START,
+            eventTime=datetime.datetime.now().isoformat(),
+            run=Run(runId=str(generate_new_uuid())),
+            job=Job(namespace="file", name="test"),
+            producer="prod",
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"Failed to write to log file `{file_path}-.*\\.json`: Network connection failed",
+        ):
+            transport.emit(event)
+
+
+@mock.patch("openlineage.client.transport.file.datetime")
+def test_file_transport_get_file_path_with_timestamp(mock_dt):
+    """Test that _get_file_path generates correct timestamped paths when not in append mode."""
+    mock_dt.now().strftime.return_value = "20230815-143052.123456"
+
+    log_dir = tempfile.TemporaryDirectory()
+    base_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(log_file_path=base_path, append=False)
+    transport = FileTransport(config)
+
+    file_path = transport._get_file_path()
+    assert file_path == f"{base_path}-20230815-143052.123456.json"
+
+
+def test_file_transport_get_file_path_with_append():
+    """Test that _get_file_path returns original path when in append mode."""
+    log_dir = tempfile.TemporaryDirectory()
+    base_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(log_file_path=base_path, append=True)
+    transport = FileTransport(config)
+
+    file_path = transport._get_file_path()
+    assert file_path == base_path
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+def test_file_transport_open_file_local_fallback():
+    """Test that _open_file falls back to built-in open when no fsspec configuration is provided."""
+    log_dir = tempfile.TemporaryDirectory()
+    file_path = join(log_dir.name, "logtest")
+
+    config = FileConfig(log_file_path=file_path)
+    transport = FileTransport(config)
+
+    # Should use built-in open since no fsspec configuration
+    with transport._open_file(file_path, "w") as f:
+        f.write("test content")
+
+    # Verify file was created using standard filesystem
+    assert os.path.exists(file_path)
+    with open(file_path, "r") as f:
+        assert f.read() == "test content"
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+@mock.patch("openlineage.client.transport.file.fsspec")
+def test_file_transport_protocol_auto_detection(mock_fsspec):
+    """Test that _open_file auto-detects protocol from URL scheme."""
+    s3_path = "s3://my-bucket/lineage/events.jsonl"
+
+    # Mock fsspec.open to return our mock file
+    mock_file = MockFile(s3_path, "w", {})
+    mock_fsspec.open.return_value.__enter__.return_value = mock_file
+    mock_fsspec.open.return_value.__exit__.return_value = None
+
+    # Protocol will be auto-detected from s3:// scheme
+    config = FileConfig(log_file_path=s3_path, storage_options={"key": "value"})
+    transport = FileTransport(config)
+
+    # Test opening file with auto-detection
+    with transport._open_file(s3_path, "w") as f:
+        f.write("test content")
+
+    # Verify that fsspec.open was called without protocol parameter (auto-detection)
+    mock_fsspec.open.assert_called_once_with(s3_path, mode="w", key="value")
+
+
+@mock.patch("openlineage.client.transport.file.FSSPEC_AVAILABLE", True)
+@mock.patch("openlineage.client.transport.file.fsspec")
+def test_file_transport_protocol_auto_detection_fallback(mock_fsspec):
+    """Test that _open_file falls back to built-in open when fsspec can't handle the path."""
+    log_dir = tempfile.TemporaryDirectory()
+    local_path = join(log_dir.name, "logtest")
+
+    # Mock fsspec.open to raise ValueError (can't handle local path)
+    mock_fsspec.open.side_effect = ValueError("No filesystem found for protocol")
+
+    config = FileConfig(log_file_path=local_path)
+    transport = FileTransport(config)
+
+    # Should fall back to built-in open
+    with transport._open_file(local_path, "w") as f:
+        f.write("test content")
+
+    # Verify fsspec was attempted first
+    mock_fsspec.open.assert_called_once_with(local_path, mode="w")
+
+    # Verify file was created using standard filesystem
+    assert os.path.exists(local_path)
+    with open(local_path, "r") as f:
+        assert f.read() == "test content"

--- a/client/python/tox.ini
+++ b/client/python/tox.ini
@@ -17,6 +17,7 @@ wheel_build_env = .pkg
 allowlist_externals = uv
 install_command = uv pip install {opts} {packages}
 extras =
+    fsspec
     kafka
     msk-iam
     test
@@ -51,6 +52,7 @@ commands =
 description = generate a DEV environment
 package = editable
 extras =
+    fsspec
     kafka
     msk-iam
     test

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -755,7 +755,6 @@ Designed mainly for integration testing, the `FileTransport` emits OpenLineage e
 - `storage_options` - dictionary, additional options passed to fsspec for authentication and configuration. Optional.
 - `filesystem` - string, dotted import path to a custom filesystem class or instance. Optional, provides explicit control over the filesystem.
 - `fs_kwargs` - dictionary, keyword arguments for constructing the filesystem when using `filesystem`. Optional.
-- `force_timestamped_files` - boolean, always create timestamped files, ignoring append setting. Optional, default: `false`.
 
 #### Behavior
 

--- a/website/docs/client/python.md
+++ b/website/docs/client/python.md
@@ -29,6 +29,40 @@ To install the package from source, use
 python -m pip install .
 ```
 
+### Optional Dependencies
+
+The Python client supports optional dependencies for enhanced functionality:
+
+#### Remote Filesystem Support
+For file transport with remote storage backends (S3, GCS, Azure, etc.):
+```bash
+pip install openlineage-python[fsspec]
+```
+
+#### Kafka Support
+For Kafka transport:
+```bash
+pip install openlineage-python[kafka]
+```
+
+#### MSK IAM Support
+For AWS MSK with IAM authentication:
+```bash
+pip install openlineage-python[msk-iam]
+```
+
+#### DataZone Support
+For AWS DataZone integration:
+```bash
+pip install openlineage-python[datazone]
+```
+
+#### All Optional Dependencies
+To install all optional dependencies:
+```bash
+pip install openlineage-python[fsspec,kafka,msk-iam,datazone]
+```
+
 ## Configuration
 
 We recommend configuring the client with an `openlineage.yml` file that contains all the
@@ -199,6 +233,30 @@ transport:
     retries: 3
   flush: true
   message_key: some-value # this has been aliased to messageKey
+```
+</TabItem>
+
+<TabItem value="file" label="File Transport with Remote Storage">
+
+Setting following environment variables:
+
+```sh
+OPENLINEAGE__TRANSPORT__TYPE=file
+OPENLINEAGE__TRANSPORT__LOG_FILE_PATH=s3://my-bucket/lineage/events.jsonl
+OPENLINEAGE__TRANSPORT__APPEND=true
+OPENLINEAGE__TRANSPORT__STORAGE_OPTIONS='{"key": "AKIAIOSFODNN7EXAMPLE", "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "endpoint_url": "https://s3.amazonaws.com"}'
+```
+
+is equivalent to passing following YAML configuration:
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  append: true
+  storage_options:
+    key: AKIAIOSFODNN7EXAMPLE
+    secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    endpoint_url: https://s3.amazonaws.com
 ```
 </TabItem>
 
@@ -687,24 +745,101 @@ client = OpenLineageClient(transport=KafkaTransport(kafka_config))
 
 ### File
 
-Designed mainly for integration testing, the `FileTransport` emits OpenLineage events to a given file(s).
+Designed mainly for integration testing, the `FileTransport` emits OpenLineage events to a given file(s). Supports both local and remote filesystems through optional fsspec integration.
 
 #### Configuration
 
 - `type` - string, must be `"file"`. Required.
 - `log_file_path` - string specifying the path of the file or file prefix (when `append` is true). Required.
 - `append` - boolean, see *Behavior* section below. Optional, default: `false`.
+- `storage_options` - dictionary, additional options passed to fsspec for authentication and configuration. Optional.
+- `filesystem` - string, dotted import path to a custom filesystem class or instance. Optional, provides explicit control over the filesystem.
+- `fs_kwargs` - dictionary, keyword arguments for constructing the filesystem when using `filesystem`. Optional.
+- `force_timestamped_files` - boolean, always create timestamped files, ignoring append setting. Optional, default: `false`.
 
 #### Behavior
 
 - If the target file is absent, it's created.
 - If `append` is `true`, each event will be appended to a single file `log_file_path`, separated by newlines.
 - If `append` is `false`, each event will be written to as separated file with name `{log_file_path}-{datetime}`.
+- When using remote filesystems, the transport automatically handles authentication and connection management through fsspec.
+
+#### Remote Filesystem Support
+
+The File transport supports remote filesystems through [fsspec](https://filesystem-spec.readthedocs.io/), which provides a unified interface for various storage backends including:
+
+- **Amazon S3** (`s3://`)
+- **Google Cloud Storage** (`gcs://` or `gs://`)
+- **Azure Blob Storage** (`az://`, `abfs://`)
+- **HDFS** (`hdfs://`)
+- **FTP/SFTP** (`ftp://`, `sftp://`)
+- **HTTP** (`http://`, `https://`)
+
+##### Installation
+
+To use remote filesystems, install the fsspec extra:
+
+```bash
+pip install openlineage-python[fsspec]
+```
+
+##### Configuration Methods
+
+**Auto-detection Configuration**: FSSpec automatically detects the protocol from URL schemes:
+
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  # Protocol auto-detected from s3:// scheme
+  storage_options:
+    key: your-access-key
+    secret: your-secret-key
+    endpoint_url: https://custom-s3-endpoint.com
+```
+
+**Explicit Filesystem Configuration**: Provide explicit control over the filesystem using the `filesystem` parameter. This supports three approaches:
+
+1. **Filesystem Class**: Reference a filesystem class that will be instantiated with `fs_kwargs`
+2. **Filesystem Instance**: Reference a pre-configured filesystem instance (ignores `fs_kwargs`)  
+3. **Factory Function**: Reference a callable that returns a filesystem instance when called with `fs_kwargs`
+
+```yaml
+# Example: Filesystem class
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  filesystem: s3fs.S3FileSystem
+  fs_kwargs:
+    key: your-access-key
+    secret: your-secret-key
+```
+
+##### Append Mode Considerations
+
+**Important**: Many cloud storage filesystems (S3, GCS, Azure) do not support reliable append operations. When append mode is requested but not supported by the underlying filesystem, these filesystems may silently switch to overwrite mode, potentially causing data loss.
+
+**Recommendations for cloud storage**:
+
+- Use `append: false` to create timestamped files for better reliability
+- Test append behavior with your specific storage backend before production use
+- Monitor file outputs to ensure expected behavior
+
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events
+  protocol: s3
+  append: false  # Recommended for cloud storage (creates timestamped files)
+  storage_options:
+    key: your-access-key
+    secret: your-secret-key
+```
 
 #### Examples
 
 <Tabs groupId="integrations">
-<TabItem value="yaml" label="Yaml Config">
+<TabItem value="yaml-local" label="Local File">
 
 ```yaml
 transport:
@@ -714,21 +849,198 @@ transport:
 ```
 
 </TabItem>
-<TabItem value="python" label="Python Code">
+<TabItem value="yaml-s3" label="Amazon S3">
+
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  append: false  # Recommended for cloud storage
+  storage_options:
+    key: AKIAIOSFODNN7EXAMPLE
+    secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    endpoint_url: https://s3.amazonaws.com
+```
+
+</TabItem>
+<TabItem value="yaml-gcs" label="Google Cloud Storage">
+
+```yaml
+transport:
+  type: file
+  log_file_path: gs://my-bucket/lineage/events.jsonl
+  append: false  # Recommended for cloud storage
+  storage_options:
+    token: /path/to/service-account.json
+    project: my-gcp-project
+```
+
+</TabItem>
+<TabItem value="yaml-azure" label="Azure Blob Storage">
+
+```yaml
+transport:
+  type: file
+  log_file_path: az://container/lineage/events.jsonl
+  append: false  # Recommended for cloud storage
+  storage_options:
+    account_name: mystorageaccount
+    account_key: base64_encoded_key
+```
+
+</TabItem>
+<TabItem value="yaml-custom-fs" label="Custom Filesystem">
+
+```yaml
+transport:
+  type: file
+  log_file_path: /custom/path/events.jsonl
+  filesystem: mymodule.MyCustomFileSystem
+  fs_kwargs:
+    endpoint: https://custom-storage.example.com
+    auth_token: custom_token_123
+    timeout: 30
+```
+
+</TabItem>
+<TabItem value="yaml-fs-instance" label="Filesystem Instance">
+
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  filesystem: mymodule.my_preconfigured_s3_instance
+  # fs_kwargs ignored when using an instance
+```
+
+</TabItem>
+<TabItem value="yaml-fs-factory" label="Filesystem Factory">
+
+```yaml
+transport:
+  type: file
+  log_file_path: s3://my-bucket/lineage/events.jsonl
+  filesystem: mymodule.create_secure_s3_filesystem
+  fs_kwargs:
+    key: AKIAIOSFODNN7EXAMPLE
+    secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    endpoint_url: https://custom-s3-endpoint.com
+    use_ssl: true
+```
+
+</TabItem>
+<TabItem value="python-local" label="Python Code (Local)">
 
 ```python
 from openlineage.client import OpenLineageClient
 from openlineage.client.transport.file import FileConfig, FileTransport
 
 file_config = FileConfig(
-  log_file_path="/path/to/your/file",
-  append=False,
+    log_file_path="/path/to/your/file",
+    append=False,
 )
 
 client = OpenLineageClient(transport=FileTransport(file_config))
 ```
-</TabItem>
 
+</TabItem>
+<TabItem value="python-s3" label="Python Code (S3)">
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport.file import FileConfig, FileTransport
+
+file_config = FileConfig(
+    log_file_path="s3://my-bucket/lineage/events.jsonl",
+    append=True,
+    storage_options={
+        "key": "AKIAIOSFODNN7EXAMPLE",
+        "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "endpoint_url": "https://s3.amazonaws.com",
+    },
+)
+
+client = OpenLineageClient(transport=FileTransport(file_config))
+```
+
+</TabItem>
+<TabItem value="python-custom" label="Python Code (Custom FS)">
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport.file import FileConfig, FileTransport
+
+file_config = FileConfig(
+    log_file_path="/custom/path/events.jsonl",
+    filesystem="s3fs.S3FileSystem",
+    fs_kwargs={
+        "key": "AKIAIOSFODNN7EXAMPLE",
+        "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "client_kwargs": {"region_name": "us-west-2"},
+    },
+)
+
+client = OpenLineageClient(transport=FileTransport(file_config))
+```
+
+</TabItem>
+<TabItem value="python-fs-instance" label="Python Code (FS Instance)">
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport.file import FileConfig, FileTransport
+import s3fs
+
+# Create filesystem instance directly
+s3_fs = s3fs.S3FileSystem(
+    key="AKIAIOSFODNN7EXAMPLE",
+    secret="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    endpoint_url="https://s3.amazonaws.com"
+)
+
+file_config = FileConfig(
+    log_file_path="s3://my-bucket/lineage/events.jsonl",
+    filesystem="__main__.s3_fs",  # Reference to the instance
+    # fs_kwargs are ignored when using an instance
+)
+
+client = OpenLineageClient(transport=FileTransport(file_config))
+```
+
+</TabItem>
+<TabItem value="python-fs-factory" label="Python Code (FS Factory)">
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.transport.file import FileConfig, FileTransport
+
+def create_custom_s3_filesystem(**kwargs):
+    """Factory function that creates a customized S3 filesystem."""
+    import s3fs
+    
+    # Apply custom defaults or modifications
+    config = {
+        "use_ssl": True,
+        "s3_additional_kwargs": {"ServerSideEncryption": "AES256"},
+        **kwargs  # Allow override via fs_kwargs
+    }
+    
+    return s3fs.S3FileSystem(**config)
+
+file_config = FileConfig(
+    log_file_path="s3://my-bucket/lineage/events.jsonl",
+    filesystem="__main__.create_custom_s3_filesystem",  # Reference to factory function
+    fs_kwargs={
+        "key": "AKIAIOSFODNN7EXAMPLE",
+        "secret": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "endpoint_url": "https://custom-s3-endpoint.com",
+    },
+)
+
+client = OpenLineageClient(transport=FileTransport(file_config))
+```
+
+</TabItem>
 </Tabs>
 
 ### Composite


### PR DESCRIPTION
### Problem

The OpenLineage Python client's file transport was limited to local filesystem operations only. Users wanting to emit lineage events to remote storage systems (S3, GCS, Azure Blob Storage, HDFS, etc.) had to implement custom solutions or use workarounds, limiting the flexibility and usability of the file transport for cloud-native deployments.

### Solution

This change expands the file transport with optional fsspec integration to support remote filesystems while maintaining backward compatibility. The enhancement provides three flexible configuration approaches:

* Auto-detection: Automatically detects filesystem type from URL protocols (s3://, gs://, az://, etc.)
* Explicit filesystem: Allows specifying custom filesystem classes, factory functions, or pre-configured instances
* Storage options: Provides credential and configuration management for various backends

Key Features:
* fsspec Integration: Optional dependency for remote filesystem support
* Flexible Configuration: Support for filesystem classes, factory functions, and instances via dotted import paths
* Credential Management: Storage options for authentication and endpoint configuration
* Graceful Fallback: Automatic fallback to built-in file operations when fsspec is unavailable or can't handle the path
* Enhanced Error Handling: Improved error messages for filesystem-specific issues

Configuration Examples:

```yaml
# Auto-detection from URL
transport:
  type: file
  log_file_path: s3://my-bucket/lineage/events.jsonl
  storage_options:
    key: AKIAIOSFODNN7EXAMPLE
    secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

# Explicit filesystem class
transport:
  type: file
  log_file_path: s3://my-bucket/lineage/events.jsonl
  filesystem: s3fs.S3FileSystem
  fs_kwargs:
    endpoint_url: https://custom-s3-endpoint.com

# Filesystem factory
transport:
  type: file
  log_file_path: s3://my-bucket/lineage/events.jsonl
  filesystem: my_mod.create_secure_s3_filesystem
  fs_kwargs:
    use_ssl: true
```

The implementation maintains full backward compatibility - existing local file configurations continue to work unchanged, and fsspec features are only activated when explicitly configured or when protocol URLs are detected.

#### One-line summary:
Python: Expand file transport with optional fsspec integration for remote filesystem support (S3, GCS, Azure, etc.)

### Checklist

- [*] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [*] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [*] Your changes are accompanied by tests (_if relevant_)
- [*] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [*] You've updated any relevant documentation (_if relevant_)
- [*] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [*] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project