### PR TITLE
website: deploy only last 10 versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,6 +16,21 @@ const getCurrentVersion = () => {
   }
 };
 
+// Get only the most recent versions to build (limit to reduce memory usage)
+const getVersionsToBuild = () => {
+  const versionsPath = path.resolve(__dirname, "versions.json");
+  if (!fs.existsSync(versionsPath)) {
+    return ["current"];
+  }
+
+  const allVersions = require(versionsPath);
+  // Build only the 10 most recent versions (plus "current")
+  const MAX_VERSIONS_TO_BUILD = 10;
+  const versionsToBuild = allVersions.slice(0, Math.min(MAX_VERSIONS_TO_BUILD, allVersions.length));
+
+  return ["current", ...versionsToBuild];
+};
+
 // Replaces every occurrence of "{{PREPROCESSOR:OPENLINEAGE_VERSION}}" with the current version of the documentation.
 const openLineageVersionProvider = ({ filePath, fileContent }) => {
   return fileContent.replace(/{{PREPROCESSOR:OPENLINEAGE_VERSION}}/g, getCurrentVersion());
@@ -67,6 +82,8 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           exclude: ["**/partials/**"],
+          // Only build the 10 most recent versions to reduce memory usage
+          onlyIncludeVersions: getVersionsToBuild(),
           editUrl: ({ versionDocsDirPath, docPath, version }) => {
             if (version === "current") {
               return `https://github.com/OpenLineage/OpenLineage/tree/main/website/docs/${docPath}`;


### PR DESCRIPTION
This decreases memory pressure for website build process. Most likely we'd need to deploy older versions as separate static sites if we want more history.