### PR TITLE
fix(dbt): raise KeyError instead of RuntimeError in _get_model_node

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -858,7 +858,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             node_type = "source"
             manifest_node = self.compiled_manifest["sources"][node_id]
         else:
-            raise RuntimeError(f"{node_id} not found in nodes or sources")
+            raise KeyError(node_id)
         catalog_node = get_from_nullable_chain(self.catalog, ["nodes", node_id])
         return ModelNode(type=node_type, metadata_node=manifest_node, catalog_node=catalog_node)
 


### PR DESCRIPTION
## Summary
- **Fix exception type mismatch** in `_get_model_node()` that causes the dbt integration to crash when a `node_id` is not found in the manifest
- `@handle_keyerror` only catches `KeyError`, but `_get_model_node()` was raising `RuntimeError` — escaping the decorator as an unhandled exception
- Inconsistent with the other 3 decorated methods (`_get_attached_dataset`, `_get_assertion`, `_get_node_tags`) which all rely on natural `KeyError`
- Changed to `raise KeyError(node_id)` so the decorator catches it, logs a warning, and returns `None` — matching the graceful degradation pattern

## Test plan
- [ ] Verify existing dbt structured_logs tests pass
- [ ] Confirm `_get_model_node()` returns `None` (via the decorator) when given a non-existent node_id, instead of crashing with `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)