### PR TITLE
Java: Add support for jTDS JDBC URL format

### DIFF
--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServerJtds.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForSqlServerJtds.java
@@ -1,0 +1,99 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForSqlServerJtds {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://test-host.com")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIPv4() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://192.168.1.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://192.168.1.1")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithCredentials() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname;user=fred;password=sec%40ret",
+                "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithDatabase() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname/MYTESTDB", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname")
+        .hasFieldOrPropertyWithValue("name", "MYTESTDB.schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithPort() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname:1433", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname:1433")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithInstance() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname;instance=someinstance",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname/someinstance")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    Properties props = new Properties();
+    props.setProperty("instance", "someinstance");
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname", "schema.table1", props))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname/someinstance")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithExtraProperties() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:jtds:sqlserver://hostname;autoCommit=true;appName=MyApp;",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://hostname")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithUppercaseUrl() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jDBC:JTDS:SQLSERVER://TEST.HOST.COM/MYDB", "SCHEMA.TABLE1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "sqlserver://test.host.com")
+        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+  }
+}


### PR DESCRIPTION
### Problem

Currently, `JdbcDatasetUtils` supports only official SQL Server JDBC driver by Microsoft. But there other JDBC drivers, like jTDS JDBC Driver. These have different URL formats:

```
jdbc:sqlserver://127.0.0.1:1433;databaseName=mydb
jdbc:jtds:sqlserver://127.0.0.1:1433/mydb
```

### Solution

Adjust `SqlServerJdbcExtractor` to handle both url formats.

#### One-line summary:

Java: Add support for jTDS JDBC URL format

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [X] You've updated any relevant documentation (_if relevant_)
- [X] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project