### PR TITLE
Add license and license files to pyproject.toml

### DIFF
--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -7,6 +7,8 @@ name = "openlineage-python"
 version = "1.46.0"
 description = "OpenLineage Python Client"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = [
   "openlineage",
 ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->

Add License info to pyproject.toml so it will show on https://pypi.org/project/openlineage-sql/

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->

PEP 639 specifies that licences are described in separate properties. PyPi respects these fields and if project is missing them it does not show the license.

See more https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

### Checklist
- [ ] AI was used in creating this PR
