### PR TITLE
CI: Pin prek version to 0.2.0.

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1286,7 +1286,7 @@ jobs:
       - restore_cache:
           name: Restore pre-commit cache
           keys:
-            - v1.0-prek-deps-{{ checksum ".pre-commit-config.yaml" }}
+            - v1.1-prek-deps-{{ checksum ".pre-commit-config.yaml" }}
       - restore_cache:
           name: Restore pmd cache
           keys:
@@ -1303,14 +1303,14 @@ jobs:
           command: |
             python -m venv venv
             . venv/bin/activate
-            pip3 install prek
+            pip3 install prek==0.2.0
             # Install the hooks now so that they'll be cached
             prek install-hooks
 
       - save_cache:
           paths:
             - ~/.cache/prek
-          key: v1.0-prek-deps-{{ checksum ".pre-commit-config.yaml" }}
+          key: v1.1-prek-deps-{{ checksum ".pre-commit-config.yaml" }}
           name: Save pre-commit cache
 
       - run:


### PR DESCRIPTION
### Problem

prek fails on main. Most probably it has something to do with cached prek dependencies and newer version of the library.
Locally everything works with deps cached before it started to happen.

### Solution

Pin prek to 0.2.0. Bump cache version.


### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project