### PR TITLE
spark: Fix job name trimming

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/dataset/DatasetConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/DatasetConfig.java
@@ -15,6 +15,7 @@ import io.openlineage.client.dataset.partition.trimmer.MultiDirDateTrimmer;
 import io.openlineage.client.dataset.partition.trimmer.YearMonthTrimmer;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,10 @@ public class DatasetConfig implements MergeConfig<DatasetConfig> {
   @Getter
   @JsonProperty("extraTrimmers")
   private String extraTrimmers;
+
+  public static DatasetConfig defaultConfig() {
+    return new DatasetConfig(Collections.emptyMap(), null, null);
+  }
 
   @Override
   public DatasetConfig mergeWithNonNull(DatasetConfig other) {

--- a/client/java/src/main/java/io/openlineage/client/dataset/partition/DatasetReducer.java
+++ b/client/java/src/main/java/io/openlineage/client/dataset/partition/DatasetReducer.java
@@ -45,7 +45,7 @@ public class DatasetReducer {
 
   public DatasetReducer(OpenLineage openLineage, DatasetConfig datasetConfig) {
     if (datasetConfig == null) {
-      this.datasetConfig = new DatasetConfig(Collections.emptyMap(), null, null);
+      this.datasetConfig = DatasetConfig.defaultConfig();
     } else this.datasetConfig = datasetConfig;
     this.openLineage = openLineage;
   }

--- a/client/java/src/test/java/io/openlineage/client/dataset/partition/ReducedDatasetTest.java
+++ b/client/java/src/test/java/io/openlineage/client/dataset/partition/ReducedDatasetTest.java
@@ -10,12 +10,11 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage.Dataset;
 import io.openlineage.client.dataset.DatasetConfig;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class ReducedDatasetTest {
 
-  DatasetConfig config = new DatasetConfig(Collections.emptyMap(), null, null);
+  DatasetConfig config = DatasetConfig.defaultConfig();
   Dataset dataset = mock(Dataset.class);
   ReducedDataset reducedDataset;
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetReducerUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/DatasetReducerUtils.java
@@ -14,7 +14,6 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,8 +39,8 @@ public class DatasetReducerUtils {
     Collection<DatasetNameTrimmer> nameTrimmers =
         Optional.of(context.getOpenLineageConfig())
             .map(SparkOpenLineageConfig::getDatasetConfig)
-            .map(DatasetConfig::getDatasetNameTrimmers)
-            .orElse(Collections.emptyList());
+            .orElse(DatasetConfig.defaultConfig())
+            .getDatasetNameTrimmers();
 
     return datasetIdentifier.withTrimmedName(nameTrimmers);
   }
@@ -51,8 +50,8 @@ public class DatasetReducerUtils {
     Collection<DatasetNameTrimmer> nameTrimmers =
         Optional.of(context.getOpenLineageConfig())
             .map(SparkOpenLineageConfig::getDatasetConfig)
-            .map(DatasetConfig::getDatasetNameTrimmers)
-            .orElse(Collections.emptyList());
+            .orElse(DatasetConfig.defaultConfig())
+            .getDatasetNameTrimmers();
 
     return new DatasetIdentifier(datasetName, "").withTrimmedName(nameTrimmers).getName();
   }


### PR DESCRIPTION
### Problem

https://github.com/OpenLineage/OpenLineage/pull/4108 introduced logic that trims job names similar to how dataset names are trimmed. This does not work however, unless some kind of dataset config is explicitly provided.

### Solution

This changes the behaviour to use default trimmers in case there is no dataset config.

#### One-line summary:

Fix job name trimming

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project