### PR TITLE
documentation: Adding IBM as OpenLineage producer, and contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 | [Astronomer](https://www.astronomer.io/) | Integrations, clients, spec, documentation, developer and user support, community management, talks                |
 | [Atlan](https://atlan.com/)          | Contributions to Airflow integration, Python client and documentation                                              |
 | [Datadog](https://www.datadoghq.com/) | Contributions to dbt integration                                                                                   |
+| [IBM](https://www.ibm.com/)          | Contributions to clients, spec, and documentation                                                        |
 | [oleander](https://oleander.dev)    | Contributions to integrations, clients, spec, documentation, and talks |
 
 For pointers on getting started as a contributor, see the [OpenLineage Contributing Guide](CONTRIBUTING.md).

--- a/website/static/ecosystem/producers.tsx
+++ b/website/static/ecosystem/producers.tsx
@@ -88,6 +88,15 @@ export const Producers: Array<Partner> = [
     org_url: "https://github.com/dagworks-inc/hamilton",
   },
   {
+    image: "ibm_logo_bkgd.svg",
+    org: "IBM",
+    full_name: "IBM",
+    description:
+      "IBM watsonx.data emits OpenLineage events from its query and processing engines, capturing lineage for structured workloads. Watsonx.data integration emits OpenLineage events from ingestion and transformation pipelines, including those that process unstructured data.",
+    docs_url: "https://www.ibm.com/docs/en/watsonx/wdi/saas?topic=lineage-openlineage-integration",
+    org_url: "https://www.ibm.com/products/watsonx-data-intelligence/data-lineage",
+  },
+  {
     image: "keboola_logo_lg.svg",
     org: "Keboola",
     full_name: "Keboola",


### PR DESCRIPTION
Signed-off-by: Jakub Moravec <jkb.moravec@gmail.com

<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
Adding IBM as OpenLineage producer and contributor

### Meaningful description
I would like to list IBM among Producers on the website as watsonx.data and watsonx.data intelligence are producing OpenLineage now - https://www.ibm.com/new/announcements/openlineage-for-a-unified-lineage-view-across-structured-and-unstructured-data-to-enable-explainable-ai, https://www.ibm.com/docs/en/watsonx/wdi/saas?topic=lineage-openlineage-integration

and also list IBM among the contributors (please let me know if explicit justification is needed)



### Checklist
- [ ] AI was used in creating this PR
