### PR TITLE
spark: Add missing facets in inputs for Databricks Unity Catalog

### DIFF
--- a/integration/spark/app/src/test/resources/databricks_notebooks/unity_catalog.py
+++ b/integration/spark/app/src/test/resources/databricks_notebooks/unity_catalog.py
@@ -1,0 +1,49 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+from pyspark.sql import functions as f
+from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
+# Adjust the catalog name as necessary
+catalog = "PROVIDE_NAME"
+
+if os.path.exists("/tmp/events.log"):
+    os.remove("/tmp/events.log")
+
+runtime_version = os.environ.get("DATABRICKS_RUNTIME_VERSION", None).replace(".", "_")
+
+schema = f"{catalog}.default"
+tbl1 = f"{schema}.tbl1_{runtime_version}"
+tbl2 = f"{schema}.tbl2_{runtime_version}"
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+spark.sql(f"DROP TABLE IF EXISTS {tbl1}")
+spark.sql(f"DROP TABLE IF EXISTS {tbl2}")
+
+tbl1_df = spark.createDataFrame(
+    [
+        (1, "alpha", 10),
+        (2, "beta", 20),
+        (3, "gamma", 30),
+        (4, "delta", 40),
+    ],
+    schema=StructType(
+        [
+            StructField("id", IntegerType(), True),
+            StructField("name", StringType(), True),
+            StructField("value", IntegerType(), True),
+        ]
+    ),
+)
+tbl1_df.write.format("delta").saveAsTable(tbl1)
+
+tbl2_df = spark.table(tbl1).withColumn("value_x2", f.col("value") * f.lit(2))
+tbl2_df.write.format("delta").saveAsTable(tbl2)
+
+time.sleep(3)
+
+event_file = "dbfs:/databricks/openlineage/events_{}.log".format(runtime_version)
+dbutils.fs.rm(event_file, True)
+dbutils.fs.cp("file:/tmp/events.log", event_file)

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -168,6 +168,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
         .ifPresent(
             v -> DatasetVersionUtils.buildVersionOutputFacets(context, datasetFacetsBuilder, v));
 
+    addCatalogAndStorageFacets(catalogTable, datasetFacetsBuilder);
     return Collections.singletonList(datasetFactory.getDataset(di, datasetFacetsBuilder));
   }
 
