### PR TITLE
dbt: use alias when naming datasets

### DIFF
--- a/integration/common/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/openlineage/common/provider/dbt/processor.py
@@ -73,6 +73,9 @@ class UnsupportedDbtCommand(Exception):
 
 @attr.define
 class ModelNode:
+    # in reality Literal["model", "test", "snapshot", "source", "seed"]
+    # but way too much work to convince mypy that it's true
+    type: str
     metadata_node: Dict
     catalog_node: Optional[Dict] = None
 
@@ -261,15 +264,17 @@ class DbtArtifactProcessor:
                 if node.startswith("model."):
                     inputs.append(
                         ModelNode(
-                            nodes[node],
-                            get_from_nullable_chain(context.catalog, ["nodes", node]),
+                            type="model",
+                            metadata_node=nodes[node],
+                            catalog_node=get_from_nullable_chain(context.catalog, ["nodes", node]),
                         )
                     )
                 elif node.startswith("source."):
                     inputs.append(
                         ModelNode(
-                            context.manifest["sources"][node],
-                            get_from_nullable_chain(context.catalog, ["sources", node]),
+                            type="source",
+                            metadata_node=context.manifest["sources"][node],
+                            catalog_node=get_from_nullable_chain(context.catalog, ["sources", node]),
                         )
                     )
 
