### PR TITLE
spark: Fix BigQuery symlinks with ".db" suffix

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
@@ -10,7 +10,6 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.fs.Path;
@@ -42,11 +41,17 @@ class BigQueryMetastoreCatalogTypeHandler extends BaseCatalogTypeHandler {
   Path defaultTableLocation(Path warehouseLocation, Identifier identifier) {
     // namespace1.namespace2.table -> /warehouseLocation/namespace1/namespace2/table
     String[] namespace = identifier.namespace();
-    if (namespace.length > 0 && !namespace[namespace.length - 1].endsWith(".db")) {
-      namespace[namespace.length - 1] = namespace[namespace.length - 1] + ".db";
-    }
     ArrayList<String> pathComponents = new ArrayList<>(namespace.length + 1);
-    pathComponents.addAll(Arrays.asList(namespace));
+
+    int lastIndex = namespace.length - 1;
+    for (int i = 0; i < namespace.length; i++) {
+      if (i == lastIndex && !namespace[i].endsWith(".db")) {
+        pathComponents.add(namespace[i] + ".db");
+      } else {
+        pathComponents.add(namespace[i]);
+      }
+    }
+
     pathComponents.add(identifier.name());
     return new Path(warehouseLocation, String.join(Path.SEPARATOR, pathComponents));
   }

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -558,19 +558,14 @@ class IcebergHandlerTest {
     Catalog icebergCatalog = mock(Catalog.class);
     when(sparkCatalog.icebergCatalog()).thenReturn(icebergCatalog);
 
-    TableIdentifier tableIdentifier =
-        TableIdentifier.parse(Identifier.of(new String[] {"database"}, "table").toString());
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+    TableIdentifier tableIdentifier = TableIdentifier.parse(identifier.toString());
     when(icebergCatalog.loadTable(tableIdentifier))
-        .thenThrow(
-            new org.apache.iceberg.exceptions.NoSuchTableException(
-                Identifier.of(new String[] {"database"}, "table").toString()));
+        .thenThrow(new org.apache.iceberg.exceptions.NoSuchTableException(identifier.toString()));
 
     DatasetIdentifier datasetIdentifier =
         icebergHandler.getDatasetIdentifier(
-            sparkSession,
-            sparkCatalog,
-            Identifier.of(new String[] {"database"}, "table"),
-            new HashMap<>());
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
 
     assertThat(datasetIdentifier)
         .hasFieldOrPropertyWithValue("namespace", "gcs://bucket")
@@ -581,6 +576,12 @@ class IcebergHandlerTest {
         .hasFieldOrPropertyWithValue("namespace", "gcs://bucket/path/to/iceberg/warehouse")
         .hasFieldOrPropertyWithValue("name", "database.table")
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+
+    DatasetIdentifier secondDatasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(secondDatasetIdentifier).isEqualTo(datasetIdentifier);
   }
 
   @Test


### PR DESCRIPTION
### One-line summary for changelog:
Fix BigQuery symlinks with ".db" suffix


### Meaningful description

#### Problem
".db" suffix is normally added to a namespace in context of physical location. When working with logical location (which is what we can find in symlink), there should be no such suffix.
Currently only the first OL event with symlinks is valid, without the suffix. All the following events have the ".db" suffix in the symlink name.

For example, we could have START event, 2 RUNNING events and a COMPLETE event for some job, the symlinks would look like this:

```
START
    output:
        symlinks: "name": "{bq_dataset}.{bq_external_table}",

RUNNING
    output:
        symlinks: "name": "`{bq_dataset}.db`.{bq_external_table}",

RUNNING
    output:
        symlinks: "name": "`{bq_dataset}.db`.{bq_external_table}",

COMPLETE
    output:
        symlinks: "name": "`{bq_dataset}.db`.{bq_external_table}"
```

#### Solution
Namespaces can be nested, so we in the end we have a namespace array.
defaultTableLocation() method is used to resolve the namespace in the physical storage (e.g. gcs), which means it has to add the ".db" suffix to the last element in the namespace array.
The thing is, that element was being modified in place (mutated) by this line:
`namespace[namespace.length - 1] = namespace[namespace.length - 1] + ".db"`.

Since the same namespace array from the Spark Identifier object is used both to create the logical symlink (via getIdentifier()) and to construct the physical path (via defaultTableLocation()), this mutation caused the ".db" suffix to leak, for next events, into the symlink namespace where it shouldn't appear (and possibly to other places).
The solution is to modify the defaultTableLocation() method to achieve the same thing, but without mutating the Identifier object.
