### PR TITLE
[Spark] run java client build in new shell to use local env variables

### DIFF
--- a/integration/spark/buildDependencies.sh
+++ b/integration/spark/buildDependencies.sh
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -x -e
-(cd ../../client/java && ./gradlew generateCode publishToMavenLocal -x test --rerun-tasks)
+(cd ../../client/java && $SHELL -l -i -c './gradlew generateCode publishToMavenLocal -x test --rerun-tasks')
 (cd ../spark-extension-interfaces && ./gradlew clean publishToMavenLocal -x test)
 (cd ../sql/iface-java && ./script/compile.sh && ./script/build.sh)


### PR DESCRIPTION

### One-line summary for changelog:
run java client build in new shell to use local env variables


### Meaningful description
`integration/spark/buildDependencies.sh` builds the integration dependencies, if there is a difference between the spark integration java version and client java version (e.g. by using `jenv`), the integrations version is used which can cause build failure

executing maven command in new shell will load local java version


### Checklist
- [X] AI was used in creating this PR
