### PR TITLE
add support for microbatch source write

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -36,6 +36,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuild
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
@@ -92,7 +93,8 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new DropTableDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
             .add(new SparkExtensionV1OutputDatasetBuilder(context))
-            .add(new AlterTableCommandDatasetBuilder(context));
+            .add(new AlterTableCommandDatasetBuilder(context))
+            .add(new WriteToMicroBatchDataSourceV1DatasetBuilder(context, datasetFactory));
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -35,6 +35,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuild
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
@@ -89,7 +90,8 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
             .add(new SubqueryAliasOutputDatasetBuilder(context))
             .add(new DropTableDatasetBuilder(context))
             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
-            .add(new AlterTableCommandDatasetBuilder(context));
+            .add(new AlterTableCommandDatasetBuilder(context))
+            .add(new WriteToMicroBatchDataSourceV1DatasetBuilder(context, datasetFactory));
 
     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
       builder.add(new ReplaceIcebergDataDatasetBuilder(context));

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/AbstractQueryPlanDatasetBuilder.java
@@ -75,6 +75,8 @@ public abstract class AbstractQueryPlanDatasetBuilder<T, P extends LogicalPlan, 
                     .collect(Collectors.toList());
               } else if (PlanUtils.safeIsDefinedAt(visitor, qe.optimizedPlan())) {
                 return PlanUtils.safeApply(visitor, qe.optimizedPlan());
+              } else if (PlanUtils.safeIsDefinedAt(visitor, qe.analyzed())) {
+                return PlanUtils.safeApply(visitor, qe.analyzed());
               } else {
                 return Collections.<D>emptyList();
               }

--- a/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+++ b/integration/spark/spark34/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
@@ -1,0 +1,92 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.streaming.FileStreamSink;
+import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+
+/**
+ * {@link LogicalPlan} visitor that matches {@link WriteToMicroBatchDataSourceV1} commands and
+ * extracts the output {@link OpenLineage.Dataset} being written to micro batch data sources using
+ * the V1 API.
+ */
+@Slf4j
+public class WriteToMicroBatchDataSourceV1DatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<WriteToMicroBatchDataSourceV1> {
+
+  private final DatasetFactory<OpenLineage.OutputDataset> factory;
+
+  public WriteToMicroBatchDataSourceV1DatasetBuilder(
+      OpenLineageContext context, DatasetFactory<OpenLineage.OutputDataset> factory) {
+    super(context, false);
+    this.factory = factory;
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    if (!(event instanceof SparkListenerSQLExecutionEnd)) {
+      return false;
+    }
+    SparkListenerSQLExecutionEnd see = (SparkListenerSQLExecutionEnd) event;
+    return isDefinedAtLogicalPlan(see.qe().analyzed());
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
+    return logicalPlan instanceof WriteToMicroBatchDataSourceV1;
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, WriteToMicroBatchDataSourceV1 writeToMicroBatchV1) {
+    // Currently, only FileStreamSink is supported
+    if (writeToMicroBatchV1.sink() instanceof FileStreamSink) {
+      FileStreamSink fileStreamSink = (FileStreamSink) writeToMicroBatchV1.sink();
+      DatasetIdentifier datasetIdentifier =
+          getFileSinkDatasetIdentifier(writeToMicroBatchV1, getFileStreamSinkPath(fileStreamSink));
+      OpenLineage.OutputDataset dataset =
+          factory.getDataset(datasetIdentifier, writeToMicroBatchV1.schema());
+      return Collections.singletonList(dataset);
+    }
+    log.debug("Unsupported Sink type: {}", writeToMicroBatchV1.sink().getClass().getName());
+    return Collections.emptyList();
+  }
+
+  private DatasetIdentifier getFileSinkDatasetIdentifier(
+      WriteToMicroBatchDataSourceV1 writeToMicroBatchV1, String fileStreamSinkPath) {
+    DatasetIdentifier datasetIdentifier = PathUtils.fromURI(URI.create(fileStreamSinkPath));
+
+    // Add symlink if catalog table is available
+    if (writeToMicroBatchV1.catalogTable().isDefined()) {
+      DatasetIdentifier catalogIdentifier =
+          PathUtils.fromCatalogTable(
+              writeToMicroBatchV1.catalogTable().get(), context.getSparkSession().orElse(null));
+      return datasetIdentifier.withSymlink(
+          catalogIdentifier.getName(),
+          catalogIdentifier.getNamespace(),
+          DatasetIdentifier.SymlinkType.TABLE);
+    }
+    return datasetIdentifier;
+  }
+
+  private String getFileStreamSinkPath(FileStreamSink sink) {
+    // The only way to get the path without using reflection
+    return sink.toString().substring("FileSink[".length(), sink.toString().length() - 1).trim();
+  }
+}

