### PR TITLE
sql: bump python version for macOS build to 3.10

### DIFF
--- a/integration/sql/iface-py/script/build-macos.sh
+++ b/integration/sql/iface-py/script/build-macos.sh
@@ -31,8 +31,8 @@ fi
 rustup target add aarch64-apple-darwin
 rustup target add x86_64-apple-darwin
 
-echo "Installing Python 3.9"
-uv python install 3.9
+echo "Installing Python 3.10"
+uv python install 3.10
 
 # Maturin is build tool that we're using. It can build python wheels based on standard Rust Cargo.toml.
 echo "Installing Maturin"
@@ -53,7 +53,7 @@ uv tool run maturin build --target universal2-apple-darwin --out target/wheels -
 
 echo "Package build, trying to import"
 echo "Platform:"
-echo "from distutils import util; print(util.get_platform())" | uv run -
+echo "import platform; print(platform.platform())" | uv run -
 # Verify that it imports and works properly
 uv pip install openlineage-sql --no-index --find-links target/wheels --force-reinstall
 echo "from openlineage_sql import parse, ColumnLineage; import sys; sys.exit(len(parse([\"SELECT b.a from b\"]).column_lineage) != 1)" | uv run -


### PR DESCRIPTION
### Problem

Python 3.9 is going to have support ended [soon](https://peps.python.org/pep-0596/#lifespan). MacOS build script for SQL integration still uses 3.9.

### Solution

Bump to 3.10 and migrate from distutils: [https://peps.python.org/pep-0632/#migration-advice](https://peps.python.org/pep-0632/#migration-advice)

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project