### PR TITLE
feat: enhance isDefinedAt method to check for SparkPartitioningAwareScan interface

### DIFF
--- a/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergInputStatisticsInputDatasetFacetBuilder.java
+++ b/integration/spark/vendor/iceberg/src/main/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergInputStatisticsInputDatasetFacetBuilder.java
@@ -49,9 +49,21 @@ public class IcebergInputStatisticsInputDatasetFacetBuilder
       return false;
     }
 
-    // should be defined for `org.apache.iceberg.spark.source.SparkBatchQueryScan` which is not
-    // public class
-    return x.getClass().getCanonicalName().startsWith("org.apache.iceberg.spark");
+    try {
+      // Load the target interface class by its fully qualified name
+      Class<?> targetInterface =
+          Class.forName("org.apache.iceberg.spark.source.SparkPartitioningAwareScan");
+
+      // isAssignableFrom checks if x's class is the same as, or is a superclass or
+      // superinterface of, the specified targetInterface. This is the correct way
+      // to perform a runtime 'instanceof' check against a class/interface
+      // that may not be visible at compile time.
+      return targetInterface.isAssignableFrom(x.getClass());
+
+    } catch (ClassNotFoundException e) {
+      // If the class/interface doesn't exist in the classpath, then x can't be an instance of it.
+      return false;
+    }
   }
 
   @Override

--- a/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergInputStatisticsInputDatasetFacetBuilderTest.java
+++ b/integration/spark/vendor/iceberg/src/test/java/io/openlineage/spark/agent/vendor/iceberg/lifecycle/plan/IcebergInputStatisticsInputDatasetFacetBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.vendor.iceberg.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import org.apache.spark.sql.connector.read.Scan;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class IcebergInputStatisticsInputDatasetFacetBuilderTest {
+
+  @Mock private OpenLineageContext context;
+
+  private IcebergInputStatisticsInputDatasetFacetBuilder builder;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    builder = new IcebergInputStatisticsInputDatasetFacetBuilder(context);
+  }
+
+  @Test
+  void testIsDefinedAtReturnsFalseForNonScanObject() {
+    // Given
+    Object nonScanObject = new Object();
+
+    // When
+    boolean result = builder.isDefinedAt(nonScanObject);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsDefinedAtReturnsFalseForNullObject() {
+    // Given
+    Object nullObject = null;
+
+    // When
+    boolean result = builder.isDefinedAt(nullObject);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsDefinedAtReturnsFalseForGenericScanObject() {
+    // Given
+    Scan genericScan = mock(Scan.class);
+
+    // When
+    boolean result = builder.isDefinedAt(genericScan);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testIsDefinedAtReturnsFalseWhenSparkPartitioningAwareScanClassNotFound() {
+    // This test verifies the behavior when the Iceberg class is not on the classpath
+    // Since we're testing with a mock Scan that doesn't implement SparkPartitioningAwareScan,
+    // the method should return false
+
+    // Given
+    Scan scan = mock(Scan.class);
+
+    // When
+    boolean result = builder.isDefinedAt(scan);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  // Note: Testing the positive case (when isDefinedAt returns true) would require
+  // having the actual SparkPartitioningAwareScan class on the classpath and creating
+  // a proper implementation or mock that extends/implements it. This would typically
+  // be done in integration tests where the full Iceberg dependency is available.
+}


### PR DESCRIPTION
### Problem

Not all `Scan` classes have `tasks` method in IcebergInputStatisticsInputDatasetFacetBuilder.

### Solution

Check for SparkPartitioningAwareScan interface which should always have the method defined.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project