### PR TITLE
Make output statistics available within complete event

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/OpenLineageSparkListener.java
@@ -246,9 +246,6 @@ public class OpenLineageSparkListener extends org.apache.spark.scheduler.SparkLi
     meterRegistry.counter("openlineage.spark.event.job.end").increment();
     circuitBreaker.run(
         () -> {
-          if (SparkVersionUtils.isSpark3OrHigher(sparkVersion)) {
-            jobMetrics.cleanUp(jobEnd.jobId());
-          }
           if (context != null) {
             context.end(jobEnd);
           }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/JobMetricsHolder.java
@@ -67,11 +67,10 @@ public class JobMetricsHolder {
    * @return
    */
   public Map<Metric, Number> pollMetrics(int jobId) {
-    if (jobMetrics.containsKey(jobId)) {
-      return jobMetrics.remove(jobId);
-    } else {
-      return computeJobMetricsAndClearTemporaryResults(jobId);
+    if (!jobMetrics.containsKey(jobId)) {
+      jobMetrics.put(jobId, computeJobMetricsAndClearTemporaryResults(jobId));
     }
+    return jobMetrics.get(jobId);
   }
 
   private Map<Metric, Number> computeJobMetricsAndClearTemporaryResults(int jobId) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -41,6 +41,7 @@ class JobMetricsHolderTest {
         .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 110L);
 
     // second poll event should clear the maps
+    underTest.cleanUp(0);
     Map<JobMetricsHolder.Metric, Number> secondPollResult = underTest.pollMetrics(0);
     assertThat(secondPollResult).isEmpty();
   }
@@ -125,12 +126,13 @@ class JobMetricsHolderTest {
   }
 
   @Test
-  void testPollingMetricsClearsMetrics() {
+  void testCleanUpClearsMaps() {
     // add some stage and metric
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
     underTest.addMetrics(1, outputTaskMetrics(100, 10));
 
     assertThat(underTest.pollMetrics(0).get(Metric.WRITE_RECORDS)).isEqualTo(10L);
+    underTest.cleanUp(0);
     assertThat(underTest.pollMetrics(0)).isEmpty();
   }
 


### PR DESCRIPTION
Currently output statistics are available onJobEnd which makes them emitting with `RUNING` event type. 
This brings some confusion to the backend users. 
With this change `outputStatistics` facet gets emitted on both on job end and on sql end events. 