### PR TITLE
spark: respect overridden appName in EventEmitter

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -71,7 +71,7 @@ public class EventEmitter {
             .transport(new TransportFactory(config.getTransportConfig()).build())
             .disableFacets(disabledFacets.toArray(new String[0]))
             .build();
-    this.applicationJobName = applicationJobName;
+    this.applicationJobName = this.overriddenAppName.orElse(applicationJobName);
     this.applicationRunId = UUIDUtils.generateNewUUID();
   }
 

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/EventEmitterTest.java
@@ -1,0 +1,29 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import lombok.SneakyThrows;
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+
+class EventEmitterTest {
+  @SneakyThrows
+  @Test
+  void testApplicationNameOverride() {
+    String appName = "test-app";
+    String overrideName = "override-app";
+
+    SparkConf sparkConf =
+        new SparkConf().setAppName(appName).set(ArgumentParser.SPARK_CONF_APP_NAME, overrideName);
+    SparkOpenLineageConfig olConfig = ArgumentParser.parse(sparkConf);
+    EventEmitter eventEmitter = new EventEmitter(olConfig, appName);
+
+    assertThat(eventEmitter.getApplicationJobName()).isEqualTo(overrideName);
+  }
+}


### PR DESCRIPTION
### Problem

Fix inconsistency in `parent.jobName` that refers to `spark.app.name` instead of overridden `spark.openlineage.appName` if provided.

Closes: #4021

### Solution

Both `SparkSQLExecutionContext` and `RddExecutionContext` make calls to [EventEmitter.getApplicationJobName](https://github.com/EugeneYushin/OpenLineage/blob/a43ec9e92f82dede0293e4ac8702cdc34b93f653/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java#L347) while [building parent facet](
https://github.com/EugeneYushin/OpenLineage/blob/a43ec9e92f82dede0293e4ac8702cdc34b93f653/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java#L147).
The property is set to `spark.app.name` currently and doesn't respect `spark.openlineage.appName`.


#### One-line summary:
Respect `spark.openlineage.appName` while building `EventEmitter` instance.

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project