### PR TITLE
spark: serialize event to json for logging

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -109,7 +109,11 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
 
-    log.debug("Posting event for start {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Posting event for start {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    }
+
     eventEmitter.emit(event);
   }
 
@@ -193,10 +197,12 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
 
-    log.debug(
-        "Posting event for stage submitted {}: {}",
-        executionId,
-        OpenLineageClientUtils.toJson(event));
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Posting event for stage submitted {}: {}",
+          executionId,
+          OpenLineageClientUtils.toJson(event));
+    }
     eventEmitter.emit(event);
   }
 
@@ -226,10 +232,12 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
 
-    log.debug(
-        "Posting event for stage completed {}: {}",
-        executionId,
-        OpenLineageClientUtils.toJson(event));
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Posting event for stage completed {}: {}",
+          executionId,
+          OpenLineageClientUtils.toJson(event));
+    }
     eventEmitter.emit(event);
   }
 
@@ -284,7 +292,11 @@ class SparkSQLExecutionContext implements ExecutionContext {
                 .jobFacetsBuilder(getJobFacetsBuilder(olContext.getQueryExecution().get()))
                 .build());
 
-    log.debug("Posting event for start {}: {}", executionId, event);
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "Posting event for start {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    }
+
     eventEmitter.emit(event);
   }
 
@@ -337,7 +349,11 @@ class SparkSQLExecutionContext implements ExecutionContext {
       // clean up metrics on complete only
       JobMetricsHolder.getInstance().cleanUp(jobEnd.jobId());
     }
-    log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+
+    if (log.isDebugEnabled()) {
+      log.debug("Posting event for end {}: {}", executionId, OpenLineageClientUtils.toJson(event));
+    }
+
     eventEmitter.emit(event);
   }
 


### PR DESCRIPTION
### Problem

Events appear in logs as Java objects refs instead of their serialized json representation:
```
Posting event for start 0: io.openlineage.client.OpenLineage$RunEvent@55cb6d00
vs
Posting event for end 0: {\"eventTime\":\"2025-09-10T12:42:36.745Z\",\"producer\":...
```

### Solution

Wrap logger calls with `OpenLineageClientUtils.toJson`.

#### One-line summary:

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project