### PR TITLE
spark: Issue-3818 fix. Additional catch for TypeNotPresentException

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -338,6 +338,9 @@ public class PlanUtils {
     } catch (NoClassDefFoundError e) {
       log.info("isDefinedAt method failed on {}", e.getMessage());
       return false;
+    } catch (TypeNotPresentException e) {
+      log.info("isDefinedAt method failed due to missing type: {}", e.getTypeName());
+      return false;
     }
   }
 


### PR DESCRIPTION
### Problem

Closes: #3818 

### Solution

Additional catch for TypeNotPresentException thrown in spark 3.0.2 due to missing RefreshTableCommand class.

#### One-line summary:

Additional catch for TypeNotPresentException thrown in spark 3.0.2 due to missing RefreshTableCommand class.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project