### PR TITLE
feat: Add debug mode to file transport

### DIFF
--- a/client/python/src/openlineage/client/serde.py
+++ b/client/python/src/openlineage/client/serde.py
@@ -44,9 +44,10 @@ class Serde:
         return cast("dict[Any, Any]", cls.remove_nulls_and_enums(obj))
 
     @classmethod
-    def to_json(cls, obj: Any) -> str:
+    def to_json(cls, obj: Any, **kwargs: Any) -> str:
         return json.dumps(
             cls.to_dict(obj),
             sort_keys=True,
             default=lambda o: f"<<non-serializable: {type(o).__qualname__}>>",
+            **kwargs,
         )

--- a/client/python/tests/test_events.py
+++ b/client/python/tests/test_events.py
@@ -259,3 +259,27 @@ def test_job_event() -> None:
     )
 
     assert Serde.to_json(job_event) == get_sorted_json("serde_example_job_event.json")
+
+
+def test_serde_to_json_kwargs_passed() -> None:
+    """Test that kwargs are correctly passed through to json.dumps in Serde.to_json."""
+    from unittest.mock import ANY, patch
+
+    test_obj = ListOfStrings(values=["test"])
+
+    with patch("openlineage.client.serde.json.dumps") as mock_dumps:
+        mock_dumps.return_value = '{"test": "value"}'
+
+        # Call with various kwargs
+        Serde.to_json(test_obj, indent=2, separators=(",", ":"), ensure_ascii=False)
+
+        # Verify json.dumps was called with the dict and exact kwargs
+        # First arg is the dict from to_dict, then kwargs
+        mock_dumps.assert_called_once_with(
+            {"values": ["test"]},  # The dict from Serde.to_dict
+            sort_keys=True,
+            default=ANY,  # Lambda function, use ANY to match
+            indent=2,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
feat: Add debug mode to file transport, that adds more information to file paths


### Meaningful description
I use file transport a lot for debugging, and it would be nice to have a job name in the file path, and also prettified jsons already so it's easier to read. It's False by default, so no impact for current users. We can extend it to include even more details in the future if needed.
