### PR TITLE
spark: Fix spark dataset facet for inputs

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -273,9 +273,9 @@ class OpenLineageRunEventBuilder {
       Map<String, InputDatasetFacet> inputFacetsMap = new HashMap<>();
       nodes.forEach(
           event -> inputDatasetFacetBuilders.forEach(fn -> fn.accept(event, inputFacetsMap::put)));
-      Map<String, DatasetFacets> datasetFacetsMap = new HashMap<>();
+      Map<String, DatasetFacet> datasetFacetsMap = new HashMap<>();
       nodes.forEach(
-          event -> inputDatasetFacetBuilders.forEach(fn -> fn.accept(event, inputFacetsMap::put)));
+          event -> datasetFacetBuilders.forEach(fn -> fn.accept(event, datasetFacetsMap::put)));
       return datasets.stream()
           .map(
               ds ->


### PR DESCRIPTION
### Problem

It looks like common dataset facet builders are not being built properly. When creating a custom data facet I can't see them in inputs. This could be because datasetFacetsMap is always empty in buildInputDatasets. 

Closes: #4120

### Solution

Replace the duplicate inputDatasetFacetBuilders with datasetFacetBuilders (similar to buildOutputDatasets)

#### One-line summary:
Fix common dataset facets for inputs

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [x] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [x] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [x] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [x] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project