### PR TITLE
fix: python client facet generator after moving to uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
         name: Generate OpenLineage facets for Python client.
         language: python
         entry: python ./client/python/src/openlineage/client/generator/generate.py
-        files: ^spec/.*\.json$|^client/python/facets\.py$|^client/python/src/openlineage/client/generator
+        files: ^spec/.*\.json$|^client/python/src/openlineage/client/facet.*\.py$|^client/python/src/openlineage/client/event_v2\.py$|^client/python/src/openlineage/client/generat.*|^client/python/redact_fields\.yml$
         exclude: ^spec/tests/.*$
         pass_filenames: false
         additional_dependencies: ["ruff==0.12.10", "click", "datamodel-code-generator==0.33.0"]

--- a/client/python/src/openlineage/client/generator/generate.py
+++ b/client/python/src/openlineage/client/generator/generate.py
@@ -22,17 +22,18 @@ from base import (  # type: ignore[import-not-found]
 
 # locations definitions
 FILE_LOCATION = pathlib.Path(__file__).resolve().parent
-PYTHON_CLIENT_LOCATION = FILE_LOCATION.parent.parent.parent.parent
-BASE_LOCATION = PYTHON_CLIENT_LOCATION.parent.parent
-BASE_SPEC_LOCATION = BASE_LOCATION / "spec" / "OpenLineage.json"
-FACETS_SPEC_LOCATION = BASE_LOCATION / "spec" / "facets"
-DEFAULT_OUTPUT_LOCATION = PYTHON_CLIENT_LOCATION / "openlineage" / "client" / "generated"
+PYTHON_CLIENT_DIR_LOCATION = FILE_LOCATION.parent.parent.parent.parent
+PYTHON_CLIENT_SRC_LOCATION = PYTHON_CLIENT_DIR_LOCATION / "src" / "openlineage" / "client"
+REPO_ROOT_LOCATION = PYTHON_CLIENT_DIR_LOCATION.parent.parent
+BASE_SPEC_LOCATION = REPO_ROOT_LOCATION / "spec" / "OpenLineage.json"
+FACETS_SPEC_LOCATION = REPO_ROOT_LOCATION / "spec" / "facets"
+DEFAULT_OUTPUT_LOCATION = PYTHON_CLIENT_SRC_LOCATION / "generated"
 TEMPLATES_LOCATION = FILE_LOCATION / "templates"
 
 HEADER = (FILE_LOCATION / "header.py").resolve().read_text()
 
 # structures to customize code generation
-REDACT_FIELDS = yaml.safe_load((PYTHON_CLIENT_LOCATION / "redact_fields.yml").read_text())
+REDACT_FIELDS = yaml.safe_load((PYTHON_CLIENT_DIR_LOCATION / "redact_fields.yml").read_text())
 
 
 def get_redact_fields(module_name: str) -> dict[str, dict[str, list[str]]]:
@@ -50,7 +51,7 @@ def generate_facet_v2_module(module_location: pathlib.Path) -> None:
     output = jinja2.Environment(autoescape=True).from_string(facet_v2_template).render(facets_modules=modules)
     format_and_save_output(
         output=output,
-        location=PYTHON_CLIENT_LOCATION / "openlineage" / "client" / "facet_v2.py",
+        location=PYTHON_CLIENT_SRC_LOCATION / "facet_v2.py",
         header=HEADER,
     )
 
@@ -93,6 +94,9 @@ def main(output_location: pathlib.Path) -> None:
                 header=HEADER,
             )
 
+    # Add empty init file to output directory
+    with open(output_location / "__init__.py", "w") as init_file:
+        init_file.write(HEADER)
     generate_facet_v2_module(DEFAULT_OUTPUT_LOCATION)
 
 


### PR DESCRIPTION
### Problem

After changes made in #3893, the facet generation path is broken, it's generating facets under an old path. Also, after adjusting paths, I don't know why, but the init file keeps getting deleted from the `generated` directory.

### Solution

Adjusted paths to account for new src paths. Also added explicit init file generation. Not sure why it's needed, maybe @JDarDagran you have some idea?

Also extended the pre-commit path so that the facet generation is triggered whenever any file touched by generator is modified, to avoid the case where file that is automatically generated is modified manually and it does not trigger the generation process.

#### One-line summary:

fix: python client facet generator paths after moving to uv

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project