### PR TITLE
fix: remove numpy import from serde

### DIFF
--- a/client/python/openlineage/client/serde.py
+++ b/client/python/openlineage/client/serde.py
@@ -4,18 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 from enum import Enum
 from typing import Any, cast
 
 import attr
 
 log = logging.getLogger(__name__)
-
-try:
-    import numpy
-except ImportError:
-    log.warning("ImportError occurred when trying to import numpy module.")
 
 
 class Serde:
@@ -39,7 +33,7 @@ class Serde:
             )
 
         # Pandas can use numpy.int64 object
-        if "numpy" in sys.modules and isinstance(obj, numpy.int64):
+        if getattr(getattr(obj, "__class__", None), "__name__", None) == "int64":
             return int(obj)
         return obj
 


### PR DESCRIPTION
### Problem

We're only using numpy in one place in our code, to serialize numpy.int64 as int. The same check can be done without importing numpy, that as it turns out [here](https://github.com/apache/airflow/pull/56266#issuecomment-3357202583), can be quite heavy in top level code.

### Solution

Check int64 class using `__class__.__name__` instead of isinstance.

#### One-line summary:
fix: remove numpy import from serde

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project