### PR TITLE
[Spark] add dataproc metastore properties to catalog properties for hive catalog

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/CatalogDatasetFacetUtils.java
@@ -8,6 +8,8 @@ package io.openlineage.spark.agent.util;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
@@ -37,11 +39,31 @@ public class CatalogDatasetFacetUtils {
                       .name("default")
                       .framework("hive")
                       .type("hive")
-                      .source("spark");
+                      .source("spark")
+                      .catalogProperties(
+                          getDataprocMetastoreProperties(pair.getLeft().getConf(), context));
               PathUtils.getMetastoreUri(pair.getLeft())
                   .map(PathUtils::prepareHiveUri)
                   .ifPresent(uri -> builder.metadataUri(uri.toString()));
               return builder.warehouseUri(pair.getRight().toString()).build();
             });
+  }
+
+  private static OpenLineage.CatalogDatasetFacetCatalogProperties getDataprocMetastoreProperties(
+      SparkConf sparkConf, OpenLineageContext context) {
+    Map<String, String> properties = new HashMap<>();
+    SparkConfUtils.findSparkConfigKey(sparkConf, "spark.dataproc.metastore.project-id")
+        .ifPresent(v -> properties.put("spark.dataproc.metastore.project-id", v));
+    SparkConfUtils.findSparkConfigKey(sparkConf, "spark.dataproc.metastore.location")
+        .ifPresent(v -> properties.put("spark.dataproc.metastore.location", v));
+    SparkConfUtils.findSparkConfigKey(sparkConf, "spark.dataproc.metastore.instanceId")
+        .ifPresent(v -> properties.put("spark.dataproc.metastore.instanceId", v));
+    if (properties.isEmpty()) {
+      return null;
+    }
+    OpenLineage.CatalogDatasetFacetCatalogPropertiesBuilder catalogPropertiesBuilder =
+        context.getOpenLineage().newCatalogDatasetFacetCatalogPropertiesBuilder();
+    properties.forEach(catalogPropertiesBuilder::put);
+    return catalogPropertiesBuilder.build();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/CreateReplaceDatasetBuilder.java
@@ -63,7 +63,6 @@ public class CreateReplaceDatasetBuilder
     Identifier identifier;
     StructType schema;
     OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange lifecycleStateChange;
-
     if (x instanceof CreateTableAsSelect) {
       CreateTableAsSelect command = (CreateTableAsSelect) x;
       tableCatalog = command.catalog();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -6,6 +6,7 @@
 package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +34,8 @@ abstract class BaseCatalogTypeHandler {
     return new Path(warehouseLocation, String.join(Path.SEPARATOR, pathComponents));
   }
 
-  Map<String, String> catalogProperties(Map<String, String> catalogConf) {
+  Map<String, String> catalogProperties(
+      Map<String, String> catalogConf, OpenLineageContext context) {
     return Collections.emptyMap();
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
@@ -9,6 +9,7 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,7 +58,8 @@ class BigQueryMetastoreCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Map<String, String> catalogProperties(Map<String, String> catalogConf) {
+  Map<String, String> catalogProperties(
+      Map<String, String> catalogConf, OpenLineageContext context) {
     Map<String, String> properties = new HashMap<>();
 
     // Backward compatibility: prefer official Iceberg keys, fall back to Google's legacy keys

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
@@ -10,8 +10,10 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.SparkConfUtils;
+import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -47,5 +49,24 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
       metastoreUri = new URI(confUri);
     }
     return new DatasetIdentifier(table, PathUtils.prepareHiveUri(metastoreUri).toString());
+  }
+
+  @Override
+  Map<String, String> catalogProperties(
+      Map<String, String> catalogConf, OpenLineageContext context) {
+    Map<String, String> properties = new HashMap<>();
+    context
+        .getSparkSession()
+        .ifPresent(
+            session -> {
+              org.apache.spark.SparkConf conf = session.sparkContext().conf();
+              SparkConfUtils.findSparkConfigKey(conf, "spark.dataproc.metastore.project-id")
+                  .ifPresent(v -> properties.put("spark.dataproc.metastore.project-id", v));
+              SparkConfUtils.findSparkConfigKey(conf, "spark.dataproc.metastore.location")
+                  .ifPresent(v -> properties.put("spark.dataproc.metastore.location", v));
+              SparkConfUtils.findSparkConfigKey(conf, "spark.dataproc.metastore.instanceId")
+                  .ifPresent(v -> properties.put("spark.dataproc.metastore.instanceId", v));
+            });
+    return properties;
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -110,7 +110,7 @@ public class IcebergHandler implements CatalogHandler {
       builder.metadataUri(catalogUri);
     }
 
-    Map<String, String> catalogProperties = catalogTypeHandler.catalogProperties(conf);
+    Map<String, String> catalogProperties = catalogTypeHandler.catalogProperties(conf, context);
     if (!catalogProperties.isEmpty()) {
       OpenLineage.CatalogDatasetFacetCatalogPropertiesBuilder catalogPropertiesBuilder =
           context.getOpenLineage().newCatalogDatasetFacetCatalogPropertiesBuilder();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
@@ -9,6 +9,7 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.IcebergHandler.TYPE;
 
 import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,12 +46,13 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  Map<String, String> catalogProperties(Map<String, String> catalogConf) {
+  Map<String, String> catalogProperties(
+      Map<String, String> catalogConf, OpenLineageContext context) {
     if (catalogConf.getOrDefault(CatalogProperties.URI, "").startsWith(BIGLAKE_CATALOG_URI)) {
       Map<String, String> properties = new HashMap<>();
       properties.put("gcp_project_id", catalogConf.get("header.x-goog-user-project"));
       return properties;
     }
-    return super.catalogProperties(catalogConf);
+    return super.catalogProperties(catalogConf, context);
   }
 }


### PR DESCRIPTION
### One-line summary for changelog:
add dataproc metastore properties to catalog properties for hive catalog when available


### Meaningful description
The Dataproc Metastore is a Hive metastore available as external service. There is no way to tell directly from catalog properties if the metastore is normal Hive metastore or Dataproc Metastore. 

On DP clusters the `spark.metastore` properties will be added so when catalog facet is created, they will be included in the catalog properites.

### Checklist
- [X] AI was used in creating this PR
