### PR TITLE
spark: fix false hive glue detection

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -32,16 +32,7 @@ public class AwsUtils {
                   getGlueCatalogId(sparkConf, hadoopConf)
                       .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
     } else {
-      try {
-        return awsRegion()
-            .flatMap(
-                region ->
-                    getGlueCatalogId(sparkConf, hadoopConf)
-                        .map(glueCatalogId -> "arn:aws:glue:" + region + ":" + glueCatalogId));
-      } catch (Exception e) {
-        log.error("Failed to retrieve Glue", e);
-        return Optional.empty();
-      }
+      return Optional.empty();
     }
   }
 


### PR DESCRIPTION
### Problem

OpenLineage falsely detects glue symlinks when using hive metastore and AWS account is configured.

In the #3695 PR, AwsUtils `getGlueArn` is set to do glue ARN resolution even if it does not satisfies `isHiveUsingGlue` check. This causes non-glue hive catalog to be identified as glue when AWS account ID is configured in the session. This issue specifically happen when AWS account ID is configured in the session because Glue ARN resolution will fallback to configured AWS account ID when other resolution methods fail. 

Closes: #4051

### Solution

#### One-line summary: Remove Glue ARN resolution attempt when `isHiveUsingGlue` is not satisfied

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project