### PR TITLE
[Spark] BigQuery Metastore add fallback for BigQuery project ID configuration

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
@@ -54,7 +54,11 @@ class BigQueryMetastoreCatalogTypeHandler extends BaseCatalogTypeHandler {
   @Override
   Map<String, String> catalogProperties(Map<String, String> catalogConf) {
     Map<String, String> properties = new HashMap<>();
-    properties.put("gcp_project_id", catalogConf.get("gcp.bigquery.project-id"));
+    String projectId = catalogConf.get("gcp.bigquery.project-id");
+    if (projectId == null || projectId.isEmpty()) {
+      projectId = catalogConf.get("gcp_project");
+    }
+    properties.put("gcp_project_id", projectId);
     properties.put("gcp_location", catalogConf.get("gcp.bigquery.location"));
     return properties;
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -617,4 +617,38 @@ class IcebergHandlerTest {
     assertThat(facet.getCatalogProperties().getAdditionalProperties())
         .hasFieldOrPropertyWithValue("gcp_project_id", "some_gcp_project_id");
   }
+
+  @Test
+  void testGetBigQueryMetastoreCatalogDataWithAlternateProjectKey() {
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(context.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkCatalog.name()).thenReturn("bq_metastore_catalog");
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map4(
+                "spark.sql.catalog.bq_metastore_catalog.catalog-impl",
+                "org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog",
+                "spark.sql.catalog.bq_metastore_catalog.warehouse",
+                "gcs://bucket/path/to/iceberg/warehouse",
+                "spark.sql.catalog.bq_metastore_catalog.gcp_project",
+                "my-gcp-project",
+                "spark.sql.catalog.bq_metastore_catalog.gcp.bigquery.location",
+                "eu"));
+
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
+        icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
+    assertTrue(catalogDatasetFacet.isPresent());
+
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
+
+    assertEquals("bq_metastore_catalog", facet.getName());
+    assertEquals("bigquerymetastore", facet.getType());
+    assertEquals("gcs://bucket/path/to/iceberg/warehouse", facet.getWarehouseUri());
+    assertEquals("iceberg", facet.getFramework());
+    assertThat(facet.getCatalogProperties().getAdditionalProperties())
+        .hasFieldOrPropertyWithValue("gcp_location", "eu")
+        .hasFieldOrPropertyWithValue("gcp_project_id", "my-gcp-project");
+  }
 }


### PR DESCRIPTION
### Problem

Previously, the BigQuery project ID was retrieved solely using the configuration key `gcp.bigquery.project-id`. This creates an issue with the current Dataproc Serverless runtimes, which utilize the "beta" BigQueryMetastore implementation that relies on `gcp_project`. Without a fallback, `gcp_project_id` will not be populated in the `catalog` facet.

### Solution

This change introduces a fallback mechanism for resolving the BigQuery project ID from catalog configurations. The system will now first attempt to retrieve the project ID using ⁠`gcp.bigquery.project-id`. If this key is not found or its value is empty, it will then attempt to retrieve the project ID from ⁠`gcp_project`. This ensures that BigQuery integrations function correctly regardless of which configuration key is provided, preventing regressions for existing deployments using the `⁠gcp_project` key.

- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)

#### One-line summary:

Add fallback for BigQuery project ID configuration

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project