### PR TITLE
fix: pre-commit failing on pygrep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,8 +101,9 @@ repos:
       - id: forbid-attr-s
         name: Check for @attr.s
         description: "Checks if @attr.s is used instead of desired @attr.define"
-        language: pygrep
-        entry: "@(attr\\.s|s)(\\s|\\n|\\()"
+        language: system
+        entry:
+          bash -c 'grep -n -E "@attr\.s" "$@" && exit 1 || rc=$?; if [ $rc -eq 1 ]; then exit 0; else exit $rc; fi' --
         files: "\\.(py|md)$"
         # Exclude tests directories and deprecated modules that can use @attr.s
         exclude: |
@@ -114,8 +115,10 @@ repos:
       - id: check-python-generated-imports
         name: Check python imports from generated modules
         description: "Checks if objects are correctly imported in python from event_v2 and facet_v2 modules"
-        language: pygrep
-        entry: "from openlineage.client.generated"
+        language: system
+        entry:
+          bash -c 'grep -n -E "from openlineage\.client\.generated" "$@" && exit 1 || rc=$?; if [ $rc -eq 1 ]; then exit
+          0; else exit $rc; fi' --
         files: "\\.py$"
         # Exclude internal modules that must import this way
         exclude: |


### PR DESCRIPTION
### Problem

Pre-commit is [failing](https://app.circleci.com/pipelines/github/OpenLineage/OpenLineage/16807/workflows/f83b3d4c-01b9-4915-a359-d2af9b35bfdd/jobs/461709) on main on pygrep, but locally it works well. I've tried to debug, but have no idea why the failure is happening.

### Solution

Implemented the same logic without python, as bash oneliner. I'm not sure if it won't affect other pre-commits so let's keep an eye on it, maybe we need to put it in a separate script file. For now it seems to be solving the problem.

#### One-line summary:
fix: pre-commit failing on pygrep
### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project