### PR TITLE
spark: Fix SPI conflicts caused by package relocation

### DIFF
--- a/integration/spark/build.gradle
+++ b/integration/spark/build.gradle
@@ -200,6 +200,8 @@ shadowJar {
     relocate "software.amazon", "io.openlineage.spark.shaded.software.amazon"
     relocate "org.reactivestreams", "io.openlineage.spark.shaded.org.reactivestreams"
     relocate "io.netty", "io.openlineage.spark.shaded.io.netty"
+    
+    mergeServiceFiles()
 
     manifest {
         attributes(


### PR DESCRIPTION
closes: #4227

### One-line summary for changelog:
Fix SPI conflicts caused by package relocation


### Meaningful description
When relocating a package which comes with service provider config in `META-INF/services`, for example
```kotlin
relocate "software.amazon", "io.openlineage.spark.shaded.software.amazon"
```
the service provider config would not get relocated, causing conflicts in some runtimes.

`META-INF/services/` before
```
com.fasterxml.jackson.core.JsonFactory
com.fasterxml.jackson.core.ObjectCodec
com.fasterxml.jackson.databind.Module
io.micrometer.context.ThreadLocalAccessor
io.openlineage.client.transports.TransportBuilder
reactor.blockhound.integration.BlockHoundIntegration
software.amazon.awssdk.http.async.SdkAsyncHttpService
software.amazon.awssdk.http.SdkHttpService
software.amazon.awssdk.thirdparty.jackson.core.JsonFactory
```

`META-INF/services/` after
```
io.micrometer.context.ThreadLocalAccessor
io.openlineage.client.transports.TransportBuilder
io.openlineage.spark.shaded.com.fasterxml.jackson.core.JsonFactory
io.openlineage.spark.shaded.com.fasterxml.jackson.core.ObjectCodec
io.openlineage.spark.shaded.com.fasterxml.jackson.databind.Module
io.openlineage.spark.shaded.software.amazon.awssdk.http.async.SdkAsyncHttpService
io.openlineage.spark.shaded.software.amazon.awssdk.http.SdkHttpService
io.openlineage.spark.shaded.software.amazon.awssdk.thirdparty.jackson.core.JsonFactory
reactor.blockhound.integration.BlockHoundIntegration
```
