### PR TITLE
change condition for biglake catalog check

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
@@ -21,8 +21,7 @@ import org.apache.spark.sql.SparkSession;
 class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   private static final String REST_CATALOG_TYPE = "rest";
-  private static final String BIGLAKE_CATALOG_URI =
-      "https://biglake.googleapis.com/iceberg/v1beta/restcatalog";
+  private static final String BIGLAKE_CATALOG_URI = "https://biglake.googleapis.com/";
 
   @Override
   String getType() {
@@ -47,7 +46,7 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   Map<String, String> catalogProperties(Map<String, String> catalogConf) {
-    if (BIGLAKE_CATALOG_URI.equals(catalogConf.get(CatalogProperties.URI))) {
+    if (catalogConf.getOrDefault(CatalogProperties.URI, "").startsWith(BIGLAKE_CATALOG_URI)) {
       Map<String, String> properties = new HashMap<>();
       properties.put("gcp_project_id", catalogConf.get("header.x-goog-user-project"));
       return properties;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Change condition for adding project_id to catalog properties.


### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
Until now the project_id was added if the catalog url was equal to
```
https://biglake.googleapis.com/iceberg/v1beta/restcatalog
```
Which was problematic as there are other options e.g. `v1` instead `v1beta` that are also valid.
Changed condition to check only for prefix
```
https://biglake.googleapis.com/
```




### Checklist
- [ ] AI was used in creating this PR
