### PR TITLE
fix(dbt): attach ExtractionErrorRunFacet on metadata extraction failures

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -868,7 +868,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         if not errors:
             return None
         return extraction_error_run.ExtractionErrorRunFacet(
-            totalTasks=len(errors) + 1,
+            totalTasks=len(errors),
             failedTasks=len(errors),
             errors=errors,
         )


### PR DESCRIPTION
## Summary
- When `@handle_keyerror`-decorated methods fail (e.g. a node_id is missing from the manifest), the decorator now records the error and attaches a built-in `ExtractionErrorRunFacet` to the emitted `RunEvent`
- Previously, extraction failures were invisible to downstream consumers — events were emitted with missing data (empty outputs, no tags) but no indication that extraction had failed
- The `_get_model_node` method now raises `KeyError` instead of `RuntimeError` so the `@handle_keyerror` decorator can catch it consistently

## Test plan
- [x] All 75 existing `structured_logs` tests pass (`pytest tests/ -k "structured_log" -v`)
- [ ] Verify `ExtractionErrorRunFacet` appears in RunEvents when a node_id is missing from the manifest
- [ ] Confirm existing behavior is preserved — warnings are still logged and `None` is still returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)