### PR TITLE
fix dbt singular tests in structured logs handling

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -456,8 +456,14 @@ class DbtArtifactProcessor:
                 node_columns = test_node
 
             else:
-                name = test_node["test_metadata"]["name"]
-                node_columns = test_node["test_metadata"]
+                test_metadata = test_node.get("test_metadata")
+                if test_metadata:
+                    name = test_metadata["name"]
+                    node_columns = test_metadata
+                else:
+                    # Singular test — no test_metadata, use node name directly
+                    name = test_node["name"]
+                    node_columns = test_node
 
             # Extract severity from config, normalize to lowercase
             config = test_node.get("config", {})

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -497,8 +497,10 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         """
         all_nodes = {**self.compiled_manifest["nodes"], **self.compiled_manifest["sources"]}
         test_node = all_nodes[test_node_id]
-        attached_node_id = test_node["attached_node"]
+        attached_node_id = test_node.get("attached_node")
         input_dataset = None
+        # TODO: For singular tests (no attached_node), use SQL parsing on the compiled
+        # node's SQL to extract the referenced datasets and attach the assertion to them.
         if attached_node_id:
             attached_model_node = self._get_model_node(attached_node_id)
             input_dataset = self.node_to_dataset(node=attached_model_node, has_facets=True)
@@ -507,7 +509,15 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
     @handle_keyerror
     def _get_assertion(self, node_id: str, success: bool) -> Optional[dq.Assertion]:
         manifest_test_node = self.compiled_manifest["nodes"][node_id]
-        name = manifest_test_node["test_metadata"]["name"]
+        test_metadata = manifest_test_node.get("test_metadata")
+        if test_metadata:
+            name = test_metadata["name"]
+            column = get_from_nullable_chain(test_metadata, ["kwargs", "column_name"])
+        else:
+            # Singular test — no test_metadata, use node name directly
+            name = manifest_test_node["name"]
+            column = None
+
         config = manifest_test_node.get("config", {})
 
         # Extract severity, normalize to lowercase
@@ -518,7 +528,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         return dq.Assertion(
             assertion=name,
             success=success,
-            column=get_from_nullable_chain(manifest_test_node["test_metadata"], ["kwargs", "column_name"]),
+            column=column,
             severity=severity,
         )
 

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -1614,3 +1614,55 @@ class TestGetAssertionSeverity:
 
         assert assertion is not None
         assert assertion.severity is None
+
+
+class TestGetAssertionSingularTests:
+    """Tests for singular test handling in _get_assertion (no test_metadata)."""
+
+    @pytest.fixture
+    def processor(self):
+        processor = DbtStructuredLogsProcessor(
+            producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            job_namespace="dbt-test-namespace",
+            project_dir=CURRENT_DIR,
+            target="postgres",
+            dbt_command_line=["dbt", "test"],
+        )
+        return processor
+
+    def test_singular_test_no_test_metadata(self, processor):
+        """Singular tests have no test_metadata; assertion name should come from node name."""
+        processor._compiled_manifest = {
+            "nodes": {
+                "test.project.assert_no_future_dates": {
+                    "name": "assert_no_future_dates",
+                    "config": {"severity": "ERROR"},
+                    # No test_metadata key
+                }
+            },
+            "sources": {},
+        }
+
+        assertion = processor._get_assertion("test.project.assert_no_future_dates", success=True)
+
+        assert assertion is not None
+        assert assertion.assertion == "assert_no_future_dates"
+        assert assertion.success is True
+        assert assertion.column is None
+        assert assertion.severity == "error"
+
+    def test_singular_test_no_attached_node(self, processor):
+        """Singular tests have no attached_node; _get_attached_dataset should return None."""
+        processor._compiled_manifest = {
+            "nodes": {
+                "test.project.assert_no_future_dates": {
+                    "name": "assert_no_future_dates",
+                    # No attached_node key
+                }
+            },
+            "sources": {},
+        }
+
+        dataset = processor._get_attached_dataset("test.project.assert_no_future_dates")
+
+        assert dataset is None

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -254,3 +254,48 @@ class TestParseSeverity:
 
         assertion = assertions["model.project.my_model"][0]
         assert assertion.severity is None
+
+
+class TestParseSingularTests:
+    """Tests for singular test handling in parse_assertions (no test_metadata)."""
+
+    @pytest.fixture
+    def processor(self):
+        processor = DbtArtifactProcessor(
+            producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            job_namespace="test-namespace",
+        )
+        processor.manifest_version = 11  # Use version < 12 for test_metadata path
+        return processor
+
+    def test_singular_test_no_test_metadata(self, processor):
+        """Singular tests (manifest v<12) have no test_metadata; name comes from node name."""
+        nodes = {
+            "test.project.assert_no_future_dates": {
+                "name": "assert_no_future_dates",
+                # No test_metadata key
+            }
+        }
+        manifest = {
+            "parent_map": {
+                "test.project.assert_no_future_dates": ["model.project.my_model"],
+            }
+        }
+        run_results = {
+            "results": [
+                {
+                    "unique_id": "test.project.assert_no_future_dates",
+                    "status": "pass",
+                }
+            ]
+        }
+        context = DbtRunContext(manifest=manifest, run_results=run_results)
+
+        assertions = processor.parse_assertions(context, nodes)
+
+        assert "model.project.my_model" in assertions
+        assert len(assertions["model.project.my_model"]) == 1
+        assertion = assertions["model.project.my_model"][0]
+        assert assertion.assertion == "assert_no_future_dates"
+        assert assertion.success is True
+        assert assertion.column is None


### PR DESCRIPTION
AI description:

dbt singular tests are standalone SQL files in the `tests/` directory, as opposed to generic tests defined in YAML. Unlike generic tests, singular tests do not have a `test_metadata` field in their manifest node, nor do they have an `attached_node`. The structured logs processor's `_get_assertion()` was unconditionally accessing `manifest_test_node["test_metadata"]["name"]`, which raised a `KeyError` for singular tests. Because this method is wrapped with `@handle_keyerror`, the exception was silently caught and misreported as "Did not find node `test.<project>.<test_name>` in the dbt manifest", obscuring the real cause. The same issue existed in `_get_attached_dataset()`, which accessed `test_node["attached_node"]` without guarding against the key being absent. A parallel bug existed in the artifact-based processor's `parse_assertions()` for manifest versions below 12, where `test_node["test_metadata"]["name"]` was accessed unconditionally in the non-v12 branch.

The fix adds a `test_metadata` presence check in both `_get_assertion()` and `parse_assertions()`: when `test_metadata` is present (generic test), the existing logic applies; when it is absent (singular test), the assertion name is taken directly from `manifest_test_node["name"]` and `column` is set to `None`. In `_get_attached_dataset()`, the dict access is changed to `.get("attached_node")` so that singular tests — which have no attached model — return `None` gracefully rather than raising. The result is that singular tests now emit clean OpenLineage events without spurious warnings, though they produce empty `inputs` since there is no attached dataset to carry the `DataQualityAssertions` facet.

### Checklist
- [*] AI was used in creating this PR: Claude Code
