### PR TITLE
Fix spark connector on databricks setup

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/CompositeTransport.java
@@ -17,9 +17,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@ToString
 public class CompositeTransport extends Transport {
 
   private final CompositeConfig config;
@@ -94,6 +96,7 @@ public class CompositeTransport extends Transport {
                     f.get();
                   } catch (InterruptedException | ExecutionException e) {
                     // do nothing, continue with the next transport
+                    log.warn("One of the composite transports failed with: {}", e.getMessage());
                   }
                 });
       } catch (InterruptedException e) {

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -53,6 +54,7 @@ import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.Timeout;
 
 @Slf4j
+@ToString
 public final class HttpTransport extends Transport {
   private static final String API_V1 = "/api/v1";
 

--- a/client/java/src/main/java/io/openlineage/client/transports/TransportResolver.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/TransportResolver.java
@@ -5,6 +5,8 @@
 
 package io.openlineage.client.transports;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Predicate;
@@ -12,7 +14,27 @@ import java.util.stream.StreamSupport;
 
 public class TransportResolver {
 
+  // The Service Loader mechanism can often become cumbersome. For instance, class loader issues may
+  // arise when the Kinesis transport loader is missing from the classpath, yet a corresponding
+  // definition exists in the manifest — resulting in a ServiceConfigurationError.
+  // To prevent such issues, it’s preferable to support the most common transports directly, without
+  // relying on the Service Loader mechanism.
+  // This method is the default approach used by the Spark integration through
+  @SuppressWarnings("PMD.DoubleBraceInitialization")
+  private static final Collection<TransportBuilder> COMMON_BUILDERS =
+      Arrays.asList(
+          new HttpTransportBuilder(),
+          new CompositeTransportBuilder(),
+          new FileTransportBuilder(),
+          new TransformTransportBuilder(),
+          new KafkaTransportBuilder());
+
   public static Class<? extends TransportConfig> resolveTransportConfigByType(String type) {
+    for (TransportBuilder builder : COMMON_BUILDERS) {
+      if (builder.getType().equalsIgnoreCase(type)) {
+        return builder.getConfig().getClass();
+      }
+    }
     TransportBuilder builder = getTransportBuilder(b -> b.getType().equalsIgnoreCase(type));
     return builder.getConfig().getClass();
   }
@@ -24,6 +46,11 @@ public class TransportResolver {
   }
 
   public static Transport resolveTransportByConfig(TransportConfig transportConfig) {
+    for (TransportBuilder builder : COMMON_BUILDERS) {
+      if (transportConfig.getClass().equals(builder.getConfig().getClass())) {
+        return builder.build(transportConfig);
+      }
+    }
     TransportBuilder builder =
         getTransportBuilder(b -> b.getConfig().getClass().equals(transportConfig.getClass()));
     return builder.build(transportConfig);

--- a/client/java/src/test/java/io/openlineage/client/transports/TransportResolverTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/TransportResolverTest.java
@@ -1,0 +1,27 @@
+/*
+/* Copyright 2018-2025 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.transports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class TransportResolverTest {
+
+  @Test
+  void testResolveTransportConfigByTypeForCommonType() {
+    assertThat(TransportResolver.resolveTransportConfigByType("http")).isSameAs(HttpConfig.class);
+  }
+
+  @Test
+  void testResolveTransportByConfigForCommonType() {
+    HttpConfig config = new HttpConfig();
+    config.setUrl(URI.create("https://localhost:1500/api/v1/lineage"));
+    assertThat(TransportResolver.resolveTransportByConfig(config))
+        .isInstanceOf(HttpTransport.class);
+  }
+}


### PR DESCRIPTION
Complex Spark OpenLineage setups on Databricks suffer from severe class loading issues. 
This PR provides a fix to mitigate those:
* avoids ServiceLoader approach for common transports,
* makes SparkConf of OpenLineage accessible from a listener, 
* limits method calls within a listener constructor. 