### PR TITLE
Add `spark.openlineage.applicationRunId` override

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/ArgumentParser.java
@@ -36,6 +36,7 @@ public class ArgumentParser {
   public static final String SPARK_CONF_PARENT_JOB_NAME = "spark.openlineage.parentJobName";
   public static final String SPARK_CONF_PARENT_RUN_ID = "spark.openlineage.parentRunId";
   public static final String SPARK_CONF_APP_NAME = "spark.openlineage.appName";
+  public static final String SPARK_CONF_APP_RUN_ID = "spark.openlineage.applicationRunId";
   public static final String ARRAY_PREFIX_CHAR = "[";
   public static final String ARRAY_SUFFIX_CHAR = "]";
   public static final String SPARK_CONF_TRANSPORT_TYPE = "spark.openlineage.transport.type";
@@ -118,6 +119,9 @@ public class ArgumentParser {
     findSparkConfigKey(conf, SPARK_CONF_APP_NAME)
         .filter(str -> !str.isEmpty())
         .ifPresent(config::setOverriddenAppName);
+    findSparkConfigKey(conf, SPARK_CONF_APP_RUN_ID)
+        .filter(str -> !str.isEmpty())
+        .ifPresent(config::setOverriddenApplicationRunId);
 
     findSparkConfigKey(conf, SPARK_CONF_NAMESPACE).ifPresent(config::setNamespace);
     findSparkConfigKey(conf, SPARK_CONF_PARENT_JOB_NAME).ifPresent(config::setParentJobName);

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/EventEmitter.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EventEmitter {
   @Getter private OpenLineageClient client;
   @Getter private Optional<String> overriddenAppName;
+  @Getter private Optional<String> overriddenApplicationRunId;
   @Getter private String jobNamespace;
   @Getter private Optional<String> parentJobName;
   @Getter private Optional<String> parentJobNamespace;
@@ -48,6 +49,7 @@ public class EventEmitter {
     this.rootParentJobNamespace = Optional.ofNullable(config.getRootParentJobNamespace());
     this.rootParentRunId = convertToUUID(config.getRootParentRunId());
     this.overriddenAppName = Optional.ofNullable(config.getOverriddenAppName());
+    this.overriddenApplicationRunId = Optional.ofNullable(config.getOverriddenApplicationRunId());
     this.customEnvironmentVariables =
         config.getFacetsConfig() != null
             ? config.getFacetsConfig().getCustomEnvironmentVariables() != null
@@ -72,7 +74,7 @@ public class EventEmitter {
             .disableFacets(disabledFacets.toArray(new String[0]))
             .build();
     this.applicationJobName = this.overriddenAppName.orElse(applicationJobName);
-    this.applicationRunId = UUIDUtils.generateNewUUID();
+    this.applicationRunId = this.overriddenApplicationRunId.orElse(UUIDUtils.generateNewUUID());
   }
 
   public void emit(OpenLineage.RunEvent event) {

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -46,6 +46,7 @@ class ArgumentParserTest {
   private static final String ROOT_PARENT_JOB_NAMESPACE = "root-namespace";
   private static final String ROOT_PARENT_RUN_ID = "ea445b5c-1a1a-2b2b-3c3c-01c7c52b6e54";
   private static final String APP_NAME = "test";
+  private static final UUID APP_RUN_ID = UUID.fromString("ea445b5c-22eb-457a-8007-01c7c52b6e54");
   private static final String ENDPOINT = "api/v1/lineage";
   private static final String AUTH_TYPE = "api_key";
   private static final String API_KEY = "random_token";
@@ -89,7 +90,8 @@ class ArgumentParserTest {
             .set("spark.openlineage.rootParentJobName", ROOT_PARENT_JOB_NAME)
             .set("spark.openlineage.rootParentJobNamespace", ROOT_PARENT_JOB_NAMESPACE)
             .set("spark.openlineage.rootParentRunId.", ROOT_PARENT_RUN_ID)
-            .set(ArgumentParser.SPARK_CONF_APP_NAME, APP_NAME);
+            .set(ArgumentParser.SPARK_CONF_APP_NAME, APP_NAME)
+            .set(ArgumentParser.SPARK_CONF_APP_RUN_ID, APP_RUN_ID);
 
     config = ArgumentParser.parse(sparkConf);
     assertEquals(JOB_NAMESPACE, config.getParentJobNamespace());
@@ -97,6 +99,7 @@ class ArgumentParserTest {
     assertEquals(JOB_NAME, config.getParentJobName());
     assertEquals(RUN_ID, config.getParentRunId());
     assertEquals(APP_NAME, config.getOverriddenAppName());
+    assertEquals(APP_RUN_ID, config.getOverriddenApplicationRunId());
 
     assertEquals(ROOT_PARENT_JOB_NAME, config.getRootParentJobName());
     assertEquals(ROOT_PARENT_JOB_NAMESPACE, config.getRootParentJobNamespace());

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -44,6 +44,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
   private String rootParentJobNamespace;
   private String rootParentRunId;
   private String overriddenAppName;
+  private String overriddenApplicationRunId;
   private String testExtensionProvider;
   private JobNameConfig jobName;
 
@@ -71,6 +72,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       String rootParentJobNamespace,
       String rootParentRunId,
       String overriddenAppName,
+      String overriddenApplicationRunId,
       String testExtensionProvider,
       JobNameConfig jobName,
       JobConfig job,
@@ -92,6 +94,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     this.rootParentJobNamespace = rootParentJobNamespace;
     this.rootParentRunId = rootParentRunId;
     this.overriddenAppName = overriddenAppName;
+    this.overriddenApplicationRunId = overriddenApplicationRunId;
     this.testExtensionProvider = testExtensionProvider;
     this.jobName = jobName;
     this.columnLineageConfig = columnLineageConfig;
@@ -178,6 +181,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(rootParentJobNamespace, other.rootParentJobNamespace),
         mergePropertyWith(rootParentRunId, other.rootParentRunId),
         mergePropertyWith(overriddenAppName, other.overriddenAppName),
+        mergePropertyWith(overriddenApplicationRunId, other.overriddenApplicationRunId),
         mergePropertyWith(testExtensionProvider, other.testExtensionProvider),
         mergePropertyWith(jobName, other.jobName),
         mergePropertyWith(jobConfig, other.jobConfig),


### PR DESCRIPTION
### One-line summary for changelog:
Add support to override the application `runID` via the property `spark.openlineage.applicationRunId`.


### Meaningful description
This PR adds support to override the application `runID` via the property `spark.openlineage.applicationRunId` similar to`spark.openlineage.appName`. 

Related PR https://github.com/OpenLineage/openlineage-site/pull/21
