### PR TITLE
spark: Fix CLL on hiveless runtimes

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/column/ColumnLevelLineageUtils.java
@@ -9,6 +9,7 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.dataset.namespace.resolver.DatasetNamespaceCombinedResolver;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageBuilder;
 import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageContext;
+import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.ColumnLineageConfig;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -33,6 +34,9 @@ import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand;
  */
 @Slf4j
 public class ColumnLevelLineageUtils {
+
+  private static final String CREATE_HIVE_TABLE_AS_SELECT_COMMAND =
+      "org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand";
 
   public static Optional<OpenLineage.ColumnLineageDatasetFacet> buildColumnLineageDatasetFacet(
       SparkListenerEvent event,
@@ -110,7 +114,7 @@ public class ColumnLevelLineageUtils {
       plan = ((SaveIntoDataSourceCommand) logicalPlan).query();
     } else if (logicalPlan instanceof CreateDataSourceTableAsSelectCommand) {
       plan = ((CreateDataSourceTableAsSelectCommand) logicalPlan).query();
-    } else if (logicalPlan instanceof CreateHiveTableAsSelectCommand) {
+    } else if (PlanUtils.safeIsInstanceOf(logicalPlan, CREATE_HIVE_TABLE_AS_SELECT_COMMAND)) {
       plan = ((CreateHiveTableAsSelectCommand) logicalPlan).query();
     } else {
       plan = logicalPlan;


### PR DESCRIPTION
### Problem

PR #4031 introduced changes to CLL that would fail when running in runtimes without spark-hive package included, because `org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand` class would not be on classpath.

### Solution

Adjust the code using PlanUtils.safeIsInstanceOf(), so it wouldn't fail when the class is missing.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Fix CLL issue on hiveless runtimes introduced by #4031

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project