@@ -307,8 +312,9 @@ class DbtArtifactProcessor:
 
             output_dataset = self.node_to_output_dataset(
                 ModelNode(
-                    output_node,
-                    get_from_nullable_chain(context.catalog, ["nodes", run["unique_id"]]),
+                    type=jobType.lower(),
+                    metadata_node=output_node,
+                    catalog_node=get_from_nullable_chain(context.catalog, ["nodes", run["unique_id"]]),
                 ),
                 has_facets=True,
                 adapter_response=run.get("adapter_response", None),
@@ -343,7 +349,11 @@ class DbtArtifactProcessor:
         events = DbtEvents()
         manifest_nodes = {**context.manifest["nodes"], **context.manifest["sources"]}
         for name, node in manifest_nodes.items():
-            if not name.startswith("model.") and not name.startswith("source."):
+            if name.startswith("model."):
+                node_type = "model"
+            elif name.startswith("source."):
+                node_type = "source"
+            else:
                 continue
             if len(assertions[name]) == 0:
                 continue
@@ -353,7 +363,7 @@ class DbtArtifactProcessor:
             )
 
             namespace, name, _, _ = self.extract_dataset_data(
-                ModelNode(node), assertion_facet, has_facets=False
+                ModelNode(type=node_type, metadata_node=node), assertion_facet, has_facets=False
             )
 
             job_name = self._format_dataset_name(
@@ -598,12 +608,16 @@ class DbtArtifactProcessor:
                 facets["schema"] = schema_dataset.SchemaDatasetFacet(fields=fields)
         else:
             facets = {}
+        if node.type == "source":
+            table = node.metadata_node["name"]
+        else:
+            table = node.metadata_node["alias"]
         return (
             self.dataset_namespace,
             self._format_dataset_name(
                 node.metadata_node["database"],
                 node.metadata_node["schema"],
-                node.metadata_node["name"],
+                table,
             ),
             facets,
             input_facets,

--- a/integration/common/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/openlineage/common/provider/dbt/structured_logs.py
@@ -809,10 +809,16 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         """
         Builds a ModelNode of a given node_id
         """
-        all_nodes = {**self.compiled_manifest["nodes"], **self.compiled_manifest["sources"]}
-        manifest_node = all_nodes[node_id]
+        if node_id in self.compiled_manifest["nodes"]:
+            node_type = "model"
+            manifest_node = self.compiled_manifest["nodes"][node_id]
+        elif node_id in self.compiled_manifest["sources"]:
+            node_type = "source"
+            manifest_node = self.compiled_manifest["sources"][node_id]
+        else:
+            raise RuntimeError(f"{node_id} not found in nodes or sources")
         catalog_node = get_from_nullable_chain(self.catalog, ["nodes", node_id])
-        return ModelNode(metadata_node=manifest_node, catalog_node=catalog_node)
+        return ModelNode(type=node_type, metadata_node=manifest_node, catalog_node=catalog_node)
 
     def _get_model_inputs(self, node_id) -> List[ModelNode]:
         """

--- a/integration/common/tests/dbt/alias/dbt_project.yml
+++ b/integration/common/tests/dbt/alias/dbt_project.yml
@@ -1,0 +1,37 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'dbt_small_test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'bigquery'
+
+# These configurations specify where dbt should look for different types of files.
+# The `model-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the {% raw %} `{{ config(...) }}` {% endraw %} macro.
+models:
+  dbt_small_test:
+      # Applies to all files under models/example/
+      example:
+          materialized: view

--- a/integration/common/tests/dbt/alias/profiles.yml
+++ b/integration/common/tests/dbt/alias/profiles.yml
@@ -1,0 +1,13 @@
+bigquery:
+    target: dev
+    outputs:
+        dev:
+            type: bigquery
+            method: service-account
+            keyfile: /home/example/.gcp/bq-key.json
+            project: random-gcp-project
+            dataset: dbt_test1
+            threads: 2
+            timeout_seconds: 300
+            location: EU
+            priority: interactive

--- a/integration/common/tests/dbt/alias/result.json
+++ b/integration/common/tests/dbt/alias/result.json
@@ -1,0 +1,118 @@
+[
+  {
+    "eventType": "START",
+    "eventTime": "{{ is_datetime(result) }}",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "job": { "name": "dbt-job-name", "namespace": "dbt" },
+          "run": { "runId": "{{ any(result) }}" }
+        },
+        "dbt_version": {
+          "version": "{{ any(result) }}"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "{{ any(result) }}",
+          "openlineageAdapterVersion": "{{ any(result) }}"
+        },
+        "dbt_run": {
+          "invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004"
+        }
+      }
+    },
+    "job": {
+      "namespace": "job-namespace",
+      "name": "random-gcp-project.dbt_test1.dbt_test.test_model"
+    },
+    "inputs": [
+      {
+        "namespace": "bigquery",
+        "name": "random-gcp-project.dbt_test1.source_table"
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "bigquery",
+        "name": "random-gcp-project.dbt_test1.test_model"
+      }
+    ]
+  },
+  {
+    "eventType": "COMPLETE",
+    "eventTime": "{{ is_datetime(result) }}",
+    "run": {
+      "runId": "{{ any(result) }}",
+      "facets": {
+        "parent": {
+          "job": { "name": "dbt-job-name", "namespace": "dbt" },
+          "run": { "runId": "{{ any(result) }}" }
+        },
+        "dbt_version": {
+          "version": "{{ any(result) }}"
+        },
+        "processing_engine": {
+          "name": "dbt",
+          "version": "{{ any(result) }}",
+          "openlineageAdapterVersion": "{{ any(result) }}"
+        },
+        "dbt_run": {
+          "invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004"
+        }
+      }
+    },
+    "job": {
+      "namespace": "job-namespace",
+      "name": "random-gcp-project.dbt_test1.dbt_test.test_model",
+      "facets": {
+        "sql": {
+          "query": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1",
+          "dialect": "bigquery"
+        },
+        "jobType": {
+          "jobType": "MODEL",
+          "integration": "DBT",
+          "processingType": "BATCH"
+        }
+      }
+    },
+    "inputs": [
+      {
+        "namespace": "bigquery",
+        "name": "random-gcp-project.dbt_test1.source_table",
+        "facets": {
+          "dataSource": {
+            "name": "bigquery",
+            "uri": "bigquery"
+          },
+          "documentation": {
+            "description": "A source table"
+          }
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "namespace": "bigquery",
+        "name": "random-gcp-project.dbt_test1.test_model_alias",
+        "facets": {
+          "dataSource": {
+            "name": "bigquery",
+            "uri": "bigquery"
+          },
+          "schema": {
+            "fields": [
+              {
+                "name": "id"
+              }
+            ]
+          },
+          "documentation": {
+            "description": "A starter dbt model"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/integration/common/tests/dbt/alias/target/manifest.json
+++ b/integration/common/tests/dbt/alias/target/manifest.json
@@ -1,0 +1,147 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v2.json",
+		"dbt_version": "0.21.0",
+		"generated_at": "2021-07-07T12:44:44.367050Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {},
+		"project_id": "dc5b36ac8a5ba619cc093366efe36d3d",
+		"user_id": "7bae5953-769e-4aa1-81f6-55a82ac4d4d4",
+		"send_anonymous_usage_stats": true,
+		"adapter_type": "bigquery"
+	},
+	"nodes": {
+		"model.dbt_test.test_model": {
+			"raw_sql": "select *\nfrom {{ source('dbt_test1', 'source_table') }}\nwhere id = 1",
+			"compiled": true,
+			"resource_type": "model",
+			"depends_on": {
+				"macros": ["macro.dbt.create_or_replace_view", "macro.dbt.persist_docs"],
+				"nodes": ["source.dbt_test.dbt_test1.source_table"]
+			},
+			"config": {
+				"enabled": true,
+				"materialized": "view",
+				"persist_docs": {},
+				"vars": {},
+				"quoting": {},
+				"column_types": {},
+				"alias": null,
+				"schema": null,
+				"database": null,
+				"tags": [],
+				"full_refresh": null,
+				"post-hook": [],
+				"pre-hook": []
+			},
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"fqn": ["dbt_test", "example", "test_model"],
+			"unique_id": "model.dbt_test.test_model",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "example/test_second_parallel_dbt_model.sql",
+			"original_file_path": "models/example/test_model.sql",
+			"name": "test_model",
+			"alias": "test_model_alias",
+			"checksum": {
+				"name": "sha256",
+				"checksum": "318f640067e471c6a2e8d370039786939aaf4197c4be4ee64677e59f1f1a9a34"
+			},
+			"tags": [],
+			"refs": [],
+			"sources": [
+				["dbt_test1", "source_table"]
+			],
+			"description": "A starter dbt model",
+			"columns": {
+				"id": {
+					"name": "id",
+					"description": "The primary key for this table",
+					"meta": {},
+					"data_type": null,
+					"quote": null,
+					"tags": []
+				}
+			},
+			"meta": {},
+			"docs": {
+				"show": true
+			},
+			"patch_path": "dbt_test://models/example/schema.yml",
+			"compiled_path": "target/compiled/dbt_test/models/example/test_model.sql",
+			"build_path": "target/run/dbt_test/models/example/test_model.sql",
+			"deferred": false,
+			"unrendered_config": {},
+			"created_at": 1625661884,
+			"compiled_sql": "select *\nfrom `random-gcp-project`.`dbt_test1`.`source_table`\nwhere id = 1",
+			"extra_ctes_injected": true,
+			"extra_ctes": [],
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`test_model`"
+		}
+	},
+  	"sources": {
+		"source.dbt_test.dbt_test1.source_table": {
+			"fqn": ["dbt_test", "example", "dbt_test1", "source_table"],
+			"database": "random-gcp-project",
+			"schema": "dbt_test1",
+			"unique_id": "source.dbt_test.dbt_test1.source_table",
+			"package_name": "dbt_test",
+			"root_path": "/home/example/code/dbt-test",
+			"path": "models/example/schema.yml",
+			"original_file_path": "models/example/schema.yml",
+			"name": "source_table",
+			"source_name": "dbt_test1",
+			"source_description": "",
+			"loader": "",
+			"identifier": "source_table",
+			"resource_type": "source",
+			"quoting": {
+				"database": null,
+				"schema": null,
+				"identifier": null,
+				"column": null
+			},
+			"loaded_at_field": null,
+			"freshness": {
+				"warn_after": null,
+				"error_after": null,
+				"filter": null
+			},
+			"external": null,
+			"description": "A source table",
+			"columns": {},
+			"meta": {},
+			"source_meta": {},
+			"tags": [],
+			"config": {
+				"enabled": true
+			},
+			"patch_path": null,
+			"unrendered_config": {},
+			"relation_name": "`random-gcp-project`.`dbt_test1`.`source_table`",
+			"created_at": 1625661884
+		}
+	},
+	"macros": {},
+	"docs": {
+		"dbt.__overview__": {
+			"unique_id": "dbt.__overview__",
+			"package_name": "dbt",
+			"root_path": "/home/example/tools/pyenv/versions/3.9.2/lib/python3.9/site-packages/dbt/include/global_project",
+			"path": "overview.md",
+			"original_file_path": "docs/overview.md",
+			"name": "__overview__",
+			"block_contents": "### Welcome!\n\nWelcome to the auto-generated documentation for your dbt project!\n\n### Navigation\n\nYou can use the `Project` and `Database` navigation tabs on the left side of the window to explore the models\nin your project.\n\n#### Project Tab\nThe `Project` tab mirrors the directory structure of your dbt project. In this tab, you can see all of the\nmodels defined in your dbt project, as well as models imported from dbt packages.\n\n#### Database Tab\nThe `Database` tab also exposes your models, but in a format that looks more like a database explorer. This view\nshows relations (tables and views) grouped into database schemas. Note that ephemeral models are _not_ shown\nin this interface, as they do not exist in the database.\n\n### Graph Exploration\nYou can click the blue icon on the bottom-right corner of the page to view the lineage graph of your models.\n\nOn model pages, you'll see the immediate parents and children of the model you're exploring. By clicking the `Expand`\nbutton at the top-right of this lineage pane, you'll be able to see all of the models that are used to build,\nor are built from, the model you're exploring.\n\nOnce expanded, you'll be able to use the `--models` and `--exclude` model selection syntax to filter the\nmodels in the graph. For more information on model selection, check out the [dbt docs](https://docs.getdbt.com/docs/model-selection-syntax).\n\nNote that you can also right-click on models to interactively filter and explore the graph.\n\n---\n\n### More information\n\n- [What is dbt](https://docs.getdbt.com/docs/overview)?\n- Read the [dbt viewpoint](https://docs.getdbt.com/docs/viewpoint)\n- [Installation](https://docs.getdbt.com/docs/installation)\n- Join the [chat](https://community.getdbt.com/) on Slack for live questions and support."
+		}
+	},
+	"exposures": {},
+	"selectors": {},
+	"disabled": [],
+	"parent_map": {
+		"model.dbt_test.test_model": ["source.dbt_test.dbt_test1.source_table"]
+	},
+	"child_map": {
+		"model.dbt_test.test_model": []
+	}
+}

--- a/integration/common/tests/dbt/alias/target/run_results.json
+++ b/integration/common/tests/dbt/alias/target/run_results.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v2.json",
+		"dbt_version": "0.21.0",
+		"generated_at": "2021-07-07T12:44:51.891863Z",
+		"invocation_id": "b8513ee2-6c1f-44ed-a13d-3fc35ef81004",
+		"env": {}
+	},
+	"results": [{
+		"status": "success",
+		"timing": [{
+			"name": "compile",
+			"started_at": "2021-07-07T12:44:46.053875Z",
+			"completed_at": "2021-07-07T12:44:46.063996Z"
+		}, {
+			"name": "execute",
+			"started_at": "2021-07-07T12:44:46.069306Z",
+			"completed_at": "2021-07-07T12:44:46.972743Z"
+		}],
+		"thread_id": "Thread-2",
+		"execution_time": 0.9195568561553955,
+		"adapter_response": {
+			"_message": "OK",
+			"code": "CREATE VIEW"
+		},
+		"message": "OK",
+		"failures": null,
+		"unique_id": "model.dbt_test.test_model"
+	}],
+	"elapsed_time": 7.067806243896484,
+	"args": {
+		"log_format": "default",
+		"write_json": true,
+		"use_experimental_parser": false,
+		"profiles_dir": "./tests/dbt/small",
+		"use_cache": true,
+		"version_check": true,
+		"which": "run",
+		"rpc_method": "run"
+	}
+}

--- a/integration/common/tests/dbt/structured_logs/postgres/build_command/results/build_ol_events.json
+++ b/integration/common/tests/dbt/structured_logs/postgres/build_command/results/build_ol_events.json
@@ -5456,7 +5456,7 @@
     "outputs": [
       {
         "namespace": "postgres://postgres:5432",
-        "name": "postgres.public_dbt_test__audit.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+        "name": "postgres.public_dbt_test__audit.accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
         "facets": {
           "dataSource": {
             "name": "postgres://postgres:5432",
@@ -5722,7 +5722,7 @@
     "outputs": [
       {
         "namespace": "postgres://postgres:5432",
-        "name": "postgres.public_dbt_test__audit.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned",
+        "name": "postgres.public_dbt_test__audit.accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58",
         "facets": {
           "dataSource": {
             "name": "postgres://postgres:5432",
@@ -6485,7 +6485,7 @@
     "outputs": [
       {
         "namespace": "postgres://postgres:5432",
-        "name": "postgres.public_dbt_test__audit.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+        "name": "postgres.public_dbt_test__audit.accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
         "facets": {
           "dataSource": {
             "name": "postgres://postgres:5432",
@@ -6751,7 +6751,7 @@
     "outputs": [
       {
         "namespace": "postgres://postgres:5432",
-        "name": "postgres.public_dbt_test__audit.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card",
+        "name": "postgres.public_dbt_test__audit.accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef",
         "facets": {
           "dataSource": {
             "name": "postgres://postgres:5432",


### PR DESCRIPTION
Right now when users use alias feature: https://docs.getdbt.com/reference/resource-configs/alias we don't take it into account when naming the datasets, which is wrong - the alias is the actual identifier that the table has in the db.