### PR TITLE
chore: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,15 @@
-### Problem
+<!--
+Thanks for opening a pull request!
+Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).
 
-👋 Thanks for opening a pull request! Please include a brief summary of the problem your change is trying to solve, or bug fix. If your change fixes a bug or you'd like to provide context on why you're making the change, please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) as follows:
+If your contribution relates to an existing issue, reference it using one of the following formats:
+closes: #ISSUE
+related: #ISSUE
+-->
 
-Closes: #ISSUE-NUMBER
+### One-line summary for changelog:
+<!-- Concise, informative sentence to help future readers understand the change. -->
 
-### Solution
 
-Please describe your change as it relates to the problem, or bug fix, as well as any dependencies. If your change requires a schema change, please describe the schema modification(s) and whether it's a _backwards-incompatible_ or _backwards-compatible_ change, then select one of the following:
-
-> **Note:** All schema changes require discussion. Please [link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) for context.
-
-- [ ] Your change modifies the [core](https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json) OpenLineage model
-- [ ] Your change modifies one or more OpenLineage [facets](https://github.com/OpenLineage/OpenLineage/tree/main/spec/facets)
-
-If you're contributing a new integration, please specify the scope of the integration and how/where it has been tested (e.g., Apache Spark integration supports `S3` and `GCS` filesystem operations, tested with AWS EMR).
-
-#### One-line summary:
-
-### Checklist
-
-- [ ] You've [signed-off](https://github.com/OpenLineage/OpenLineage/blob/main/why-the-dco.md) your work
-- [ ] Your pull request title follows our [guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md#creating-pull-requests)
-- [ ] Your changes are accompanied by tests (_if relevant_)
-- [ ] Your change contains a [small diff](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and is self-contained
-- [ ] You've updated any relevant documentation (_if relevant_)
-- [ ] Your comment includes a one-liner for the changelog about the specific purpose of the change (_not required for changes to tests, docs, or CI config_)
-- [ ] You've versioned the core OpenLineage model or facets according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver) (_if relevant_)
-- [ ] You've added a [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) to source files (_if relevant_)
-
-----
-SPDX-License-Identifier: Apache-2.0\
-Copyright 2018-2025 contributors to the OpenLineage project
+### Meaningful description
+<!-- Brief description of the problem, solution and alternatives considered. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,15 @@ agrees with the [Developer Certificate of Origin (DCO)](why-the-dco.md).
 To ensure your pull request is accepted, follow these guidelines:
 
 * All changes should be accompanied by tests
+* Relevant documentation should be updated.
 * Do your best to have a [well-formed commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for your change
-  * Do your best to have a [well-formed](https://frontside.com/blog/2020-04-15-7-reasons-for-good-pull-request-descriptions) pull request description for your change
+* Do your best to have a [well-formed pull request description](https://frontside.com/blog/2020-04-15-7-reasons-for-good-pull-request-descriptions) for your change
 * [Keep diffs small](https://kurtisnusbaum.medium.com/stacked-diffs-keeping-phabricator-diffs-small-d9964f4dcfa6) and self-contained
-* If your change fixes a bug, please [link the issue](https://help.github.com/articles/closing-issues-using-keywords) in your pull request description
+* If your change relates to an issue, please [link it](https://help.github.com/articles/closing-issues-using-keywords) in your pull request description
 * Your pull request title should be of the form `component: name`, where `component` is the part of openlineage repo that your PR changes. For example: `flink: add Iceberg source visitor`
 * Review tags added by a bot after PR creation, they should indicate parts of the repository that your PR refers to
+* Changes to the core OpenLineage model or facets require prior discussion and must be versioned according to [SchemaVer](https://docs.snowplowanalytics.com/docs/pipeline-components-and-applications/iglu/common-architecture/schemaver)
+* License [header](https://github.com/OpenLineage/OpenLineage/tree/main/.github/header_templates.md) must be present in all files.
 
 ### Branching
 


### PR DESCRIPTION
Our PR template seems a bit too complex, is often ignored and is duplicating information from the Contribution guidelines. I've updated it and refreshed the contribution guidelines. We should keep it up to date and only keep a reference to it in the Pr template.

----
SPDX-License-Identifier: Apache-2.0\
Copyright 2018-2025 contributors to the OpenLineage project