--- a/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/integration/spark/spark34/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -1,0 +1,326 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.net.URI;
+import java.util.List;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.QueryExecution;
+import org.apache.spark.sql.execution.streaming.FileStreamSink;
+import org.apache.spark.sql.execution.streaming.Sink;
+import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import scala.Option;
+
+class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
+
+  private DatasetFactory<OpenLineage.OutputDataset> factory;
+  private WriteToMicroBatchDataSourceV1DatasetBuilder builder;
+  private WriteToMicroBatchDataSourceV1 writeToMicroBatchV1;
+  private FileStreamSink fileStreamSink;
+  private Sink unsupportedSink;
+  private SparkListenerSQLExecutionEnd event;
+  private StructType schema;
+
+  @BeforeEach
+  void setUp() {
+    OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+    SparkSession sparkSession = mock(SparkSession.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+
+    OpenLineageContext openLineageContext =
+        OpenLineageContext.builder()
+            .sparkSession(sparkSession)
+            .sparkContext(sparkContext)
+            .openLineage(openLineage)
+            .meterRegistry(new SimpleMeterRegistry())
+            .openLineageConfig(new SparkOpenLineageConfig())
+            .build();
+
+    @SuppressWarnings("unchecked")
+    DatasetFactory<OpenLineage.OutputDataset> typedFactory = mock(DatasetFactory.class);
+    factory = typedFactory;
+    builder = new WriteToMicroBatchDataSourceV1DatasetBuilder(openLineageContext, factory);
+
+    writeToMicroBatchV1 = mock(WriteToMicroBatchDataSourceV1.class);
+    fileStreamSink = mock(FileStreamSink.class);
+    unsupportedSink = mock(Sink.class);
+
+    QueryExecution queryExecution = mock(QueryExecution.class);
+    when(queryExecution.analyzed()).thenReturn(writeToMicroBatchV1);
+
+    event = mock(SparkListenerSQLExecutionEnd.class);
+    when(event.qe()).thenReturn(queryExecution);
+
+    schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, false),
+              DataTypes.createStructField("name", DataTypes.StringType, true)
+            });
+  }
+
+  @Test
+  void testIsDefinedAtLogicalPlan() {
+    assertTrue(builder.isDefinedAtLogicalPlan(writeToMicroBatchV1));
+    assertFalse(builder.isDefinedAtLogicalPlan(mock(LogicalPlan.class)));
+  }
+
+  @Test
+  void testIsDefinedAtEvent_WithCorrectEvent() {
+    assertTrue(builder.isDefinedAt(event));
+  }
+
+  @Test
+  void testIsDefinedAtEvent_WithIncorrectEvent() {
+    SparkListenerEvent wrongEvent = mock(SparkListenerEvent.class);
+    assertFalse(builder.isDefinedAt(wrongEvent));
+  }
+
+  @Test
+  void testIsDefinedAtEvent_WithCorrectEventButWrongLogicalPlan() {
+    QueryExecution queryExecution = mock(QueryExecution.class);
+    when(queryExecution.analyzed()).thenReturn(mock(LogicalPlan.class));
+    when(event.qe()).thenReturn(queryExecution);
+
+    assertFalse(builder.isDefinedAt(event));
+  }
+
+  @Test
+  void testApply_WithUnsupportedSink() {
+    when(writeToMicroBatchV1.sink()).thenReturn(unsupportedSink);
+
+    List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+    assertTrue(result.isEmpty());
+    verify(factory, never()).getDataset(any(DatasetIdentifier.class), any(StructType.class));
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_ValidPath_NoCatalogTable() {
+    String testPath = "file:///tmp/test-output";
+    String sinkToString = "FileSink[" + testPath + "]";
+    DatasetIdentifier expectedDatasetIdentifier = new DatasetIdentifier("test-output", "file://");
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
+      pathUtilsMock
+          .when(() -> PathUtils.fromURI(URI.create(testPath)))
+          .thenReturn(expectedDatasetIdentifier);
+
+      when(factory.getDataset(eq(expectedDatasetIdentifier), eq(schema)))
+          .thenReturn(expectedDataset);
+
+      List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+      assertEquals(1, result.size());
+      assertEquals(expectedDataset, result.get(0));
+      verify(factory).getDataset(eq(expectedDatasetIdentifier), eq(schema));
+    }
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_ValidPath_WithCatalogTable() {
+    String testPath = "file:///tmp/test-output";
+    String sinkToString = "FileSink[" + testPath + "]";
+    DatasetIdentifier pathDatasetIdentifier = new DatasetIdentifier("test-output", "file://");
+    DatasetIdentifier catalogDatasetIdentifier =
+        new DatasetIdentifier("catalog_table", "catalog_namespace");
+    DatasetIdentifier expectedDatasetIdentifier =
+        pathDatasetIdentifier.withSymlink(
+            catalogDatasetIdentifier.getName(),
+            catalogDatasetIdentifier.getNamespace(),
+            DatasetIdentifier.SymlinkType.TABLE);
+
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+    CatalogTable catalogTable = mock(CatalogTable.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
+      pathUtilsMock
+          .when(() -> PathUtils.fromURI(URI.create(testPath)))
+          .thenReturn(pathDatasetIdentifier);
+      pathUtilsMock
+          .when(() -> PathUtils.fromCatalogTable(eq(catalogTable), any()))
+          .thenReturn(catalogDatasetIdentifier);
+
+      when(factory.getDataset(eq(expectedDatasetIdentifier), eq(schema)))
+          .thenReturn(expectedDataset);
+
+      List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+      assertEquals(1, result.size());
+      assertEquals(expectedDataset, result.get(0));
+      verify(factory).getDataset(eq(expectedDatasetIdentifier), eq(schema));
+    }
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_CatalogTableException() {
+    String testPath = "file:///tmp/test-output";
+    String sinkToString = "FileSink[" + testPath + "]";
+    DatasetIdentifier pathDatasetIdentifier = new DatasetIdentifier("test-output", "file://");
+    CatalogTable catalogTable = mock(CatalogTable.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.apply(catalogTable));
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
+      pathUtilsMock
+          .when(() -> PathUtils.fromURI(URI.create(testPath)))
+          .thenReturn(pathDatasetIdentifier);
+      pathUtilsMock
+          .when(() -> PathUtils.fromCatalogTable(eq(catalogTable), any()))
+          .thenThrow(new RuntimeException("Catalog table error"));
+
+      // This should throw the exception since the current implementation doesn't catch it
+      assertThrows(RuntimeException.class, () -> builder.apply(event, writeToMicroBatchV1));
+    }
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_InvalidToStringFormat() {
+    String invalidSinkToString = "InvalidFormat[/tmp/test]";
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(invalidSinkToString);
+
+    // The current implementation will try to extract from any string, leading to "rmat[/tmp/test"
+    // This will cause a URI creation exception
+    assertThrows(IllegalArgumentException.class, () -> builder.apply(event, writeToMicroBatchV1));
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_EmptyPath() {
+    String sinkToString = "FileSink[]";
+    DatasetIdentifier expectedDatasetIdentifier = new DatasetIdentifier("", "");
+    OpenLineage.OutputDataset expectedDataset = mock(OpenLineage.OutputDataset.class);
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
+      pathUtilsMock
+          .when(() -> PathUtils.fromURI(URI.create("")))
+          .thenReturn(expectedDatasetIdentifier);
+
+      when(factory.getDataset(eq(expectedDatasetIdentifier), eq(schema)))
+          .thenReturn(expectedDataset);
+
+      // The empty path creates an empty URI which is valid, so no exception is thrown
+      List<OpenLineage.OutputDataset> result = builder.apply(event, writeToMicroBatchV1);
+
+      assertEquals(1, result.size());
+      assertEquals(expectedDataset, result.get(0));
+      verify(factory).getDataset(eq(expectedDatasetIdentifier), eq(schema));
+    }
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_NullToString() {
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(null);
+
+    // The null toString will cause a NullPointerException
+    assertThrows(NullPointerException.class, () -> builder.apply(event, writeToMicroBatchV1));
+  }
+
+  @Test
+  void testApply_WithFileStreamSink_ToStringThrowsException() {
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenThrow(new RuntimeException("toString failed"));
+
+    // The exception from toString will propagate
+    assertThrows(RuntimeException.class, () -> builder.apply(event, writeToMicroBatchV1));
+  }
+
+  @Test
+  void testApply_WithDatasetFactoryException() {
+    String testPath = "file:///tmp/test-output";
+    String sinkToString = "FileSink[" + testPath + "]";
+    DatasetIdentifier expectedDatasetIdentifier = new DatasetIdentifier("test-output", "file://");
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenReturn(schema);
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    try (MockedStatic<PathUtils> pathUtilsMock = mockStatic(PathUtils.class)) {
+      pathUtilsMock
+          .when(() -> PathUtils.fromURI(URI.create(testPath)))
+          .thenReturn(expectedDatasetIdentifier);
+
+      when(factory.getDataset(eq(expectedDatasetIdentifier), eq(schema)))
+          .thenThrow(new RuntimeException("Factory error"));
+
+      // The exception from factory will propagate
+      assertThrows(RuntimeException.class, () -> builder.apply(event, writeToMicroBatchV1));
+    }
+  }
+
+  @Test
+  void testApply_WithSchemaException() {
+    String testPath = "file:///tmp/test-output";
+    String sinkToString = "FileSink[" + testPath + "]";
+
+    when(writeToMicroBatchV1.sink()).thenReturn(fileStreamSink);
+    when(writeToMicroBatchV1.schema()).thenThrow(new RuntimeException("Schema error"));
+    when(writeToMicroBatchV1.catalogTable()).thenReturn(Option.empty());
+    when(fileStreamSink.toString()).thenReturn(sinkToString);
+
+    // The exception from schema will propagate
+    assertThrows(RuntimeException.class, () -> builder.apply(event, writeToMicroBatchV1));
+  }
+}


### PR DESCRIPTION
### Problem

While writing data from kafka topic to a table 

```

org.apache.spark.sql.Dataset<org.apache.spark.sql.Row> df = spark
                .readStream()
                .format("kafka")
                .option("kafka.bootstrap.servers", kafkaBootstrapServers)
                .option("subscribe", topic)
                .option("startingOffsets", "earliest")
                .load();

...

org.apache.spark.sql.streaming.StreamingQuery query = df
                .select("...")
                .writeStream()
                .toTable(tableName);
```

spark uses `WriteToMicroBatchDataSourceV1` and we don't get lineage because:
1. `WriteToMicroBatchDataSourceV1` doesn't have dataset builder 
2. `WriteToMicroBatchDataSourceV1` doesn't appear on optimized logical plan and its optimized to just `Project` from which we can't infer any information other than schema.

So we don't have output datasets for it 



### Solution

1. Implement `WriteToMicroBatchDataSourceV1DatasetBuilder`
2. change the logic of dataset extraction so if node was not found in optimized plan, the analyzed plan will be checked.

#### One-line summary:

Implement new dataset builder and add checking the nodes of analyzed plan. 

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [X] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project