### PR TITLE
Correcting case format specification for components of custom facet keys.

### DIFF
--- a/spec/OpenLineage.md
+++ b/spec/OpenLineage.md
@@ -118,7 +118,7 @@ The prefix must be a distinct identifier named after the project defining them t
 defined in the [OpenLineage.json](OpenLineage.json) spec. The entity is the core entity for which the facet is attached.
 
 When attached to a core entity, the key should follow the pattern `{prefix}_{name}`, where both prefix and name are in
-snakeCase.
+camelCase.
 
 An example of a valid name is `BigQueryStatisticsJobFacet` and key is `bigQuery_statistics`.
 


### PR DESCRIPTION
### One-line summary for changelog:
Correcting case format specification for components of custom facet keys.

### Meaningful description
The documentation specifies the prefix and name components of a facet key being "snakeCase". Given that the example provided uses 'camelCase' for those components, and the "snakeCase" statement itself being formatted using 'camelCase', this change assumes this was done in error, and corrects it.