### PR TITLE
prevent classloader issue by gating log behind additional flag, log the exception

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/OpenLineageRunEventBuilder.java
@@ -237,9 +237,10 @@ class OpenLineageRunEventBuilder {
         .getQueryExecution()
         .ifPresent(
             qe -> {
-              if (log.isDebugEnabled()) {
-                log.debug("Traversing optimized plan {}", qe.optimizedPlan().toJSON());
-                log.debug("Physical plan executed {}", qe.executedPlan().toJSON());
+              if (openLineageContext.getOpenLineageConfig().getDebugConfig() != null
+                  && openLineageContext.getOpenLineageConfig().getDebugConfig().isLogPlanAsJson()) {
+                log.info("Traversing optimized plan {}", qe.optimizedPlan().toJSON());
+                log.info("Physical plan executed {}", qe.executedPlan().toJSON());
               }
             });
     if (log.isDebugEnabled()) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java
@@ -95,7 +95,8 @@ public final class SparkOpenLineageExtensionVisitorWrapper {
                   } catch (Exception e) {
                     log.error(
                         "Can't invoke 'isDefinedAt' method on {} class instance",
-                        objectAndMethod.left.getClass().getCanonicalName());
+                        objectAndMethod.left.getClass().getCanonicalName(),
+                        e);
                   }
                   return false;
                 });
@@ -131,7 +132,8 @@ public final class SparkOpenLineageExtensionVisitorWrapper {
         } catch (Exception e) {
           log.warn(
               "Can't invoke apply method on {} class instance",
-              objectAndMethod.left.getClass().getCanonicalName());
+              objectAndMethod.left.getClass().getCanonicalName(),
+              e);
         }
       }
     }
@@ -191,7 +193,8 @@ public final class SparkOpenLineageExtensionVisitorWrapper {
         } catch (Exception e) {
           log.error(
               "Can't invoke apply method on {} class instance",
-              objectAndMethod.left.getClass().getCanonicalName());
+              objectAndMethod.left.getClass().getCanonicalName(),
+              e);
         }
       }
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/DebugConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/DebugConfig.java
@@ -33,6 +33,9 @@ public class DebugConfig {
 
   @JsonProperty Integer payloadSizeLimitInKilobytes;
 
+  @JsonProperty("logPlanAsJson")
+  boolean logPlanAsJson;
+
   public boolean isSmartDebugActive(boolean hasDetectedInputs, boolean hasDetectedOutputs) {
     if (!smartEnabled) {
       return false;

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/FacetUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/FacetUtilsTest.java
@@ -73,7 +73,7 @@ class FacetUtilsTest {
 
   @Test
   void testAttachSmartDebugFacetWhenSmartDebugNotActive() {
-    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100));
+    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100, false));
     when(olc.getSparkContext()).thenReturn(Optional.empty());
     when(olc.getSparkSession()).thenReturn(Optional.empty());
     when(olc.getLogicalPlan()).thenReturn(null);
@@ -95,7 +95,7 @@ class FacetUtilsTest {
     when(olc.getSparkSession()).thenReturn(Optional.of(sparkSession));
     when(sparkSession.catalog()).thenReturn(null);
     when(olc.getLogicalPlan()).thenReturn(null);
-    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100));
+    when(solc.getDebugConfig()).thenReturn(new DebugConfig(true, "any-missing", false, 100, false));
     RunFacetsBuilder runFacetsBuilder = mock(RunFacetsBuilder.class);
 
     FacetUtils.attachSmartDebugFacet(olc, runFacetsBuilder);


### PR DESCRIPTION
  - SparkOpenLineageExtensionVisitorWrapper (integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java) builds a list
    of all thread context classloaders, mutates some of them with defineClass, then uses ExtensionClassloader which picks the first loader that can load a class. The order of those
    loaders is not deterministic (thread set order is arbitrary).
  - When DEBUG toJSON() runs, it walks the logical plan. BigQuery nodes (or their shaded OpenLineage visitor classes) can be loaded by the connector’s classloader before the wrapper
    runs. That is a different loader than the OpenLineage integration’s.
  - Once a class is loaded by one loader, that loader caches it. If later the wrapper loads the same class name via a different loader (e.g., Class.forName(...) with OL’s loader),
    you now have two distinct classes with the same name. They are not assignment‑compatible.
  - The visitor checks instanceof or casts to its own interface types (shaded). If the logical plan node implements a different copy of that interface (loaded earlier by a different
    loader), instanceof is false or a ClassCastException is thrown. That manifests as “Can’t invoke apply…” and missing lineage.