### PR TITLE
spark: Fix missing inputs and CLL for AWS DynamicFrame

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/AwsDynamicFrameIntegrationTest.java
@@ -126,5 +126,21 @@ class AwsDynamicFrameIntegrationTest {
         .isNotEmpty();
     assertThat(events.stream().flatMap(e -> e.getOutputs().stream()).collect(Collectors.toList()))
         .isNotEmpty();
+
+    RunEvent insertEvent =
+        events.stream()
+            .filter(
+                e ->
+                    e.getJob().getName().contains("execute_insert_into_hadoop_fs_relation_command"))
+            .filter(e -> RunEvent.EventType.COMPLETE.equals(e.getEventType()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No insert event found"));
+
+    assertThat(insertEvent.getInputs()).hasSize(1);
+    assertThat(insertEvent.getInputs().get(0).getName()).isEqualTo("/test_data");
+
+    assertThat(insertEvent.getOutputs()).hasSize(1);
+    assertThat(insertEvent.getOutputs().get(0).getName()).isEqualTo("/tmp/glue-test-job");
+    assertThat(insertEvent.getOutputs().get(0).getFacets().getColumnLineage()).isNotNull();
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/Rdds.java
@@ -15,6 +15,7 @@ import java.util.Stack;
 import java.util.stream.Collectors;
 import org.apache.spark.Dependency;
 import org.apache.spark.rdd.HadoopRDD;
+import org.apache.spark.rdd.NewHadoopRDD;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.scheduler.StageInfo;
@@ -74,9 +75,7 @@ public class Rdds {
                 .map(Dependency::rdd)
                 .collect(Collectors.toList()));
       }
-      if (cur instanceof HadoopRDD) {
-        ret.add(cur);
-      } else if (cur instanceof FileScanRDD) {
+      if (isFileLikeRDD(cur)) {
         ret.add(cur);
       }
     }
@@ -84,8 +83,10 @@ public class Rdds {
   }
 
   public static List<RDD<?>> findFileLikeRdds(Set<RDD<?>> rdds) {
-    return rdds.stream()
-        .filter(r -> r instanceof HadoopRDD || r instanceof FileScanRDD)
-        .collect(Collectors.toList());
+    return rdds.stream().filter(Rdds::isFileLikeRDD).collect(Collectors.toList());
+  }
+
+  private static boolean isFileLikeRDD(RDD<?> rdd) {
+    return rdd instanceof HadoopRDD || rdd instanceof NewHadoopRDD || rdd instanceof FileScanRDD;
   }
 }

--- a/website/docs/integrations/spark/quickstart/quickstart_glue.md
+++ b/website/docs/integrations/spark/quickstart/quickstart_glue.md
@@ -3,10 +3,6 @@ sidebar_position: 2
 title: Quickstart with AWS Glue
 ---
 
-:::info
-The `DynamicFrames` API is currently not supported. Use `DataFrames`, `DataSets` or `RDD` instead.
-:::
-
 ## Enable OpenLineage
 
 :::caution


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Fix missing inputs and CLL for AWS DynamicFrame

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
When writing from AWS DynamicFrame (example below), the emitted event would have outputs, but without CLL.
The inputs would be completely missing.
OL already knows how to extract paths from NewHadoopRDD (used by DynamicFrame), but this RDD was not treated as "file-like", which resulted in the missing lineage in events.

```python
data = glueContext.create_dynamic_frame.from_options(
    "s3",
    {"paths": ["/test_data/dynamic_data.json"]},
    "json",
    {"withHeader": False, "multiline": False},
)
filtered = data.filter(f=lambda x: x["name"] in ["Sally"] and x["location"]["state"] in ["WY"])

filtered.toDF().write.mode("overwrite").json("/tmp/glue-test-job")
```
