### PR TITLE
docs: add deprecation note to airflow readme before final release

### DIFF
--- a/integration/airflow/README.md
+++ b/integration/airflow/README.md
@@ -1,3 +1,12 @@
+# Status: Package is no longer maintained !
+
+For Airflow 2.7+ use the `apache-airflow-providers-openlineage` 
+[package](https://airflow.apache.org/docs/apache-airflow-providers-openlineage).
+
+This package can still be used with Airflow versions prior to 2.7, but it is no longer maintained. 
+It will not receive ANY bug fixes, security updates or new features.
+
+
 # OpenLineage Airflow Integration
 
 A library that integrates [Airflow `DAGs`]() with [OpenLineage](https://openlineage.io) for automatic metadata collection.


### PR DESCRIPTION
Before we remove Airflow integration as described in #4098 , we should update README with a clear message about this  so that's it's visible on PyPi,