### PR TITLE
Restyled community and ecosystem cards for dark mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -103,8 +103,14 @@
   #eco-typography {
     color: #fff;
   }
-  #community-typography {
+  .community-typography {
     color: #fff;
+  }
+  #community-talk-descrip {
+    padding-top: 5px;
+  }
+  #community-talk-conf {
+    padding-bottom: 5px;
   }
 }
 

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -75,7 +75,7 @@ const MeetupCard = (meetup: Meetup) => {
           },
         }}
       >
-        <Typography variant="h5" color="text.secondary">
+        <Typography className="community-typography" variant="h5" color="text.secondary">
           {meetup.city}
         </Typography>
       </CardContent>
@@ -165,18 +165,23 @@ const TalkCard = (talk: Talk) => {
             },
           }}
         >
-          <Typography id="community-typography" variant="h4" color="text.primary" className="pb-5">
+          <Typography id="community-talk-conf" className="community-typography" variant="h4" color="text.primary">
             {talk.conf}
           </Typography>
-          <Typography id="community-typography" variant="h5" color="text.secondary">
+          <Typography className="community-typography" variant="h5" color="text.secondary">
             {talk.title}
           </Typography>
           {talk.speakers.map((speaker) => (
-            <Typography id="community-typography" variant="h6" color="text.secondary" key={speaker.toString()}>
+            <Typography className="community-typography" variant="h6" color="text.secondary" key={speaker.toString()}>
               {speaker}
             </Typography>
           ))}
-          <Typography id="community-typography" variant="body1" color="text.secondary" className="pt-5">
+          <Typography
+            id="community-talk-descrip"
+            className="community-typography"
+            variant="body1"
+            color="text.secondary"
+          >
             {talk.description}
           </Typography>
         </CardContent>
@@ -257,13 +262,13 @@ export default function CommunityResources(): JSX.Element {
               title="TSC meeting"
             />
             <CardContent sx={{ flexGrow: 1 }}>
-              <Typography id="community-typography" variant="h6" color="text.secondary">
+              <Typography className="community-typography" variant="h6" color="text.secondary">
                 TSC Meetings
               </Typography>
-              <Typography id="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
+              <Typography className="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
                 Every third Wednesday, 9:30-10:30am PT
               </Typography>
-              <Typography id="community-typography" variant="body2" color="text.secondary">
+              <Typography className="community-typography" variant="body2" color="text.secondary">
                 Review releases, hear about new features, and discuss the roadmap. Open to all!
               </Typography>
             </CardContent>
@@ -315,13 +320,13 @@ export default function CommunityResources(): JSX.Element {
               title="Slack"
             />
             <CardContent sx={{ flexGrow: 1 }}>
-              <Typography id="community-typography" variant="h6" color="text.secondary">
+              <Typography className="community-typography" variant="h6" color="text.secondary">
                 OpenLineage Slack
               </Typography>
-              <Typography id="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
+              <Typography className="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
                 Connect with the community
               </Typography>
-              <Typography id="community-typography" variant="body2" color="text.secondary">
+              <Typography className="community-typography" variant="body2" color="text.secondary">
                 Get help from experts, learn about releases and events, and sync up with contributors.
               </Typography>
             </CardContent>
@@ -363,13 +368,13 @@ export default function CommunityResources(): JSX.Element {
               title="GitHub"
             />
             <CardContent sx={{ flexGrow: 1 }}>
-              <Typography id="community-typography" variant="h6" color="text.secondary">
+              <Typography className="community-typography" variant="h6" color="text.secondary">
                 GitHub Organization
               </Typography>
-              <Typography id="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
+              <Typography className="community-typography" sx={{ my: 1 }} variant="body2" color="text.secondary">
                 Contribute to the project
               </Typography>
-              <Typography id="community-typography" variant="body2" color="text.secondary">
+              <Typography className="community-typography" variant="body2" color="text.secondary">
                 Access the main codebase, website repo, and workshops. Contributions welcome!
               </Typography>
             </CardContent>


### PR DESCRIPTION
### One-line summary for changelog: restyled cards on community and ecosystem pages for dark mode

### Meaningful description
This is second attempt at styling cards on the community and ecosystem pages for dark mode so that backgrounds and colors are consistent with other backgrounds and colors across the site. This time the new CSS selectors target elements by id rather than by MuiTypography-root, which did not work in prod.

<img width="1590" height="1005" alt="Screenshot_20260201_085631" src="https://github.com/user-attachments/assets/b9589945-59b0-4210-8fbd-4e1c738c51f7" />
<img width="1611" height="1008" alt="Screenshot_20260201_085529" src="https://github.com/user-attachments/assets/23ecff97-2a0e-4511-ba5d-671ec31fd8b0" />