### PR TITLE
fix(spark): Handle null Glue ARN in IcebergHandler (#4162)

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -170,7 +170,8 @@ public class IcebergHandler implements CatalogHandler {
             catalogName);
       }
       String tableName = identifier.toString();
-      maybeSymlink = Optional.of(catalogTypeHandler.getIdentifier(session, catalogConf, tableName));
+      maybeSymlink =
+          Optional.ofNullable(catalogTypeHandler.getIdentifier(session, catalogConf, tableName));
     }
 
     if (!maybeTableLocation.isPresent() && warehouseLocation == null) {


### PR DESCRIPTION
AI description:
The IcebergHandler was throwing a NullPointerException when processing Iceberg datasets that use AWS Glue catalog. This issue was introduced in PR #4053, which modified the Glue ARN resolution logic to prevent false detection of Glue symlinks in Hive metastores. As a side effect, the `getGlueArn` method now returns `null` in certain scenarios where it previously returned a value, causing `Optional.of()` to fail when wrapping the null result from `catalogTypeHandler.getIdentifier()`.

The fix changes `Optional.of()` to `Optional.ofNullable()` on line 174, which safely handles null values returned by the catalog type handler. This allows the IcebergHandler to gracefully handle cases where the Glue ARN cannot be resolved, preventing the NPE and ensuring that Iceberg datasets with Glue catalog are properly processed.