### PR TITLE
Python: fix .with_additional_properties() annotation

### DIFF
--- a/client/python/src/openlineage/client/generated/base.py
+++ b/client/python/src/openlineage/client/generated/base.py
@@ -86,7 +86,7 @@ class BaseFacet(RedactMixin):
     def skip_redact(self) -> list[str]:
         return self._base_skip_redact + self._additional_skip_redact
 
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "BaseFacet":
+    def with_additional_properties(self, **kwargs: Any) -> "BaseFacet":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 

--- a/client/python/src/openlineage/client/generated/column_lineage_dataset.py
+++ b/client/python/src/openlineage/client/generated/column_lineage_dataset.py
@@ -38,7 +38,7 @@ class Fields(RedactMixin):
     original data available (like a hash of PII for example)
     """
 
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "Fields":
+    def with_additional_properties(self, **kwargs: Any) -> "Fields":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 
@@ -75,7 +75,7 @@ class InputField(RedactMixin):
     transformations: list[Transformation] | None = attr.field(factory=list)
     _skip_redact: ClassVar[list[str]] = ["namespace", "name", "field"]
 
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "InputField":
+    def with_additional_properties(self, **kwargs: Any) -> "InputField":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 
@@ -116,7 +116,7 @@ class Transformation(RedactMixin):
 
     _skip_redact: ClassVar[list[str]] = ["type", "subtype", "masking"]
 
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "Transformation":
+    def with_additional_properties(self, **kwargs: Any) -> "Transformation":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 

--- a/client/python/src/openlineage/client/generated/job_dependencies_run.py
+++ b/client/python/src/openlineage/client/generated/job_dependencies_run.py
@@ -61,7 +61,7 @@ class JobDependency(RedactMixin):
     Example: EXECUTE_EVERY_TIME|EXECUTE_ON_SUCCESS|EXECUTE_ON_FAILURE
     """
 
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "JobDependency":
+    def with_additional_properties(self, **kwargs: Any) -> "JobDependency":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 

--- a/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
+++ b/client/python/src/openlineage/client/generator/templates/dataclass.jinja2
@@ -161,7 +161,7 @@ class {{ class_name }}:
 {%- endif -%}
 {#- add additional properties method -#}
 {%- if additionalProperties == True %}
-    def with_additional_properties(self, **kwargs: dict[str, Any]) -> "{{ class_name }}":
+    def with_additional_properties(self, **kwargs: Any) -> "{{ class_name }}":
         """Add additional properties to updated class instance."""
         current_attrs = [a.name for a in attr.fields(self.__class__)]
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Python: fix `.with_additional_properties()` annotation


### Meaningful description

Currently this code fails on mypy:
```bash
from openlineage.client.generated.base import BaseFacet

facet = BaseFacet().with_additional_properties(a="b")
```

```
123.py:3: error: Argument "a" to "with_additional_properties" of "BaseFacet" has incompatible type "str"; expected "dict[str, Any]"  [arg-type]
    facet = BaseFacet().with_additional_properties(a="b")
                                                     ^~~
Found 1 error in 1 file (checked 1 source file)
```

This is because `def func(**kwargs: dict[str, Any])` expect _every item_ of `kwargs` map to be a `dict[str, Any]`.