### PR TITLE
Spark: optimize lineage extraction when reading a lot of S3 objects

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -219,9 +219,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                           relation.schema(),
                           datasetFacetsBuilder));
                 } else {
-                  return rootPaths.stream()
-                      .map(p -> PlanUtils.getDirectoryPath(p, hadoopConfig))
-                      .distinct()
+                  return PlanUtils.getDirectoryPaths(rootPaths, hadoopConfig).stream()
                       .map(
                           p -> {
                             // TODO- refactor this to return a single partitioned dataset based on

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddPathUtils.java
@@ -90,7 +90,7 @@ public class RddPathUtils {
         log.debug("Hadoop RDD input paths {}", Arrays.toString(inputPaths));
         log.debug("Hadoop RDD job conf {}", rdd.getJobConf());
       }
-      return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, hadoopConf));
+      return PlanUtils.getDirectoryPaths(Arrays.asList(inputPaths), hadoopConf).stream();
     }
   }
 
@@ -107,7 +107,7 @@ public class RddPathUtils {
             org.apache.hadoop.mapreduce.lib.input.FileInputFormat.getInputPaths(
                 new Job(((NewHadoopRDD<?, ?>) rdd).getConf()));
 
-        return Arrays.stream(inputPaths).map(p -> PlanUtils.getDirectoryPath(p, rdd.getConf()));
+        return PlanUtils.getDirectoryPaths(Arrays.asList(inputPaths), rdd.getConf()).stream();
       } catch (IOException e) {
         log.error("Openlineage spark agent could not get input paths", e);
       }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -167,8 +168,8 @@ class LogicalRelationDatasetBuilderTest {
                 .toSeq());
 
     try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
-      when(PlanUtils.getDirectoryPath(p1, hadoopConfig)).thenReturn(new Path("/tmp"));
-      when(PlanUtils.getDirectoryPath(p2, hadoopConfig)).thenReturn(new Path("/tmp"));
+      when(PlanUtils.getDirectoryPaths(any(Collection.class), any(Configuration.class)))
+          .thenReturn(Collections.singletonList(new Path("/tmp")));
 
       List<OpenLineage.Dataset> datasets =
           builder.apply(mock(SparkListenerEvent.class), logicalRelation);

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -7,6 +7,7 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -43,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import scala.Option;
+import scala.collection.JavaConverters;
 import scala.collection.immutable.HashMap;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -84,10 +87,10 @@ class LogicalRelationDatasetBuilderTest {
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
+
     when(fileIndex.rootPaths())
         .thenReturn(
-            scala.collection.JavaConverters.collectionAsScalaIterableConverter(
-                    Arrays.asList(path, path))
+            JavaConverters.collectionAsScalaIterableConverter(Arrays.asList(path, path))
                 .asScala()
                 .toSeq());
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(new OpenLineage.DatasetFacetsBuilder());
@@ -95,7 +98,8 @@ class LogicalRelationDatasetBuilderTest {
 
     try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PlanUtils.getDirectoryPath(path, hadoopConfig)).thenReturn(new Path("/tmp"));
+        when(PlanUtils.getDirectoryPaths(any(), eq(hadoopConfig)))
+            .thenReturn(Collections.singletonList(new Path("/tmp")));
         when(DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(logicalRelation))
             .thenReturn(Optional.of(SOME_VERSION));
 


### PR DESCRIPTION
Currently, `io.openlineage.spark.agent.util.PlanUtils#getDirectoryPath` method checks for each asset read if this is a file or directory. In case of a regular file, it returns its parent directory. This leads to problems when a method is called on hundreds of thousands of files and each and each call requires `getFileStatus` call to S3. 

Actually, these calls are not necessary as all the files come from the same directory. Before running `getFileStatus`, the code can check if the parent dir was already added.