### PR TITLE
Add flink support for DatasetConfigFacet for flink native listener

### DIFF
--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
@@ -5,6 +5,7 @@
 
 package io.openlineage.flink.visitor.facet;
 
+import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.flink.api.OpenLineageContext;
@@ -13,7 +14,9 @@ import io.openlineage.flink.wrapper.TableLineageDatasetWrapper;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 
@@ -34,6 +37,18 @@ public class TableLineageFacetVisitor implements DatasetFacetVisitor {
   @Override
   public void apply(LineageDatasetWithIdentifier dataset, DatasetFacetsBuilder builder) {
     buildSchemaFacet(dataset.getFlinkDataset(), builder);
+    buildConfigFacet(dataset.getFlinkDataset(), builder);
+  }
+
+  private void buildConfigFacet(LineageDataset flinkDataset, DatasetFacetsBuilder builder) {
+    for (LineageDatasetFacet facet : flinkDataset.facets().values()) {
+      if (facet instanceof DatasetConfigFacet) {
+        OpenLineage.DefaultDatasetFacet datasetFacet =
+            (OpenLineage.DefaultDatasetFacet) context.getOpenLineage().newDatasetFacet();
+        datasetFacet.getAdditionalProperties().putAll(((DatasetConfigFacet) facet).config());
+        builder.put(facet.name(), datasetFacet);
+      }
+    }
   }
 
   private void buildSchemaFacet(LineageDataset flinkDataset, DatasetFacetsBuilder builder) {

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitorTest.java
@@ -10,14 +10,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacet;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.OpenLineage.DefaultDatasetFacet;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.client.Versions;
 import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
 import org.apache.flink.table.planner.lineage.TableLineageDataset;
@@ -62,5 +68,36 @@ class TableLineageFacetVisitorTest {
     assertThat(fields.get(1))
         .hasFieldOrPropertyWithValue("name", "col_b")
         .hasFieldOrPropertyWithValue("type", "type2");
+  }
+
+  @Test
+  void testApplyWithConfigFacet() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+    DatasetFacetsBuilder facetsBuilder = openLineage.newDatasetFacetsBuilder();
+    Schema schema = mock(Schema.class);
+    when(table.table().getUnresolvedSchema()).thenReturn(schema);
+    when(schema.getColumns()).thenReturn(Arrays.asList());
+
+    DatasetConfigFacet configFacet = mock(DatasetConfigFacet.class);
+    when(configFacet.name()).thenReturn("config");
+    Map<String, String> config = new HashMap<>();
+    config.put("key1", "value1");
+    config.put("key2", "value2");
+    when(configFacet.config()).thenReturn(config);
+
+    Map<String, LineageDatasetFacet> facets = new HashMap<>();
+    facets.put("config", configFacet);
+    when(table.facets()).thenReturn(facets);
+
+    visitor.apply(
+        new LineageDatasetWithIdentifier(new DatasetIdentifier("namespace", "name"), table),
+        facetsBuilder);
+
+    Map<String, DatasetFacet> additionalProps = facetsBuilder.build().getAdditionalProperties();
+    DefaultDatasetFacet resultFacet = (DefaultDatasetFacet) additionalProps.get("config");
+
+    assertThat(resultFacet).isNotNull();
+    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key1", "value1");
+    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key2", "value2");
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
- Added support for native `DatasetConfigFacet` provided by flink.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
- Flink's lineage API (FLIP-314) includes DatasetConfigFacet, a native interface that allows any connector to expose dataset configuration as key-value pairs. Currently, the flink-native-listener ignores this facet even when connectors populate it. This PR adds support for forwarding DatasetConfigFacet entries as custom OpenLineage dataset facets.
- Code link in native flink for this facet: https://github.com/apache/flink/blob/4f85d3074eccfe628e2926269ec7e943c61d2a9c/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetConfigFacet.java#L28C18-L28C36

### Checklist
- [ ] AI was used in creating this PR
