### PR TITLE
Draft solution

### DIFF
--- a/integration/spark/app/integrations/container/pysparkDeltaCTASCatalogComplete.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaCTASCatalogComplete.json
@@ -1,0 +1,93 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "delta-namespace",
+    "name": "delta_integration_test.atomic_create_table_as_select.default_tbl2"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/delta/tbl1",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "storage": {
+          "storageLayer": "delta",
+          "fileFormat": "parquet"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "catalog": {
+          "framework": "delta",
+          "type": "delta",
+          "name": "spark_catalog",
+          "source": "spark"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/delta",
+              "name": "default.tbl1",
+              "type": "TABLE"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/delta/tbl2",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "storage": {
+          "storageLayer": "delta",
+          "fileFormat": "parquet"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "catalog": {
+          "framework": "delta",
+          "type": "delta",
+          "name": "spark_catalog",
+          "source": "spark"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/delta",
+              "name": "default.tbl2",
+              "type": "TABLE"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/integrations/container/pysparkDeltaCTASCatalogStart.json
+++ b/integration/spark/app/integrations/container/pysparkDeltaCTASCatalogStart.json
@@ -1,0 +1,51 @@
+{
+  "eventType": "START",
+  "job": {
+    "namespace": "delta-namespace",
+    "name": "delta_integration_test.atomic_create_table_as_select.default_tbl2"
+  },
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/delta/tbl1",
+      "facets": {
+        "dataSource": {
+          "name": "file",
+          "uri": "file"
+        },
+        "storage": {
+          "storageLayer": "delta",
+          "fileFormat": "parquet"
+        },
+        "schema": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "long"
+            },
+            {
+              "name": "b",
+              "type": "long"
+            }
+          ]
+        },
+        "catalog": {
+          "framework": "delta",
+          "type": "delta",
+          "name": "spark_catalog",
+          "source": "spark"
+        },
+        "symlinks": {
+          "identifiers": [
+            {
+              "namespace": "file:/tmp/delta",
+              "name": "default.tbl1",
+              "type": "TABLE"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": []
+}

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark32DatasetBuilderFactory.java
@@ -19,6 +19,7 @@ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceCatalogExtractor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -57,6 +58,7 @@ public class Spark32DatasetBuilderFactory implements DatasetBuilderFactory {
     DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     Builder builder =
         ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new CreateReplaceCatalogExtractor(context))
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
             .add(new InMemoryRelationInputDatasetBuilder(context))
             .add(new CommandPlanVisitor(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark34DatasetBuilderFactory.java
@@ -34,6 +34,7 @@ import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuild
 import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
 import io.openlineage.spark32.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
+import io.openlineage.spark33.agent.lifecycle.plan.CreateReplaceCatalogExtractor;
 import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
@@ -57,6 +58,7 @@ public class Spark34DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     Builder builder =
         ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new CreateReplaceCatalogExtractor(context))
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
             .add(new InMemoryRelationInputDatasetBuilder(context))
             .add(new CommandPlanVisitor(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark35DatasetBuilderFactory.java
@@ -38,6 +38,7 @@ import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuild
 import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceCatalogExtractor;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.MergeRowsColumnLineageVisitor;
 import java.util.Collection;
@@ -55,6 +56,7 @@ public class Spark35DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     Builder builder =
         ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new CreateReplaceCatalogExtractor(context))
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
             .add(new InMemoryRelationInputDatasetBuilder(context))
             .add(new CommandPlanVisitor(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark3DatasetBuilderFactory.java
@@ -16,6 +16,7 @@ import io.openlineage.spark.agent.util.DeltaUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceCatalogExtractor;
 import io.openlineage.spark3.agent.lifecycle.plan.CreateReplaceDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
 import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
@@ -49,6 +50,7 @@ public class Spark3DatasetBuilderFactory implements DatasetBuilderFactory {
     DatasetFactory<OpenLineage.InputDataset> datasetFactory = DatasetFactory.input(context);
     Builder builder =
         ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new CreateReplaceCatalogExtractor(context))
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
             .add(new InMemoryRelationInputDatasetBuilder(context))
             .add(new CommandPlanVisitor(context))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -36,6 +36,7 @@ import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuil
 import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
 import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceCatalogExtractor;
 import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
 import io.openlineage.spark35.agent.lifecycle.plan.MergeRowsColumnLineageVisitor;
 import io.openlineage.spark40.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
@@ -55,6 +56,7 @@ public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
     DatasetFactory<InputDataset> datasetFactory = DatasetFactory.input(context);
     Builder builder =
         ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new CreateReplaceCatalogExtractor(context))
             .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
             .add(new InMemoryRelationInputDatasetBuilder(context))
             .add(new CommandPlanVisitor(context))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -168,6 +168,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
         .ifPresent(
             v -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, v));
 
+    addCatalogFacet(datasetFacetsBuilder);
     return Collections.singletonList(datasetFactory.getDataset(di, datasetFacetsBuilder));
   }
 
@@ -280,5 +281,9 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
   protected Optional<String> getDatasetVersion(LogicalRelation x) {
     // not implemented
     return Optional.empty();
+  }
+
+  protected void addCatalogFacet(DatasetCompositeFacetsBuilder facetsBuilder) {
+    // not implemented
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
@@ -1,0 +1,90 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.ScalaConversionUtils.fromMap;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage.StoredTableCatalog;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.CreateV2Table;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+
+@Slf4j
+public class CreateReplaceCatalogExtractor<D extends OpenLineage.Dataset>
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, LogicalPlan, D> {
+
+  private static final String CREATE_V2_TABLE =
+      "org.apache.spark.sql.catalyst.plans.logical.CreateV2Table";
+
+  public CreateReplaceCatalogExtractor(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof CreateTableAsSelect)
+        || (x instanceof ReplaceTable)
+        || (x instanceof ReplaceTableAsSelect)
+        // Class CreateV2Table was removed in Spark Catalyst 3.3.0. For some reason, it is also
+        // missing on Databricks platform when Spark context is in version 3.2.1. This hacky way
+        // allows checking for the class also when it is not available on the class path
+        || PlanUtils.safeIsInstanceOf(x, CREATE_V2_TABLE);
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan logicalPlan) {
+    // intentionally unimplemented
+    throw new UnsupportedOperationException("apply(LogicalPlan) is not implemented");
+  }
+
+  @Override
+  public List<D> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (x instanceof CreateTableAsSelect) {
+      return apply((CreateTableAsSelect) x);
+    } else if (x instanceof ReplaceTableAsSelect) {
+      return apply((ReplaceTableAsSelect) x);
+    } else if (PlanUtils.safeIsInstanceOf(x, CREATE_V2_TABLE)) {
+      return apply((CreateV2Table) x);
+    } else {
+      return apply((ReplaceTable) x);
+    }
+  }
+
+  protected List<D> apply(CreateV2Table plan) {
+    TableCatalogStorage.put(
+        context.getJobName(), StoredTableCatalog.of(plan.catalog(), fromMap(plan.properties())));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(CreateTableAsSelect plan) {
+    TableCatalogStorage.put(
+        context.getJobName(), StoredTableCatalog.of(plan.catalog(), fromMap(plan.properties())));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTable plan) {
+    TableCatalogStorage.put(
+        context.getJobName(), StoredTableCatalog.of(plan.catalog(), fromMap(plan.properties())));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTableAsSelect plan) {
+    TableCatalogStorage.put(
+        context.getJobName(), StoredTableCatalog.of(plan.catalog(), fromMap(plan.properties())));
+    return Collections.emptyList();
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -6,9 +6,12 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.scheduler.SparkListenerEvent;
@@ -36,5 +39,14 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
   @Override
   protected Optional<String> getDatasetVersion(LogicalRelation x) {
     return DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(x);
+  }
+
+  @Override
+  protected void addCatalogFacet(DatasetCompositeFacetsBuilder facetsBuilder) {
+    TableCatalogStorage.get(context.getJobName())
+        .ifPresent(
+            tc ->
+                CatalogUtils3.addStorageAndCatalogFacets(
+                    context, tc.getTableCatalog(), tc.getTableProperties(), facetsBuilder));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/TableCatalogStorage.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/utils/TableCatalogStorage.java
@@ -1,0 +1,32 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+public class TableCatalogStorage {
+  private static final Map<String, StoredTableCatalog> catalogs = new HashMap<>();
+
+  public static void put(String key, StoredTableCatalog catalog) {
+    catalogs.put(key, catalog);
+  }
+
+  public static Optional<StoredTableCatalog> get(String key) {
+    return Optional.ofNullable(catalogs.get(key));
+  }
+
+  @Getter
+  @RequiredArgsConstructor(staticName = "of")
+  public static class StoredTableCatalog {
+    private final TableCatalog tableCatalog;
+    private final Map<String, String> tableProperties;
+  }
+}

--- a/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
+++ b/integration/spark/spark33/src/main/java/io/openlineage/spark33/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
@@ -1,0 +1,115 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark33.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.ScalaConversionUtils.fromMap;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage.StoredTableCatalog;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+@Slf4j
+public class CreateReplaceCatalogExtractor<D extends OpenLineage.Dataset>
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, LogicalPlan, D> {
+
+  public CreateReplaceCatalogExtractor(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof CreateTableAsSelect)
+        || (x instanceof ReplaceTable)
+        || (x instanceof ReplaceTableAsSelect)
+        || (x instanceof CreateTable);
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan logicalPlan) {
+    // intentionally unimplemented
+    throw new UnsupportedOperationException("apply(LogicalPlan) is not implemented");
+  }
+
+  @Override
+  public List<D> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (x instanceof CreateTableAsSelect) {
+      return apply((CreateTableAsSelect) x);
+    } else if (x instanceof ReplaceTableAsSelect) {
+      return apply((ReplaceTableAsSelect) x);
+    } else if (x instanceof CreateTable) {
+      return apply((CreateTable) x);
+    } else {
+      return apply((ReplaceTable) x);
+    }
+  }
+
+  protected List<D> apply(CreateTable plan) {
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(),
+                    StoredTableCatalog.of(catalogPlugin, fromMap(plan.tableSpec().properties()))));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(CreateTableAsSelect plan) {
+    Map<String, String> tableProperties = fromMap(plan.tableSpec().properties());
+    tableProperties.putAll(fromMap(plan.writeOptions()));
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(), StoredTableCatalog.of(catalogPlugin, tableProperties)));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTable plan) {
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(),
+                    StoredTableCatalog.of(catalogPlugin, fromMap(plan.tableSpec().properties()))));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTableAsSelect plan) {
+    Map<String, String> tableProperties = fromMap(plan.tableSpec().properties());
+    tableProperties.putAll(fromMap(plan.writeOptions()));
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(), StoredTableCatalog.of(catalogPlugin, tableProperties)));
+    return Collections.emptyList();
+  }
+
+  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
+    try {
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+      log.error("Could not obtain catalog plugin", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
+++ b/integration/spark/spark35/src/main/java/io/openlineage/spark35/agent/lifecycle/plan/CreateReplaceCatalogExtractor.java
@@ -1,0 +1,115 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark35.agent.lifecycle.plan;
+
+import static io.openlineage.spark.agent.util.ScalaConversionUtils.fromMap;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.api.AbstractQueryPlanDatasetBuilder;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage;
+import io.openlineage.spark3.agent.utils.TableCatalogStorage.StoredTableCatalog;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTable;
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableAsSelect;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTable;
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTableAsSelect;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+
+@Slf4j
+public class CreateReplaceCatalogExtractor<D extends OpenLineage.Dataset>
+    extends AbstractQueryPlanDatasetBuilder<SparkListenerEvent, LogicalPlan, D> {
+
+  public CreateReplaceCatalogExtractor(OpenLineageContext context) {
+    super(context, false);
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan x) {
+    return (x instanceof CreateTableAsSelect)
+        || (x instanceof ReplaceTable)
+        || (x instanceof ReplaceTableAsSelect)
+        || (x instanceof CreateTable);
+  }
+
+  @Override
+  public List<D> apply(LogicalPlan logicalPlan) {
+    // intentionally unimplemented
+    throw new UnsupportedOperationException("apply(LogicalPlan) is not implemented");
+  }
+
+  @Override
+  public List<D> apply(SparkListenerEvent event, LogicalPlan x) {
+    if (x instanceof CreateTableAsSelect) {
+      return apply((CreateTableAsSelect) x);
+    } else if (x instanceof ReplaceTableAsSelect) {
+      return apply((ReplaceTableAsSelect) x);
+    } else if (x instanceof CreateTable) {
+      return apply((CreateTable) x);
+    } else {
+      return apply((ReplaceTable) x);
+    }
+  }
+
+  protected List<D> apply(CreateTable plan) {
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(),
+                    StoredTableCatalog.of(catalogPlugin, fromMap(plan.tableSpec().properties()))));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(CreateTableAsSelect plan) {
+    Map<String, String> tableProperties = fromMap(plan.tableSpec().properties());
+    tableProperties.putAll(fromMap(plan.writeOptions()));
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(), StoredTableCatalog.of(catalogPlugin, tableProperties)));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTable plan) {
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(),
+                    StoredTableCatalog.of(catalogPlugin, fromMap(plan.tableSpec().properties()))));
+    return Collections.emptyList();
+  }
+
+  protected List<D> apply(ReplaceTableAsSelect plan) {
+    Map<String, String> tableProperties = fromMap(plan.tableSpec().properties());
+    tableProperties.putAll(fromMap(plan.writeOptions()));
+    callCatalogMethod(plan.name())
+        .ifPresent(
+            catalogPlugin ->
+                TableCatalogStorage.put(
+                    context.getJobName(), StoredTableCatalog.of(catalogPlugin, tableProperties)));
+    return Collections.emptyList();
+  }
+
+  private Optional<TableCatalog> callCatalogMethod(LogicalPlan plan) {
+    try {
+      return Optional.of((TableCatalog) MethodUtils.invokeMethod(plan, "catalog", (Object[]) null));
+    } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+      log.error("Could not obtain catalog plugin", e);
+      return Optional.empty();
+    }
+  }
+}


### PR DESCRIPTION
### Problem

Catalog and Storage facets are missing in inputs for Delta catalog.
The implementation of those facets is heavily based on data source v2, the catalog is recognized based on the TableCatalog class.
Delta catalog works with LogicalRelations, which do not know anything about TableCatalog.

### Solution

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project