### PR TITLE
Downgrade buildconfig

### DIFF
--- a/client/java/transports-s3/build.gradle
+++ b/client/java/transports-s3/build.gradle
@@ -34,10 +34,6 @@ sourceSets {
     }
 }
 
-tasks.named('compileTestJava') {
-    dependsOn tasks.named('generateTestBuildConfigClasses')
-}
-
 dependencies {
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     implementation(platform("software.amazon.awssdk:bom:${awssdkVersion}"))


### PR DESCRIPTION
After upgrading build config to 6.0.1 (https://github.com/OpenLineage/OpenLineage/pull/4166), the CI builds started to fail. Downgrading as a temporary solution

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
