### PR TITLE
[Docs] Update Catalog and Symlinks Dataset Facet Documentation

### DIFF
--- a/website/docs/spec/facets/dataset-facets/catalog.md
+++ b/website/docs/spec/facets/dataset-facets/catalog.md
@@ -24,14 +24,16 @@ Example:
     ...
     "inputs": {
         "facets": {
-          "_producer": "https://some.producer.com/version/1.0",
-          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/CatalogDatasetFacet.json",
-          "framework": "iceberg",
-          "type": "polaris",
-          "name": "my_iceberg_catalog",
-          "metadataUri": "http://host:1234/iceberg_database",
-          "warehouseUri": "s3://bucket/path/to/iceberg/warehouse",
-          "source": "spark"
+            "catalog": {
+                "_producer": "https://some.producer.com/version/1.0",
+                "_schemaURL": "https://github.com/OpenLineage/OpenLineage/blob/main/spec/facets/CatalogDatasetFacet.json",
+                "framework": "iceberg",
+                "type": "polaris",
+                "name": "my_iceberg_catalog",
+                "metadataUri": "http://host:1234/iceberg_database",
+                "warehouseUri": "s3://bucket/path/to/iceberg/warehouse",
+                "source": "spark"
+            }
         }
     }
     ...

--- a/website/docs/spec/facets/dataset-facets/symlinks.md
+++ b/website/docs/spec/facets/dataset-facets/symlinks.md
@@ -4,20 +4,32 @@ sidebar_position: 11
 
 # Symlinks Facet
 
+The symlinks facet is used to list alternative identifiers for a single dataset. A dataset might be referenced by its physical location (e.g., a file path) in one context and by a logical name (e.g., a database table name) in another. This facet allows OpenLineage to understand that these different identifiers refer to the same entity, creating a unified lineage graph.
+
+Fields Description
+- `identifiers`: An array containing one or more alternative identifiers for the dataset.
+    - `namespace`: The namespace of the alternative identifier (e.g., Glue Catalog).
+    - `name`: The name of the dataset within the given namespace (e.g., Glue Table).
+    - `type`: A string describing the type of the identifier.
+
+`namespace`, `name` and `type` are required fields
+
 Example:
 
 ```json
 {
     ...
     "inputs": {
+        "namespace": "s3://{bucket name}",
+        "name": "{object key}",
         "facets": {
             "symlinks": {
                 "_producer": "https://some.producer.com/version/1.0",
-                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/SymlinksDatasetFacet.json",
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json",
                 "identifiers": [
-                    "namespace": "example_namespace",
-                    "name": "example_dataset_1",
-                    "type": "table"
+                    "namespace": "arn:aws:glue:{region}:{account id}",
+                    "name": "table/{database name}/{table name}",
+                    "type": "TABLE"
                 ]
             }
         }
@@ -25,4 +37,4 @@ Example:
     ...
 }
 ```
-The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-0/SymlinksDatasetFacet.json).
+The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json).


### PR DESCRIPTION
### Problem

There was no description for Symlinks and the JSON on the Catalog facet was missing `catalog` attribute

### Solution

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Added `catalog` attribute. Also, attempted to provide accurate documentation for Symlinks.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project