### PR TITLE
fix: correct Feast integration sidebar position for alphabetical ordering

### DIFF
--- a/website/docs/integrations/feast.md
+++ b/website/docs/integrations/feast.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 title: Feast
 ---
 

--- a/website/docs/integrations/feast.md
+++ b/website/docs/integrations/feast.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: Feast
 ---
 


### PR DESCRIPTION
## Summary\n\nFixes the sidebar ordering of integration pages. Feast was at `sidebar_position: 9`, placing it after Spark instead of in alphabetical order.\n\nCloses #4300\n\n## Change\n\nChanged `sidebar_position` from `9` to `4` in `website/docs/integrations/feast.md` to maintain alphabetical nav ordering:\n\n1. About (1)\n2. Airflow (2)\n3. dbt (3)\n4. **Feast (4)** ← was 9\n5. Flink\n6. Great Expectations\n7. Hive\n8. Spark\n9. Trino