### PR TITLE
fix(ci): remove approval-integration-airflow step with no downstream jobs

### DIFF
--- a/.circleci/workflows/openlineage-python.yml
+++ b/.circleci/workflows/openlineage-python.yml
@@ -54,18 +54,6 @@ workflows:
             - build-integration-sql-python-x86
             - build-integration-sql-python-arm
             - build-integration-sql-python-macos
-      - approval-integration-airflow:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
-          type: approval
-          requires:
-            - unit-test-integration-airflow
-            - unit-test-integration-common
-            - unit-tests-client-python
-            - build-integration-sql-python-x86
-            - build-integration-sql-python-arm
-            - build-integration-sql-python-macos
       - build-integration-airflow:
           filters:
             branches:
@@ -73,7 +61,12 @@ workflows:
             tags:
               only: /^[0-9]+(\.[0-9]+){2}(-rc\.[0-9]+)?$/
           requires:
-            - approval-integration-airflow
+            - unit-test-integration-airflow
+            - unit-test-integration-common
+            - unit-tests-client-python
+            - build-integration-sql-python-x86
+            - build-integration-sql-python-arm
+            - build-integration-sql-python-macos
       - unit-test-client-python:
           filters:
             tags:


### PR DESCRIPTION
### Problem

After removing Airflow integration tests and adjusting CI, the `approval-integration-airflow` has no downstream jobs unless running on main, where the approval is not needed.

<img width="1514" height="758" alt="image" src="https://github.com/user-attachments/assets/a168438d-6e15-491c-8d82-e841e53cca6f" />


### Solution

 I think we can safely remove it and shift the dependencies to the only downstream job that exists on main.

#### One-line summary:

fix(ci): remove approval-integration-airflow step with no downstream jobs

### Checklist

- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
- [ ] Your changes are accompanied by tests (_if relevant_)
- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
- [ ] You've updated any relevant documentation (_if relevant_)
- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project