### PR TITLE
fix bitnami docker image location

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkScalaContainerTest.java
@@ -220,10 +220,10 @@ class SparkScalaContainerTest {
     final Network network = newNetwork();
     final String className = "io.openlineage.spark.streaming.Kafka2KafkaJob";
     final DockerImageName kafkaDockerImageName =
-        DockerImageName.parse("docker.io/bitnami/kafka:3.4.1");
+        DockerImageName.parse("docker.io/bitnamilegacy/kafka:3.4.1");
 
     GenericContainer zookeeperContainer =
-        new GenericContainer(DockerImageName.parse("docker.io/bitnami/zookeeper:3.7"))
+        new GenericContainer(DockerImageName.parse("docker.io/bitnamilegacy/zookeeper:3.7"))
             .withEnv("ALLOW_ANONYMOUS_LOGIN", "yes")
             .withEnv("ZOO_AUTOPURGE_INTERVAL", "1")
             .withNetwork(network)


### PR DESCRIPTION
Based on: https://hub.docker.com/r/bitnami/kafka

```
Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative⁠](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:

Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
All existing container images have been migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the [Bitnami Secure Images announcement⁠](https://github.com/bitnami/containers/issues/83267).
```