### PR TITLE
fix(flink): Use Flink 2.x-only class for version detection (#4007)

### DIFF
--- a/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ClassUtils.java
+++ b/integration/flink/shared/src/main/java/io/openlineage/flink/utils/ClassUtils.java
@@ -49,11 +49,16 @@ public class ClassUtils {
     return false;
   }
 
+  /**
+   * Checks if Flink 2.x-specific classes are present on the classpath. Uses
+   * JobStatusChangedListenerFactory as it is a Flink 2.x-only class that is not backported through
+   * connectors (unlike LineageGraph which can appear in Flink 1.x with modern connectors).
+   */
   public static boolean hasFlink2Classes() {
     try {
       ClassUtils.class
           .getClassLoader()
-          .loadClass("org.apache.flink.streaming.api.lineage.LineageGraph");
+          .loadClass("org.apache.flink.core.execution.JobStatusChangedListenerFactory");
       return true;
     } catch (Exception e) {
       // swallow- we don't care


### PR DESCRIPTION
AI description:

The Flink 1.x integration was incorrectly detecting Flink 2.x environments when modern connectors (like `flink-connector-kafka:3.4.0-1.20`) were used. The version detection relied on checking for the presence of `LineageGraph` class, which is part of the new V2 connector APIs that were backported to Flink 1.x through modern connectors. This caused a false positive detection, triggering an `IllegalArgumentException` that prevented the OpenLineage listener from being registered programmatically, forcing users to either downgrade to old OpenLineage versions (1.15.0) or avoid using modern connectors entirely.

This fix changes the version detection to use `JobStatusChangedListenerFactory` instead of `LineageGraph`. The `JobStatusChangedListenerFactory` class is a Flink 2.x-only class that exists exclusively in the Flink core runtime and is not backported through connectors. This provides a reliable way to distinguish between Flink 1.x and 2.x environments, allowing users to use modern V2-based connectors with Flink 1.x applications while still correctly identifying the runtime version.