### PR TITLE
Hive: generate the same runId for START and STOP events

### DIFF
--- a/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/integration/TableLevelLineageTests.java
+++ b/integration/hive/hive-openlineage-hook/src/test/java/io/openlineage/hive/integration/TableLevelLineageTests.java
@@ -7,6 +7,9 @@ package io.openlineage.hive.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 
+import io.openlineage.client.OpenLineage.RunEvent;
+import io.openlineage.hive.testutils.MockServerTestUtils;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,18 @@ public class TableLevelLineageTests extends ContainerHiveTestBase {
     //        assertThat(emitted).size().isEqualTo(1);
     //
     // assertThat(emitted.get(0).getEventType()).isEqualTo(OpenLineage.RunEvent.EventType.FAIL);
+  }
+
+  @Test
+  public void testRunEventsHaveSameRunId() {
+    createManagedHiveTable("employees", "id int, name string, team int");
+    runHiveQuery("create table result_t as select * from employees");
+
+    List<RunEvent> emitted = MockServerTestUtils.getEventsEmitted(mockServerClient);
+    assertThat(emitted).hasSize(2);
+    assertThat(emitted.get(0).getEventType()).isEqualTo(RunEvent.EventType.START);
+    assertThat(emitted.get(1).getEventType()).isEqualTo(RunEvent.EventType.COMPLETE);
+    assertThat(emitted.get(0).getRun().getRunId()).isEqualTo(emitted.get(1).getRun().getRunId());
   }
 
   @Test


### PR DESCRIPTION
### Problem

RunEvents generated by Hive integration in preHook (#4079) and postHook have different runId.

### Solution

#### One-line summary:

Hive: generate the same runId for START and STOP events

### Checklist

- [X] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [X] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [X] Your changes are accompanied by tests (_if relevant_)
- [X] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project