### PR TITLE
dbt: correct send-events command argument parsing

### DIFF
--- a/integration/dbt/src/openlineage/dbt/__init__.py
+++ b/integration/dbt/src/openlineage/dbt/__init__.py
@@ -306,7 +306,9 @@ def consume_local_artifacts(
     pre_run_time = time.time()
     # Execute dbt in external process
 
-    force_send_events = len(args) > 1 and args[1] == "send-events"
+    force_send_events = (len(args) > 0 and args[0] == "send-events") or (
+        len(args) > 1 and args[1] == "send-events"
+    )
     if not force_send_events:
         with subprocess.Popen(["dbt"] + args, stdout=sys.stdout, stderr=sys.stderr) as process:
             return_code = process.wait()


### PR DESCRIPTION
Fix index error when running 'dbt-ol send-events'. The command was on;y checking args[1], causing an IndexError if args contains only ['send-events'] after sys.argv parsing.

Fixes https://github.com/OpenLineage/OpenLineage/issues/4239