### PR TITLE
spark: fix empty sources jar generation

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -45,7 +45,11 @@ dependencies {
 
 task sourceJar(type: Jar) {
     archiveClassifier = 'sources'
-    from sourceSets.main.allJava
+    subprojects.each { subproj ->
+        subproj.plugins.withType(JavaPlugin) {
+            from(subproj.sourceSets.main.allSource)
+        }
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
### Problem

[Original PR](https://github.com/OpenLineage/OpenLineage/pull/2471#issuecomment-1964668795) with sources/javadocs intro leads to empty jar generation:
```
curl https://repo1.maven.org/maven2/io/openlineage/openlineage-spark_2.12/1.37.0/openlineage-spark_2.12-1.37.0-sources.jar -o openlineage-spark_2.12-1.37.0-sources.jar
jar tvf openlineage-spark_2.12-1.37.0-sources.jar
     0 Mon Aug 11 17:23:52 MSK 2025 META-INF/
    25 Mon Aug 11 17:23:52 MSK 2025 META-INF/MANIFEST.MF
```

As a result, IDE can't find the sources to put breakpoints during debugging. It's hard to map decompiled code to original one, e.g.:
<img width="1036" height="442" alt="image" src="https://github.com/user-attachments/assets/75301ddd-d577-4657-a9f2-921e436962cd" />

### Solution
`integrations/spark` is a top-level wrapper around sub-modules like `app`/`shared`/etc. and doesn't come with `src` folder. Traverse dependencies and generate single sources jar from all of them.
Note, it should be more clear to publish each individual sub-project and its sources/docs instead. But this contradicts the current project setup and requires bigger refactoring.

While the similar approach can be applied to javadocs, some extra care of lombok/delombok should be done in order to find auto-generated refs. Spark integration is confined in setting `spark.extraListeners: io.openlineage.spark.agent.OpenLineageSparkListener` mostly and debugging then, so extra complexity of setting javadoc can be extracted into separate efforts if needed.

```
./gradlew build
jar tvf build/libs/openlineage-spark_2.12-1.38.0-SNAPSHOT-sources.jar| wc -l
     368

./gradlew publishToMavenLocal
ar tvf ~/.m2/repository/io/openlineage/openlineage-spark_2.12/1.38.0-SNAPSHOT/openlineage-spark_2.12-1.38.0-SNAPSHOT-sources.jar | wc -l
     368
jar tvf ~/.m2/repository/io/openlineage/openlineage-spark_2.12/1.38.0-SNAPSHOT/openlineage-spark_2.12-1.38.0-SNAPSHOT-sources.jar | head -10
     0 Sun Sep 14 12:55:56 MSK 2025 META-INF/
    25 Thu Sep 11 12:53:26 MSK 2025 META-INF/MANIFEST.MF
     0 Thu Sep 11 10:20:18 MSK 2025 io/
     0 Thu Sep 11 10:20:18 MSK 2025 io/openlineage/
     0 Thu Sep 11 10:20:18 MSK 2025 io/openlineage/spark/
     0 Sun Sep 14 09:53:42 MSK 2025 io/openlineage/spark/agent/
  8529 Thu Sep 11 10:20:18 MSK 2025 io/openlineage/spark/agent/ArgumentParser.java
     0 Sun Sep 14 09:53:42 MSK 2025 io/openlineage/spark/agent/lifecycle/
  1963 Thu Sep 11 10:20:18 MSK 2025 io/openlineage/spark/agent/lifecycle/DatasetBuilderFactoryProvider.java
  1832 Thu Sep 11 10:20:18 MSK 2025 io/openlineage/spark/agent/lifecycle/SparkSQLQueryParser.java
```

#### One-line summary:
Fix publishing empty java source.

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project