### PR TITLE
Note about port 5000 on MacOS

### DIFF
--- a/website/blog/dbt-with-marquez/index.mdx
+++ b/website/blog/dbt-with-marquez/index.mdx
@@ -48,6 +48,7 @@ Next, let’s start a local Marquez instance to store our lineage metadata. Make
 git clone https://github.com/MarquezProject/marquez.git && cd marquez
 ./docker/up.sh
 ```
+> **Note:** Port 5000 is now reserved for MacOS. If running locally on MacOS, you can run `./docker/up.sh --api-port 9000` to configure the API to listen on port 9000 instead. Keep in mind that you will need to update the URLs below with the appropriate port number.
 
 Check to make sure Marquez is up by visiting [http://localhost:3000](http://localhost:3000). You should see an empty Marquez instance with a message saying there isn’t any data. Also, you should be able to see the server output from your requests in the terminal window where Marquez is running. Keep this window open until we’re done.
 

--- a/website/docs/guides/dbt.md
+++ b/website/docs/guides/dbt.md
@@ -32,6 +32,7 @@ Next, start a local Marquez instance to store lineage metadata. Make sure Docker
 git clone https://github.com/MarquezProject/marquez.git && cd marquez
 ./docker/up.sh
 ```
+> **Note:** Port 5000 is now reserved for MacOS. If running locally on MacOS, you can run `./docker/up.sh --api-port 9000` to configure the API to listen on port 9000 instead. Keep in mind that you will need to update the URLs below with the appropriate port number.
 
 Check to make sure Marquez is up by visiting http://localhost:3000. The page should display an empty Marquez instance and a message saying there is no data. Also, it should be possible to see the server output from requests in the terminal window where Marquez is running. This window should remain open.
 

--- a/website/src/pages/getting-started/index.mdx
+++ b/website/src/pages/getting-started/index.mdx
@@ -37,6 +37,7 @@ $ git clone https://github.com/MarquezProject/marquez.git && cd marquez
 
 $ ./docker/up.sh
 ```
+> **Note:** Port 5000 is now reserved for MacOS. If running locally on MacOS, you can run `./docker/up.sh --api-port 9000` to configure the API to listen on port 9000 instead. Keep in mind that you will need to update the URLs below with the appropriate port number.
 
 :::info
 Pass the `--build` flag to the script to build images from source, or `--tag X.Y.Z` to use a tagged image.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Added a note about port 5000 being already reserved in MacOS. This is important as the documentation doesn't specify changing the Marquez API port to be mapped to a port other than 5000.


### Meaningful description
I was exploring using the `dbt-ol` python CLI tool and the [documentation](https://openlineage.io/getting-started/#run-marquez-with-docker) also helps in setting up Marquez to visualize the lineage. On following the documentation, I was able to set up Marquez (on MacOS) but on publishing the OpenLineage events using `dbt-ol`, I was getting the following response: -

```
HTTP/1.1 403 Forbidden
Content-Length: 0
Server: AirTunes/860.7.1
X-Apple-ProcessingTime: 1
X-Apple-RequestReceivedTimestamp: 661472885
```

The Marquez [README.md](https://github.com/MarquezProject/marquez/blob/main/README.md) has the following note: -

> Note: Port 5000 is now reserved for MacOS. If running locally on MacOS, you can run ./docker/up.sh --api-port 9000 to configure the API to listen on port 9000 instead. Keep in mind that you will need to update the URLs below with the appropriate port number.

I have added the above note to all the applicable documentation (that involves setting up Marquez).

 