### PR TITLE
emit application level FAIL event instead of COMPLETE when at least o…

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -279,6 +279,7 @@ class RddExecutionContext implements ExecutionContext {
     FacetUtils.attachSmartDebugFacet(olContext, runFacetsBuilder);
 
     EventType eventType = getEventType(jobEnd.jobResult());
+    updateStatus(eventType);
     OpenLineage.RunEvent event =
         olContext
             .getOpenLineage()

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkApplicationExecutionContext.java
@@ -5,7 +5,6 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
-import static io.openlineage.client.OpenLineage.RunEvent.EventType.COMPLETE;
 import static io.openlineage.client.OpenLineage.RunEvent.EventType.START;
 import static io.openlineage.spark.agent.util.TimeUtils.toZonedTime;
 
@@ -118,7 +117,7 @@ class SparkApplicationExecutionContext implements ExecutionContext {
                         .getOpenLineage()
                         .newRunEventBuilder()
                         .eventTime(toZonedTime(applicationEnd.time())))
-                .eventType(COMPLETE)
+                .eventType(getStatus())
                 .jobBuilder(getJobBuilder())
                 .jobFacetsBuilder(getJobFacetsBuilder())
                 .overwriteRunId(Optional.of(olContext.getApplicationUuid()))

--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/SparkSQLExecutionContext.java
@@ -329,6 +329,7 @@ class SparkSQLExecutionContext implements ExecutionContext {
       eventType = COMPLETE;
     }
     emittedOnJobEnd = true;
+    updateStatus(eventType);
 
     RunEvent event =
         runEventBuilder.buildRun(

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/ExecutionContextDefaultMethodsTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/ExecutionContextDefaultMethodsTest.java
@@ -1,0 +1,103 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
+import org.apache.spark.scheduler.ActiveJob;
+import org.apache.spark.scheduler.SparkListenerApplicationEnd;
+import org.apache.spark.scheduler.SparkListenerApplicationStart;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.SparkListenerStageCompleted;
+import org.apache.spark.scheduler.SparkListenerStageSubmitted;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ExecutionContext interface default methods. Uses a minimal mock implementation to test
+ * the default status tracking behavior.
+ */
+class ExecutionContextDefaultMethodsTest {
+
+  /**
+   * Minimal mock implementation that only uses default methods from ExecutionContext. This allows
+   * us to test the interface's default behavior in isolation.
+   */
+  private static class MockExecutionContext implements ExecutionContext {
+    @Override
+    public void setActiveJob(ActiveJob activeJob) {}
+
+    @Override
+    public void start(SparkListenerApplicationStart applicationStart) {}
+
+    @Override
+    public void start(SparkListenerJobStart jobStart) {}
+
+    @Override
+    public void start(SparkListenerSQLExecutionStart sqlStart) {}
+
+    @Override
+    public void start(SparkListenerStageSubmitted stageSubmitted) {}
+
+    @Override
+    public void end(SparkListenerApplicationEnd applicationEnd) {}
+
+    @Override
+    public void end(SparkListenerJobEnd jobEnd) {}
+
+    @Override
+    public void end(SparkListenerSQLExecutionEnd sqlEnd) {}
+
+    @Override
+    public void end(SparkListenerStageCompleted stageCompleted) {}
+
+    // getStatus() and updateStatus() will use the interface's default implementations
+  }
+
+  @Test
+  void testDefaultGetStatusReturnsStart() {
+    ExecutionContext context = new MockExecutionContext();
+
+    // Default implementation uses shared static status initialized to START
+    assertThat(context.getStatus()).isEqualTo(EventType.START);
+  }
+
+  @Test
+  void testDefaultUpdateToRunningAndComplete() {
+    ExecutionContext context = new MockExecutionContext();
+
+    assertThat(context.updateStatus(EventType.RUNNING).getStatus()).isEqualTo(EventType.RUNNING);
+    assertThat(context.getStatus()).isEqualTo(EventType.RUNNING);
+
+    assertThat(context.updateStatus(EventType.COMPLETE).getStatus()).isEqualTo(EventType.COMPLETE);
+    assertThat(context.getStatus()).isEqualTo(EventType.COMPLETE);
+  }
+
+  @Test
+  void testDefaultCannotChangeCompleteToFail() {
+    ExecutionContext context = new MockExecutionContext();
+
+    assertThat(context.updateStatus(EventType.COMPLETE).getStatus()).isEqualTo(EventType.COMPLETE);
+    assertThat(context.getStatus()).isEqualTo(EventType.COMPLETE);
+
+    assertThat(context.updateStatus(EventType.FAIL).getStatus()).isEqualTo(EventType.COMPLETE);
+    assertThat(context.getStatus()).isEqualTo(EventType.COMPLETE);
+  }
+
+  @Test
+  void testDefaultCannotChangeFailToComplete() {
+    ExecutionContext context = new MockExecutionContext();
+
+    assertThat(context.updateStatus(EventType.COMPLETE).getStatus()).isEqualTo(EventType.COMPLETE);
+    assertThat(context.getStatus()).isEqualTo(EventType.COMPLETE);
+
+    assertThat(context.updateStatus(EventType.FAIL).getStatus()).isEqualTo(EventType.COMPLETE);
+    assertThat(context.getStatus()).isEqualTo(EventType.COMPLETE);
+  }
+}

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/ExecutionContext.java
@@ -5,7 +5,11 @@
 
 package io.openlineage.spark.agent.lifecycle;
 
+import static io.openlineage.client.OpenLineage.RunEvent.EventType.START;
+
+import io.openlineage.client.OpenLineage.RunEvent.EventType;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerApplicationStart;
@@ -25,6 +29,8 @@ public interface ExecutionContext {
    */
   String CAMEL_TO_SNAKE_CASE =
       "[\\s\\-_]?((?<=.)[A-Z](?=[a-z\\s\\-_])|(?<=[^A-Z])[A-Z]|((?<=[\\s\\-_])[a-z\\d]))";
+
+  AtomicReference<EventType> status = new AtomicReference<>(START);
 
   void setActiveJob(ActiveJob activeJob);
 
@@ -49,4 +55,13 @@ public interface ExecutionContext {
   }
 
   default void setActiveJobId(Integer activeJobId) {}
+
+  default EventType getStatus() {
+    return status.get();
+  }
+
+  default ExecutionContext updateStatus(EventType newStatus) {
+    status.updateAndGet(c -> newStatus);
+    return this;
+  }
 }


### PR DESCRIPTION
…ne job from the application has FAIL status

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->
related: #4183 
### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Spark: Emit `FAIL` application event if any jobs inside it failed

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
Current behaviour is: application end event always has a `COMPLETE` type. 
Implemented functionality to collect the statuses of spark jobs and in case of any failure, emit application end `FAIL` event.