### PR TITLE
tests: change bitnami to bitnamilegacy for postgres image in integration tests

### DIFF
--- a/integration/airflow/tests/integration/tests/docker-compose.yml
+++ b/integration/airflow/tests/integration/tests/docker-compose.yml
@@ -225,7 +225,7 @@ services:
     restart: always
 
   postgres:
-    image: bitnami/postgresql:12.1.0
+    image: bitnamilegacy/postgresql:12.1.0
     networks:
       - app_net
     ports:


### PR DESCRIPTION
### Problem

Airflow tests are failing on main trying to get postgres image.

[Notice](https://hub.docker.com/r/bitnami/postgresql):
<img width="1243" height="447" alt="image" src="https://github.com/user-attachments/assets/8da5ac03-6560-4470-bf9b-16fdf51a638d" />

### Solution

We're using old postgres image, so we can use legacy one with no updates anyway.

#### One-line summary:
tests: change bitnami to bitnamilegacy for postgres image in integration tests

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project