### PR TITLE
chore: Update license headers copyright year to 2026

### DIFF
--- a/client/python/src/openlineage/client/generated/execution_parameters_run.py
+++ b/client/python/src/openlineage/client/generated/execution_parameters_run.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 contributors to the OpenLineage project
+# Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkRddGenericIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkRddGenericIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlCollector.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/SqlCollector.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/SnowflakeTable.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/SnowflakeTable.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/SnowflakeColumnLineageVisitor.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/SnowflakeColumnLineageVisitor.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/SnowflakeColumnLineageVisitorDelegate.java
+++ b/integration/spark/vendor/snowflake/src/main/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/SnowflakeColumnLineageVisitorDelegate.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 

--- a/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/ColumnLevelLineageSnowflakeTest.java
+++ b/integration/spark/vendor/snowflake/src/test/java/io/openlineage/spark/agent/vendor/snowflake/lifecycle/plan/column/ColumnLevelLineageSnowflakeTest.java
@@ -1,5 +1,5 @@
 /*
-/* Copyright 2018-2025 contributors to the OpenLineage project
+/* Copyright 2018-2026 contributors to the OpenLineage project
 /* SPDX-License-Identifier: Apache-2.0
 */
 


### PR DESCRIPTION
PR's raised last year, but merged this year introduced outdated license headers. Updating.