### PR TITLE
spark: more friendly normalization of job names

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/NameNormalizer.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/naming/NameNormalizer.java
@@ -36,7 +36,7 @@ public class NameNormalizer {
         normalizedAccents
             .replaceAll("([a-z])([A-Z])", "$1 $2")
             .replaceAll("(?<!^)([A-Z])([a-z])", " $1$2")
-            .replaceAll("(\\d)(?=\\D)", "$1 ");
+            .replaceAll("(\\d)([A-Z])", "$1 $2");
     /*
     Now we replace non-letters with underscores and make everything lowercase.
      */

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/api/naming/NameNormalizerTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/api/naming/NameNormalizerTest.java
@@ -42,7 +42,7 @@ class NameNormalizerTest {
         NameNormalizer.normalize("foreignLetters ąśé•¶€ are supported"));
     assertEquals("but_to_a_degree", NameNormalizer.normalize("but to a degree 这是一个例子"));
     assertEquals(
-        "323_digits123_should45_be_also34_fine89",
+        "323digits123_should45_be_also34_fine89",
         NameNormalizer.normalize("323digits123Should45BE_ALSO34 fine89"));
 
     assertEquals("a_test_application", NameNormalizer.normalize("A Test Application"));
@@ -52,5 +52,9 @@ class NameNormalizerTest {
     assertEquals(
         "test_with_a_single_letter_between_words",
         NameNormalizer.normalize("Test With a Single LetterBetweenWords"));
+
+    assertEquals(
+        "c9acd38e_71d4_4a61_89d5_fd4ff842bf79_0",
+        NameNormalizer.normalize("c9acd38e_71d4_4a61_89d5_fd4ff842bf79_0"));
   }
 }


### PR DESCRIPTION
UUIDs should not be normalized.