### PR TITLE
fix(python): remove unneeded `build` runtime dependency

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "requests>=2.32.4",
   "httpx>=0.27.0",
   "packaging>=21.0",
-  "build>=1.2.2"
 ]
 optional-dependencies.kafka = [
   "confluent-kafka>=2.1.1",


### PR DESCRIPTION
The `build` package was listed as a runtime dependency but is never imported at runtime. It is only needed at build time and is already handled by the build system configuration.

Closes #4279
