### PR TITLE
Python: Don't silence import errors in DefaultTransportFactory

### DIFF
--- a/client/python/openlineage/client/transport/factory.py
+++ b/client/python/openlineage/client/transport/factory.py
@@ -8,7 +8,7 @@ import os
 
 from openlineage.client.transport.noop import NoopConfig, NoopTransport
 from openlineage.client.transport.transport import Config, Transport, TransportFactory
-from openlineage.client.utils import try_import_from_string
+from openlineage.client.utils import import_from_string
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class DefaultTransportFactory(TransportFactory):
         transport_class_type_or_str = self.transports.get(transport_type, transport_type)
 
         if isinstance(transport_class_type_or_str, str):
-            transport_class = try_import_from_string(transport_class_type_or_str)
+            transport_class = import_from_string(transport_class_type_or_str)
         else:
             transport_class = transport_class_type_or_str
         if not inspect.isclass(transport_class) or not issubclass(transport_class, Transport):
@@ -71,7 +71,7 @@ class DefaultTransportFactory(TransportFactory):
         config_class = transport_class.config_class
 
         if isinstance(config_class, str):
-            config_class = try_import_from_string(config_class)
+            config_class = import_from_string(config_class)
         if not inspect.isclass(config_class) or not issubclass(config_class, Config):
             msg = f"Config {config_class} has to be class, and subclass of Config"
             raise TypeError(msg)


### PR DESCRIPTION
### Problem

If user passed custom transport class name or config name within OpenLineage config, and it cannot be loaded, then import error will be silenced, and replaced with generic error.

### Solution

#### One-line summary:

Python: Don't silence import errors in DefaultTransportFactory

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project