### PR TITLE
Java: Send Content-Encoding header for compressed requests

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpConfig.java
@@ -20,10 +20,14 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public final class HttpConfig implements TransportConfig, MergeConfig<HttpConfig> {
+  @AllArgsConstructor
+  @Getter
   public enum Compression {
     @JsonProperty("gzip")
-    GZIP
-  };
+    GZIP("gzip");
+
+    private final String contentEncoding;
+  }
 
   @Getter @Setter private URI url;
   @Getter @Setter private @Nullable String endpoint;

--- a/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
+++ b/client/java/src/main/java/io/openlineage/client/transports/HttpTransport.java
@@ -9,6 +9,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
 import static org.apache.hc.core5.http.HttpHeaders.ACCEPT;
 import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
+import static org.apache.hc.core5.http.HttpHeaders.CONTENT_ENCODING;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 
 import io.openlineage.client.OpenLineage;
@@ -227,6 +228,9 @@ public final class HttpTransport extends Transport {
     // if tokenProvider preset overwrite authorization
     if (tokenProvider != null) {
       request.addHeader(AUTHORIZATION, tokenProvider.getToken());
+    }
+    if (compression != null) {
+      request.addHeader(CONTENT_ENCODING, compression.getContentEncoding());
     }
   }
 

--- a/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
+++ b/client/java/src/test/java/io/openlineage/client/transports/HttpTransportTest.java
@@ -200,11 +200,12 @@ class HttpTransportTest {
 
   @Test
   @SneakyThrows
-  void httpTransportSendsAuthAndQueryParams() throws IOException {
+  void httpTransportSendsHeadersAndQueryParams() throws IOException {
     CloseableHttpClient http = mock(CloseableHttpClient.class);
     HttpConfig config = new HttpConfig();
     config.setUrl(URI.create("https://localhost:1500"));
     config.setUrlParams(singletonMap("param", "value"));
+    config.setCompression(HttpConfig.Compression.GZIP);
     ApiKeyTokenProvider auth = new ApiKeyTokenProvider();
     auth.setApiKey("apiKey");
     config.setAuth(auth);
@@ -225,6 +226,7 @@ class HttpTransportTest {
 
     assertThat(captor.getValue().getFirstHeader("Authorization").getValue())
         .isEqualTo("Bearer apiKey");
+    assertThat(captor.getValue().getFirstHeader("Content-Encoding").getValue()).isEqualTo("gzip");
     assertThat(captor.getValue().getUri())
         .isEqualTo(URI.create("https://localhost:1500/api/v1/lineage?param=value"));
   }


### PR DESCRIPTION
### One-line summary for changelog:
Send `Content-Encoding` header for compressed requests from the Java client


### Meaningful description
This PR ensures that the Java client sends the `Content-Encoding` header whenever request body compression is enabled, so the server can correctly decode the incoming payload. This behavior already exists in the Python client and is now consistently applied in the Java client.