### PR TITLE
Add Paimon dataset naming support

### DIFF
--- a/client/python/src/openlineage/client/naming/dataset.py
+++ b/client/python/src/openlineage/client/naming/dataset.py
@@ -484,6 +484,22 @@ class WASBS(DatasetNaming):
         return self.object_key
 
 
+@attr.define
+class Paimon(DatasetNaming):
+    """Naming implementation for Paimon."""
+
+    warehouse_path: str = attr.field(validator=_check_not_empty)
+    catalog: str = attr.field(validator=_check_not_empty)
+    database: str = attr.field(validator=_check_not_empty)
+    table: str = attr.field(validator=_check_not_empty)
+
+    def get_namespace(self) -> str:
+        return f"paimon://{self.warehouse_path}"
+
+    def get_name(self) -> str:
+        return f"{self.catalog}.{self.database}.{self.table}"
+
+
 class PubSubResourceType(Enum):
     """Enum representing supported Pub/Sub resource types."""
 

--- a/client/python/tests/test_dataset.py
+++ b/client/python/tests/test_dataset.py
@@ -27,6 +27,7 @@ from openlineage.client.naming.dataset import (
     OceanBase,
     Oracle,
     Postgres,
+    Paimon,
     PubSubNaming,
     PubSubResourceType,
     Redshift,
@@ -240,6 +241,24 @@ class TestWASBS:
         wasbs = WASBS("my-container", "my-service", "path/to/object")
         assert wasbs.get_namespace() == "wasbs://my-container@my-service.dfs.core.windows.net"
         assert wasbs.get_name() == "path/to/object"
+
+
+class TestPaimon:
+    def test_paimon_naming(self):
+        paimon = Paimon(
+            "file:/tmp/paimon-warehouse/my_db/my_table",
+            "my_catalog",
+            "my_db",
+            "my_table",
+        )
+        assert paimon.get_namespace() == "paimon://file:/tmp/paimon-warehouse/my_db/my_table"
+        assert paimon.get_name() == "my_catalog.my_db.my_table"
+
+    def test_paimon_validation(self):
+        with pytest.raises(ValueError, match="warehouse_path cannot be None"):
+            Paimon(None, "paimon", "my-database", "my-table")
+        with pytest.raises(ValueError, match="catalog cannot be empty"):
+            Paimon("file:/tmp/warehouse", "", "my-database", "my-table")
 
 
 class TestPubSubNaming:


### PR DESCRIPTION
Add Paimon dataset naming support, this follows the naming and namespace convention from native lineage support provided by paimon/flink.