### PR TITLE
dbt: Use get method for dbt project version retrieval

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/local.py
+++ b/integration/common/src/openlineage/common/provider/dbt/local.py
@@ -106,7 +106,7 @@ class DbtLocalArtifactProcessor(DbtArtifactProcessor):
 
         self.target = target
         self.project_name = dbt_project["name"]
-        self.project_version = dbt_project["version"]
+        self.project_version = dbt_project.get("version")
         self.profile_name = profile_name or dbt_project.get("profile")
         if not self.profile_name:
             raise KeyError(f"profile not found in {dbt_project}")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->

Uses `.get()` for optional dbt project's `version` key.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->

Per dbt's [docs](https://docs.getdbt.com/reference/project-configs/version#:~:text=Starting%20in%20dbt%20version%201.5%2C%20version%20in%20the%20dbt_project.yml%20is%20an%20optional%20parameter):
> Starting in dbt version 1.5, version in the dbt_project.yml is an optional parameter.

However, the existing `dbt_project["version"]` throws an error if the `version` tag is omitted from `dbt_project.yml` rather than return `None`, which is fixed by this patch.

### Checklist
- [ ] AI was used in creating this PR
