### PR TITLE
limit iceberg tests to java 11+

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/SparkIcebergIntegrationTest.java
@@ -401,6 +401,12 @@ class SparkIcebergIntegrationTest {
   @Test
   @SneakyThrows
   void testAppendWithRDDProcessing() {
+    if (JAVA_VERSION.startsWith("1.8") && System.getProperty(SPARK_VERSION).startsWith("3.5")) {
+      // This test will not work as Iceberg classes used are Java 11
+      // The iceberg vendor module has empty sources on Java 8 + Iceberg 1.7
+      assertThat(true).isTrue();
+      return;
+    }
     clearTables("source_table", "target_table");
     createTempDataset(2).createOrReplaceTempView("temp");
 
@@ -427,6 +433,12 @@ class SparkIcebergIntegrationTest {
   @Test
   @SneakyThrows
   void testAppendWithRDDTransformations() {
+    if (JAVA_VERSION.startsWith("1.8") && System.getProperty(SPARK_VERSION).startsWith("3.5")) {
+      // This test will not work as Iceberg classes used are Java 11
+      // The iceberg vendor module has empty sources on Java 8 + Iceberg 1.7
+      assertThat(true).isTrue();
+      return;
+    }
     clearTables("src_table", "resulting_table");
     createTempDataset(2).createOrReplaceTempView("temp");
 


### PR DESCRIPTION
The tests testAppendWithRDDTransformations and testAppendWithRDDProcessing were added recently but they depend on the Iceberg vendor module's SparkInputPartitionExtractor to extract schema from DataSourceRDD partitions. 
On Java 8 + Spark 3.5, the Iceberg vendor module is compiled with empty source directories (see vendor/iceberg/build.gradle line 45-53) because Iceberg 1.7.0 requires Java 11+.

The fix is consistent with other tests in this file:

```
  @Test
  @EnabledIfSystemProperty(named = SPARK_VERSION, matches = "([34].*)") // Spark version >= 3.*
  @SuppressWarnings("PMD.JUnitTestContainsTooManyAsserts")
  void sparkEmitsInputAndOutputStatistics() {
    if (JAVA_VERSION.startsWith("1.8") && System.getProperty(SPARK_VERSION).startsWith("3.5")) {
      // Assertion below will not work as Iceberg classes used are Java 11
      // This is however not related to OpenLineage implementation itself but rather to the Iceberg
      // classes compatibility. For Spark 3.5, we use Iceberg 1.7.0. We want to run OpenLineage
      // tests with Spark 3.5 and Java 8, but Iceberg 1.7.0 requires Java 11. This is why we skip
      assertThat(true).isTrue();
      return;
    }
```