### PR TITLE
ci: upgrade Datadog static analyzer action to v3

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -16,11 +16,9 @@ jobs:
           node-version: 24
       - name: Check code meets quality and security standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
           dd_app_key: ${{ secrets.DD_APP_KEY }}
-          dd_service: openlineage
-          dd_env: ci
           dd_site: us5.datadoghq.com
           cpu_count: 2


### PR DESCRIPTION
Upgrade DataDog/datadog-static-analyzer-github-action from v1 to v3 and remove unsupported dd_service and dd_env inputs.

### Checklist
- [*] AI was used in creating this PR: Claude
