### PR TITLE
Fetch input statistics for single input RDD

### DIFF
--- a/integration/spark/app/integrations/container/pysparkSingleRDDStatistics.json
+++ b/integration/spark/app/integrations/container/pysparkSingleRDDStatistics.json
@@ -1,0 +1,26 @@
+{
+  "inputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/rdd_input",
+      "inputFacets": {
+        "inputStatistics": {
+          "rowCount": 4,
+          "size": "${json-unit.any-number}"
+        }
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "file",
+      "name": "/tmp/rdd_output",
+      "outputFacets": {
+        "outputStatistics": {
+          "rowCount": 4,
+          "size": "${json-unit.any-number}"
+        }
+      }
+    }
+  ]
+}

--- a/integration/spark/app/src/test/resources/spark_scripts/spark_single_input_rdd.py
+++ b/integration/spark/app/src/test/resources/spark_scripts/spark_single_input_rdd.py
@@ -1,0 +1,27 @@
+# Copyright 2018-2025 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+from pyspark.sql import SparkSession
+
+spark = (
+    SparkSession.builder.master("local")
+    .appName("Open Lineage Integration single input RDD with input statistics")
+    .getOrCreate()
+)
+
+input_dir = "/tmp/rdd_input"
+os.makedirs(input_dir, exist_ok=True)
+lines = ["hello world", "hello pyspark rdd", "spark rdd transforms are fun", "hello again world"]
+with open(os.path.join(input_dir, "sample.txt"), "w", encoding="utf-8") as f:
+    f.write("\n".join(lines))
+
+
+def fake_map(x):
+    time.sleep(0.1)  # catching active job won't work for super fast RDD operations
+    return x
+
+
+os.makedirs("/tmp/rdd_output", exist_ok=True)  # emulate writing to a partitioned location
+(spark.sparkContext.textFile("/tmp/rdd_input").map(fake_map).saveAsTextFile("/tmp/rdd_output/20251030"))

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/facets/builder/OutputStatisticsOutputDatasetFacetBuilder.java
@@ -46,10 +46,9 @@ public class OutputStatisticsOutputDatasetFacetBuilder
       return;
     }
 
-    Map<JobMetricsHolder.Metric, Number> metrics =
-        jobMetricsHolder.pollMetrics(context.getActiveJobId().get());
-    if (metrics.containsKey(JobMetricsHolder.Metric.WRITE_BYTES)
-        || metrics.containsKey(JobMetricsHolder.Metric.WRITE_RECORDS)) {
+    if (jobMetricsHolder.containsWriteMetrics(context.getActiveJobId().get())) {
+      Map<JobMetricsHolder.Metric, Number> metrics =
+          jobMetricsHolder.pollMetrics(context.getActiveJobId().get());
       consumer.accept(
           "outputStatistics",
           context

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/JobMetricsHolderTest.java
@@ -29,16 +29,18 @@ class JobMetricsHolderTest {
     // on job start event
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1, 2, 3)));
     // on task end event
-    underTest.addMetrics(1, outputTaskMetrics(0, 0));
-    underTest.addMetrics(2, outputTaskMetrics(10, 1));
-    underTest.addMetrics(3, outputTaskMetrics(100, 1));
+    underTest.addMetrics(1, taskMetrics(0, 0, 0, 0));
+    underTest.addMetrics(2, taskMetrics(10, 1, 10, 1));
+    underTest.addMetrics(3, taskMetrics(100, 1, 100, 1));
 
     // on job end event
     Map<JobMetricsHolder.Metric, Number> result = underTest.pollMetrics(0);
 
     assertThat(result)
         .containsEntry(JobMetricsHolder.Metric.WRITE_RECORDS, 2L)
-        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 110L);
+        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 110L)
+        .containsEntry(Metric.READ_RECORDS, 2L)
+        .containsEntry(JobMetricsHolder.Metric.READ_BYTES, 110L);
 
     // second poll event should clear the maps
     underTest.cleanUp(0);
@@ -52,8 +54,8 @@ class JobMetricsHolderTest {
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
     underTest.addJobStages(1, new HashSet<>(Arrays.asList(2)));
     // on task end event
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
-    underTest.addMetrics(2, outputTaskMetrics(10, 1));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
+    underTest.addMetrics(2, taskMetrics(10, 1, 10, 1));
 
     // on job end event
     Map<JobMetricsHolder.Metric, Number> job0 = underTest.pollMetrics(0);
@@ -61,16 +63,20 @@ class JobMetricsHolderTest {
 
     assertThat(job0)
         .containsEntry(JobMetricsHolder.Metric.WRITE_RECORDS, 10L)
-        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 100L);
+        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 100L)
+        .containsEntry(JobMetricsHolder.Metric.READ_RECORDS, 10L)
+        .containsEntry(JobMetricsHolder.Metric.READ_BYTES, 100L);
     assertThat(job1)
         .containsEntry(JobMetricsHolder.Metric.WRITE_RECORDS, 1L)
