### PR TITLE
dbt: parse key:value tags in DBT tags facet

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -326,9 +326,7 @@ class DbtArtifactProcessor:
 
             run_facets: Dict[str, RunFacet] = {}
             if tags := output_node.get("tags", None):
-                run_facets["tags"] = tags_run.TagsRunFacet(
-                    tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-                )
+                run_facets["tags"] = self._dbt_tags_facet(tags)
 
             output_dataset = self.node_to_output_dataset(
                 ModelNode(
@@ -410,9 +408,7 @@ class DbtArtifactProcessor:
 
             run_facets: Dict[str, RunFacet] = {}
             if tags := node.get("tags", None):
-                run_facets["tags"] = tags_run.TagsRunFacet(
-                    tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-                )
+                run_facets["tags"] = self._dbt_tags_facet(tags)
 
             run_id = str(generate_new_uuid())
             dataset_facets: Dict[str, InputDatasetFacet] = {"dataQualityAssertions": assertion_facet}
@@ -771,6 +767,27 @@ class DbtArtifactProcessor:
         if not self.adapter_type:
             return None
         return self.adapter_type.value.lower()
+
+    @staticmethod
+    def _parse_dbt_tag(tag: str) -> tags_run.TagsRunFacetFields:
+        """Parse a dbt tag into an OpenLineage run tag.
+
+        Supported formats:
+        - "tag" -> key="tag", value="true", source="DBT"
+        - "key:value" -> key="key", value="value", source="DBT"
+        - "key:value:source" -> key="key", value="value", source="source"
+
+        Any other format falls back to the legacy behavior to preserve compatibility.
+        """
+        parts = tag.split(":")
+        if len(parts) == 2:
+            return tags_run.TagsRunFacetFields(key=parts[0], value=parts[1], source="DBT")
+        if len(parts) == 3:
+            return tags_run.TagsRunFacetFields(key=parts[0], value=parts[1], source=parts[2])
+        return tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT")
+
+    def _dbt_tags_facet(self, tags: Sequence[str]) -> tags_run.TagsRunFacet:
+        return tags_run.TagsRunFacet(tags=[self._parse_dbt_tag(tag) for tag in tags])
 
     def get_run(
         self, run_id: str, query_id: Optional[str] = None, run_facets: Optional[dict[str, Any]] = None

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -21,7 +21,6 @@ from openlineage.client.facet_v2 import (
     job_type_job,
     processing_engine_run,
     sql_job,
-    tags_run,
 )
 from openlineage.client.uuid import generate_new_uuid
 from openlineage.common.provider.dbt.facets import (
@@ -350,9 +349,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
         # Add tags if they exist for this node
         if tags := self._get_node_tags(node_unique_id):
-            run_facets["tags"] = tags_run.TagsRunFacet(
-                tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-            )
+            run_facets["tags"] = self._dbt_tags_facet(tags)
 
         job_name = self._get_job_name(event)
         node_metadata = self.compiled_manifest.get("nodes", {}).get(node_unique_id, {})
@@ -413,9 +410,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
         # Add tags if they exist for this node
         if tags := self._get_node_tags(node_unique_id):
-            run_facets["tags"] = tags_run.TagsRunFacet(
-                tags=[tags_run.TagsRunFacetFields(key=tag, value="true", source="DBT") for tag in tags]
-            )
+            run_facets["tags"] = self._dbt_tags_facet(tags)
 
         job_name = self._get_job_name(event)
         node_metadata = self.compiled_manifest.get("nodes", {}).get(node_unique_id, {})

--- a/integration/common/tests/dbt/test_dbt.py
+++ b/integration/common/tests/dbt/test_dbt.py
@@ -3,6 +3,7 @@
 
 import pytest
 from openlineage.client import set_producer
+from openlineage.client.facet_v2 import tags_run
 from openlineage.common.provider.dbt.processor import (
     DbtArtifactProcessor,
     DbtRunContext,
@@ -12,6 +13,35 @@ from openlineage.common.provider.dbt.processor import (
 @pytest.fixture(scope="session", autouse=True)
 def setup_producer():
     set_producer("https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt")
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("sometag", tags_run.TagsRunFacetFields(key="sometag", value="true", source="DBT")),
+        ("team:analytics", tags_run.TagsRunFacetFields(key="team", value="analytics", source="DBT")),
+        ("env:production:INFRA", tags_run.TagsRunFacetFields(key="env", value="production", source="INFRA")),
+        ("pii:", tags_run.TagsRunFacetFields(key="pii", value="", source="DBT")),
+        ("a:b:c:d", tags_run.TagsRunFacetFields(key="a:b:c:d", value="true", source="DBT")),
+    ],
+)
+def test_parse_dbt_tag(tag, expected):
+    assert DbtArtifactProcessor._parse_dbt_tag(tag) == expected
+
+
+def test_build_dbt_tags_facet():
+    processor = DbtArtifactProcessor(
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="job-namespace",
+    )
+
+    facet = processor._dbt_tags_facet(["team:analytics", "environment:production:INFRA", "legacy-tag"])
+
+    assert facet.tags == [
+        tags_run.TagsRunFacetFields(key="team", value="analytics", source="DBT"),
+        tags_run.TagsRunFacetFields(key="environment", value="production", source="INFRA"),
+        tags_run.TagsRunFacetFields(key="legacy-tag", value="true", source="DBT"),
+    ]
 
 
 def test_seed_snapshot_nodes_do_not_throw():


### PR DESCRIPTION
Closes #4281

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
dbt: parse key:value and key:value:source model tags into structured OpenLineage run tags


### Meaningful description
### Problem

DBT tags are currently emitted as:
- `tag` -> `key=tag, value=true, source=DBT`

Issue #4281 requests support for structured DBT tags:
- `key:value`
- `key:value:source`

### Solution

Add a shared DBT tag parser in the common DBT processor and use it in both:
- local artifact parsing
- structured log parsing

Behavior:
- `tag` -> `key=tag, value=true, source=DBT`
- `key:value` -> `key=key, value=value, source=DBT`
- `key:value:source` -> `key=key, value=value, source=source`

For tags with more than two `:` separators, preserve legacy behavior for compatibility.

Used CODEX for Local and Manual testing
Ran:
- `uv run pytest integration/common/tests/dbt/test_dbt.py`
- `uv run pytest integration/common/tests/dbt/structured_logs/test_structured_logs.py`

Also manually validated with:
- `dbt-ol send-events`
- a real `dbt-ol run` using `dbt-duckdb`



### Checklist
- [x] AI was used in creating this PR
