### PR TITLE
sql: Fix Seg Faults when parsing complex queries

### DIFF
--- a/integration/sql/impl/Cargo.toml
+++ b/integration/sql/impl/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["rlib"]
 [dependencies]
 anyhow = {workspace = true}
 
-sqlparser = {git = "https://github.com/OpenLineage/sqlparser-rs/", branch = "main"}
+sqlparser = "=0.59.0"

--- a/integration/sql/impl/tests/table_lineage/tests_cte.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_cte.rs
@@ -50,7 +50,7 @@ fn parse_bugged_cte() {
         meta.errors.first().unwrap(),
         &ExtractionError {
             index: 0,
-            message: "Expected: ), found: user_id at Line: 3, Column: 20".to_string(),
+            message: "Expected: ), found: ( at Line: 3, Column: 34".to_string(),
             origin_statement: sql.to_string(),
         }
     );


### PR DESCRIPTION
### Problem

SQL Parser is not able to parse some of the queries, mainly more complex ones. Apparently it runs out of stack memory. 

Given a troublesome SQL query:
- With 1 MB stack size (default on Linux x64) the parsing fails with 139 error code.
- With 2 MB stack size (default on macOS ARM64) the parsing is successful.

Closes: #3973

### Solution

OpenLineage is currently using sqlparser (https://docs.rs/sqlparser) v0.50.0 from a custom fork. 
Testing showed that starting with v0.52.0, the issue is gone.
The solution is to migrate to the latest version of sqlparser, which is v0.59.0

#### One-line summary:

sql: Fix Seg Faults when parsing complex queries

### Checklist

- [x] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [x] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [x] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [x] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project