-        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 10L);
+        .containsEntry(JobMetricsHolder.Metric.WRITE_BYTES, 10L)
+        .containsEntry(JobMetricsHolder.Metric.READ_RECORDS, 1L)
+        .containsEntry(JobMetricsHolder.Metric.READ_BYTES, 10L);
   }
 
   @Test
   void testCleanUpClearsBothMaps() {
     underTest.addJobStages(0, Collections.singleton(1));
-    underTest.addMetrics(1, outputTaskMetrics(10, 1));
+    underTest.addMetrics(1, taskMetrics(10, 1, 10, 1));
 
     underTest.cleanUp(0);
 
@@ -89,7 +95,7 @@ class JobMetricsHolderTest {
     // on job start event
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
     // on task end event
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
 
     underTest.cleanUp(0);
 
@@ -117,7 +123,7 @@ class JobMetricsHolderTest {
   void testMetricsCanBePolledAfterCleanup() {
     // add some stage and metric
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
 
     underTest.cleanUp(0);
     Map<JobMetricsHolder.Metric, Number> jobMetrics = underTest.pollMetrics(0);
@@ -129,7 +135,7 @@ class JobMetricsHolderTest {
   void testCleanUpClearsMaps() {
     // add some stage and metric
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
 
     assertThat(underTest.pollMetrics(0).get(Metric.WRITE_RECORDS)).isEqualTo(10L);
     underTest.cleanUp(0);
@@ -139,7 +145,7 @@ class JobMetricsHolderTest {
   @Test
   void testEmptyMetrics() {
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
-    underTest.addMetrics(1, outputTaskMetrics(0, 0));
+    underTest.addMetrics(1, taskMetrics(0, 0, 0, 0));
 
     assertThat(underTest.pollMetrics(0)).isEmpty();
   }
@@ -148,19 +154,45 @@ class JobMetricsHolderTest {
   void testMultipleTasksPerStage() {
     // add some stage and metric
     underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
-    underTest.addMetrics(1, outputTaskMetrics(100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
+    underTest.addMetrics(1, taskMetrics(100, 10, 100, 10));
 
     Map<Metric, Number> metrics = underTest.pollMetrics(0);
     assertThat(metrics.get(Metric.WRITE_RECORDS)).isEqualTo(30L);
     assertThat(metrics.get(Metric.WRITE_BYTES)).isEqualTo(300L);
+    assertThat(metrics.get(Metric.READ_RECORDS)).isEqualTo(30L);
+    assertThat(metrics.get(Metric.READ_BYTES)).isEqualTo(300L);
   }
 
-  private TaskMetrics outputTaskMetrics(int bytes, int records) {
+  @Test
+  void testContainsMetrics() {
+    underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
+    underTest.addMetrics(1, taskMetrics(0, 0, 0, 0));
+
+    assertThat(underTest.containsReadMetrics(0)).isFalse();
+    assertThat(underTest.containsWriteMetrics(0)).isFalse();
+
+    underTest = new JobMetricsHolder();
+    underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
+    underTest.addMetrics(1, taskMetrics(1, 0, 0, 0));
+    assertThat(underTest.containsReadMetrics(0)).isTrue();
+    assertThat(underTest.containsWriteMetrics(0)).isFalse();
+
+    underTest = new JobMetricsHolder();
+    underTest.addJobStages(0, new HashSet<>(Arrays.asList(1)));
+    underTest.addMetrics(1, taskMetrics(0, 0, 1, 0));
+    assertThat(underTest.containsReadMetrics(0)).isFalse();
+    assertThat(underTest.containsWriteMetrics(0)).isTrue();
+  }
+
+  private TaskMetrics taskMetrics(
+      int bytesRead, int recordsRead, int bytesWritten, int recordsWritten) {
     TaskMetrics taskMetrics = new TaskMetrics();
-    taskMetrics.outputMetrics()._bytesWritten().add(bytes);
-    taskMetrics.outputMetrics()._recordsWritten().add(records);
+    taskMetrics.outputMetrics()._bytesWritten().add(bytesWritten);
+    taskMetrics.outputMetrics()._recordsWritten().add(recordsWritten);
+    taskMetrics.inputMetrics()._bytesRead().add(bytesRead);
+    taskMetrics.inputMetrics()._recordsRead().add(recordsRead);
     return taskMetrics;
   }
 }


### PR DESCRIPTION
 * Adds an integration test for a simple RDD job with a single input and single output.
 * Fixes caputring output statistics for RDDs (covered within an integration test above)
 * If a job is RDD job and has single input dataset, input statistics from task metrics should be captured. 

In general, if a job reads a single dataset, then task read metrics can be used to create `inputStatistics` facet. Follow-up PRs to support SQL jobs and RDD jobs with multiple inputs normalized to a single one can be implemented later to cover fully the usecase. 

In case of a run with multiple inputs, task metrics cannot be used to collect read metrics. 