### PR TITLE
Python: Improve logging in AsyncHttpTransport

### DIFF
--- a/client/python/openlineage/client/transport/async_http.py
+++ b/client/python/openlineage/client/transport/async_http.py
@@ -336,7 +336,7 @@ class AsyncHttpTransport(Transport):
                 elif not processed_items:
                     current_time = time.time()
                     if current_time - last_processed_time >= 10.0:
-                        log.warning(
+                        log.debug(
                             "No new events processed for %.1fs. Queue empty: %s, "
                             "active tasks: %d, max concurrent: %d, "
                             "query stats: pending %d success %d failed %s",


### PR DESCRIPTION
### Problem

I've implemented integration which reads new rows in audit log table, converts them to OpenLineage events, and sends them using AsyncHttpTransport. There may be no rows in this table for some time, and in this case transport spams with warnings like:
```
server-1  | 2025-09-09 12:56:11.991 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:11.991 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:21.992 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:23.750 MainProcess:1 uvicorn.access:473 [INFO] 127.0.0.1:50038 - "GET /healthcheck/livez HTTP/1.1" 200
server-1  | 2025-09-09 12:56:31.999 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:42.007 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:52.009 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:56:53.878 MainProcess:1 uvicorn.access:473 [INFO] 127.0.0.1:48932 - "GET /healthcheck/livez HTTP/1.1" 200
server-1  | 2025-09-09 12:57:02.010 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:12.011 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:22.019 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:24.008 MainProcess:1 uvicorn.access:473 [INFO] 127.0.0.1:44092 - "GET /healthcheck/livez HTTP/1.1" 200
server-1  | 2025-09-09 12:57:32.021 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:42.029 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:52.037 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:57:54.139 MainProcess:1 uvicorn.access:473 [INFO] 127.0.0.1:53700 - "GET /healthcheck/livez HTTP/1.1" 200
server-1  | 2025-09-09 12:58:02.043 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:58:12.049 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
server-1  | 2025-09-09 12:58:22.051 MainProcess:1 openlineage.client.transport.async_http:339 [WARNING] No new events processed for 10.0s. Queue empty: True, active tasks: 0, max concurrent: 100, query stats: pending 0 success 2070 failed 0
```

### Solution

Show this warning only if there are events to process.

#### One-line summary:

Python: Improve logging in AsyncHttpTransport

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project