### PR TITLE
spark: fix spark iceberg glue catalog symlink

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
@@ -26,10 +27,12 @@ public class AwsUtils {
   public static final String AWS_GLUE_HIVE_FACTORY_CLASS =
       "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory";
   private static final String HIVE_METASTORE_GLUE_CATALOG_ID_KEY = "hive.metastore.glue.catalogid";
+  private static final String SPARK_SQL_CATALOG_PREFIX = "spark.sql.catalog.";
+  private static final String GLUE_CATALOG_SUFFIX = "GlueCatalog";
 
   @SneakyThrows
   public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
-    if (isHiveUsingGlue(sparkConf, hadoopConf)) {
+    if (isHiveUsingGlue(sparkConf, hadoopConf) || isIcebergUsingGlue(sparkConf)) {
       return awsRegion()
           .flatMap(
               region ->
@@ -183,6 +186,11 @@ public class AwsUtils {
     }
 
     return Optional.empty();
+  }
+
+  private static boolean isIcebergUsingGlue(SparkConf sparkConf) {
+    return Arrays.stream(sparkConf.getAllWithPrefix(SPARK_SQL_CATALOG_PREFIX))
+        .anyMatch(tuple -> tuple._2().endsWith(GLUE_CATALOG_SUFFIX));
   }
 
   private static boolean isHiveUsingGlue(SparkConf sparkConf, Configuration hadoopConf) {

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -253,6 +253,51 @@ class IcebergHandlerTest {
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
+  @Test
+  @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "us-west-2")
+  void testGetDatasetIdentifierForIcebergGlueCatalog() {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    sparkConf.set("spark.glue.accountId", "1122334455");
+    sparkConf.set(
+        "spark.sql.catalog.iceberg.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog");
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.iceberg.catalog-impl",
+                "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.iceberg.warehouse",
+                "/tmp/warehouse"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("iceberg");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession,
+            sparkCatalog,
+            Identifier.of(new String[] {"database"}, "table"),
+            new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("namespace", "arn:aws:glue:us-west-2:1122334455")
+        .hasFieldOrPropertyWithValue("name", "table/database/table")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
+  }
+
   private static Stream<Arguments> missingTableOptions() {
     return Stream.of(
         Arguments.of(Identifier.of(new String[] {}, "table"), "table", "/tmp/iceberg/table"),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:

related: #ISSUE
-->

### One-line summary for changelog:
Fixes dataset symlinks when using glue catalog for iceberg. 
closes: #4162 

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->

[getGlueArn](https://github.com/OpenLineage/OpenLineage/blob/291532fd436babd68edef682d6e07d56d0fecd31/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java#L31) currently returns null if not hive, [this](https://github.com/OpenLineage/OpenLineage/commit/d5db993253568d53c43ed9f8850788b6064b27d2) fixed the NPE, however if the ARN is null it looks like the identifier won't be [created](https://github.com/OpenLineage/OpenLineage/blob/291532fd436babd68edef682d6e07d56d0fecd31/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java#L37) at all.

Adding a function **isIcebergUsingGlue** that checks if the catalog used is glue, and if so return an ARN. 
Glue is determined by spark conf prefix "spark.sql.catalog."
e.g. 
spark.sql.catalog.iceberg.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog

### Checklist
- [x] AI was used in creating this PR