@@ -280,5 +281,10 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
   protected Optional<String> getDatasetVersion(LogicalRelation x) {
     // not implemented
     return Optional.empty();
+  }
+
+  protected void addCatalogAndStorageFacets(
+      CatalogTable catalogTable, DatasetCompositeFacetsBuilder builder) {
+    // not implemented
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatabricksUtils.java
@@ -31,6 +31,11 @@ public class DatabricksUtils {
     return conf.contains(SPARK_DATABRICKS_WORKSPACE_URL);
   }
 
+  public static boolean isDatabricksUnityCatalogEnabled(SparkConf conf) {
+    return isRunOnDatabricksPlatform(conf)
+        && "true".equals(conf.get("spark.databricks.unityCatalog.enabled", "false"));
+  }
+
   public static Optional<String> getWorkspaceUrl(OpenLineageContext context) {
     return context
         .getSparkSession()

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -7,10 +7,12 @@ package io.openlineage.spark.agent.util;
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
+import java.io.File;
 import java.net.URI;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
@@ -80,6 +82,10 @@ public class PathUtils {
       URI hiveUri = prepareHiveUri(metastoreUri.get());
       String tableName = nameFromTableIdentifier(catalogTable.identifier());
       symlinkDataset = Optional.of(FilesystemDatasetUtils.fromLocationAndName(hiveUri, tableName));
+    } else if (DatabricksUtils.isDatabricksUnityCatalogEnabled(sparkConf)) {
+      String tableName = nameFromTableIdentifier(catalogTable.identifier());
+      String namespace = StringUtils.substringBeforeLast(location.toString(), File.separator);
+      symlinkDataset = Optional.of(new DatasetIdentifier(tableName, namespace));
     } else {
       Optional<URI> warehouseLocation =
           getWarehouseLocation(sparkConf, hadoopConf)

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -308,6 +308,37 @@ class PathUtilsTest {
   }
 
   @Test
+  void testFromCatalogWithDatabricksUnityCatalog() throws URISyntaxException {
+    sparkConf.set("spark.databricks.workspaceUrl", "https://databricks-workspace.example.com");
+    sparkConf.set("spark.databricks.unityCatalog.enabled", "true");
+
+    TableIdentifier tableIdentifier = mock(TableIdentifier.class);
+    when(tableIdentifier.database()).thenReturn(Option.apply("database"));
+    when(tableIdentifier.table()).thenReturn("mytable");
+    when(catalogTable.identifier()).thenReturn(tableIdentifier);
+    when(catalogStorageFormat.locationUri())
+        .thenReturn(
+            Option.apply(
+                new URI(
+                    "s3://bucket/5087cc52-ff07-4f8c-9580-0d4a962b4585/tables/1252e580-77ab-4b0c-a1a2-c3ff9acae0a3")));
+    when(catalogTable.storage()).thenReturn(catalogStorageFormat);
+
+    DatasetIdentifier datasetIdentifier = PathUtils.fromCatalogTable(catalogTable, sparkSession);
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue(
+            "name",
+            "5087cc52-ff07-4f8c-9580-0d4a962b4585/tables/1252e580-77ab-4b0c-a1a2-c3ff9acae0a3")
+        .hasFieldOrPropertyWithValue("namespace", "s3://bucket");
+    assertThat(datasetIdentifier.getSymlinks()).hasSize(1);
+    assertThat(datasetIdentifier.getSymlinks().get(0))
+        .hasFieldOrPropertyWithValue("name", "database.mytable")
+        .hasFieldOrPropertyWithValue(
+            "namespace", "s3://bucket/5087cc52-ff07-4f8c-9580-0d4a962b4585/tables")
+        .hasFieldOrPropertyWithValue("type", SymlinkType.TABLE);
+  }
+
+  @Test
   void testFromCatalogWithDefaultStorage() throws URISyntaxException {
     when(catalogStorageFormat.locationUri())
         .thenReturn(Option.apply(new URI("hdfs://namenode:8020/warehouse/database.db/table")));

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -6,13 +6,24 @@
 package io.openlineage.spark3.agent.lifecycle.plan;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.dataset.DatasetCompositeFacetsBuilder;
+import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.catalog.CatalogUtils3;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
+import java.lang.reflect.InvocationTargetException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.catalog.CatalogTable;
+import org.apache.spark.sql.connector.catalog.CatalogManager;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.execution.datasources.LogicalRelation;
+import org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog;
+import scala.Option;
 
 /**
  * Class extending {@link io.openlineage.spark.agent.lifecycle.plan.LogicalRelationDatasetBuilder}
@@ -36,5 +47,43 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
   @Override
   protected Optional<String> getDatasetVersion(LogicalRelation x) {
     return DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(x);
+  }
+
+  @Override
+  protected void addCatalogAndStorageFacets(
+      CatalogTable catalogTable, DatasetCompositeFacetsBuilder builder) {
+    if (!context.getSparkSession().isPresent()) {
+      return;
+    }
+    if (catalogTable == null || catalogTable.identifier() == null) {
+      log.debug("No table identifier, cannot add catalog/storage facets");
+      return;
+    }
+
+    String catalogName;
+    try {
+      //noinspection unchecked
+      catalogName =
+          ((Option<String>) MethodUtils.invokeMethod(catalogTable.identifier(), "catalog")).get();
+    } catch (NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchElementException e) {
+      log.debug("No catalog name, cannot add catalog/storage facets");
+      return;
+    }
+
+    CatalogManager catalogManager = context.getSparkSession().get().sessionState().catalogManager();
+    Optional.of(catalogManager.catalog(catalogName))
+        .filter(catalogPlugin -> !(catalogPlugin instanceof V2SessionCatalog))
+        .filter(catalogPlugin -> catalogPlugin instanceof TableCatalog)
+        .map(TableCatalog.class::cast)
+        .ifPresent(
+            tableCatalog ->
+                CatalogUtils3.addStorageAndCatalogFacets(
+                    context,
+                    tableCatalog,
+                    ScalaConversionUtils.fromMap(catalogTable.properties()),
+                    builder));
   }
 }


### PR DESCRIPTION
### Problem

Catalog, Storage and Symlinks facets are missing in inputs for Databricks Unity Catalog.

#### Catalog/Storage facets

The implementation of those facets is heavily based on Data Source v2 API, the catalog is being recognized based on the TableCatalog class.
When using Databricks Unity Catalog, it works with the older API and in the logical plan we get LogicalRelations, which do not know anything about TableCatalog, meaning we do not have enough information to build those facets properly.

#### Symlinks facets

The symlink facet is constructed based on a CatalogTable object. There is a logic in the code, checking if the location of the data is within the warehouse (see the code below). If it's not, we don't build the symlink facet. 
```java
if (warehouseLocation.isPresent()) {
  URI relativePath = warehouseLocation.get().relativize(locationUri);
  if (!relativePath.equals(locationUri)) {
    // if there is no metastore, and table has custom location,
    // it cannot be accessed via default warehouse location
    String tableName = nameFromTableIdentifier(catalogTable.identifier());
    symlinkDataset =
        Optional.of(
            FilesystemDatasetUtils.fromLocationAndName(warehouseLocation.get(), tableName));
  }
}
```

This does not work with Databricks Unity Catalog, because the warehouse URI is meaningless in this context. Unity Catalog manages it's locations on the Databricks side and the actual warehouse URI is not known to Spark. There is a default warehouse URI configured in Spark, but it will always be different than the actual data location, meaning there would never be a symlinks facet created.

### Solution

#### Catalog/Storage facets

Knowing the name of the catalog, it is possible to get the TableCatalog from Spark's Catalog Manager. Normally, it would give us a generic `V2SessionCatalog`, which does not really help, because we still don't know what kind of catalog it is, but because of the proprietary implementation on Databricks, the Catalog Manager gives us `com.databricks.sql.managedcatalog.UnityCatalogV2Proxy`. As long as we can get that object, the facets can be built in the same way as if it was using the V2 API.

#### Symlinks facets

If it is running on Databricks with Unity Catalog enabled, build the symlinks facet ignoring the warehouse URI.

#### One-line summary:

Add missing facets in inputs for Databricks Unity Catalog

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project