### PR TITLE
spec: add a batch API endpoint as part of the core specification

### DIFF
--- a/spec/OpenLineage.yml
+++ b/spec/OpenLineage.yml
@@ -9,8 +9,8 @@ info:
 paths:
   /lineage:
     post:
-      summary: Send an event related to the state of a run
-      description: Updates a run state for a job.
+      summary: Send an event related to the state of a run, job, or a dataset
+      description: Updates a state of a run, job, or a dataset.
       operationId: postRunEvent
       tags:
         - OpenLineage
@@ -25,3 +25,79 @@ paths:
       responses:
         "200":
           description: OK
+  /lineage/batch:
+    post:
+      summary: Send a batch of events related to the state of a run, job, or a dataset
+      description: A batch of events with updates of a state of a run, job, or a dataset.
+      operationId: postEventBatch
+      tags:
+        - OpenLineage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                oneOf:
+                  - $ref: "OpenLineage.json#/$defs/RunEvent"
+                  - $ref: "OpenLineage.json#/$defs/DatasetEvent"
+                  - $ref: "OpenLineage.json#/$defs/JobEvent"
+      responses:
+        "204":
+          description: OK response - batch was received
+        "200":
+          description: OK response - batch was received, response body contains processing details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - success
+                      - partial_success
+                    description: Indicates that some events failed to process
+                  summary:
+                    type: object
+                    properties:
+                      received:
+                        type: integer
+                        example: 10
+                      successful:
+                        type: integer
+                        example: 6
+                      failed:
+                        type: integer
+                        example: 4
+                      retriable:
+                        type: integer
+                        example: 2
+                      non_retriable:
+                        type: integer
+                        example: 2
+                    required:
+                      - received
+                      - successful
+                      - failed
+                  failed_events:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        index:
+                          type: integer
+                          example: 0
+                        reason:
+                          type: string
+                          description:
+                            "Failure reason (example values: Unsupported event type, Unsupported facets, Server error,
+                            Timeout)"
+                          example: "Unsupported event type, Unsupported facets, Server error, Timeout"
+                        retriable:
+                          type: boolean
+                          example: true
+                required:
+                  - status
+                  - summary


### PR DESCRIPTION
### Problem

Some of the existing consumers and producers can work with batches of OpenLineage events, but the API for this is not standardized. 

### Solution

This PR aims to document the API endpoint, provide necessary documentation, and potentially even SDK support. The first PR draft contains only a subset of the changes to allow for discussion about the proposal and alignment on what should be in the scope of the PR. 

The batch API endpoint should be optional, meaning a clear contract is needed for clients to determine whether or not it is supported (and fallback to the existing single-event API if it is not supported). I would like to discuss which of the following approaches is preferable: 
- if the endpoint returns HTTP 404/501, it should be considered unsupported by the client and the client should fallback to the single-event API
- an additional endpoint (e.g. `/api/v1/options`) could be added, the response would determine if both APIs are supported, or if the implementation supports only the single-event API. While this would be a cleaner design, it comes with a problem of requiring all implementations supporting the new options endpoint so in the end, the proposed change would not be completely opt-in. For that reason, I consider the former approach to be better. 

#### One-line summary:

Add a batch API endpoint as part of the core specification. 

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project