### PR TITLE
Explicit lineage proposal

### DIFF
--- a/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
@@ -93,6 +93,7 @@ This example shows how the new facets can replace ColumnLevelLineageDatasetFacet
 ```
 
 This single entry combines:
+
 - **Entity-level**: output_X comes from input_A
 - **Dataset-wide op**: group_by_col affects entire output
 - **Column mapping**: col_a -> col1
@@ -373,3 +374,4 @@ Reading specific columns from a structured table and writing to an unstructured 
   ]
 }
 ```
+

--- a/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
@@ -57,7 +57,7 @@ This example shows how the new facets can replace ColumnLevelLineageDatasetFacet
             "total": {
               "inputs": [
                 { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
-                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
+                  "transformations": [{ "type": "DIRECT", "subtype": "AGGREGATION" }] }
               ]
             }
           }
@@ -107,7 +107,6 @@ A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dat
 
 ```json
 {
-  "eventType": "COMPLETE",
   "eventTime": "2026-03-25T10:00:00.000Z",
   "dataset": {
     "namespace": "postgresql://warehouse:5432",
@@ -130,7 +129,7 @@ A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dat
 
 ## 5. Static job lineage (on JobEvent)
 
-A catalog declares what a job is designed to do. LineageJobFacet on the job:
+A catalog declares what a job is designed to do. This is treated as design/static lineage because the event does not contain a run section. LineageJobFacet on the job:
 
 ```json
 {
@@ -232,7 +231,7 @@ The per-field detail names a `LineageJobInput` (`type: JOB` with no `namespace`/
             "fields": {
               "total": {
                 "inputs": [
-                  { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+                  { "type": "JOB", "transformations": [{ "type": "DIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
                 ]
               }
             }
@@ -256,7 +255,6 @@ A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` v
 
 ```json
 {
-  "eventType": "COMPLETE",
   "job": {
     "namespace": "airflow://prod",
     "name": "dag_b",
@@ -380,4 +378,3 @@ Reading specific columns from a structured table and writing to an unstructured 
   ]
 }
 ```
-

--- a/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
@@ -2,7 +2,7 @@
 
 This file contains examples for [ExplicitLineageProposal.md](ExplicitLineageProposal.md). See [ExplicitLineageSchema.md](ExplicitLineageSchema.md) for the proposed schema.
 
-## 1. Dataset-level lineage on RunEvent (solves #4359)
+## 1. Dataset-level lineage on RunEvent
 
 ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunFacet on the run:
 
@@ -38,7 +38,9 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
 
 `inputs`/`outputs` remain as the carrier for dataset facets, as the fallback for older consumers, and as the event boundary for the job's direct input/output participation.
 
-## 2. Column-level lineage on RunEvent (subsumes CLL)
+## 2. Column-level lineage on RunEvent
+
+This example shows how the new facets can replace ColumnLevelLineageDatasetFacet.
 
 ```json
 "run": {
@@ -204,7 +206,47 @@ extract_task (JOB) ──> extracted_data (DATASET)
 
 That edge is implicit in the RunEvent boundary, not repeated with a `LineageJobInput`.
 
-## 8. Job-to-job — declared chain on JobEvent
+### 8. Enriched generator — field-level transformation detail, job still implicit
+
+The same extract task as in previous example, but the producer knows that `total` was derived via a `sum()` aggregation over the (untracked) external API response. 
+There is still no tracked upstream dataset, so the entry's top-level `inputs` is `[]`. 
+The per-field detail names an `LineageJobInput` (`type: JOB` with no `namespace`/`name`), which resolves to the event's own job, and carries the transformation:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-789",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/extract",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
+            "inputs": [],
+            "fields": {
+              "total": {
+                "inputs": [
+                  { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "airflow://prod", "name": "data_pipeline.extract_task" },
+  "inputs": [],
+  "outputs": [
+    { "namespace": "postgres://prod", "name": "extracted_data" }
+  ]
+}
+```
+
+The implicit edge `extract_task (JOB) ──> extracted_data (DATASET)` is unchanged — the identity-less `LineageJobInput` only adds the column-level transformation that event membership could not express.
+
+## 9. Job-to-job — declared chain on JobEvent
 
 A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` via a non-materialized handoff. No intermediate dataset exists. The catalog declares the design-time data flow on the JobEvent for `dag_b`:
 
@@ -235,7 +277,7 @@ A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` v
 
 Note that `runId` is omitted on both ends — declared lineage describes the job definition, not a specific execution. The same shape would apply to a non-materialized view consumed by a downstream job, or to an Airflow task receiving data via XCom from an upstream task.
 
-## 9. Job-to-job — observed chain on RunEvent
+## 10. Job-to-job — observed chain on RunEvent
 
 The same data flow as Example 8, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
 
@@ -266,7 +308,7 @@ The same data flow as Example 8, observed at runtime by an integration that can 
 }
 ```
 
-## 10. Job-to-job — cross-namespace chain
+## 11. Job-to-job — cross-namespace chain
 
 A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in a separate Beam pipeline. Neither job is in the namespace of the other, and the topic is not modeled as a dataset. The Beam pipeline emits the cross-namespace chain on its RunEvent:
 
@@ -298,7 +340,7 @@ A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in
 
 The source job (`flink://ingest/event_normalizer`) is in a different namespace from both the event's job and the target entry. Without explicit `(namespace, name)` on both ends, the chain could not be expressed.
 
-## 11. Structured-to-unstructured — known source columns, no target schema
+## 12. Structured-to-unstructured — known source columns, no target schema
 
 Reading specific columns from a structured table and writing to an unstructured file (e.g., a PDF). The target has no schema, so there is no `fields` map — but we can still express that the output came from specific source columns:
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
@@ -4,17 +4,19 @@ This file contains examples for [ExplicitLineageProposal.md](ExplicitLineageProp
 
 ## 1. Dataset-level lineage on RunEvent
 
-ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunFacet on the run:
+ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. `LineageJobFacet` on the job:
 
 ```json
 {
   "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-123",
+  "run": { "runId": "abc-123" },
+  "job": {
+    "namespace": "http://etl-server:8080",
+    "name": "bulk_etl",
     "facets": {
       "lineage": {
         "_producer": "https://example.com/etl",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
         "entries": [
           { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
             "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
@@ -24,7 +26,6 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
       }
     }
   },
-  "job": { "namespace": "http://etl-server:8080", "name": "bulk_etl" },
   "inputs": [
     { "namespace": "postgresql://warehouse:5432", "name": "table_a" },
     { "namespace": "postgresql://warehouse:5432", "name": "table_b" }
@@ -43,12 +44,13 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
 This example shows how the new facets can replace ColumnLevelLineageDatasetFacet.
 
 ```json
-"run": {
-  "runId": "abc-123",
+"job": {
+  "namespace": "http://etl-server:8080",
+  "name": "analytics_etl",
   "facets": {
     "lineage": {
       "_producer": "...",
-      "_schemaURL": "...",
+      "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
       "entries": [
         { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
           "fields": {
@@ -178,8 +180,8 @@ Conceptually, the event still establishes:
 transactions (DATASET) ──> fraud_detector (JOB)
 ```
 
-That edge is implicit in the RunEvent boundary, not repeated in `LineageRunFacet`. 
-OpenLineage consumer may use that to visualize the relationship.
+That edge is implicit in the RunEvent boundary, not repeated in a lineage facet.
+An OpenLineage consumer may use it to visualise the relationship.
 
 ## 7. Data generator — job produces data without tracked input
 
@@ -211,17 +213,19 @@ That edge is implicit in the RunEvent boundary, not repeated with a `LineageJobI
 
 The same extract task as in previous example, but the producer knows that `total` was derived via a `sum()` aggregation over the (untracked) external API response. 
 There is still no tracked upstream dataset, so the entry's top-level `inputs` is `[]`. 
-The per-field detail names an `LineageJobInput` (`type: JOB` with no `namespace`/`name`), which resolves to the event's own job, and carries the transformation:
+The per-field detail names a `LineageJobInput` (`type: JOB` with no `namespace`/`name`), which resolves to the event's own job, and carries the transformation:
 
 ```json
 {
   "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-789",
+  "run": { "runId": "abc-789" },
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "data_pipeline.extract_task",
     "facets": {
       "lineage": {
         "_producer": "https://example.com/extract",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
         "entries": [
           { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
             "inputs": [],
@@ -237,7 +241,6 @@ The per-field detail names an `LineageJobInput` (`type: JOB` with no `namespace`
       }
     }
   },
-  "job": { "namespace": "airflow://prod", "name": "data_pipeline.extract_task" },
   "inputs": [],
   "outputs": [
     { "namespace": "postgres://prod", "name": "extracted_data" }
@@ -280,17 +283,19 @@ Note that `runId` is omitted on both ends — declared lineage describes the job
 
 ## 10. Job-to-job — observed chain on RunEvent
 
-The same data flow as Example 8, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
+The same data flow as Example 9, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
 
 ```json
 {
   "eventType": "COMPLETE",
-  "run": {
-    "runId": "run-b-001",
+  "run": { "runId": "run-b-001" },
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "dag_b.task_1",
     "facets": {
       "lineage": {
         "_producer": "https://example.com/airflow",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
         "entries": [
           { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
             "runId": "run-b-001",
@@ -303,7 +308,6 @@ The same data flow as Example 8, observed at runtime by an integration that can 
       }
     }
   },
-  "job": { "namespace": "airflow://prod", "name": "dag_b.task_1" },
   "inputs": [],
   "outputs": []
 }
@@ -316,12 +320,14 @@ A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in
 ```json
 {
   "eventType": "COMPLETE",
-  "run": {
-    "runId": "beam-run-77",
+  "run": { "runId": "beam-run-77" },
+  "job": {
+    "namespace": "beam://analytics",
+    "name": "enrichment_pipeline",
     "facets": {
       "lineage": {
         "_producer": "https://example.com/beam",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
         "entries": [
           { "namespace": "beam://analytics", "name": "enrichment_pipeline", "type": "JOB",
             "runId": "beam-run-77",
@@ -333,7 +339,6 @@ A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in
       }
     }
   },
-  "job": { "namespace": "beam://analytics", "name": "enrichment_pipeline" },
   "inputs": [],
   "outputs": []
 }
@@ -348,12 +353,14 @@ Reading specific columns from a structured table and writing to an unstructured 
 ```json
 {
   "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-012",
+  "run": { "runId": "abc-012" },
+  "job": {
+    "namespace": "analytics",
+    "name": "event_processor",
     "facets": {
       "lineage": {
         "_producer": "https://example.com/export",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
         "entries": [
           { "namespace": "file://", "name": "R.pdf", "type": "DATASET",
             "inputs": [
@@ -365,7 +372,6 @@ Reading specific columns from a structured table and writing to an unstructured 
       }
     }
   },
-  "job": { "namespace": "analytics", "name": "event_processor" },
   "inputs": [
     { "namespace": "postgres://prod", "name": "X" }
   ],

--- a/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageExamples.md
@@ -1,0 +1,333 @@
+# Explicit Lineage: Examples
+
+This file contains examples for [ExplicitLineageProposal.md](ExplicitLineageProposal.md). See [ExplicitLineageSchema.md](ExplicitLineageSchema.md) for the proposed schema.
+
+## 1. Dataset-level lineage on RunEvent (solves #4359)
+
+ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunFacet on the run:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-123",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/etl",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
+          { "namespace": "postgresql://warehouse:5432", "name": "table_d", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_b", "type": "DATASET" }] }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "http://etl-server:8080", "name": "bulk_etl" },
+  "inputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_a" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_b" }
+  ],
+  "outputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_c" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_d" }
+  ]
+}
+```
+
+`inputs`/`outputs` remain as the carrier for dataset facets, as the fallback for older consumers, and as the event boundary for the job's direct input/output participation.
+
+## 2. Column-level lineage on RunEvent (subsumes CLL)
+
+```json
+"run": {
+  "runId": "abc-123",
+  "facets": {
+    "lineage": {
+      "_producer": "...",
+      "_schemaURL": "...",
+      "entries": [
+        { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
+          "fields": {
+            "total": {
+              "inputs": [
+                { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
+                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## 3. Mixed granularity (dataset + column + dataset-wide ops)
+
+```json
+"entries": [
+  { "namespace": "postgresql://analytics:5432", "name": "output_X", "type": "DATASET",
+    "inputs": [
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" },
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "group_by_col",
+        "transformations": [{ "type": "INDIRECT", "subtype": "GROUP_BY" }] }
+    ],
+    "fields": {
+      "col1": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "col_a" }
+        ]
+      },
+      "col2": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+]
+```
+
+This single entry combines:
+- **Entity-level**: output_X comes from input_A
+- **Dataset-wide op**: group_by_col affects entire output
+- **Column mapping**: col_a -> col1
+- **Partial info**: col2 comes from input_A (source column unknown)
+
+## 4. Dataset-to-dataset (job-less, on DatasetEvent)
+
+A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dataset:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2026-03-25T10:00:00.000Z",
+  "dataset": {
+    "namespace": "postgresql://warehouse:5432",
+    "name": "public.customer_view",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageDatasetFacet.json",
+        "inputs": [
+          { "namespace": "postgresql://warehouse:5432", "name": "public.customers", "type": "DATASET" },
+          { "namespace": "postgresql://warehouse:5432", "name": "public.orders", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+}
+```
+
+> Note: no `namespace`/`name`/`type` on the facet itself — the target is implicit from the dataset it's attached to.
+
+## 5. Static job lineage (on JobEvent)
+
+A catalog declares what a job is designed to do. LineageJobFacet on the job:
+
+```json
+{
+  "job": {
+    "namespace": "http://airflow:8080",
+    "name": "daily_etl",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "postgresql://warehouse:5432", "name": "output_table", "type": "DATASET",
+            "inputs": [
+              { "namespace": "postgresql://warehouse:5432", "name": "source_table", "type": "DATASET" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "source_table" }],
+  "outputs": [{ "namespace": "postgresql://warehouse:5432", "name": "output_table" }]
+}
+```
+
+## 6. Data sink — job consumes data without tracked output
+
+A fraud detection job reads transactions and sends alerts, but doesn't write to any tracked dataset. No lineage facet entry is needed: the input dataset is consumed by the event's job because it appears in `inputs`, and there is no tracked output dataset for it to feed.
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-456"
+  },
+  "job": { "namespace": "validation", "name": "fraud_detector" },
+  "inputs": [
+    { "namespace": "postgres://prod", "name": "transactions" }
+  ],
+  "outputs": []
+}
+```
+
+Conceptually, the event still establishes:
+
+```
+transactions (DATASET) ──> fraud_detector (JOB)
+```
+
+That edge is implicit in the RunEvent boundary, not repeated in `LineageRunFacet`. 
+OpenLineage consumer may use that to visualize the relationship.
+
+## 7. Data generator — job produces data without tracked input
+
+An extract task pulls data from an external API (not modeled as a dataset) and writes to a table. No lineage facet entry is needed: the output dataset is produced by the event's job because it appears in `outputs`, and there is no tracked input dataset identified for it.
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-789"
+  },
+  "job": { "namespace": "airflow://prod", "name": "data_pipeline.extract_task" },
+  "inputs": [],
+  "outputs": [
+    { "namespace": "postgres://prod", "name": "extracted_data" }
+  ]
+}
+```
+
+Conceptually, the event still establishes:
+
+```
+extract_task (JOB) ──> extracted_data (DATASET)
+```
+
+That edge is implicit in the RunEvent boundary, not repeated with a `LineageJobInput`.
+
+## 8. Job-to-job — declared chain on JobEvent
+
+A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` via a non-materialized handoff. No intermediate dataset exists. The catalog declares the design-time data flow on the JobEvent for `dag_b`:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "dag_b",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+Note that `runId` is omitted on both ends — declared lineage describes the job definition, not a specific execution. The same shape would apply to a non-materialized view consumed by a downstream job, or to an Airflow task receiving data via XCom from an upstream task.
+
+## 9. Job-to-job — observed chain on RunEvent
+
+The same data flow as Example 8, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "run-b-001",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/airflow",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
+            "runId": "run-b-001",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB",
+                "runId": "run-a-042" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "airflow://prod", "name": "dag_b.task_1" },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+## 10. Job-to-job — cross-namespace chain
+
+A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in a separate Beam pipeline. Neither job is in the namespace of the other, and the topic is not modeled as a dataset. The Beam pipeline emits the cross-namespace chain on its RunEvent:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "beam-run-77",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/beam",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "beam://analytics", "name": "enrichment_pipeline", "type": "JOB",
+            "runId": "beam-run-77",
+            "inputs": [
+              { "namespace": "flink://ingest", "name": "event_normalizer", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "beam://analytics", "name": "enrichment_pipeline" },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+The source job (`flink://ingest/event_normalizer`) is in a different namespace from both the event's job and the target entry. Without explicit `(namespace, name)` on both ends, the chain could not be expressed.
+
+## 11. Structured-to-unstructured — known source columns, no target schema
+
+Reading specific columns from a structured table and writing to an unstructured file (e.g., a PDF). The target has no schema, so there is no `fields` map — but we can still express that the output came from specific source columns:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-012",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/export",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "file://", "name": "R.pdf", "type": "DATASET",
+            "inputs": [
+              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "A" },
+              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "B" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "analytics", "name": "event_processor" },
+  "inputs": [
+    { "namespace": "postgres://prod", "name": "X" }
+  ],
+  "outputs": [
+    { "namespace": "file://", "name": "R.pdf" }
+  ]
+}
+```

--- a/proposals/explicit_lineage_facet/ExplicitLineageGuide.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageGuide.md
@@ -195,7 +195,7 @@ new model. The `total` column of `output` aggregates `amount` from `input`:
             "total": {
               "inputs": [
                 { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
-                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
+                  "transformations": [{ "type": "DIRECT", "subtype": "AGGREGATION" }] }
               ]
             }
           }
@@ -266,7 +266,6 @@ A view derives from base tables with no job in the picture. Use
 
 ```json
 {
-  "eventType": "COMPLETE",
   "eventTime": "2026-03-25T10:00:00.000Z",
   "dataset": {
     "namespace": "postgresql://warehouse:5432",
@@ -382,7 +381,7 @@ stays `[]`, because there is still no tracked upstream dataset:
             "fields": {
               "total": {
                 "inputs": [
-                  { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+                  { "type": "JOB", "transformations": [{ "type": "DIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
                 ]
               }
             }
@@ -414,7 +413,6 @@ JobEvent it is the declared chain, with `runId` omitted:
 
 ```json
 {
-  "eventType": "COMPLETE",
   "job": {
     "namespace": "airflow://prod",
     "name": "dag_b",

--- a/proposals/explicit_lineage_facet/ExplicitLineageGuide.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageGuide.md
@@ -1,0 +1,560 @@
+# Explicit lineage facets: developer guide
+
+**Status**: Experimental  
+**Issue**: [OpenLineage#4359](https://github.com/OpenLineage/OpenLineage/issues/4359)
+
+---
+
+> Experimental
+>
+> This feature is experimental. It is a large change to how OpenLineage models
+> lineage, so we are still actively looking for feedback. We may merge the code
+> and the spec, and ship it as part of the OpenLineage libraries. We may also
+> change it or drop the idea altogether. If you have a use case, an objection or
+> a suggestion, please raise it on the issue.
+
+---
+
+This guide shows you how to declare data flow explicitly with the two proposed
+lineage facets. It walks through the model, the shared types, and worked
+examples for each pattern.
+
+Read the [proposal](ExplicitLineageProposal.md) for the design rationale, the
+[schema](ExplicitLineageSchema.md) for field-by-field definitions, and the
+[examples](ExplicitLineageExamples.md) for the full set of event samples.
+
+## What this solves
+
+OpenLineage infers dataset-level lineage from the cartesian product of `inputs`
+and `outputs` on a run. When a job reads A and B and writes C and D, the model
+infers four edges: A to C, A to D, B to C, and B to D. If the real flow is only
+A to C and B to D, half those edges are wrong.
+
+For a bulk ETL job that processes 10 independent tables in one run, most of the
+inferred graph is noise.
+
+`ColumnLineageDatasetFacet` solves this at column granularity. But many
+integrations know that table A feeds table C without knowing the column
+mapping, and there is no way to state that dataset-level fact without also
+claiming that A feeds D.
+
+The explicit lineage facets let you state the exact edges. They also cover
+patterns the current model cannot express at all: dataset-to-dataset derivation
+with no job, job-to-job data flow with no intermediate dataset, and mixed
+dataset- and column-level detail in one event.
+
+## The two facets
+
+You declare lineage with one of two facets. The event type decides which facet
+you use and how a consumer reads it.
+
+| Facet | Lives on | Event type | Semantics |
+|---|---|---|---|
+| `LineageJobFacet` | the job (`job.facets.lineage`) | RunEvent | data flow observed during this run, accumulative |
+| `LineageJobFacet` | the job (`job.facets.lineage`) | JobEvent | declared, static data flow for this job, replace |
+| `LineageDatasetFacet` | the dataset (`dataset.facets.lineage`) | DatasetEvent | structural derivation of this dataset, replace |
+
+Lineage is a property of the job, not of each run, so there is no separate
+run-level facet. `LineageJobFacet` is a job facet, and the `job` object appears
+on both RunEvent and JobEvent, so the same facet serves both. The event type
+tells a consumer whether to merge entries across events for a run (accumulative)
+or take the latest event as the whole picture (replace).
+
+`LineageDatasetFacet` sits on a dataset and describes what feeds into it. The
+target is implicit: it is the dataset the facet is attached to. This is the same
+position as `ColumnLineageDatasetFacet`, which it evolves.
+
+### Which facet to use
+
+Pick the facet from what you are doing:
+
+- you instrument a running job, such as Spark, Airflow, dbt or Flink: put `LineageJobFacet` on the job in your RunEvent, this is the most common case
+- you declare what a job is designed to do, from a catalog or metadata tool, with no specific run: put `LineageJobFacet` on the job in a JobEvent
+- you describe how a dataset derives from other datasets with no job involved, such as a view, an alias or manual documentation: put `LineageDatasetFacet` on the dataset in a DatasetEvent
+
+An event carries only one kind of lineage facet. You cannot mix
+`LineageJobFacet` and `LineageDatasetFacet` in the same event.
+
+## Building blocks
+
+Both facets are built from the same shared types.
+
+```
+LineageJobFacet          — lineage for a job (RunEvent and JobEvent)
+  └─ entries[]              — one entry per target entity
+
+LineageDatasetFacet      — lineage for a dataset (DatasetEvent)
+  ├─ inputs[]              — entity-level sources (LineageInput[])
+  └─ fields{}              — column-level sources (field name → LineageFieldEntry)
+
+LineageDatasetEntry      — a target that is a dataset
+  ├─ namespace, name        — identity of the target dataset
+  ├─ type = "DATASET"
+  ├─ inputs[]               — entity-level sources (LineageInput[])
+  └─ fields{}               — column-level sources (field name → LineageFieldEntry)
+
+LineageJobEntry          — a target that is a job
+  ├─ namespace, name        — identity of the target job, or omit both for the event's own job
+  ├─ type = "JOB"
+  ├─ runId                  — optional, binds the edge to a specific run
+  └─ inputs[]               — entity-level sources (LineageInput[])
+
+LineageFieldEntry        — column-level lineage for one target field
+  └─ inputs[]               — sources feeding this field (LineageInput[])
+
+LineageInput             — one source, either a dataset or a job
+  ├─ LineageDatasetInput      namespace, name, type="DATASET", field?, transformations?
+  └─ LineageJobInput          namespace?, name?, type="JOB", runId?, transformations?
+
+LineageTransformation    — how a source was transformed
+  ├─ type                   — DIRECT or INDIRECT
+  ├─ subtype                — for example IDENTITY, AGGREGATION, FILTER, JOIN, GROUP_BY
+  ├─ description            — human-readable text
+  └─ masking                — whether the transformation masks data, such as hashing personal data
+```
+
+Lineage is always written from the target's point of view. An entry names a
+target and lists the inputs that feed into it. It never lists the outputs the
+target feeds. This holds for dataset targets and job targets alike, and it
+matches how `ColumnLineageDatasetFacet` already works.
+
+### Dataset sources and job sources
+
+The `type` field discriminates a source or a target between a dataset and a job:
+
+- `DATASET` names a table, file, topic or similar, this is the common case
+- `JOB` names a job, used for job-to-job chains and for adding transformation detail to the event's own job
+
+A `JOB` source or target identifies the job by `namespace` and `name`. Omitting
+both means the event's own job. The next sections show when each form applies.
+
+## Examples
+
+The examples below cover each capability. The
+[examples file](ExplicitLineageExamples.md) holds the full set as complete
+events.
+
+### Dataset-level lineage
+
+A bulk ETL job reads `table_a` and `table_b` and writes `table_c` and
+`table_d`. The real flow is only A to C and B to D. `LineageJobFacet` on the job
+states the two edges:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": { "runId": "abc-123" },
+  "job": {
+    "namespace": "http://etl-server:8080",
+    "name": "bulk_etl",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/etl",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
+          { "namespace": "postgresql://warehouse:5432", "name": "table_d", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_b", "type": "DATASET" }] }
+        ]
+      }
+    }
+  },
+  "inputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_a" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_b" }
+  ],
+  "outputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_c" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_d" }
+  ]
+}
+```
+
+The facet has one entry per output dataset, and each names its own source. There
+is no cartesian product. The `inputs` and `outputs` arrays stay in place: they
+carry the dataset facets, such as schema and quality, and they let older
+consumers still see every dataset involved.
+
+### Column-level lineage
+
+This is the capability `ColumnLineageDatasetFacet` provides, expressed in the
+new model. The `total` column of `output` aggregates `amount` from `input`:
+
+```json
+"job": {
+  "namespace": "http://etl-server:8080",
+  "name": "analytics_etl",
+  "facets": {
+    "lineage": {
+      "_producer": "...",
+      "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+      "entries": [
+        { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
+          "fields": {
+            "total": {
+              "inputs": [
+                { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
+                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Mixed granularity
+
+One entry can hold dataset-level, dataset-wide and column-level detail at the
+same time. You provide what you know:
+
+```json
+"entries": [
+  { "namespace": "postgresql://analytics:5432", "name": "output_X", "type": "DATASET",
+    "inputs": [
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" },
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "group_by_col",
+        "transformations": [{ "type": "INDIRECT", "subtype": "GROUP_BY" }] }
+    ],
+    "fields": {
+      "col1": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "col_a" }
+        ]
+      },
+      "col2": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+]
+```
+
+This one entry states four things:
+
+- entity-level: `output_X` comes from `input_A`
+- dataset-wide operation: `group_by_col` affects the whole output
+- column mapping: `col_a` feeds `col1`
+- partial detail: `col2` comes from `input_A`, but the source column is unknown
+
+The granularity comes from two choices: whether the target is a whole dataset or
+a named field, and whether the source names a field. The table below reads each
+row as `target <- source`.
+
+| Target | Source | Source field | Meaning | Example |
+|---|---|---|---|---|
+| dataset | dataset | no | dataset-level lineage | `output_table <- input_table` |
+| dataset | dataset | yes | dataset-wide operation, such as GROUP BY | `output_table <- input.group_by_col` |
+| dataset field | dataset | yes | column-level lineage | `output.total <- input.amount` |
+| dataset field | dataset | no | partial column lineage, source column unknown | `output.region <- lookup_table` |
+| dataset | job, identified | — | dataset produced from a named upstream job | `output_table <- dag_a.task_3` |
+| dataset field | own job, no identity | — | field produced by the event's own job, with transformation detail | `extracted_data.total <- sum() by own job` |
+| job | dataset | no | named target job consumes a whole dataset | `dag_b.task_1 <- transactions` |
+| job | dataset | yes | named target job consumes specific columns | `dag_b.task_1 <- transactions.amount` |
+| own job, no identity | dataset | — | dataset consumed by the event's own job, with transformation detail | `own job <- transactions (FILTER)` |
+| job | job | — | job-to-job chain, no intermediate dataset | `dag_b.task_1 <- dag_a.task_3` |
+
+### Dataset-to-dataset derivation, no job
+
+A view derives from base tables with no job in the picture. Use
+`LineageDatasetFacet` on the dataset in a DatasetEvent:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2026-03-25T10:00:00.000Z",
+  "dataset": {
+    "namespace": "postgresql://warehouse:5432",
+    "name": "public.customer_view",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageDatasetFacet.json",
+        "inputs": [
+          { "namespace": "postgresql://warehouse:5432", "name": "public.customers", "type": "DATASET" },
+          { "namespace": "postgresql://warehouse:5432", "name": "public.orders", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+}
+```
+
+The facet has no `namespace`, `name` or `type`. The target is the dataset it is
+attached to. This is what makes it the natural facet: you describe the entity
+the facet sits on.
+
+### Declared job lineage
+
+A catalog states what a job is designed to do, without running it. Use
+`LineageJobFacet` on the job in a JobEvent:
+
+```json
+{
+  "job": {
+    "namespace": "http://airflow:8080",
+    "name": "daily_etl",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "postgresql://warehouse:5432", "name": "output_table", "type": "DATASET",
+            "inputs": [
+              { "namespace": "postgresql://warehouse:5432", "name": "source_table", "type": "DATASET" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "source_table" }],
+  "outputs": [{ "namespace": "postgresql://warehouse:5432", "name": "output_table" }]
+}
+```
+
+A JobEvent uses replace semantics: the latest event is the complete declared
+lineage for the job. The typical producers are data catalogs, metadata import
+tools and manual documentation systems.
+
+### Sinks and generators
+
+A sink is a job that reads data but writes no tracked dataset, such as a fraud
+detector that reads transactions and sends alerts. A generator is the inverse: a
+job that produces data with no tracked input, such as an extract task that pulls
+from an external API.
+
+You do not need a lineage facet for the plain cases. Event membership already
+carries them:
+
+- an input dataset that no entry references is consumed by the event's own job
+- an output dataset that no entry describes is produced by the event's own job
+
+So a sink is just `inputs` with an empty `outputs`:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": { "runId": "abc-456" },
+  "job": { "namespace": "validation", "name": "fraud_detector" },
+  "inputs": [{ "namespace": "postgres://prod", "name": "transactions" }],
+  "outputs": []
+}
+```
+
+This still establishes the edge `transactions (DATASET) -> fraud_detector (JOB)`.
+The edge is implicit in the event boundary, not repeated in a facet. A generator
+is the mirror image: empty `inputs`, one entry in `outputs`.
+
+Adding a `LineageJobEntry` for the event's own job here would only restate what
+the event already carries, so do not do it.
+
+### Enriched generator: transformation detail on the event's own job
+
+A generator often knows how it produced a column, even with no tracked upstream
+dataset. Here an extract task derives `total` with a `sum()` over an untracked
+API response.
+
+To record that, a field's input names an identity-less `LineageJobInput`: a
+`{ "type": "JOB" }` source with no `namespace` or `name`. It resolves to the
+event's own job and carries the transformation. The entry's top-level `inputs`
+stays `[]`, because there is still no tracked upstream dataset:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": { "runId": "abc-789" },
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "data_pipeline.extract_task",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/extract",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
+            "inputs": [],
+            "fields": {
+              "total": {
+                "inputs": [
+                  { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [],
+  "outputs": [{ "namespace": "postgres://prod", "name": "extracted_data" }]
+}
+```
+
+The implicit edge from the job to `extracted_data` is unchanged. The
+identity-less input only adds the per-column transformation that event
+membership cannot express. The sink case works the same way in reverse: an
+identity-less `LineageJobEntry` adds transformation detail for data the job
+consumes.
+
+### Job-to-job chains
+
+Some data flows through a job that you cannot recover from `inputs`, `outputs`
+and the event's own job. The intermediate may be a non-materialized view, a
+stored procedure calling a function, in-memory passing such as Airflow XCom, or a
+streaming handoff through an unmodelled topic.
+
+A `LineageJobEntry` with a `LineageJobInput` states direct job-to-job flow. On a
+JobEvent it is the declared chain, with `runId` omitted:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "dag_b",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+On a RunEvent, an integration that can identify the runs on each end populates
+`runId` to bind the chain to specific executions. Either job may be in a
+different namespace from the event's own job, so the explicit `namespace` and
+`name` on both ends are load-bearing: these chains cannot be rebuilt from the
+event's own job field.
+
+## Semantic rules
+
+### One lineage facet per event
+
+An event carries lineage in one facet only. A RunEvent or JobEvent uses
+`LineageJobFacet` on the job. A DatasetEvent uses `LineageDatasetFacet` on the
+dataset. `LineageDatasetFacet` must not appear on a RunEvent or JobEvent, and
+`LineageJobFacet` must not appear on a DatasetEvent.
+
+### Keep populating inputs and outputs
+
+Producers must keep populating `inputs` and `outputs`, and must include every
+dataset referenced in a lineage facet. These arrays do three things a lineage
+facet does not:
+
+- carry the dataset facets, such as schema, ownership and quality, which attach to input and output datasets and not to lineage edges
+- let older consumers see every dataset involved
+- define the event-job boundary, so dangling inputs and outputs map to the event's own job
+
+When a lineage facet is present, these arrays are not a dataset-to-dataset
+lineage source. A consumer must not infer the cartesian product from them.
+
+### Provide at least one of inputs or fields
+
+An entry, or `LineageDatasetFacet` itself, should have at least one of `inputs`
+or `fields`. An entry with neither is valid but carries no lineage.
+
+### An empty inputs array is meaningful
+
+`"inputs": []` states that the entity has no upstream source. This differs from
+the entity not appearing in lineage at all, which falls back to the cartesian
+product, and from `inputs` being absent, where the entry gives only column-level
+detail through `fields`.
+
+### Semantics follow the event type
+
+The same `LineageJobFacet` reads differently depending on its event:
+
+- on a RunEvent it is accumulative, each event adds to the run's picture and a consumer merges entries across events for the same `runId`, and it describes data flow observed during the run
+- on a JobEvent it uses replace, the latest event is the complete declared lineage for the job
+- `LineageDatasetFacet` on a DatasetEvent also uses replace, the latest event is the complete derivation of the dataset
+
+### Job entries express data flow only
+
+A `type: JOB` source or target expresses data flow. Scheduling and control-flow
+dependencies stay in `JobDependenciesRunFacet`. Containment stays in
+`ParentRunFacet`. Omitting `namespace` and `name` together means the event's own
+job, and you may use that form only to add transformation detail, never to
+restate an edge the event boundary already carries. Emit `namespace` and `name`
+together or omit them together.
+
+## Precedence rules for consumers
+
+During the transition, one event may carry a lineage facet,
+`ColumnLineageDatasetFacet` and `inputs`/`outputs` at once. Read them in this
+order:
+
+1. If a lineage facet is present, take it as the complete explicit lineage between tracked entities. Do not infer extra dataset-to-dataset edges from `inputs`/`outputs` or from `ColumnLineageDatasetFacet`.
+2. Read the event's own job from `inputs` and `outputs`. A dangling input is consumed by the event's job, and a dangling output is produced by it. These boundary edges do not create a cartesian product.
+3. If no lineage facet is present, use `ColumnLineageDatasetFacet` on output datasets where available, then fall back to the cartesian product of inputs and outputs.
+4. If a lineage facet and `ColumnLineageDatasetFacet` both describe the same output dataset, the lineage facet wins.
+
+## How this relates to existing facets
+
+### ParentRunFacet
+
+`ParentRunFacet` expresses containment and hierarchy: task X is part of DAG Y.
+Lineage facets express data flow. The two are orthogonal, and a consumer
+combines both. The optional `runId` on job entries and inputs identifies which
+execution an edge refers to, not a parent-child link between runs.
+
+### JobDependenciesRunFacet
+
+`JobDependenciesRunFacet` expresses scheduling and control flow: task B waits for
+task A. Lineage facets express data flow: task B receives data from table X. A
+job can have one without the other, so the two facets are complementary.
+
+### ColumnLineageDatasetFacet
+
+`LineageDatasetFacet` supersedes `ColumnLineageDatasetFacet`. It expresses
+everything the column-lineage facet does, plus dataset-level lineage and mixed
+granularity. During the transition both may appear on one event, and the lineage
+facet takes precedence.
+
+## Migration and compatibility
+
+Adding these facets is a non-breaking change. The facets are optional, so
+existing producers, consumers and validators keep working.
+
+The client libraries will translate between the old model
+(`inputs`/`outputs`/`ColumnLineageDatasetFacet`) and the new facets, so
+producers and consumers do not have to change at the same time. A configuration
+option controls it:
+
+```
+openlineage.lineage.compatibility = none | legacy | modern | both
+```
+
+| Mode | Producer emits | Client generates | Use case |
+|---|---|---|---|
+| `none` | whatever it wants | nothing | full control |
+| `legacy` | lineage facets | inputs, outputs, column lineage | new producer, old consumers |
+| `modern` | inputs, outputs, column lineage | lineage facets | old producer, new consumers |
+| `both` | either or both | whichever is missing | transition period, the default |
+
+Forward translation to the old model is lossy. Dataset-level inputs with no
+field, field entries whose source has no field, and identity-less job inputs
+cannot be represented in `ColumnLineageDatasetFacet`. Reverse translation from
+the old model is lossless, because column lineage is a subset of what the
+lineage facets express. Translation applies to RunEvent and JobEvent only. For a
+DatasetEvent, `LineageDatasetFacet` is the only representation.
+
+The transition should be generous, measured in years. See the
+[proposal](ExplicitLineageProposal.md) for the full translation mapping and the
+producer and consumer strategies.

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -1,0 +1,840 @@
+# Proposal: Explicit Lineage — Facet-Based Approach
+
+**Issue**: [OpenLineage#4359](https://github.com/OpenLineage/OpenLineage/issues/4359)  
+**Status**: Draft  
+**Date**: 2026-04-02
+
+---
+
+## Problem Statement
+
+OpenLineage's current model infers dataset-level lineage from the cartesian product of inputs x outputs on a run. When a single job reads datasets A,B and writes to C,D, the inferred lineage is {A,B} -> {C,D} — four edges. If the real flow is only A -> C and B -> D, two of those edges are false positives. For a bulk ETL job processing 10 independent tables, the lineage graph becomes 90% false positives.
+
+The existing `ColumnLineageDatasetFacet` (CLL) solves this at column granularity, but leaves a gap at dataset granularity: integrators often know "Table A derived Table B" without column-level detail. If they can't provide CLL, they fall back to the cartesian product.
+
+Additionally, the current model cannot express:
+
+- **Dataset-to-dataset derivation** — no mechanism for views, aliases, or manually documented lineage without an intermediate job
+- **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level for some outputs and column-level for others
+- **Job-to-job data flow** — no way to express that one job feeds data to another without an intermediate dataset (e.g., non-materialized views, stored procedures calling functions, in-memory data passing)
+
+## Goals
+
+**Narrow goal**: Enable producers to explicitly define which inputs feed which outputs at dataset granularity, solving the false-positive problem.
+
+**Wide goal**: Create a unified lineage structure that handles dataset-level, column-level, and dataset-to-dataset lineage in a single model — eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future (e.g., job-to-job data flow) without requiring new facets or model changes.
+
+This proposal aims for the wide goal, as the incremental effort over the narrow goal is small and the payoff is large. Full job-to-job data flow chains are out of scope for this initial version, but `type: JOB` is supported for **sink and generator** use cases — jobs that consume data without a tracked output, or produce data without a tracked input. The design accommodates full job-to-job lineage as a future extension (see [Future Evolution](#future-evolution)).
+
+## Why Facets Instead of a Top-Level Property
+
+The top-level proposal places lineage as a top-level `lineage` array on `BaseEvent`. This is semantically clean, but working group members raised concerns about changing the model shape:
+
+> **Julien**: "Unless we have a strong reason to change the mechanism... I think we should avoid creating situations where we have 2 ways to do the same thing. Could you describe an alternative design where this is captured in facets?"
+
+> **Nelson**: "I was the initial proposer of the new top level property, but with the current state of the facet approach, I find it indifferent. All cases seem to be covered by a datasetLineage facet."
+
+The facet-based approach preserves the exact same semantics and capabilities as the top-level property, but works within the existing extensibility mechanism (facets) instead of adding a new top-level field. The trade-off: we need three facets (one per entity type) with semantic restrictions on which event type each appears in.
+
+## Proposed Solution
+
+We introduce three new facets — **LineageRunFacet**, **LineageJobFacet**, and **LineageDatasetFacet** — each carrying explicit lineage information and each restricted (by spec text, not JSON Schema) to a single event type:
+
+| Facet | Entity it lives on | Allowed event type | Semantics |
+|---|---|---|---|
+| `LineageRunFacet` | Run | RunEvent only | Observed data flow during this specific run |
+| `LineageJobFacet` | Job | JobEvent only | Declared/static data flow for this job definition |
+| `LineageDatasetFacet` | Dataset | DatasetEvent only | Structural derivation of this dataset (views, aliases, manual docs) |
+
+**Why the one-facet-per-event-type restriction?** If a RunEvent carried both a LineageRunFacet (on the run) and LineageDatasetFacet (on output datasets), the semantics would be ambiguous — which takes precedence? Do they merge? Rather than define complex interaction rules, we disallow the combination entirely. Each event type has exactly one place where lineage lives.
+
+This restriction may be relaxed in a future version with clear type-of-lineage or hierarchy semantics defined (see [Future Evolution](#future-evolution)).
+
+**LineageDatasetFacet** is the natural one. It sits on an output dataset and describes what feeds into that specific dataset — the same position as CLL. The target entity is implicit (the dataset the facet is attached to). This is a direct evolution of CLL.
+
+**LineageRunFacet** and **LineageJobFacet** are the pragmatic ones. They sit on the run/job entity but describe relationships between other entities (datasets). This is unusual for a facet — normally a facet describes properties of the entity it's on. But it works because the event type provides the semantic frame: "during this run, data flowed this way" or "this job is designed to move data this way."
+
+
+## Proposed Schema
+
+### LineageDatasetFacet (DatasetFacet)
+
+The natural facet. Lives on datasets in DatasetEvent. The target entity is implicit — it's the dataset the facet is attached to.
+
+```json
+"LineageDatasetFacet": {
+  "type": "object",
+  "description": "Explicit lineage for this dataset. Describes which source entities feed into it, at entity and/or column granularity. Supersedes ColumnLineageDatasetFacet.",
+  "allOf": [{ "$ref": "#/$defs/DatasetFacet" }],
+  "properties": {
+    "inputs": {
+      "type": "array",
+      "description": "Dataset-level source inputs. When a source includes a 'field' property, it represents a dataset-wide operation (e.g., GROUP BY) where that source column affects the entire target dataset.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    },
+    "fields": {
+      "type": "object",
+      "description": "Column-level lineage. Maps target field names to their source inputs.",
+      "additionalProperties": {
+        "$ref": "#/$defs/LineageFieldEntry"
+      }
+    }
+  }
+}
+```
+
+> Note: no `namespace`, `name`, or `type` on this facet — the target is the dataset it's attached to.
+
+
+### LineageRunFacet (RunFacet)
+
+Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail.
+
+```json
+"LineageRunFacet": {
+  "type": "object",
+  "description": "Explicit lineage observed during this run. Describes data flow between entities at entity and/or column granularity.",
+  "allOf": [{ "$ref": "#/$defs/RunFacet" }],
+  "properties": {
+    "lineage": {
+      "type": "array",
+      "description": "Lineage entries describing data flow observed during this run.",
+      "items": {
+        "$ref": "#/$defs/LineageEntry"
+      }
+    }
+  },
+  "required": ["lineage"]
+}
+```
+
+### LineageJobFacet (JobFacet)
+
+Lives on the job object in JobEvent. Same structure as LineageRunFacet.
+
+```json
+"LineageJobFacet": {
+  "type": "object",
+  "description": "Explicit lineage declared for this job definition. Describes designed/static data flow at entity and/or column granularity.",
+  "allOf": [{ "$ref": "#/$defs/JobFacet" }],
+  "properties": {
+    "lineage": {
+      "type": "array",
+      "description": "Lineage entries describing data flow designed for this job.",
+      "items": {
+        "$ref": "#/$defs/LineageEntry"
+      }
+    }
+  },
+  "required": ["lineage"]
+}
+```
+
+### Shared Types
+
+#### LineageEntry (discriminated union)
+
+Used by LineageRunFacet and LineageJobFacet. Each entry describes ONE target entity and what feeds into it. The `type` field discriminates between dataset targets and job targets:
+
+```json
+"LineageEntry": {
+  "oneOf": [
+    { "$ref": "#/$defs/LineageDatasetEntry" },
+    { "$ref": "#/$defs/LineageJobEntry" }
+  ]
+}
+```
+
+The `enum` constraint on each subtype's `type` field (`"DATASET"` or `"JOB"`) ensures only one branch can match during validation.
+
+#### LineageDatasetEntry
+
+A lineage target that is a dataset. Supports both entity-level and column-level lineage:
+
+```json
+"LineageDatasetEntry": {
+  "type": "object",
+  "description": "Describes data flowing into a target dataset from source entities, at entity and/or column granularity.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the target dataset"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the target dataset"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["DATASET"],
+      "description": "Must be DATASET"
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Entity-level source inputs. Each item is a LineageInput (dataset or job).",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    },
+    "fields": {
+      "type": "object",
+      "description": "Column-level lineage. Maps target field names to their source inputs.",
+      "additionalProperties": {
+        "$ref": "#/$defs/LineageFieldEntry"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+#### LineageJobEntry
+
+A lineage target that is a job. Used for **sink** scenarios where a job consumes data without producing a tracked output dataset. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
+
+```json
+"LineageJobEntry": {
+  "type": "object",
+  "description": "Describes data flowing into a target job (sink). Used when a job consumes data without producing a tracked output dataset.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the target job"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the target job"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["JOB"],
+      "description": "Must be JOB"
+    },
+    "runId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. The specific run ID of the target job, when the lineage is tied to a particular execution."
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Source inputs feeding into this job.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+#### LineageFieldEntry
+
+```json
+"LineageFieldEntry": {
+  "type": "object",
+  "description": "Column-level lineage for a single target field.",
+  "properties": {
+    "inputs": {
+      "type": "array",
+      "description": "Source entities and/or fields that feed into this target field.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    }
+  },
+  "required": ["inputs"]
+}
+```
+
+#### LineageInput (discriminated union)
+
+A source entity that feeds data into a lineage target. The `type` field discriminates between dataset sources and job sources:
+
+```json
+"LineageInput": {
+  "oneOf": [
+    { "$ref": "#/$defs/LineageDatasetInput" },
+    { "$ref": "#/$defs/LineageJobInput" }
+  ]
+}
+```
+
+Same pattern — the `enum` on each subtype's `type` field disambiguates.
+
+#### LineageDatasetInput
+
+A source input that is a dataset. Supports optional field reference and transformations:
+
+```json
+"LineageDatasetInput": {
+  "type": "object",
+  "description": "A source dataset that feeds data into a lineage target.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the source dataset"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the source dataset"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["DATASET"],
+      "description": "Must be DATASET"
+    },
+    "field": {
+      "type": "string",
+      "description": "The specific field/column of the source dataset. Optional — when omitted at column level, means 'source column unknown'."
+    },
+    "transformations": {
+      "type": "array",
+      "description": "Transformations applied to the source data. Same structure as ColumnLineageDatasetFacet.",
+      "items": {
+        "$ref": "#/$defs/LineageTransformation"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+#### LineageJobInput
+
+A source input that is a job. Used for **generator** scenarios where a job produces data without a tracked input dataset, or for job-to-job data flow. Supports an optional `runId` to tie to a specific execution:
+
+```json
+"LineageJobInput": {
+  "type": "object",
+  "description": "A source job that feeds data into a lineage target. Used when data comes from another job without an intermediate tracked dataset.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the source job"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the source job"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["JOB"],
+      "description": "Must be JOB"
+    },
+    "runId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution."
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+#### LineageTransformation
+
+Reuses the existing CLL transformation structure:
+
+```json
+"LineageTransformation": {
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "DIRECT or INDIRECT"
+    },
+    "subtype": {
+      "type": "string",
+      "description": "E.g., IDENTITY, AGGREGATION, FILTER, JOIN, etc."
+    },
+    "description": {
+      "type": "string"
+    },
+    "masking": {
+      "type": "boolean"
+    }
+  },
+  "required": ["type"]
+}
+```
+
+## Why `type: JOB` Is Needed: Sinks and Generators
+
+The current OpenLineage model assumes every lineage edge connects **dataset to dataset**, with a job in the middle. But two common cases break this assumption:
+
+### Sinks: jobs that consume data without a tracked output
+
+A **sink** is a job that reads data but doesn't write to any tracked dataset — for example, a fraud detection job that reads a `transactions` table, runs validation, and sends alerts (not modeled as a dataset). In the current spec this produces `inputs: [transactions], outputs: []` — no lineage edge exists because there's nothing to connect the input *to*. The data consumption is invisible in the lineage graph.
+
+With `type: JOB` as a lineage **target** (`LineageJobEntry`), we can express: "data flows into the fraud_detector job itself." The job becomes the terminal node:
+
+```
+transactions (DATASET) ──> fraud_detector (JOB)
+```
+
+### Generators: jobs that produce data without a tracked input
+
+A **generator** is the inverse: a job that produces data without reading from any tracked dataset — for example, an extract task that pulls from an external API and passes data in-memory to the next processing step. With `type: JOB` as a lineage **source** (`LineageJobInput`), we can express: "the data flowing into this dataset came from the extract_task job":
+
+```
+extract_task (JOB) ──> transformed_data (DATASET)
+```
+
+### Alternatives considered
+
+Without `type: JOB`, the alternatives are all problematic:
+
+- **Fake temporary datasets** — pollutes the catalog with entities that don't exist; requires two independent jobs to agree on the same fake dataset name
+- **Leave it out of the lineage facet** — this is a **regression**, not an acceptable trade-off. The current spec already captures sink/generator relationships implicitly through the `inputs`/`outputs` arrays. A new explicit lineage model that loses information the old model could express is strictly worse. We should not ship a feature that degrades existing capabilities.
+- **Rely on inputs/outputs arrays for the missing edges** — forces consumers to inspect both the lineage facet AND inputs/outputs for a complete picture, defeating the purpose of explicit lineage as the single source of truth
+
+By allowing `type: JOB` in lineage entries, the lineage facet remains **self-contained and complete**. Note that full job-to-job data flow chains (job -> job -> job) are out of scope for this version — `type: JOB` is scoped to sink and generator patterns only.
+
+## Granularity Matrix
+
+The combination of entry type, field presence on targets, and field presence on sources enables all granularity levels:
+
+**Dataset targets (`type: DATASET`):**
+
+| Target has fields? | Source has field? | Meaning | Example |
+|---|---|---|---|
+| — (entity-level inputs) | No | Dataset-level lineage | `output_table <- input_table` |
+| — (entity-level inputs) | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
+| Yes (in fields map) | Yes | Column-level lineage | `output.total <- input.amount` |
+| Yes (in fields map) | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
+
+**Job targets (`type: JOB`) — sinks:**
+
+| Source type | Meaning | Example |
+|---|---|---|
+| DATASET (no field) | Job consumes entire dataset | `fraud_detector <- transactions` |
+| DATASET (with field) | Job consumes specific columns | `fraud_detector <- transactions.amount` |
+
+**Job sources (`type: JOB`) — generators:**
+
+| Target type | Meaning | Example |
+|---|---|---|
+| DATASET | Dataset produced by upstream job | `output_table <- extract_task` |
+
+## Examples
+
+### 1. Dataset-level lineage on RunEvent (solves #4359)
+
+ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunFacet on the run:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-123",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/etl",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "lineage": [
+          { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
+          { "namespace": "postgresql://warehouse:5432", "name": "table_d", "type": "DATASET",
+            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_b", "type": "DATASET" }] }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "http://etl-server:8080", "name": "bulk_etl" },
+  "inputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_a" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_b" }
+  ],
+  "outputs": [
+    { "namespace": "postgresql://warehouse:5432", "name": "table_c" },
+    { "namespace": "postgresql://warehouse:5432", "name": "table_d" }
+  ]
+}
+```
+
+`inputs`/`outputs` remain as the carrier for dataset facets and as the fallback for older consumers. The LineageRunFacet defines the actual data flow for newer consumers.
+
+### 2. Column-level lineage on RunEvent (subsumes CLL)
+
+```json
+"run": {
+  "runId": "abc-123",
+  "facets": {
+    "lineage": {
+      "_producer": "...",
+      "_schemaURL": "...",
+      "lineage": [
+        { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
+          "fields": {
+            "total": {
+              "inputs": [
+                { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
+                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### 3. Mixed granularity (dataset + column + dataset-wide ops)
+
+```json
+"lineage": [
+  { "namespace": "postgresql://analytics:5432", "name": "output_X", "type": "DATASET",
+    "inputs": [
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" },
+      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "group_by_col",
+        "transformations": [{ "type": "INDIRECT", "subtype": "GROUP_BY" }] }
+    ],
+    "fields": {
+      "col1": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "col_a" }
+        ]
+      },
+      "col2": {
+        "inputs": [
+          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+]
+```
+
+This single entry combines:
+- **Entity-level**: output_X comes from input_A
+- **Dataset-wide op**: group_by_col affects entire output
+- **Column mapping**: col_a -> col1
+- **Partial info**: col2 comes from input_A (source column unknown)
+
+### 4. Dataset-to-dataset (job-less, on DatasetEvent)
+
+A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dataset:
+
+```json
+{
+  "dataset": {
+    "namespace": "postgresql://warehouse:5432",
+    "name": "public.customer_view",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageDatasetFacet.json",
+        "inputs": [
+          { "namespace": "postgresql://warehouse:5432", "name": "public.customers", "type": "DATASET" },
+          { "namespace": "postgresql://warehouse:5432", "name": "public.orders", "type": "DATASET" }
+        ]
+      }
+    }
+  }
+}
+```
+
+> Note: no `namespace`/`name`/`type` on the facet itself — the target is implicit from the dataset it's attached to.
+
+### 5. Static job lineage (on JobEvent)
+
+A catalog declares what a job is designed to do. LineageJobFacet on the job:
+
+```json
+{
+  "job": {
+    "namespace": "http://airflow:8080",
+    "name": "daily_etl",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "lineage": [
+          { "namespace": "postgresql://warehouse:5432", "name": "output_table", "type": "DATASET",
+            "inputs": [
+              { "namespace": "postgresql://warehouse:5432", "name": "source_table", "type": "DATASET" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "source_table" }],
+  "outputs": [{ "namespace": "postgresql://warehouse:5432", "name": "output_table" }]
+}
+```
+
+### 6. Data sink — job consumes data without tracked output
+
+A fraud detection job reads transactions and sends alerts, but doesn't write to any tracked dataset. The job itself is the lineage target:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-456",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/validation",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "lineage": [
+          { "namespace": "validation", "name": "fraud_detector", "type": "JOB",
+            "inputs": [
+              { "namespace": "postgres://prod", "name": "transactions", "type": "DATASET" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "validation", "name": "fraud_detector" },
+  "inputs": [
+    { "namespace": "postgres://prod", "name": "transactions" }
+  ],
+  "outputs": []
+}
+```
+
+### 7. Data generator — job produces data without tracked input
+
+An extract task pulls data from an external API (not modeled as a dataset) and writes to a table. The upstream job is the lineage source:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-789",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/etl",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "lineage": [
+          { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "data_pipeline.extract_task", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "airflow://prod", "name": "data_pipeline.extract_task" },
+  "inputs": [],
+  "outputs": [
+    { "namespace": "postgres://prod", "name": "extracted_data" }
+  ]
+}
+```
+
+### 8. Structured-to-unstructured — known source columns, no target schema
+
+Reading specific columns from a structured table and writing to an unstructured file (e.g., a PDF). The target has no schema, so there is no `fields` map — but we can still express that the output came from specific source columns:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "abc-012",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/export",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "lineage": [
+          { "namespace": "file://", "name": "R.pdf", "type": "DATASET",
+            "inputs": [
+              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "A" },
+              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "B" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "analytics", "name": "event_processor" },
+  "inputs": [
+    { "namespace": "postgres://prod", "name": "X" }
+  ],
+  "outputs": [
+    { "namespace": "file://", "name": "R.pdf" }
+  ]
+}
+```
+
+## How the Three Facets Map to the Top-Level Proposal
+
+The facet-based approach is a structural reshuffling of the top-level proposal, not a semantic change:
+
+| Top-level proposal | Facet proposal | Difference |
+|---|---|---|
+| `event.lineage[]` on RunEvent | `event.run.facets.lineage.lineage[]` | Deeper nesting, lives on run entity |
+| `event.lineage[]` on JobEvent | `event.job.facets.lineage.lineage[]` | Deeper nesting, lives on job entity |
+| `event.lineage[]` on DatasetEvent | `event.dataset.facets.lineage.{inputs,fields}` | Flattened — target is implicit |
+| Semantic constraints per event type | Built into the facet type itself | Same semantics, different enforcement |
+
+The capabilities and extensibility are identical — both approaches can express the same lineage information and accommodate the same future extensions.
+
+## Precedence Rules
+
+1. **If a lineage facet is present on the event**, it is the complete picture of lineage for that event. Consumers should derive all lineage edges from the facet and should not infer additional edges from `inputs`/`outputs` arrays or CLL facets. The `inputs`/`outputs` arrays remain as dataset facet carriers and backward-compatibility fallback, but are not a lineage source when a lineage facet is present.
+2. **If no lineage facet is present**: use CLL on output datasets if available, then fall back to cartesian product of inputs x outputs (current behavior unchanged).
+3. **If both a lineage facet and CLL are present** for the same output dataset, the lineage facet takes precedence.
+
+## Semantic Constraints
+
+These constraints are documented in spec text rather than enforced by JSON Schema. They are intentionally conservative — motivated by keeping lineage cohesive within a single event and avoiding the need to define interaction/precedence rules between multiple lineage facets. Any of these restrictions may be relaxed in a future version if use cases emerge; the current goal is to keep the initial proposal simple and unambiguous.
+
+1. **One lineage facet per event**: A single event MUST NOT carry more than one type of lineage facet. A RunEvent uses LineageRunFacet; a JobEvent uses LineageJobFacet; a DatasetEvent uses LineageDatasetFacet. Mixing them is forbidden.
+
+2. **Event type restriction**: LineageRunFacet MUST only appear on RunEvent. LineageJobFacet MUST only appear on JobEvent. LineageDatasetFacet MUST only appear on DatasetEvent.
+
+3. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets and the fallback for older consumers.
+
+4. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
+
+5. At least one of `inputs` or `fields` SHOULD be present on a LineageDatasetEntry (or on LineageDatasetFacet directly). For LineageJobEntry, `inputs` SHOULD be present.
+
+6. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
+
+7. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
+
+8. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
+
+9. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
+
+10. **`type: JOB` scope**: In this version, `type: JOB` is supported for sink and generator patterns only — a job as the terminal target of data flow, or a job as the origin source of data flow. Full job-to-job data flow chains (job -> job) are reserved for a future version.
+
+## Interaction with Existing Features
+
+### ParentRunFacet (hierarchy)
+
+Remains orthogonal. Hierarchy expresses containment and scheduling (task X is part of DAG Y). Lineage facets express data flow. A consumer combines both dimensions.
+
+### JobDependenciesRunFacet (control flow)
+
+Remains as-is for scheduling and control flow dependencies. Lineage facets express DATA flow dependencies. Spec prose documents the distinction: a job may depend on another job for scheduling (control flow) without having a data dependency, and vice versa. In the future, job-to-job data flow might be added to the lineage facet model.
+
+### inputs[] / outputs[] arrays
+
+Remain as-is. They serve two purposes that lineage facets do not replace:
+
+- **Dataset facet carrier**: Dataset facets (schema, ownership, data quality, etc.) are attached to InputDataset and OutputDataset objects. There is no mechanism to attach facets to entities referenced in lineage entries.
+- **Backward compatibility**: Older consumers that don't understand lineage facets still get the full list of datasets involved via inputs/outputs.
+
+When a lineage facet is present, these arrays are **not a lineage source**. Consumers should derive lineage exclusively from the facet. The arrays exist for the two purposes above only.
+
+### ColumnLineageDatasetFacet (CLL)
+
+LineageDatasetFacet supersedes CLL. It can express everything CLL expresses, plus dataset-level lineage and mixed granularity. During the transition period, both may coexist on the same event — the lineage facet takes precedence.
+
+## Migration & Compatibility
+
+### This is a non-breaking change
+
+New facets are optional. Adding new facet types does not break existing producers, consumers, or validators — this is the standard extensibility mechanism in OpenLineage.
+
+### Client-side automatic translation
+
+The OpenLineage client libraries (Java, Python) should provide built-in bidirectional translation between the old model (inputs/outputs/CLL) and the new lineage facets, gated by a configuration option. This is the key mechanism that makes migration painless — neither producers nor consumers need to change simultaneously.
+
+The translation happens transparently in the client library's event emission path, after the producer constructs the event but before it is sent to the transport.
+
+### CLL <-> Lineage field mapping
+
+**CLL -> Lineage (lossless):**
+
+| CLL structure | Lineage facet equivalent |
+|---|---|
+| `fields.{col}.inputFields[i]` | `fields.{col}.inputs[i]` with `field` on source |
+| `dataset[i]` (GROUP BY, FILTER) | Top-level `inputs[i]` with `field` on source |
+| Target dataset identity | Implicit — same dataset the facet is on |
+
+**Lineage -> CLL (lossy):**
+
+| Lineage facet structure | CLL mapping | Loss |
+|---|---|---|
+| Entity-level inputs (no field on source) | dropped | CLL has no dataset-level concept |
+| Entity-level inputs (field on source) | -> `dataset[]` array | None |
+| `fields.{col}.inputs` (field on source) | -> `fields.{col}.inputFields` | None |
+| `fields.{col}.inputs` (no field on source) | dropped | CLL requires field on source |
+
+For LineageRunFacet/LineageJobFacet: extract entries by target dataset, generate a CLL facet per output dataset, attach to the corresponding output in `outputs[]`. Same lossy mapping as above.
+
+### Forward translation: lineage facets -> inputs/outputs/CLL
+
+When a producer emits lineage facets but the downstream consumer only understands the old model, the client automatically generates the old representation:
+
+1. **Populate inputs/outputs**: Scan all LineageEntry objects. For each target dataset, add to `outputs[]` if not present. For each source dataset in inputs, add to `inputs[]` if not present.
+2. **Generate CLL facets**: For each target dataset with a `fields` map, construct a ColumnLineageDatasetFacet.
+3. **Attach CLL to output datasets**: The generated CLL facet is attached to the corresponding OutputDataset in `outputs[]`.
+
+This translation is lossy — dataset-level inputs without a field, fields entries where source has no field, and dataset-to-dataset entries with no column detail cannot be represented in CLL.
+
+### Reverse translation: inputs/outputs/CLL -> lineage facets
+
+When a producer only emits the old model but the downstream consumer expects lineage facets:
+
+1. **Output datasets with CLL**: Create a LineageEntry from each CLL facet.
+2. **Output datasets without CLL**: Create a LineageEntry with inputs containing ALL input datasets (the cartesian product — making implicit inference explicit).
+3. **Construct the facet**: Wrap all LineageEntry objects in a LineageRunFacet.
+
+This translation is lossless — CLL is a strict subset of what lineage facets can express.
+
+### Configuration
+
+```
+openlineage.lineage.compatibility = none | legacy | modern | both
+```
+
+| Mode | Producer emits | Client generates | Use case |
+|---|---|---|---|
+| `none` | Whatever it wants | Nothing | Full control, no magic |
+| `legacy` | Lineage facets | inputs/outputs/CLL | New producer, old consumers |
+| `modern` | inputs/outputs/CLL | Lineage facets | Old producer, new consumers |
+| `both` | Either or both | Whichever is missing | Transition period — everything works |
+
+**Default during transition**: `both`.
+
+### Translation scope
+
+Translation applies to RunEvent and JobEvent only. For DatasetEvent, the LineageDatasetFacet is the primary and only representation.
+
+Translation is idempotent: if both representations are already present, the client does not overwrite them. Producer-provided data always takes precedence.
+
+### Producer strategy
+
+- **Immediately**: Producers that want explicit lineage can start emitting lineage facets. With `compatibility = legacy`, old consumers still work automatically.
+- **No-effort upgrade**: Producers that haven't been updated yet can set `compatibility = modern` to get lineage facets auto-generated from their existing inputs/outputs/CLL.
+- **Phase 2 (deprecation)**: Eventually, producers migrate to emitting lineage facets natively. CLL emission can be dropped once consumers have caught up.
+
+The transition period should be generous — measured in years.
+
+### Consumer strategy
+
+Consumers should implement the following precedence: check lineage facets first, fall back to CLL, then fall back to inputs x outputs. Client-side translation on the producer side means consumers will typically find the representation they need already present.
+
+## Future Evolution
+
+A key advantage of the facet-based approach is that these three lineage facets form a natural expansion point for capabilities descoped from this initial version. Rather than introducing new facets for each new lineage capability, we extend the existing ones by adding new fields and relaxing constraints:
+
+### Job-to-job data flow chains
+
+This version supports `type: JOB` for sink and generator patterns (see [Why `type: JOB` Is Needed](#why-type-job-is-needed-sinks-and-generators)). The natural next step is full job-to-job data flow chains — expressing that one job feeds data to another without an intermediate dataset (e.g., in-memory data passing, streaming pipelines). The schema already accommodates this: `LineageJobEntry` can accept `LineageJobInput` as a source. Enabling this requires only documenting the semantics and lifting the scope restriction in Semantic Constraint 10.
+
+### Replacing JobDependenciesRunFacet
+
+Once full job-to-job lineage is supported, JobDependenciesRunFacet could be deprecated in favor of expressing both data flow and control flow dependencies through the lineage facets.
+
+### Relaxing the one-facet-per-event-type restriction
+
+Initially, we disallow mixing facet types. As the model matures and interaction semantics become well-understood, this restriction could be relaxed — for example, allowing LineageDatasetFacet on output datasets in a RunEvent alongside LineageRunFacet on the run, with clear merge/precedence rules.
+
+When this restriction is relaxed, a **lineage-type attribute** (runtime vs static) may be needed to disambiguate the semantics of a lineage facet that appears outside its "natural" event type. For instance, a LineageDatasetFacet on an output dataset within a RunEvent could be either "this is what I observed during this run" or "this is the static definition of this dataset" — an explicit attribute would resolve the ambiguity.
+
+### New entity types
+
+The `type` field is a plain string, not an enum, specifically to enable future extension. Entity types like `MODEL`, `DASHBOARD`, or `PIPELINE` could be added without a breaking schema change — only spec prose updates and client library support.
+
+**The principle is**: grow the existing facets rather than proliferate new ones. Each lineage facet is a home for lineage information scoped to its entity type. New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -98,7 +98,7 @@ Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects
   "description": "Explicit lineage observed during this run. Describes data flow between entities at entity and/or column granularity.",
   "allOf": [{ "$ref": "#/$defs/RunFacet" }],
   "properties": {
-    "lineage": {
+    "entries": {
       "type": "array",
       "description": "Lineage entries describing data flow observed during this run.",
       "items": {
@@ -106,7 +106,7 @@ Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects
       }
     }
   },
-  "required": ["lineage"]
+  "required": ["entries"]
 }
 ```
 
@@ -120,7 +120,7 @@ Lives on the job object in JobEvent. Same structure as LineageRunFacet.
   "description": "Explicit lineage declared for this job definition. Describes designed/static data flow at entity and/or column granularity.",
   "allOf": [{ "$ref": "#/$defs/JobFacet" }],
   "properties": {
-    "lineage": {
+    "entries": {
       "type": "array",
       "description": "Lineage entries describing data flow designed for this job.",
       "items": {
@@ -128,7 +128,7 @@ Lives on the job object in JobEvent. Same structure as LineageRunFacet.
       }
     }
   },
-  "required": ["lineage"]
+  "required": ["entries"]
 }
 ```
 
@@ -192,7 +192,7 @@ A lineage target that is a dataset. Supports both entity-level and column-level 
 
 #### LineageJobEntry
 
-A lineage target that is a job. Used for **sink** scenarios where a job consumes data without producing a tracked output dataset. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
+A lineage target that is a job. This is the **target/sink** side of `type: JOB` support — used when a job consumes data without producing a tracked output dataset. (The source/generator side uses `LineageJobInput`.) Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
 
 ```json
 "LineageJobEntry": {
@@ -433,7 +433,7 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
       "lineage": {
         "_producer": "https://example.com/etl",
         "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "lineage": [
+        "entries": [
           { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
             "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
           { "namespace": "postgresql://warehouse:5432", "name": "table_d", "type": "DATASET",
@@ -465,7 +465,7 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
     "lineage": {
       "_producer": "...",
       "_schemaURL": "...",
-      "lineage": [
+      "entries": [
         { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
           "fields": {
             "total": {
@@ -485,7 +485,7 @@ ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunF
 ### 3. Mixed granularity (dataset + column + dataset-wide ops)
 
 ```json
-"lineage": [
+"entries": [
   { "namespace": "postgresql://analytics:5432", "name": "output_X", "type": "DATASET",
     "inputs": [
       { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" },
@@ -520,6 +520,8 @@ A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dat
 
 ```json
 {
+  "eventType": "COMPLETE",
+  "eventTime": "2026-03-25T10:00:00.000Z",
   "dataset": {
     "namespace": "postgresql://warehouse:5432",
     "name": "public.customer_view",
@@ -552,7 +554,7 @@ A catalog declares what a job is designed to do. LineageJobFacet on the job:
       "lineage": {
         "_producer": "https://example.com/catalog",
         "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
-        "lineage": [
+        "entries": [
           { "namespace": "postgresql://warehouse:5432", "name": "output_table", "type": "DATASET",
             "inputs": [
               { "namespace": "postgresql://warehouse:5432", "name": "source_table", "type": "DATASET" }
@@ -580,7 +582,7 @@ A fraud detection job reads transactions and sends alerts, but doesn't write to 
       "lineage": {
         "_producer": "https://example.com/validation",
         "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "lineage": [
+        "entries": [
           { "namespace": "validation", "name": "fraud_detector", "type": "JOB",
             "inputs": [
               { "namespace": "postgres://prod", "name": "transactions", "type": "DATASET" }
@@ -611,7 +613,7 @@ An extract task pulls data from an external API (not modeled as a dataset) and w
       "lineage": {
         "_producer": "https://example.com/etl",
         "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "lineage": [
+        "entries": [
           { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
             "inputs": [
               { "namespace": "airflow://prod", "name": "data_pipeline.extract_task", "type": "JOB" }
@@ -642,7 +644,7 @@ Reading specific columns from a structured table and writing to an unstructured 
       "lineage": {
         "_producer": "https://example.com/export",
         "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "lineage": [
+        "entries": [
           { "namespace": "file://", "name": "R.pdf", "type": "DATASET",
             "inputs": [
               { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "A" },
@@ -669,8 +671,8 @@ The facet-based approach is a structural reshuffling of the top-level proposal, 
 
 | Top-level proposal | Facet proposal | Difference |
 |---|---|---|
-| `event.lineage[]` on RunEvent | `event.run.facets.lineage.lineage[]` | Deeper nesting, lives on run entity |
-| `event.lineage[]` on JobEvent | `event.job.facets.lineage.lineage[]` | Deeper nesting, lives on job entity |
+| `event.lineage[]` on RunEvent | `event.run.facets.lineage.entries[]` | Deeper nesting, lives on run entity |
+| `event.lineage[]` on JobEvent | `event.job.facets.lineage.entries[]` | Deeper nesting, lives on job entity |
 | `event.lineage[]` on DatasetEvent | `event.dataset.facets.lineage.{inputs,fields}` | Flattened — target is implicit |
 | Semantic constraints per event type | Built into the facet type itself | Same semantics, different enforcement |
 
@@ -711,6 +713,8 @@ These constraints are documented in spec text rather than enforced by JSON Schem
 ### ParentRunFacet (hierarchy)
 
 Remains orthogonal. Hierarchy expresses containment and scheduling (task X is part of DAG Y). Lineage facets express data flow. A consumer combines both dimensions.
+
+The optional `runId` on `LineageJobEntry` and `LineageJobInput` is also orthogonal to ParentRunFacet — it identifies which execution of a job the lineage edge refers to, not the parent-child relationship between runs.
 
 ### JobDependenciesRunFacet (control flow)
 
@@ -835,6 +839,6 @@ When this restriction is relaxed, a **lineage-type attribute** (runtime vs stati
 
 ### New entity types
 
-The `type` field is a plain string, not an enum, specifically to enable future extension. Entity types like `MODEL`, `DASHBOARD`, or `PIPELINE` could be added without a breaking schema change — only spec prose updates and client library support.
+Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the `oneOf` in `LineageEntry` and/or `LineageInput`, along with spec prose updates and client library support. This is a non-breaking schema change — existing entries remain valid.
 
 **The principle is**: grow the existing facets rather than proliferate new ones. Each lineage facet is a home for lineage information scoped to its entity type. New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -20,9 +20,9 @@ Beyond this precision gap, the current model cannot express several common patte
 
 ## Goals
 
-Create a unified lineage structure that handles all the cases outlined above on dataset-level, column-level, or mixed-level in a single model — eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future without requiring new facets or model changes.
+Create a unified lineage structure that handles all the cases outlined above — dataset-level, column-level, mixed-level, dataset-to-dataset, and job-to-job — in a single model, eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future without requiring new facets or model changes.
 
-Full job-to-job data flow chains are out of scope for this initial version, but `type: JOB` is supported for **sink and generator** use cases — jobs that consume data without a tracked output, or produce data without a tracked input. The design accommodates full job-to-job lineage as a future extension (see [Future Evolution](#future-evolution)).
+`type: JOB` is supported as a first-class entity type for three related cases: **sinks** (jobs that consume data without a tracked output), **generators** (jobs that produce data without a tracked input), and **job-to-job chains** (data flowing between jobs without an intermediate tracked dataset — e.g. stored procedures, non-materialized views, in-memory passing, streaming handoffs).
 
 ## Proposed Solution
 
@@ -180,12 +180,12 @@ A lineage target that is a dataset. Supports both entity-level and column-level 
 
 #### LineageJobEntry
 
-A lineage target that is a job. This is the **target/sink** side of `type: JOB` support — used when a job consumes data without producing a tracked output dataset. (The source/generator side uses `LineageJobInput`.) Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
+A lineage target that is a job. Used in two cases: (a) **sink** — a job consumes data without producing a tracked output dataset, with `LineageDatasetInput` sources; (b) **job-to-job chain** — a job receives data from another job with no intermediate tracked dataset, with `LineageJobInput` sources. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
 
 ```json
 "LineageJobEntry": {
   "type": "object",
-  "description": "Describes data flowing into a target job (sink). Used when a job consumes data without producing a tracked output dataset.",
+  "description": "Describes data flowing into a target job. Used for sinks (jobs without tracked outputs) and as the target end of job-to-job chains.",
   "properties": {
     "namespace": {
       "type": "string",
@@ -291,7 +291,7 @@ A source input that is a dataset. Supports optional field reference and transfor
 
 #### LineageJobInput
 
-A source input that is a job. Used for **generator** scenarios where a job produces data without a tracked input dataset, or for job-to-job data flow. Supports an optional `runId` to tie to a specific execution:
+A source input that is a job. Used in two cases: (a) **generator** — when a `DATASET` target is produced by an upstream job with no tracked input dataset; (b) **job-to-job chain** — as the source end of a `JOB → JOB` edge. Supports an optional `runId` to tie to a specific execution:
 
 ```json
 "LineageJobInput": {
@@ -348,15 +348,15 @@ Reuses the existing CLL transformation structure:
 }
 ```
 
-## Why `type: JOB` Is Needed: Sinks and Generators
+## `type: JOB` Lineage: Sinks, Generators, and Job-to-Job Chains
 
-The current OpenLineage model assumes every lineage edge connects **dataset to dataset**, with a job in the middle. But two common cases break this assumption:
+The current OpenLineage model assumes every lineage edge connects **dataset to dataset**, with a job in the middle. Three common cases break that assumption — all three are different faces of the same `type: JOB` mechanism: sometimes the job is the lineage target, sometimes the source, sometimes both.
 
 ### Sinks: jobs that consume data without a tracked output
 
-A **sink** is a job that reads data but doesn't write to any tracked dataset — for example, a fraud detection job that reads a `transactions` table, runs validation, and sends alerts (not modeled as a dataset). In the current spec this produces `inputs: [transactions], outputs: []` — no lineage edge exists because there's nothing to connect the input *to*. The data consumption is invisible in the lineage graph.
+A **sink** is a job that reads data but doesn't write to any tracked dataset — for example, a fraud detection job that reads a `transactions` table, runs validation, and sends alerts (not modeled as a dataset). In the current spec this produces `inputs: [transactions], outputs: []`. While the consumer can infer "transactions feeds fraud_detector" from the event's job field, that information is implicit — it lives outside the lineage facet. The explicit lineage facet aspires to be the single source of truth (see [Precedence Rules](#precedence-rules)); it cannot fulfill that role if sink relationships are only knowable by joining the facet with `inputs`/`outputs`.
 
-With `type: JOB` as a lineage **target** (`LineageJobEntry`), we can express: "data flows into the fraud_detector job itself." The job becomes the terminal node:
+With `type: JOB` as a lineage **target** (`LineageJobEntry`), the sink edge is expressed inside the facet:
 
 ```
 transactions (DATASET) ──> fraud_detector (JOB)
@@ -370,41 +370,59 @@ A **generator** is the inverse: a job that produces data without reading from an
 extract_task (JOB) ──> transformed_data (DATASET)
 ```
 
-### Alternatives considered
+### Job-to-job chains: data flow without an intermediate tracked dataset
 
-Without `type: JOB`, the alternatives are all problematic:
+A **job-to-job chain** is data flowing from one job directly into another with no intermediate tracked dataset. The intermediate may be ephemeral (in-memory, a stream), implicit (a stored procedure invoking a function), or simply not materialized (a non-materialized view referenced by another query). Concrete cases:
 
-- **Fake temporary datasets** — pollutes the catalog with entities that don't exist; requires two independent jobs to agree on the same fake dataset name
-- **Leave it out of the lineage facet** — this is a **regression**, not an acceptable trade-off. The current spec already captures sink/generator relationships implicitly through the `inputs`/`outputs` arrays. A new explicit lineage model that loses information the old model could express is strictly worse. We should not ship a feature that degrades existing capabilities.
-- **Rely on inputs/outputs arrays for the missing edges** — forces consumers to inspect both the lineage facet AND inputs/outputs for a complete picture, defeating the purpose of explicit lineage as the single source of truth
+- **Stored procedure chains** — `Table → Function → Stored Proc → Table`. The function and stored procedure pass data between themselves without materializing it.
+- **Non-materialized views** referenced by downstream jobs — the view's defining job feeds the consuming job directly.
+- **In-memory passing in orchestrators** — Airflow XCom, Dagster IO managers, Spark jobs that hand off DataFrames in shared context.
+- **Streaming handoffs** — a Flink job emitting to a sink consumed by another Flink job through a shared topic that the user does not model as a dataset.
 
-By allowing `type: JOB` in lineage entries, the lineage facet remains **self-contained and complete**. Note that full job-to-job data flow chains (job -> job -> job) are out of scope for this version — `type: JOB` is scoped to sink and generator patterns only.
+`LineageJobEntry` accepting `LineageJobInput` expresses this directly:
+
+```
+dag_a.task_3 (JOB) ──> dag_b.task_1 (JOB)
+```
+
+Either or both jobs may live in a different namespace from the event's own job, so the explicit `(namespace, name)` on `LineageJobEntry` and `LineageJobInput` is load-bearing — these chains cannot be reconstructed from the event's surrounding job field alone.
+
+`runId` is OPTIONAL on both ends. On a `JobEvent`, it should be omitted: declared lineage describes the job definition, not a specific execution. On a `RunEvent`, it MAY be populated to bind the chain to specific upstream/downstream executions when the producer can identify them (e.g. when an orchestrator knows which run of `dag_a.task_3` fed this run of `dag_b.task_1`).
+
+**Distinction from existing concepts.** Job-to-job lineage expresses **data flow**, not control flow or containment:
+
+- `JobDependenciesRunFacet` expresses scheduling / control-flow dependencies — Job A runs Monday, Job B runs Tuesday because the schedule says so, regardless of whether any data passes between them. It remains the home for control flow.
+- `ParentRunFacet` expresses containment — task X is part of DAG Y. Job-to-job lineage between sibling tasks within the same DAG is orthogonal to that hierarchy.
+
+`JobEvent` is the natural home for declared job-to-job lineage ("this job is designed to feed data to that job"); `RunEvent` carries observed job-to-job lineage when a runtime integration can identify both ends of the chain.
+
+### Why one mechanism for all three cases
+
+A reasonable counter-question: do we need `type: JOB` at all? Sinks and generators are already implicit in the event's `inputs`/`outputs` arrays — couldn't a flag (`generated: true`, or simply `inputs: []` with no JOB type) express them?
+
+It could, if sinks and generators were the only `type: JOB` cases. They are not. Once job-to-job chains are in scope, the JOB-type identity is irreducible:
+
+- A chain involves two jobs that may both differ from the event's job, and may live in different namespaces from each other and from the event. There is no way to flag this with `generated: true` — the spec needs `(namespace, name)` for both ends.
+- Once that machinery exists for chains, using a different mechanism for sinks and generators would split a single semantic concept ("a job participates in lineage") into three special cases, requiring three parser branches and three sets of consumer rules.
+
+The early working group discussion explicitly flagged that having JOB sometimes implicit (sinks/generators) and sometimes explicit (chains) "causes inconsistency and ambiguity" and recommended consistent explicit JOB. We adopt that recommendation: one mechanism, one shape, three uses.
+
+This also keeps the lineage facet self-contained: consumers can derive every lineage edge — dataset-to-dataset, sink, generator, chain, column-level — from the facet alone, without joining against `inputs`/`outputs`.
 
 ## Granularity Matrix
 
-The combination of entry type, field presence on targets, and field presence on sources enables all granularity levels:
+The combination of target type, source type, and field presence on either end enables all granularity levels in one table:
 
-**Dataset targets (`type: DATASET`):**
-
-| Target has fields? | Source has field? | Meaning | Example |
-|---|---|---|---|
-| — (entity-level inputs) | No | Dataset-level lineage | `output_table <- input_table` |
-| — (entity-level inputs) | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
-| Yes (in fields map) | Yes | Column-level lineage | `output.total <- input.amount` |
-| Yes (in fields map) | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
-
-**Job targets (`type: JOB`) — sinks:**
-
-| Source type | Meaning | Example |
-|---|---|---|
-| DATASET (no field) | Job consumes entire dataset | `fraud_detector <- transactions` |
-| DATASET (with field) | Job consumes specific columns | `fraud_detector <- transactions.amount` |
-
-**Job sources (`type: JOB`) — generators:**
-
-| Target type | Meaning | Example |
-|---|---|---|
-| DATASET | Dataset produced by upstream job | `output_table <- extract_task` |
+| Target type | Source type | Source field? | Meaning | Example |
+|---|---|---|---|---|
+| DATASET (entity-level) | DATASET | No | Dataset-level lineage | `output_table <- input_table` |
+| DATASET (entity-level) | DATASET | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
+| DATASET (per field) | DATASET | Yes | Column-level lineage | `output.total <- input.amount` |
+| DATASET (per field) | DATASET | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
+| DATASET | JOB | — | Generator: dataset produced by upstream job | `output_table <- extract_task` |
+| JOB | DATASET | No | Sink: job consumes entire dataset | `fraud_detector <- transactions` |
+| JOB | DATASET | Yes | Sink: job consumes specific columns | `fraud_detector <- transactions.amount` |
+| JOB | JOB | — | Job-to-job chain (no intermediate dataset) | `dag_b.task_1 <- dag_a.task_3` |
 
 ## Examples
 
@@ -619,7 +637,101 @@ An extract task pulls data from an external API (not modeled as a dataset) and w
 }
 ```
 
-### 8. Structured-to-unstructured — known source columns, no target schema
+### 8. Job-to-job — declared chain on JobEvent
+
+A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` via a non-materialized handoff. No intermediate dataset exists. The catalog declares the design-time data flow on the JobEvent for `dag_b`:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "airflow://prod",
+    "name": "dag_b",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/catalog",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
+        "entries": [
+          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+Note that `runId` is omitted on both ends — declared lineage describes the job definition, not a specific execution. The same shape would apply to a non-materialized view consumed by a downstream job, or to an Airflow task receiving data via XCom from an upstream task.
+
+### 9. Job-to-job — observed chain on RunEvent
+
+The same data flow as Example 8, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "run-b-001",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/airflow",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
+            "runId": "run-b-001",
+            "inputs": [
+              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB",
+                "runId": "run-a-042" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "airflow://prod", "name": "dag_b.task_1" },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+### 10. Job-to-job — cross-namespace chain
+
+A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in a separate Beam pipeline. Neither job is in the namespace of the other, and the topic is not modeled as a dataset. The Beam pipeline emits the cross-namespace chain on its RunEvent:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "run": {
+    "runId": "beam-run-77",
+    "facets": {
+      "lineage": {
+        "_producer": "https://example.com/beam",
+        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
+        "entries": [
+          { "namespace": "beam://analytics", "name": "enrichment_pipeline", "type": "JOB",
+            "runId": "beam-run-77",
+            "inputs": [
+              { "namespace": "flink://ingest", "name": "event_normalizer", "type": "JOB" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "job": { "namespace": "beam://analytics", "name": "enrichment_pipeline" },
+  "inputs": [],
+  "outputs": []
+}
+```
+
+The source job (`flink://ingest/event_normalizer`) is in a different namespace from both the event's job and the target entry. Without explicit `(namespace, name)` on both ends, the chain could not be expressed.
+
+### 11. Structured-to-unstructured — known source columns, no target schema
 
 Reading specific columns from a structured table and writing to an unstructured file (e.g., a PDF). The target has no schema, so there is no `fields` map — but we can still express that the output came from specific source columns:
 
@@ -681,7 +793,7 @@ These constraints are documented in spec text rather than enforced by JSON Schem
 
 9. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
 
-10. **`type: JOB` scope**: In this version, `type: JOB` is supported for sink and generator patterns only — a job as the terminal target of data flow, or a job as the origin source of data flow. Full job-to-job data flow chains (job -> job) are reserved for a future version.
+10. **`type: JOB` semantics**: A `LineageJobEntry` (target) and `LineageJobInput` (source) MUST identify the job by `(namespace, name)`. Either or both jobs MAY differ from the event's own job and from each other's namespace (e.g., for cross-namespace job-to-job chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-to-job lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`.
 
 ## Interaction with Existing Features
 
@@ -693,7 +805,7 @@ The optional `runId` on `LineageJobEntry` and `LineageJobInput` is also orthogon
 
 ### JobDependenciesRunFacet (control flow)
 
-Remains as-is for scheduling and control flow dependencies. Lineage facets express DATA flow dependencies. Spec prose documents the distinction: a job may depend on another job for scheduling (control flow) without having a data dependency, and vice versa. In the future, job-to-job data flow might be added to the lineage facet model.
+Remains as-is for scheduling and control flow dependencies. Lineage facets express DATA flow dependencies — including job-to-job data flow, see [`type: JOB` Lineage](#type-job-lineage-sinks-generators-and-job-to-job-chains). Spec prose documents the distinction: a job may depend on another job for scheduling (control flow) without having a data dependency, and vice versa. The two facets are complementary, not overlapping.
 
 ### inputs[] / outputs[] arrays
 
@@ -798,13 +910,9 @@ Consumers should implement the following precedence: check lineage facets first,
 
 A key advantage of the facet-based approach is that these three lineage facets form a natural expansion point for capabilities descoped from this initial version. Rather than introducing new facets for each new lineage capability, we extend the existing ones by adding new fields and relaxing constraints:
 
-### Job-to-job data flow chains
-
-This version supports `type: JOB` for sink and generator patterns (see [Why `type: JOB` Is Needed](#why-type-job-is-needed-sinks-and-generators)). The natural next step is full job-to-job data flow chains — expressing that one job feeds data to another without an intermediate dataset (e.g., in-memory data passing, streaming pipelines). The schema already accommodates this: `LineageJobEntry` can accept `LineageJobInput` as a source. Enabling this requires only documenting the semantics and lifting the scope restriction in Semantic Constraint 10.
-
 ### Replacing JobDependenciesRunFacet
 
-Once full job-to-job lineage is supported, JobDependenciesRunFacet could be deprecated in favor of expressing both data flow and control flow dependencies through the lineage facets.
+With job-to-job data flow now expressible in lineage facets, `JobDependenciesRunFacet` could eventually be deprecated in favor of expressing both data flow and control flow dependencies through a unified mechanism — once the spec is comfortable folding control flow into the lineage facets (e.g., via a transformation type or edge attribute distinguishing data dependencies from scheduling dependencies). For this version, the two facets remain complementary.
 
 ### Relaxing the one-facet-per-event-type restriction
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -8,33 +8,21 @@
 
 ## Problem Statement
 
-OpenLineage's current model infers dataset-level lineage from the cartesian product of inputs x outputs on a run. When a single job reads datasets A,B and writes to C,D, the inferred lineage is {A,B} -> {C,D} — four edges. If the real flow is only A -> C and B -> D, two of those edges are false positives. For a bulk ETL job processing 10 independent tables, the lineage graph becomes 90% false positives.
+OpenLineage's current model captures lineage through two mechanisms: `inputs`/`outputs` arrays on Run and Job events, and `ColumnLineageDatasetFacet` (CLL) for column-level detail on individual outputs. Most integrations today (Spark, dbt, Flink) emit one output per job, so the implicit assumption that all inputs feed all outputs happens to be correct — dataset-level lineage works fine.
 
-The existing `ColumnLineageDatasetFacet` (CLL) solves this at column granularity, but leaves a gap at dataset granularity: integrators often know "Table A derived Table B" without column-level detail. If they can't provide CLL, they fall back to the cartesian product.
+The problem appears when a single job reads and writes multiple independent datasets. The model infers the cartesian product of inputs x outputs: reading A,B and writing C,D produces four edges, even if the real flow is only A -> C and B -> D. In some cases, this makes it difficult to express a bulk ETL job processing 10 independent tables without artificially splitting it into separate jobs. CLL can resolve this at column granularity, but many integrations know "Table A feeds Table C" without column-level detail — and without CLL, the only fallback is the cartesian product.
 
-Additionally, the current model cannot express:
+Beyond this precision gap, the current model cannot express several common patterns:
 
 - **Dataset-to-dataset derivation** — no mechanism for views, aliases, or manually documented lineage without an intermediate job
-- **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level for some outputs and column-level for others
+- **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level lineage for some outputs and column-level for others in the same event
 - **Job-to-job data flow** — no way to express that one job feeds data to another without an intermediate dataset (e.g., non-materialized views, stored procedures calling functions, in-memory data passing)
 
 ## Goals
 
-**Narrow goal**: Enable producers to explicitly define which inputs feed which outputs at dataset granularity, solving the false-positive problem.
+Create a unified lineage structure that handles all the cases outlined above on dataset-level, column-level, or mixed-level in a single model — eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future without requiring new facets or model changes.
 
-**Wide goal**: Create a unified lineage structure that handles dataset-level, column-level, and dataset-to-dataset lineage in a single model — eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future (e.g., job-to-job data flow) without requiring new facets or model changes.
-
-This proposal aims for the wide goal, as the incremental effort over the narrow goal is small and the payoff is large. Full job-to-job data flow chains are out of scope for this initial version, but `type: JOB` is supported for **sink and generator** use cases — jobs that consume data without a tracked output, or produce data without a tracked input. The design accommodates full job-to-job lineage as a future extension (see [Future Evolution](#future-evolution)).
-
-## Why Facets Instead of a Top-Level Property
-
-The top-level proposal places lineage as a top-level `lineage` array on `BaseEvent`. This is semantically clean, but working group members raised concerns about changing the model shape:
-
-> **Julien**: "Unless we have a strong reason to change the mechanism... I think we should avoid creating situations where we have 2 ways to do the same thing. Could you describe an alternative design where this is captured in facets?"
-
-> **Nelson**: "I was the initial proposer of the new top level property, but with the current state of the facet approach, I find it indifferent. All cases seem to be covered by a datasetLineage facet."
-
-The facet-based approach preserves the exact same semantics and capabilities as the top-level property, but works within the existing extensibility mechanism (facets) instead of adding a new top-level field. The trade-off: we need three facets (one per entity type) with semantic restrictions on which event type each appears in.
+Full job-to-job data flow chains are out of scope for this initial version, but `type: JOB` is supported for **sink and generator** use cases — jobs that consume data without a tracked output, or produce data without a tracked input. The design accommodates full job-to-job lineage as a future extension (see [Future Evolution](#future-evolution)).
 
 ## Proposed Solution
 
@@ -665,19 +653,6 @@ Reading specific columns from a structured table and writing to an unstructured 
 }
 ```
 
-## How the Three Facets Map to the Top-Level Proposal
-
-The facet-based approach is a structural reshuffling of the top-level proposal, not a semantic change:
-
-| Top-level proposal | Facet proposal | Difference |
-|---|---|---|
-| `event.lineage[]` on RunEvent | `event.run.facets.lineage.entries[]` | Deeper nesting, lives on run entity |
-| `event.lineage[]` on JobEvent | `event.job.facets.lineage.entries[]` | Deeper nesting, lives on job entity |
-| `event.lineage[]` on DatasetEvent | `event.dataset.facets.lineage.{inputs,fields}` | Flattened — target is implicit |
-| Semantic constraints per event type | Built into the facet type itself | Same semantics, different enforcement |
-
-The capabilities and extensibility are identical — both approaches can express the same lineage information and accommodate the same future extensions.
-
 ## Precedence Rules
 
 1. **If a lineage facet is present on the event**, it is the complete picture of lineage for that event. Consumers should derive all lineage edges from the facet and should not infer additional edges from `inputs`/`outputs` arrays or CLL facets. The `inputs`/`outputs` arrays remain as dataset facet carriers and backward-compatibility fallback, but are not a lineage source when a lineage facet is present.
@@ -842,3 +817,9 @@ When this restriction is relaxed, a **lineage-type attribute** (runtime vs stati
 Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the `oneOf` in `LineageEntry` and/or `LineageInput`, along with spec prose updates and client library support. This is a non-breaking schema change — existing entries remain valid.
 
 **The principle is**: grow the existing facets rather than proliferate new ones. Each lineage facet is a home for lineage information scoped to its entity type. New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.
+
+## Appendix: Alternative Considered — Top-Level Property
+
+An earlier version of this proposal placed lineage as a top-level `lineage` array directly on `BaseEvent`, alongside `inputs` and `outputs`. This would make lineage a first-class structural element of the event model rather than a facet.
+
+Working group members raised concerns that a new top-level property would change the fundamental shape of the event model and create two parallel ways to express the same information (top-level arrays vs. facets). Since OpenLineage already has facets as its standard extensibility mechanism, the group concluded that lineage information fits naturally within that mechanism — avoiding a model-level change while preserving identical semantics and capabilities. The trade-off is slightly deeper nesting in the JSON structure and the need for three facets (one per entity type) rather than a single top-level array.

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -12,7 +12,7 @@ OpenLineage's current model captures lineage through two mechanisms: `inputs`/`o
 
 The problem appears when a single job reads and writes multiple independent datasets. The model infers the cartesian product of inputs x outputs: reading A,B and writing C,D produces four edges, even if the real flow is only A -> C and B -> D. In some cases, this makes it difficult to express a bulk ETL job processing 10 independent tables without artificially splitting it into separate jobs. CLL can resolve this at column granularity, but many integrations know "Table A feeds Table C" without column-level detail — and without CLL, the only fallback is the cartesian product.
 
-Beyond this precision gap, the current model cannot express several common patterns:
+Beyond this gap, the current model cannot express several common patterns:
 
 - **Dataset-to-dataset derivation** — no mechanism for views, aliases, or manually documented lineage without an intermediate job
 - **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level lineage for some outputs and column-level for others in the same event
@@ -71,11 +71,27 @@ inputs: []
 outputs: [transformed_data]
 ```
 
-The job-to-dataset relationship is implicit in the event boundary: `transformed_data` is produced by the event's job because it appears in `outputs` and no tracked input dataset is identified for it in the lineage facet. We intentionally do not add a `LineageJobInput` for `extract_task`; the source job is already the event's job.
+The job-to-dataset relationship is implicit in the event boundary: `transformed_data` is produced by the event's job because it appears in `outputs` and no tracked input dataset is identified for it in the lineage facet. In the simplest case we do not add any lineage entry for `extract_task`; the source job is already the event's job.
 
 ```
 extract_task (JOB) ──> transformed_data (DATASET)
 ```
+
+**Enriching a generator with field-level / transformation detail.** A generator often knows *how* it produced individual columns even though there is no tracked upstream dataset (e.g. an extract task that derives `total` via `sum()` over an external API response). To capture this without reintroducing the job as a tracked entity, a `LineageDatasetEntry` for the output dataset MAY name an **identity-less `LineageJobInput`** — a `{ "type": "JOB" }` source with no `namespace`/`name`, which resolves to the event's own job — and attach `transformations` to it:
+
+```json
+{ "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
+  "fields": {
+    "total": {
+      "inputs": [
+        { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+      ]
+    }
+  }
+}
+```
+
+This does not restate the implicit job-to-dataset edge (that remains carried by event membership); it only adds the per-field transformation detail that event membership cannot express. The output's top-level `inputs` stays `[]` — there is still no tracked upstream dataset.
 
 ### Explicit job-involving chains: data flow without an intermediate tracked dataset
 
@@ -130,7 +146,8 @@ The combination of target type, source type, and field presence on either end en
 | DATASET (entity-level) | DATASET | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
 | DATASET (per field) | DATASET | Yes | Column-level lineage | `output.total <- input.amount` |
 | DATASET (per field) | DATASET | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
-| DATASET | JOB | — | Dataset produced from an explicitly identified upstream job | `output_table <- dag_a.task_3` |
+| DATASET | JOB (identified) | — | Dataset produced from an explicitly identified upstream job | `output_table <- dag_a.task_3` |
+| DATASET (per field) | JOB (identity-less = own job) | — | Field produced by the event's own job, with transformation detail and no tracked upstream | `extracted_data.total <- sum() by own job` |
 | JOB | DATASET | No | Explicit target job consumes entire dataset | `dag_b.task_1 <- transactions` |
 | JOB | DATASET | Yes | Explicit target job consumes specific columns | `dag_b.task_1 <- transactions.amount` |
 | JOB | JOB | — | Job-to-job chain (no intermediate dataset) | `dag_b.task_1 <- dag_a.task_3` |
@@ -168,7 +185,9 @@ These constraints are documented in spec text rather than enforced by JSON Schem
 
 10. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
 
-11. **`type: JOB` semantics**: A `LineageJobEntry` (target) and `LineageJobInput` (source) MUST identify the job by `(namespace, name)`. Either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. `type: JOB` is not used to restate that the event's own job consumes event inputs or produces event outputs.
+11. **`type: JOB` semantics**: A `LineageJobEntry` (target) MUST identify the job by `(namespace, name)`. A `LineageJobInput` (source) identifies the job by `(namespace, name)` when both are present; either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. A `LineageJobInput` is **not** used to restate that the event's own job consumes event inputs or produces event outputs at dataset granularity — that remains implicit via event membership.
+
+    **Identity-less `LineageJobInput` (the event's own job)**: A `LineageJobInput` MAY omit both `namespace` and `name`, in which case it resolves to the event's own job. This form exists only to attach **field-level and/or transformation detail** to data produced by the implicit job (the generator case) — detail that event membership alone cannot carry. It MUST NOT be used as a top-level entity-level input to restate the implicit dataset-level edge. A producer MUST emit `namespace` and `name` together or omit them together.
 
 ## Interaction with Existing Features
 
@@ -226,6 +245,7 @@ The translation happens transparently in the client library's event emission pat
 | Entity-level inputs (field on source) | -> `dataset[]` array | None |
 | `fields.{col}.inputs` (field on source) | -> `fields.{col}.inputFields` | None |
 | `fields.{col}.inputs` (no field on source) | dropped | CLL requires field on source |
+| `fields.{col}.inputs` (identity-less JOB source, transformations only) | dropped | CLL has no notion of a field produced by the job with no dataset source |
 
 For LineageRunFacet/LineageJobFacet: extract entries by target dataset, generate a CLL facet per output dataset, attach to the corresponding output in `outputs[]`. Same lossy mapping as above.
 
@@ -284,23 +304,30 @@ Consumers should implement the following precedence: check lineage facets first,
 
 ## Future Evolution
 
-A key advantage of the facet-based approach is that these three lineage facets form a natural expansion point for capabilities descoped from this initial version. Rather than introducing new facets for each new lineage capability, we extend the existing ones by adding new fields and relaxing constraints:
+A key advantage of the facet-based approach is that these three lineage facets form a natural expansion point for capabilities descoped from this initial version. 
+Rather than introducing new facets for each new lineage capability, we extend the existing ones by adding new fields and relaxing constraints:
 
 ### Replacing JobDependenciesRunFacet
 
-With job-to-job data flow now expressible in lineage facets, `JobDependenciesRunFacet` could eventually be deprecated in favor of expressing both data flow and control flow dependencies through a unified mechanism — once the spec is comfortable folding control flow into the lineage facets (e.g., via a transformation type or edge attribute distinguishing data dependencies from scheduling dependencies). For this version, the two facets remain complementary.
+With job-to-job data flow now expressible in lineage facets, `JobDependenciesRunFacet` could eventually be deprecated in favor of expressing both data flow and control flow dependencies through a unified mechanism.
+To do that, the lineage facets would need to be able to express the dependency type. For example, via a transformation type or edge attribute distinguishing data dependencies from scheduling dependencies.
+For this version, the two facets remain complementary.
 
 ### Relaxing the one-facet-per-event-type restriction
 
 Initially, we disallow mixing facet types. As the model matures and interaction semantics become well-understood, this restriction could be relaxed — for example, allowing LineageDatasetFacet on output datasets in a RunEvent alongside LineageRunFacet on the run, with clear merge/precedence rules.
 
-When this restriction is relaxed, a **lineage-type attribute** (runtime vs static) may be needed to disambiguate the semantics of a lineage facet that appears outside its "natural" event type. For instance, a LineageDatasetFacet on an output dataset within a RunEvent could be either "this is what I observed during this run" or "this is the static definition of this dataset" — an explicit attribute would resolve the ambiguity.
+When this restriction is relaxed, a separate lineage-type attribute (runtime vs static) may be needed to disambiguate the semantics of a lineage facet that appears outside its "natural" event type. 
+For instance, a LineageDatasetFacet on an output dataset within a RunEvent could be either "this is what I observed during this run" or "this is the static definition of this dataset" — an explicit attribute would resolve the ambiguity.
 
 ### New entity types
 
-Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the relevant `oneOf` definitions, along with spec prose updates and client library support. This is a non-breaking schema change — existing entries remain valid.
+Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the relevant `oneOf` definitions, along with spec prose updates and client library support. 
+This would be a non-breaking schema change — existing entries remain valid.
 
-**The principle is**: grow the existing facets rather than proliferate new ones. Each lineage facet is a home for lineage information scoped to its entity type. New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.
+The principle here is to contain the lineage in the currently proposed facets rather than proliferate new ones - and duplicate the same information.
+Each lineage facet is a home for lineage information scoped to its entity type. 
+New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.
 
 ## Appendix: Alternative Considered — Top-Level Property
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -22,8 +22,6 @@ Beyond this precision gap, the current model cannot express several common patte
 
 Create a unified lineage structure that handles all the cases outlined above — dataset-level, column-level, mixed-level, dataset-to-dataset, and job-to-job — in a single model, eventually deprecating CLL. The structure should also be extensible to handle additional lineage types in the future without requiring new facets or model changes.
 
-`type: JOB` is supported as a first-class entity type for three related cases: **sinks** (jobs that consume data without a tracked output), **generators** (jobs that produce data without a tracked input), and **job-to-job chains** (data flowing between jobs without an intermediate tracked dataset — e.g. stored procedures, non-materialized views, in-memory passing, streaming handoffs).
-
 ## Proposed Solution
 
 We introduce three new facets — **LineageRunFacet**, **LineageJobFacet**, and **LineageDatasetFacet** — each carrying explicit lineage information and each restricted (by spec text, not JSON Schema) to a single event type:
@@ -45,318 +43,19 @@ This restriction may be relaxed in a future version with clear type-of-lineage o
 
 ## Proposed Schema
 
-### LineageDatasetFacet (DatasetFacet)
-
-The natural facet. Lives on datasets in DatasetEvent. The target entity is implicit — it's the dataset the facet is attached to.
-
-```json
-"LineageDatasetFacet": {
-  "type": "object",
-  "description": "Explicit lineage for this dataset. Describes which source entities feed into it, at entity and/or column granularity. Supersedes ColumnLineageDatasetFacet.",
-  "allOf": [{ "$ref": "#/$defs/DatasetFacet" }],
-  "properties": {
-    "inputs": {
-      "type": "array",
-      "description": "Dataset-level source inputs. When a source includes a 'field' property, it represents a dataset-wide operation (e.g., GROUP BY) where that source column affects the entire target dataset.",
-      "items": {
-        "$ref": "#/$defs/LineageInput"
-      }
-    },
-    "fields": {
-      "type": "object",
-      "description": "Column-level lineage. Maps target field names to their source inputs.",
-      "additionalProperties": {
-        "$ref": "#/$defs/LineageFieldEntry"
-      }
-    }
-  }
-}
-```
-
-> Note: no `namespace`, `name`, or `type` on this facet — the target is the dataset it's attached to.
-
-
-### LineageRunFacet (RunFacet)
-
-Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail.
-
-```json
-"LineageRunFacet": {
-  "type": "object",
-  "description": "Explicit lineage observed during this run. Describes data flow between entities at entity and/or column granularity.",
-  "allOf": [{ "$ref": "#/$defs/RunFacet" }],
-  "properties": {
-    "entries": {
-      "type": "array",
-      "description": "Lineage entries describing data flow observed during this run.",
-      "items": {
-        "$ref": "#/$defs/LineageEntry"
-      }
-    }
-  },
-  "required": ["entries"]
-}
-```
-
-### LineageJobFacet (JobFacet)
-
-Lives on the job object in JobEvent. Same structure as LineageRunFacet.
-
-```json
-"LineageJobFacet": {
-  "type": "object",
-  "description": "Explicit lineage declared for this job definition. Describes designed/static data flow at entity and/or column granularity.",
-  "allOf": [{ "$ref": "#/$defs/JobFacet" }],
-  "properties": {
-    "entries": {
-      "type": "array",
-      "description": "Lineage entries describing data flow designed for this job.",
-      "items": {
-        "$ref": "#/$defs/LineageEntry"
-      }
-    }
-  },
-  "required": ["entries"]
-}
-```
-
-### Shared Types
-
-#### LineageEntry (discriminated union)
-
-Used by LineageRunFacet and LineageJobFacet. Each entry describes ONE target entity and what feeds into it. The `type` field discriminates between dataset targets and job targets:
-
-```json
-"LineageEntry": {
-  "oneOf": [
-    { "$ref": "#/$defs/LineageDatasetEntry" },
-    { "$ref": "#/$defs/LineageJobEntry" }
-  ]
-}
-```
-
-The `enum` constraint on each subtype's `type` field (`"DATASET"` or `"JOB"`) ensures only one branch can match during validation.
-
-#### LineageDatasetEntry
-
-A lineage target that is a dataset. Supports both entity-level and column-level lineage:
-
-```json
-"LineageDatasetEntry": {
-  "type": "object",
-  "description": "Describes data flowing into a target dataset from source entities, at entity and/or column granularity.",
-  "properties": {
-    "namespace": {
-      "type": "string",
-      "description": "The namespace of the target dataset"
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the target dataset"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["DATASET"],
-      "description": "Must be DATASET"
-    },
-    "inputs": {
-      "type": "array",
-      "description": "Entity-level source inputs. Each item is a LineageInput (dataset or job).",
-      "items": {
-        "$ref": "#/$defs/LineageInput"
-      }
-    },
-    "fields": {
-      "type": "object",
-      "description": "Column-level lineage. Maps target field names to their source inputs.",
-      "additionalProperties": {
-        "$ref": "#/$defs/LineageFieldEntry"
-      }
-    }
-  },
-  "required": ["namespace", "name", "type"]
-}
-```
-
-#### LineageJobEntry
-
-A lineage target that is a job. Used in two cases: (a) **sink** — a job consumes data without producing a tracked output dataset, with `LineageDatasetInput` sources; (b) **job-to-job chain** — a job receives data from another job with no intermediate tracked dataset, with `LineageJobInput` sources. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
-
-```json
-"LineageJobEntry": {
-  "type": "object",
-  "description": "Describes data flowing into a target job. Used for sinks (jobs without tracked outputs) and as the target end of job-to-job chains.",
-  "properties": {
-    "namespace": {
-      "type": "string",
-      "description": "The namespace of the target job"
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the target job"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["JOB"],
-      "description": "Must be JOB"
-    },
-    "runId": {
-      "type": "string",
-      "format": "uuid",
-      "description": "Optional. The specific run ID of the target job, when the lineage is tied to a particular execution."
-    },
-    "inputs": {
-      "type": "array",
-      "description": "Source inputs feeding into this job.",
-      "items": {
-        "$ref": "#/$defs/LineageInput"
-      }
-    }
-  },
-  "required": ["namespace", "name", "type"]
-}
-```
-
-#### LineageFieldEntry
-
-```json
-"LineageFieldEntry": {
-  "type": "object",
-  "description": "Column-level lineage for a single target field.",
-  "properties": {
-    "inputs": {
-      "type": "array",
-      "description": "Source entities and/or fields that feed into this target field.",
-      "items": {
-        "$ref": "#/$defs/LineageInput"
-      }
-    }
-  },
-  "required": ["inputs"]
-}
-```
-
-#### LineageInput (discriminated union)
-
-A source entity that feeds data into a lineage target. The `type` field discriminates between dataset sources and job sources:
-
-```json
-"LineageInput": {
-  "oneOf": [
-    { "$ref": "#/$defs/LineageDatasetInput" },
-    { "$ref": "#/$defs/LineageJobInput" }
-  ]
-}
-```
-
-Same pattern — the `enum` on each subtype's `type` field disambiguates.
-
-#### LineageDatasetInput
-
-A source input that is a dataset. Supports optional field reference and transformations:
-
-```json
-"LineageDatasetInput": {
-  "type": "object",
-  "description": "A source dataset that feeds data into a lineage target.",
-  "properties": {
-    "namespace": {
-      "type": "string",
-      "description": "The namespace of the source dataset"
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the source dataset"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["DATASET"],
-      "description": "Must be DATASET"
-    },
-    "field": {
-      "type": "string",
-      "description": "The specific field/column of the source dataset. Optional — when omitted at column level, means 'source column unknown'."
-    },
-    "transformations": {
-      "type": "array",
-      "description": "Transformations applied to the source data. Same structure as ColumnLineageDatasetFacet.",
-      "items": {
-        "$ref": "#/$defs/LineageTransformation"
-      }
-    }
-  },
-  "required": ["namespace", "name", "type"]
-}
-```
-
-#### LineageJobInput
-
-A source input that is a job. Used in two cases: (a) **generator** — when a `DATASET` target is produced by an upstream job with no tracked input dataset; (b) **job-to-job chain** — as the source end of a `JOB → JOB` edge. Supports an optional `runId` to tie to a specific execution:
-
-```json
-"LineageJobInput": {
-  "type": "object",
-  "description": "A source job that feeds data into a lineage target. Used when data comes from another job without an intermediate tracked dataset.",
-  "properties": {
-    "namespace": {
-      "type": "string",
-      "description": "The namespace of the source job"
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the source job"
-    },
-    "type": {
-      "type": "string",
-      "enum": ["JOB"],
-      "description": "Must be JOB"
-    },
-    "runId": {
-      "type": "string",
-      "format": "uuid",
-      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution."
-    }
-  },
-  "required": ["namespace", "name", "type"]
-}
-```
-
-#### LineageTransformation
-
-Reuses the existing CLL transformation structure:
-
-```json
-"LineageTransformation": {
-  "type": "object",
-  "properties": {
-    "type": {
-      "type": "string",
-      "description": "DIRECT or INDIRECT"
-    },
-    "subtype": {
-      "type": "string",
-      "description": "E.g., IDENTITY, AGGREGATION, FILTER, JOIN, etc."
-    },
-    "description": {
-      "type": "string"
-    },
-    "masking": {
-      "type": "boolean"
-    }
-  },
-  "required": ["type"]
-}
-```
-
-## `type: JOB` Lineage: Sinks, Generators, and Job-to-Job Chains
-
-The current OpenLineage model assumes every lineage edge connects **dataset to dataset**, with a job in the middle. Three common cases break that assumption — all three are different faces of the same `type: JOB` mechanism: sometimes the job is the lineage target, sometimes the source, sometimes both.
+The proposed facet and shared type schemas are defined in more details in [ExplicitLineageSchema.md](ExplicitLineageSchema.md).
 
 ### Sinks: jobs that consume data without a tracked output
 
-A **sink** is a job that reads data but doesn't write to any tracked dataset — for example, a fraud detection job that reads a `transactions` table, runs validation, and sends alerts (not modeled as a dataset). In the current spec this produces `inputs: [transactions], outputs: []`. While the consumer can infer "transactions feeds fraud_detector" from the event's job field, that information is implicit — it lives outside the lineage facet. The explicit lineage facet aspires to be the single source of truth (see [Precedence Rules](#precedence-rules)); it cannot fulfill that role if sink relationships are only knowable by joining the facet with `inputs`/`outputs`.
+A **sink** is a job that reads data but doesn't write to any tracked dataset — for example, a fraud detection job that reads a `transactions` table, runs validation, and sends alerts (not modeled as a dataset). This remains represented as:
 
-With `type: JOB` as a lineage **target** (`LineageJobEntry`), the sink edge is expressed inside the facet:
+```
+job: fraud_detector
+inputs: [transactions]
+outputs: []
+```
+
+The dataset-to-job relationship is implicit in the event boundary: `transactions` is consumed by the event's job because it appears in `inputs` and does not feed any tracked output dataset in the lineage facet. We intentionally do not add a `LineageJobEntry` for `fraud_detector`; that would duplicate information already carried by the event's `job` field.
 
 ```
 transactions (DATASET) ──> fraud_detector (JOB)
@@ -364,50 +63,62 @@ transactions (DATASET) ──> fraud_detector (JOB)
 
 ### Generators: jobs that produce data without a tracked input
 
-A **generator** is the inverse: a job that produces data without reading from any tracked dataset — for example, an extract task that pulls from an external API and passes data in-memory to the next processing step. With `type: JOB` as a lineage **source** (`LineageJobInput`), we can express: "the data flowing into this dataset came from the extract_task job":
+A **generator** is the inverse: a job that produces data without reading from any tracked dataset — for example, an extract task that pulls from an external API and writes the result to a table. This remains represented as:
+
+```
+job: extract_task
+inputs: []
+outputs: [transformed_data]
+```
+
+The job-to-dataset relationship is implicit in the event boundary: `transformed_data` is produced by the event's job because it appears in `outputs` and no tracked input dataset is identified for it in the lineage facet. We intentionally do not add a `LineageJobInput` for `extract_task`; the source job is already the event's job.
 
 ```
 extract_task (JOB) ──> transformed_data (DATASET)
 ```
 
-### Job-to-job chains: data flow without an intermediate tracked dataset
+### Explicit job-involving chains: data flow without an intermediate tracked dataset
 
-A **job-to-job chain** is data flowing from one job directly into another with no intermediate tracked dataset. The intermediate may be ephemeral (in-memory, a stream), implicit (a stored procedure invoking a function), or simply not materialized (a non-materialized view referenced by another query). Concrete cases:
+An explicit job-involving chain is data flowing through a job that cannot be recovered from the event's own `job` field and `inputs`/`outputs`. The intermediate may be ephemeral (in-memory, a stream), implicit (a stored procedure invoking a function), or simply not materialized (a non-materialized view referenced by another query). Concrete cases:
 
 - **Stored procedure chains** — `Table → Function → Stored Proc → Table`. The function and stored procedure pass data between themselves without materializing it.
 - **Non-materialized views** referenced by downstream jobs — the view's defining job feeds the consuming job directly.
 - **In-memory passing in orchestrators** — Airflow XCom, Dagster IO managers, Spark jobs that hand off DataFrames in shared context.
 - **Streaming handoffs** — a Flink job emitting to a sink consumed by another Flink job through a shared topic that the user does not model as a dataset.
 
-`LineageJobEntry` accepting `LineageJobInput` expresses this directly:
+`LineageJobEntry` accepting `LineageJobInput` expresses direct job-to-job flow:
 
 ```
 dag_a.task_3 (JOB) ──> dag_b.task_1 (JOB)
 ```
 
-Either or both jobs may live in a different namespace from the event's own job, so the explicit `(namespace, name)` on `LineageJobEntry` and `LineageJobInput` is load-bearing — these chains cannot be reconstructed from the event's surrounding job field alone.
+Either or both jobs may live in a different namespace from the event's own job, so the explicit `(namespace, name)` on `LineageJobEntry` and `LineageJobInput` is load-bearing — these chains cannot be reconstructed from the event's surrounding job field alone. The same applies to a chain that ends in a dataset after an explicit upstream job, such as `dag_a.task_3 (JOB) -> output_table (DATASET)`: the upstream job identity is not the event's own job and must remain expressible as a `LineageJobInput`.
 
 `runId` is OPTIONAL on both ends. On a `JobEvent`, it should be omitted: declared lineage describes the job definition, not a specific execution. On a `RunEvent`, it MAY be populated to bind the chain to specific upstream/downstream executions when the producer can identify them (e.g. when an orchestrator knows which run of `dag_a.task_3` fed this run of `dag_b.task_1`).
+
+### Unmodeled intermediate artifacts
+
+Some pipelines pass data between jobs through intermediate artifacts that are real at runtime but intentionally not modeled as datasets. For example:
+
+```
+dataset_1 ─┐
+dataset_2 ─┼─> job_1 ── temp file 1+2 ──> job_2 ──> dataset_4
+dataset_3 ─┘        └─ temp file 3 ─────> job_2 ──> dataset_5
+```
+
+In this shape, `job_1` writes both temporary files and `job_2` reads selected files to produce different outputs. The temporary files shown in the diagram are runtime artifacts, not proposed schema entities. They should not be exposed as datasets if their names are unstable or too implementation-specific; doing so would create incoherent lineage.
+
+Without modeling those intermediate artifacts, the lineage model can only preserve coarser facts:
+
+- From `job_1`'s point of view: `job_2` depends on `dataset_1`, `dataset_2`, and `dataset_3`, or simply `job_2` depends on `job_1`.
+- From `job_2`'s point of view: `dataset_4` depends on `job_1`, and `dataset_5` also depends on `job_1`.
+
+What is lost is the partitioning of the handoff: that `dataset_4` depends on the data path through `dataset_1` and `dataset_2`, while `dataset_5` depends on the path through `dataset_3`. The proposed model cannot express that distinction unless the intermediate artifacts, or some stable abstraction for them, are represented as lineage entities.
 
 **Distinction from existing concepts.** Job-to-job lineage expresses **data flow**, not control flow or containment:
 
 - `JobDependenciesRunFacet` expresses scheduling / control-flow dependencies — Job A runs Monday, Job B runs Tuesday because the schedule says so, regardless of whether any data passes between them. It remains the home for control flow.
 - `ParentRunFacet` expresses containment — task X is part of DAG Y. Job-to-job lineage between sibling tasks within the same DAG is orthogonal to that hierarchy.
-
-`JobEvent` is the natural home for declared job-to-job lineage ("this job is designed to feed data to that job"); `RunEvent` carries observed job-to-job lineage when a runtime integration can identify both ends of the chain.
-
-### Why one mechanism for all three cases
-
-A reasonable counter-question: do we need `type: JOB` at all? Sinks and generators are already implicit in the event's `inputs`/`outputs` arrays — couldn't a flag (`generated: true`, or simply `inputs: []` with no JOB type) express them?
-
-It could, if sinks and generators were the only `type: JOB` cases. They are not. Once job-to-job chains are in scope, the JOB-type identity is irreducible:
-
-- A chain involves two jobs that may both differ from the event's job, and may live in different namespaces from each other and from the event. There is no way to flag this with `generated: true` — the spec needs `(namespace, name)` for both ends.
-- Once that machinery exists for chains, using a different mechanism for sinks and generators would split a single semantic concept ("a job participates in lineage") into three special cases, requiring three parser branches and three sets of consumer rules.
-
-The early working group discussion explicitly flagged that having JOB sometimes implicit (sinks/generators) and sometimes explicit (chains) "causes inconsistency and ambiguity" and recommended consistent explicit JOB. We adopt that recommendation: one mechanism, one shape, three uses.
-
-This also keeps the lineage facet self-contained: consumers can derive every lineage edge — dataset-to-dataset, sink, generator, chain, column-level — from the facet alone, without joining against `inputs`/`outputs`.
 
 ## Granularity Matrix
 
@@ -419,357 +130,19 @@ The combination of target type, source type, and field presence on either end en
 | DATASET (entity-level) | DATASET | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
 | DATASET (per field) | DATASET | Yes | Column-level lineage | `output.total <- input.amount` |
 | DATASET (per field) | DATASET | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
-| DATASET | JOB | — | Generator: dataset produced by upstream job | `output_table <- extract_task` |
-| JOB | DATASET | No | Sink: job consumes entire dataset | `fraud_detector <- transactions` |
-| JOB | DATASET | Yes | Sink: job consumes specific columns | `fraud_detector <- transactions.amount` |
+| DATASET | JOB | — | Dataset produced from an explicitly identified upstream job | `output_table <- dag_a.task_3` |
+| JOB | DATASET | No | Explicit target job consumes entire dataset | `dag_b.task_1 <- transactions` |
+| JOB | DATASET | Yes | Explicit target job consumes specific columns | `dag_b.task_1 <- transactions.amount` |
 | JOB | JOB | — | Job-to-job chain (no intermediate dataset) | `dag_b.task_1 <- dag_a.task_3` |
 
-## Examples
-
-### 1. Dataset-level lineage on RunEvent (solves #4359)
-
-ETL job reads A,B and writes C,D. Only A->C and B->D are real edges. LineageRunFacet on the run:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-123",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/etl",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "postgresql://warehouse:5432", "name": "table_c", "type": "DATASET",
-            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_a", "type": "DATASET" }] },
-          { "namespace": "postgresql://warehouse:5432", "name": "table_d", "type": "DATASET",
-            "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "table_b", "type": "DATASET" }] }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "http://etl-server:8080", "name": "bulk_etl" },
-  "inputs": [
-    { "namespace": "postgresql://warehouse:5432", "name": "table_a" },
-    { "namespace": "postgresql://warehouse:5432", "name": "table_b" }
-  ],
-  "outputs": [
-    { "namespace": "postgresql://warehouse:5432", "name": "table_c" },
-    { "namespace": "postgresql://warehouse:5432", "name": "table_d" }
-  ]
-}
-```
-
-`inputs`/`outputs` remain as the carrier for dataset facets and as the fallback for older consumers. The LineageRunFacet defines the actual data flow for newer consumers.
-
-### 2. Column-level lineage on RunEvent (subsumes CLL)
-
-```json
-"run": {
-  "runId": "abc-123",
-  "facets": {
-    "lineage": {
-      "_producer": "...",
-      "_schemaURL": "...",
-      "entries": [
-        { "namespace": "postgresql://analytics:5432", "name": "output", "type": "DATASET",
-          "fields": {
-            "total": {
-              "inputs": [
-                { "namespace": "postgresql://analytics:5432", "name": "input", "type": "DATASET", "field": "amount",
-                  "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION" }] }
-              ]
-            }
-          }
-        }
-      ]
-    }
-  }
-}
-```
-
-### 3. Mixed granularity (dataset + column + dataset-wide ops)
-
-```json
-"entries": [
-  { "namespace": "postgresql://analytics:5432", "name": "output_X", "type": "DATASET",
-    "inputs": [
-      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" },
-      { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "group_by_col",
-        "transformations": [{ "type": "INDIRECT", "subtype": "GROUP_BY" }] }
-    ],
-    "fields": {
-      "col1": {
-        "inputs": [
-          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET", "field": "col_a" }
-        ]
-      },
-      "col2": {
-        "inputs": [
-          { "namespace": "postgresql://analytics:5432", "name": "input_A", "type": "DATASET" }
-        ]
-      }
-    }
-  }
-]
-```
-
-This single entry combines:
-- **Entity-level**: output_X comes from input_A
-- **Dataset-wide op**: group_by_col affects entire output
-- **Column mapping**: col_a -> col1
-- **Partial info**: col2 comes from input_A (source column unknown)
-
-### 4. Dataset-to-dataset (job-less, on DatasetEvent)
-
-A VIEW derives from base tables. No job involved. LineageDatasetFacet on the dataset:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "eventTime": "2026-03-25T10:00:00.000Z",
-  "dataset": {
-    "namespace": "postgresql://warehouse:5432",
-    "name": "public.customer_view",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/catalog",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageDatasetFacet.json",
-        "inputs": [
-          { "namespace": "postgresql://warehouse:5432", "name": "public.customers", "type": "DATASET" },
-          { "namespace": "postgresql://warehouse:5432", "name": "public.orders", "type": "DATASET" }
-        ]
-      }
-    }
-  }
-}
-```
-
-> Note: no `namespace`/`name`/`type` on the facet itself — the target is implicit from the dataset it's attached to.
-
-### 5. Static job lineage (on JobEvent)
-
-A catalog declares what a job is designed to do. LineageJobFacet on the job:
-
-```json
-{
-  "job": {
-    "namespace": "http://airflow:8080",
-    "name": "daily_etl",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/catalog",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
-        "entries": [
-          { "namespace": "postgresql://warehouse:5432", "name": "output_table", "type": "DATASET",
-            "inputs": [
-              { "namespace": "postgresql://warehouse:5432", "name": "source_table", "type": "DATASET" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "inputs": [{ "namespace": "postgresql://warehouse:5432", "name": "source_table" }],
-  "outputs": [{ "namespace": "postgresql://warehouse:5432", "name": "output_table" }]
-}
-```
-
-### 6. Data sink — job consumes data without tracked output
-
-A fraud detection job reads transactions and sends alerts, but doesn't write to any tracked dataset. The job itself is the lineage target:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-456",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/validation",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "validation", "name": "fraud_detector", "type": "JOB",
-            "inputs": [
-              { "namespace": "postgres://prod", "name": "transactions", "type": "DATASET" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "validation", "name": "fraud_detector" },
-  "inputs": [
-    { "namespace": "postgres://prod", "name": "transactions" }
-  ],
-  "outputs": []
-}
-```
-
-### 7. Data generator — job produces data without tracked input
-
-An extract task pulls data from an external API (not modeled as a dataset) and writes to a table. The upstream job is the lineage source:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-789",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/etl",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "postgres://prod", "name": "extracted_data", "type": "DATASET",
-            "inputs": [
-              { "namespace": "airflow://prod", "name": "data_pipeline.extract_task", "type": "JOB" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "airflow://prod", "name": "data_pipeline.extract_task" },
-  "inputs": [],
-  "outputs": [
-    { "namespace": "postgres://prod", "name": "extracted_data" }
-  ]
-}
-```
-
-### 8. Job-to-job — declared chain on JobEvent
-
-A stored procedure `dag_b.task_1` reads its input from upstream `dag_a.task_3` via a non-materialized handoff. No intermediate dataset exists. The catalog declares the design-time data flow on the JobEvent for `dag_b`:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "job": {
-    "namespace": "airflow://prod",
-    "name": "dag_b",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/catalog",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageJobFacet.json",
-        "entries": [
-          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
-            "inputs": [
-              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "inputs": [],
-  "outputs": []
-}
-```
-
-Note that `runId` is omitted on both ends — declared lineage describes the job definition, not a specific execution. The same shape would apply to a non-materialized view consumed by a downstream job, or to an Airflow task receiving data via XCom from an upstream task.
-
-### 9. Job-to-job — observed chain on RunEvent
-
-The same data flow as Example 8, observed at runtime by an integration that can identify both the upstream and downstream runs. `runId` is populated on each end, binding the chain to specific executions:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "run-b-001",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/airflow",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "airflow://prod", "name": "dag_b.task_1", "type": "JOB",
-            "runId": "run-b-001",
-            "inputs": [
-              { "namespace": "airflow://prod", "name": "dag_a.task_3", "type": "JOB",
-                "runId": "run-a-042" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "airflow://prod", "name": "dag_b.task_1" },
-  "inputs": [],
-  "outputs": []
-}
-```
-
-### 10. Job-to-job — cross-namespace chain
-
-A streaming job in a Flink cluster feeds an in-memory topic consumed by a job in a separate Beam pipeline. Neither job is in the namespace of the other, and the topic is not modeled as a dataset. The Beam pipeline emits the cross-namespace chain on its RunEvent:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "beam-run-77",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/beam",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "beam://analytics", "name": "enrichment_pipeline", "type": "JOB",
-            "runId": "beam-run-77",
-            "inputs": [
-              { "namespace": "flink://ingest", "name": "event_normalizer", "type": "JOB" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "beam://analytics", "name": "enrichment_pipeline" },
-  "inputs": [],
-  "outputs": []
-}
-```
-
-The source job (`flink://ingest/event_normalizer`) is in a different namespace from both the event's job and the target entry. Without explicit `(namespace, name)` on both ends, the chain could not be expressed.
-
-### 11. Structured-to-unstructured — known source columns, no target schema
-
-Reading specific columns from a structured table and writing to an unstructured file (e.g., a PDF). The target has no schema, so there is no `fields` map — but we can still express that the output came from specific source columns:
-
-```json
-{
-  "eventType": "COMPLETE",
-  "run": {
-    "runId": "abc-012",
-    "facets": {
-      "lineage": {
-        "_producer": "https://example.com/export",
-        "_schemaURL": "https://openlineage.io/spec/facets/LineageRunFacet.json",
-        "entries": [
-          { "namespace": "file://", "name": "R.pdf", "type": "DATASET",
-            "inputs": [
-              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "A" },
-              { "namespace": "postgres://prod", "name": "X", "type": "DATASET", "field": "B" }
-            ]
-          }
-        ]
-      }
-    }
-  },
-  "job": { "namespace": "analytics", "name": "event_processor" },
-  "inputs": [
-    { "namespace": "postgres://prod", "name": "X" }
-  ],
-  "outputs": [
-    { "namespace": "file://", "name": "R.pdf" }
-  ]
-}
-```
+The ordinary sink and generator relationships for the event's own job are outside this matrix because they are not represented as explicit facet entries. They are represented by event membership: dangling `inputs` are consumed by the event's job, and dangling `outputs` are produced by the event's job.
 
 ## Precedence Rules
 
-1. **If a lineage facet is present on the event**, it is the complete picture of lineage for that event. Consumers should derive all lineage edges from the facet and should not infer additional edges from `inputs`/`outputs` arrays or CLL facets. The `inputs`/`outputs` arrays remain as dataset facet carriers and backward-compatibility fallback, but are not a lineage source when a lineage facet is present.
-2. **If no lineage facet is present**: use CLL on output datasets if available, then fall back to cartesian product of inputs x outputs (current behavior unchanged).
-3. **If both a lineage facet and CLL are present** for the same output dataset, the lineage facet takes precedence.
+1. **If a lineage facet is present on the event**, it is the complete picture of explicit lineage between tracked entities for that event. Consumers should derive dataset-to-dataset, column-level, and explicit job-involving edges from the facet and should not infer additional dataset-to-dataset edges from `inputs`/`outputs` arrays or CLL facets.
+2. **The event's own job remains implicit**. Even when a lineage facet is present, `inputs`/`outputs` still define the boundary of the event's job. Input datasets that are not referenced by any lineage entry are consumed directly by the event's job. Output datasets that are not described by any lineage entry are produced directly by the event's job. These implicit job-boundary relationships do not create a cartesian product between inputs and outputs.
+3. **If no lineage facet is present**: use CLL on output datasets if available, then fall back to cartesian product of inputs x outputs (current behavior unchanged).
+4. **If both a lineage facet and CLL are present** for the same output dataset, the lineage facet takes precedence.
 
 ## Semantic Constraints
 
@@ -779,7 +152,7 @@ These constraints are documented in spec text rather than enforced by JSON Schem
 
 2. **Event type restriction**: LineageRunFacet MUST only appear on RunEvent. LineageJobFacet MUST only appear on JobEvent. LineageDatasetFacet MUST only appear on DatasetEvent.
 
-3. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets and the fallback for older consumers.
+3. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets, the fallback for older consumers, and the source of implicit event-job boundary relationships for dangling inputs/outputs.
 
 4. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
 
@@ -787,13 +160,15 @@ These constraints are documented in spec text rather than enforced by JSON Schem
 
 6. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
 
-7. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
+7. A **dangling input** is an input dataset in the event `inputs` array that is not referenced as a source by any lineage entry. It is interpreted as data consumed directly by the event's job without a tracked output dataset. A **dangling output** is an output dataset in the event `outputs` array that is not represented as a lineage target. It is interpreted as data produced directly by the event's job without a tracked input dataset.
 
-8. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
+8. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
 
-9. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
+9. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
 
-10. **`type: JOB` semantics**: A `LineageJobEntry` (target) and `LineageJobInput` (source) MUST identify the job by `(namespace, name)`. Either or both jobs MAY differ from the event's own job and from each other's namespace (e.g., for cross-namespace job-to-job chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-to-job lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`.
+10. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
+
+11. **`type: JOB` semantics**: A `LineageJobEntry` (target) and `LineageJobInput` (source) MUST identify the job by `(namespace, name)`. Either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. `type: JOB` is not used to restate that the event's own job consumes event inputs or produces event outputs.
 
 ## Interaction with Existing Features
 
@@ -805,16 +180,17 @@ The optional `runId` on `LineageJobEntry` and `LineageJobInput` is also orthogon
 
 ### JobDependenciesRunFacet (control flow)
 
-Remains as-is for scheduling and control flow dependencies. Lineage facets express DATA flow dependencies — including job-to-job data flow, see [`type: JOB` Lineage](#type-job-lineage-sinks-generators-and-job-to-job-chains). Spec prose documents the distinction: a job may depend on another job for scheduling (control flow) without having a data dependency, and vice versa. The two facets are complementary, not overlapping.
+Remains as-is for scheduling and control flow dependencies. Lineage facets express DATA flow dependencies — including explicit job-involving data flow, see [Event Job Boundaries and `type: JOB` Lineage](#event-job-boundaries-and-type-job-lineage). Spec prose documents the distinction: a job may depend on another job for scheduling (control flow) without having a data dependency, and vice versa. The two facets are complementary, not overlapping.
 
 ### inputs[] / outputs[] arrays
 
-Remain as-is. They serve two purposes that lineage facets do not replace:
+Remain as-is. They serve three purposes that lineage facets do not replace:
 
 - **Dataset facet carrier**: Dataset facets (schema, ownership, data quality, etc.) are attached to InputDataset and OutputDataset objects. There is no mechanism to attach facets to entities referenced in lineage entries.
 - **Backward compatibility**: Older consumers that don't understand lineage facets still get the full list of datasets involved via inputs/outputs.
+- **Implicit event-job boundary**: The event's own job is not repeated in the lineage facet. Inputs and outputs that are not connected by explicit lineage entries still describe what the event job consumed or produced.
 
-When a lineage facet is present, these arrays are **not a lineage source**. Consumers should derive lineage exclusively from the facet. The arrays exist for the two purposes above only.
+When a lineage facet is present, these arrays are **not a dataset-to-dataset lineage source**. Consumers should not infer the cartesian product of inputs x outputs. They do, however, continue to define the event-job boundary: dangling inputs are consumed by the event's job, and dangling outputs are produced by the event's job.
 
 ### ColumnLineageDatasetFacet (CLL)
 
@@ -868,7 +244,7 @@ This translation is lossy — dataset-level inputs without a field, fields entri
 When a producer only emits the old model but the downstream consumer expects lineage facets:
 
 1. **Output datasets with CLL**: Create a LineageEntry from each CLL facet.
-2. **Output datasets without CLL**: Create a LineageEntry with inputs containing ALL input datasets (the cartesian product — making implicit inference explicit).
+2. **Output datasets without CLL**: Create a LineageEntry with inputs containing ALL input datasets (the cartesian product — making implicit dataset-to-dataset inference explicit). If there are no input datasets, create the entry with `inputs: []` to state that the output has no tracked upstream dataset.
 3. **Construct the facet**: Wrap all LineageEntry objects in a LineageRunFacet.
 
 This translation is lossless — CLL is a strict subset of what lineage facets can express.
@@ -922,7 +298,7 @@ When this restriction is relaxed, a **lineage-type attribute** (runtime vs stati
 
 ### New entity types
 
-Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the `oneOf` in `LineageEntry` and/or `LineageInput`, along with spec prose updates and client library support. This is a non-breaking schema change — existing entries remain valid.
+Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding a new subtype definition to the relevant `oneOf` definitions, along with spec prose updates and client library support. This is a non-breaking schema change — existing entries remain valid.
 
 **The principle is**: grow the existing facets rather than proliferate new ones. Each lineage facet is a home for lineage information scoped to its entity type. New capabilities land as new fields or relaxed constraints within the same facet, keeping the model simple and the number of moving parts small.
 
@@ -931,3 +307,7 @@ Adding new entity types (e.g., `MODEL`, `DASHBOARD`, `PIPELINE`) requires adding
 An earlier version of this proposal placed lineage as a top-level `lineage` array directly on `BaseEvent`, alongside `inputs` and `outputs`. This would make lineage a first-class structural element of the event model rather than a facet.
 
 Working group members raised concerns that a new top-level property would change the fundamental shape of the event model and create two parallel ways to express the same information (top-level arrays vs. facets). Since OpenLineage already has facets as its standard extensibility mechanism, the group concluded that lineage information fits naturally within that mechanism — avoiding a model-level change while preserving identical semantics and capabilities. The trade-off is slightly deeper nesting in the JSON structure and the need for three facets (one per entity type) rather than a single top-level array.
+
+## Examples
+
+Examples are defined in [ExplicitLineageExamples.md](ExplicitLineageExamples.md).

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -102,7 +102,7 @@ extract_task (JOB) ──> transformed_data (DATASET)
   "fields": {
     "total": {
       "inputs": [
-        { "type": "JOB", "transformations": [{ "type": "INDIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
+        { "type": "JOB", "transformations": [{ "type": "DIRECT", "subtype": "AGGREGATION", "description": "sum()" }] }
       ]
     }
   }

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -1,8 +1,18 @@
 # Proposal: Explicit Lineage — Facet-Based Approach
 
 **Issue**: [OpenLineage#4359](https://github.com/OpenLineage/OpenLineage/issues/4359)  
-**Status**: Draft  
+**Status**: Experimental  
 **Date**: 2026-04-02
+
+---
+
+> Experimental
+>
+> This proposal is experimental. It is a large change to how OpenLineage models
+> lineage, so we are still actively looking for feedback. We may merge the code
+> and the spec, and ship it as part of the OpenLineage libraries. We may also
+> change it or drop the idea altogether. If you have a use case, an objection or
+> a suggestion, please raise it on the issue.
 
 ---
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -8,7 +8,7 @@
 
 ## Problem Statement
 
-TODO: bit more positive sentiment here. We will support more use cases due to this proposal.
+This proposal lets OpenLineage express more lineage in one consistent model: multi-dataset jobs, dataset-to-dataset derivation, job-to-job data flow, and mixed dataset- and column-level detail. These are patterns producers see today but cannot represent. The rest of this section sets out what the current model does well and where it falls short.
 
 OpenLineage's current model captures lineage through two mechanisms: `inputs`/`outputs` arrays on Run and Job events, and `ColumnLineageDatasetFacet` (CLL - Column-Level Lineage) for column-level detail on individual outputs. Most integrations today (Spark, dbt, Flink) emit one output per job, so the implicit assumption that all inputs feed all outputs happens to be correct — dataset-level lineage works fine.
 
@@ -19,7 +19,7 @@ Beyond this gap, the current model cannot express several common patterns:
 - **Dataset-to-dataset derivation** — no mechanism for views, aliases, or manually documented lineage without an intermediate job
 - **Job-to-job data flow** — no way to express that one job feeds data to another without an intermediate dataset (e.g., non-materialized views, stored procedures calling functions, in-memory data passing)
 - **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level lineage for some outputs and column-level for others in the same event.
-- **Job-to-dataset and dataset-to-job data flows - TODO**
+- **Transformation detail on a job's own production or consumption** — a job that produces a dataset with no tracked input (a generator) or consumes one with no tracked output (a sink) can only be stated as a plain edge. There is no way to record how the job derived each column or what transformation it applied.
 
 ## Goals
 
@@ -29,23 +29,23 @@ Create a unified lineage structure that handles all the cases outlined above —
 
 The general idea is to model the relationships explicitly; rather than implicitly; following and expanding on the ColumnLevelLineageDatasetFacet.
 
-We introduce three new facets — **LineageRunFacet**, **LineageJobFacet**, and **LineageDatasetFacet** — each carrying explicit lineage information and each restricted (by spec text, not JSON Schema) to a single event type:
+We introduce two new facets — `LineageJobFacet` and `LineageDatasetFacet`. The event type decides where lineage lives and how to read it:
 
 
-| Facet                 | Entity it lives on | Allowed event type | Semantics                                                           |
-| --------------------- | ------------------ | ------------------ | ------------------------------------------------------------------- |
-| `LineageRunFacet`     | Run                | RunEvent only      | Observed data flow during this specific run                         |
-| `LineageJobFacet`     | Job                | JobEvent only      | Declared/static data flow for this job definition                   |
-| `LineageDatasetFacet` | Dataset            | DatasetEvent only  | Structural derivation of this dataset (views, aliases, manual docs) |
+| Event type   | Lineage facet         | Lives on    | Semantics                                                              |
+| ------------ | --------------------- | ----------- | --------------------------------------------------------------------- |
+| RunEvent     | `LineageJobFacet`     | the job     | Data flow observed during this run (accumulative)                     |
+| JobEvent     | `LineageJobFacet`     | the job     | Declared, static data flow for this job definition (replace)          |
+| DatasetEvent | `LineageDatasetFacet` | the dataset | Structural derivation of this dataset — views, aliases, manual (replace) |
 
 
-**Why the one-facet-per-event-type restriction?** If a RunEvent carried both a LineageRunFacet (on the run) and LineageDatasetFacet (on output datasets), the semantics would be ambiguous — which takes precedence? Do they merge? Rather than define complex interaction rules, we disallow the combination entirely. Each event type has exactly one place where lineage lives.
+Lineage is a property of the job, not of each individual run. So there is no separate run-level facet. `LineageJobFacet` is a JobFacet, and the `job` object is present on both RunEvent and JobEvent, so the same facet serves both event types. On a JobEvent it is the declared, static data flow. On a RunEvent it is the data flow observed during that run, and it MAY bind edges to specific executions through the optional `runId` on job-typed entries.
 
-This restriction may be relaxed in a future version if we define the semantics of that behavior (see [Future Evolution](#future-evolution)).
+`LineageDatasetFacet` sits on a dataset and describes what feeds into it. The target is implicit — it is the dataset the facet is attached to. This is the same position as CLL, which it evolves.
 
-**LineageDatasetFacet** is the natural one. It sits on an output dataset and describes what feeds into that specific dataset — the same position as CLL. The target entity is implicit (the dataset the facet is attached to). This is a direct evolution of CLL.
+`LineageJobFacet` is the less usual shape: it sits on the job but describes relationships between other entities (datasets and jobs), not properties of the job itself. This works because the event supplies the frame — "during this run, data flowed this way" or "this job is designed to move data this way."
 
-**LineageRunFacet** and **LineageJobFacet** are the pragmatic ones. They sit on the run/job entity but describe relationships between other entities (datasets). This is not the usual way for a facet — normally a facet describes properties of the entity it's on. But it works because the event type provides the frame on which the event is one: "during this run, data flowed this way" or "this job is designed to move data this way." This information is also used in the Sinks/Generators section below - we know they live in the context of some dataset.
+**Why one lineage facet per event type?** A RunEvent could in principle carry both a `LineageJobFacet` on the job and a `LineageDatasetFacet` on its output datasets. The semantics would then be ambiguous — which takes precedence, and do they merge? Rather than define interaction rules, we disallow the combination. Lineage for a RunEvent or JobEvent lives only in `LineageJobFacet`; lineage for a DatasetEvent lives only in `LineageDatasetFacet`. This restriction may be relaxed in a future version once the interaction semantics are defined (see [Future Evolution](#future-evolution)).
 
 ## Proposed Schema
 
@@ -116,7 +116,7 @@ An explicit job-involving chain is data flowing through a job that cannot be rec
 dag_a.task_3 (JOB) ──> dag_b.task_1 (JOB)
 ```
 
-TODO: explain that we standarize from the point of "output" - we are describing the current job's inputs
+Lineage is always expressed from the target's point of view. An entry names a target entity and lists the inputs that feed into it — never the outputs it feeds. So the chain above is recorded as an entry whose target is `dag_b.task_1`, with `dag_a.task_3` among its inputs. This matches how CLL already works, where a target dataset lists its input fields, and it keeps one orientation across both dataset and job targets.
 
 Either or both jobs may live in a different namespace from the event's own job, so the explicit `(namespace, name)` on `LineageJobEntry` and `LineageJobInput` is load-bearing — these chains cannot be reconstructed from the event's surrounding job field alone. The same applies to a chain that ends in a dataset after an explicit upstream job, such as `dag_a.task_3 (JOB) -> output_table (DATASET)`: the upstream job identity is not the event's own job and must remain expressible as a `LineageJobInput`.
 
@@ -148,29 +148,34 @@ What is lost is the partitioning of the handoff: that `dataset_4` depends on the
 
 ## Granularity Matrix
 
-TODO: This is not clear at all
+One structure covers every granularity level, from dataset-level down to column-level. Each edge is set by three choices:
 
-The combination of target type, source type, and field presence on either end enables all granularity levels in one table:
+- the target — a whole dataset, a single dataset field, or a job
+- the source — a dataset or a job
+- whether the source names a specific field
 
-
-| Target type            | Source type                   | Source field? | Meaning                                                                                   | Example                                    |
-| ---------------------- | ----------------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
-| DATASET (entity-level) | DATASET                       | No            | Dataset-level lineage                                                                     | `output_table <- input_table`              |
-| DATASET (entity-level) | DATASET                       | Yes           | Dataset-wide operation (e.g., GROUP BY)                                                   | `output_table <- input.group_by_col`       |
-| DATASET (per field)    | DATASET                       | Yes           | Column-level lineage                                                                      | `output.total <- input.amount`             |
-| DATASET (per field)    | DATASET                       | No            | Partial column lineage (source column unknown)                                            | `output.region <- lookup_table`            |
-| DATASET                | JOB (identified)              | —             | Dataset produced from an explicitly identified upstream job                               | `output_table <- dag_a.task_3`             |
-| DATASET (per field)    | JOB (identity-less = own job) | —             | Field produced by the event's own job, with transformation detail and no tracked upstream | `extracted_data.total <- sum() by own job` |
-| JOB                    | DATASET                       | No            | Explicit target job consumes entire dataset                                               | `dag_b.task_1 <- transactions`             |
-| JOB                    | DATASET                       | Yes           | Explicit target job consumes specific columns                                             | `dag_b.task_1 <- transactions.amount`      |
-| JOB                    | JOB                           | —             | Job-to-job chain (no intermediate dataset)                                                | `dag_b.task_1 <- dag_a.task_3`             |
+Read each row as `target <- source`. The combinations below show what each one means.
 
 
-The ordinary sink and generator relationships for the event's own job are outside this matrix because they are not represented as explicit facet entries. They are represented by event membership: dangling `inputs` are consumed by the event's job, and dangling `outputs` are produced by the event's job.
+| Target                        | Source                        | Source field? | Meaning                                                                                   | Example                                    |
+| ----------------------------- | ----------------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Dataset                       | Dataset                       | No            | Dataset-level lineage                                                                     | `output_table <- input_table`              |
+| Dataset                       | Dataset                       | Yes           | Dataset-wide operation (for example, GROUP BY)                                            | `output_table <- input.group_by_col`       |
+| Dataset field                 | Dataset                       | Yes           | Column-level lineage                                                                      | `output.total <- input.amount`             |
+| Dataset field                 | Dataset                       | No            | Partial column lineage (source column unknown)                                            | `output.region <- lookup_table`            |
+| Dataset                       | Job (identified)              | —             | Dataset produced from an explicitly identified upstream job                               | `output_table <- dag_a.task_3`             |
+| Dataset field                 | Own job (identity-less)       | —             | Field produced by the event's own job, with transformation detail and no tracked upstream (generator) | `extracted_data.total <- sum() by own job` |
+| Job                           | Dataset                       | No            | Explicitly identified target job consumes a whole dataset                                 | `dag_b.task_1 <- transactions`             |
+| Job                           | Dataset                       | Yes           | Explicitly identified target job consumes specific columns                                | `dag_b.task_1 <- transactions.amount`      |
+| Own job (identity-less)       | Dataset                       | —             | Dataset consumed by the event's own job, with transformation detail and no tracked output (sink) | `own job <- transactions (FILTER)`         |
+| Job                           | Job                           | —             | Job-to-job chain (no intermediate dataset)                                                | `dag_b.task_1 <- dag_a.task_3`             |
+
+
+Plain sink and generator edges for the event's own job are not in this matrix, because they are not explicit facet entries. Event membership carries them: dangling `inputs` are consumed by the event's job, and dangling `outputs` are produced by it. The two identity-less rows above only add transformation detail that event membership cannot carry.
 
 ## Precedence Rules
 
-TODO: Why are we talking about this here
+During the transition, one event may carry a lineage facet, CLL, and `inputs`/`outputs` at the same time. These rules tell a consumer which representation to trust, and in what order, so the same event is never read two ways:
 
 1. **If a lineage facet is present on the event**, it is the complete picture of explicit lineage between tracked entities for that event. Consumers should derive dataset-to-dataset, column-level, and explicit job-involving edges from the facet and should not infer additional dataset-to-dataset edges from `inputs`/`outputs` arrays or CLL facets.
 2. **The event's own job remains implicit**. Even when a lineage facet is present, `inputs`/`outputs` still define the boundary of the event's job. Input datasets that are not referenced by any lineage entry are consumed directly by the event's job. Output datasets that are not described by any lineage entry are produced directly by the event's job. These implicit job-boundary relationships do not create a cartesian product between inputs and outputs.
@@ -181,24 +186,20 @@ TODO: Why are we talking about this here
 
 These constraints are documented in spec text rather than enforced by JSON Schema. They are intentionally conservative — motivated by keeping lineage cohesive within a single event and avoiding the need to define interaction/precedence rules between multiple lineage facets. Any of these restrictions may be relaxed in a future version if use cases emerge; the current goal is to keep the initial proposal simple and unambiguous.
 
-1. **One lineage facet per event**: A single event MUST NOT carry more than one type of lineage facet. A RunEvent uses LineageRunFacet; a JobEvent uses LineageJobFacet; a DatasetEvent uses LineageDatasetFacet. Mixing them is forbidden.
-2. **Event type restriction**: LineageRunFacet MUST only appear on RunEvent. LineageJobFacet MUST only appear on JobEvent. LineageDatasetFacet MUST only appear on DatasetEvent.
+1. **One lineage facet per event type**: A RunEvent or JobEvent carries lineage in `LineageJobFacet` (on the job); a DatasetEvent carries it in `LineageDatasetFacet` (on the dataset). An event MUST NOT mix the two. `LineageDatasetFacet` MUST NOT appear on a RunEvent or JobEvent, and `LineageJobFacet` MUST NOT appear on a DatasetEvent.
+2. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets, the fallback for older consumers, and the source of implicit event-job boundary relationships for dangling inputs/outputs.
+3. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
+4. At least one of `inputs` or `fields` SHOULD be present on a LineageDatasetEntry (or on LineageDatasetFacet directly). For LineageJobEntry, `inputs` SHOULD be present.
+5. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
+6. A **dangling input** is an input dataset in the event `inputs` array that is not referenced as a source by any lineage entry. It is interpreted as data consumed directly by the event's job without a tracked output dataset. A **dangling output** is an output dataset in the event `outputs` array that is not represented as a lineage target. It is interpreted as data produced directly by the event's job without a tracked input dataset.
+7. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
+8. **Semantics follow the event type, not the facet**. The same `LineageJobFacet` is read differently depending on the event it rides on:
+    - On a RunEvent, it follows existing OpenLineage accumulative semantics — each event adds to the lineage picture for the run, and consumers merge entries across events for the same `runId`. It describes data flow observed during the run.
+    - On a JobEvent, it uses replace semantics — the latest event is the complete declared lineage for the job.
+    - `LineageDatasetFacet` on a DatasetEvent also uses replace semantics — the latest event is the complete derivation of the dataset.
 
-TODO: reconsider only LineageJobFacet vs LineageRunFacet. The lineage should be a relatively "static" property - not change every run. 
-
-1. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets, the fallback for older consumers, and the source of implicit event-job boundary relationships for dangling inputs/outputs.
-2. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
-3. At least one of `inputs` or `fields` SHOULD be present on a LineageDatasetEntry (or on LineageDatasetFacet directly). For LineageJobEntry, `inputs` SHOULD be present.
-4. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
-5. A **dangling input** is an input dataset in the event `inputs` array that is not referenced as a source by any lineage entry. It is interpreted as data consumed directly by the event's job without a tracked output dataset. A **dangling output** is an output dataset in the event `outputs` array that is not represented as a lineage target. It is interpreted as data produced directly by the event's job without a tracked input dataset.
-6. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
-7. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
-8. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
-
-TODO: Semantics should follow event types - behave differently based on event, not facets
-
-1. `**type: JOB` semantics**: A `LineageJobEntry` (target) MUST identify the job by `(namespace, name)`. A `LineageJobInput` (source) identifies the job by `(namespace, name)` when both are present; either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. A `LineageJobInput` is **not** used to restate that the event's own job consumes event inputs or produces event outputs at dataset granularity — that remains implicit via event membership.
-  **Identity-less `LineageJobInput` (the event's own job)**: A `LineageJobInput` MAY omit both `namespace` and `name`, in which case it resolves to the event's own job. This form exists only to attach **field-level and/or transformation detail** to data produced by the implicit job (the generator case) — detail that event membership alone cannot carry. It MUST NOT be used as a top-level entity-level input to restate the implicit dataset-level edge. A producer MUST emit `namespace` and `name` together or omit them together.
+9. **`type: JOB` semantics**: A `LineageJobEntry` (target) and a `LineageJobInput` (source) both identify a job by `(namespace, name)`. When both are present, the job MAY differ from the event's own job and from other jobs in the same chain, which is what makes cross-namespace job-to-job-to-dataset chains expressible. `runId` is OPTIONAL: on a RunEvent it MAY bind the edge to a specific execution; on a JobEvent it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses data flow only. Scheduling and control-flow dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`.
+10. **Identity-less job entries and inputs (the event's own job)**: A `LineageJobEntry` or `LineageJobInput` MAY omit both `namespace` and `name`, in which case it resolves to the event's own job, with its identity and run taken from the top-level event. This form exists only to attach transformation and field detail that event membership cannot carry: an identity-less `LineageJobInput` covers the generator case (data the job produces), and an identity-less `LineageJobEntry` covers the sink case (data the job consumes). It MUST NOT restate the implicit dataset-level edge that event membership already carries. A producer MUST emit `namespace` and `name` together or omit them together.
 
 ## Interaction with Existing Features
 
@@ -262,13 +263,13 @@ The translation happens transparently in the client library's event emission pat
 | `fields.{col}.inputs` (identity-less JOB source, transformations only) | dropped                       | CLL has no notion of a field produced by the job with no dataset source |
 
 
-For LineageRunFacet/LineageJobFacet: extract entries by target dataset, generate a CLL facet per output dataset, attach to the corresponding output in `outputs[]`. Same lossy mapping as above.
+For `LineageJobFacet`: extract entries by target dataset, generate a CLL facet per output dataset, attach to the corresponding output in `outputs[]`. Same lossy mapping as above.
 
 ### Forward translation: lineage facets -> inputs/outputs/CLL
 
 When a producer emits lineage facets but the downstream consumer only understands the old model, the client automatically generates the old representation:
 
-1. **Populate inputs/outputs**: Scan all LineageEntry objects. For each target dataset, add to `outputs[]` if not present. For each source dataset in inputs, add to `inputs[]` if not present.
+1. **Populate inputs/outputs**: Scan all entries in the lineage facet. For each target dataset, add to `outputs[]` if not present. For each source dataset in inputs, add to `inputs[]` if not present.
 2. **Generate CLL facets**: For each target dataset with a `fields` map, construct a ColumnLineageDatasetFacet.
 3. **Attach CLL to output datasets**: The generated CLL facet is attached to the corresponding OutputDataset in `outputs[]`.
 
@@ -278,9 +279,9 @@ This translation is lossy — dataset-level inputs without a field, fields entri
 
 When a producer only emits the old model but the downstream consumer expects lineage facets:
 
-1. **Output datasets with CLL**: Create a LineageEntry from each CLL facet.
-2. **Output datasets without CLL**: Create a LineageEntry with inputs containing ALL input datasets (the cartesian product — making implicit dataset-to-dataset inference explicit). If there are no input datasets, create the entry with `inputs: []` to state that the output has no tracked upstream dataset.
-3. **Construct the facet**: Wrap all LineageEntry objects in a LineageRunFacet.
+1. **Output datasets with CLL**: Create a lineage entry from each CLL facet.
+2. **Output datasets without CLL**: Create a lineage entry with inputs containing ALL input datasets (the cartesian product — making implicit dataset-to-dataset inference explicit). If there are no input datasets, create the entry with `inputs: []` to state that the output has no tracked upstream dataset.
+3. **Construct the facet**: Wrap all entries in a `LineageJobFacet` on the job.
 
 This translation is lossless — CLL is a strict subset of what lineage facets can express.
 
@@ -332,7 +333,7 @@ For this version, the two facets remain complementary.
 
 ### Relaxing the one-facet-per-event-type restriction
 
-Initially, we disallow mixing facet types. As the model matures and interaction semantics become well-understood, this restriction could be relaxed — for example, allowing LineageDatasetFacet on output datasets in a RunEvent alongside LineageRunFacet on the run, with clear merge/precedence rules.
+Initially, we disallow mixing facet types. As the model matures and interaction semantics become well-understood, this restriction could be relaxed — for example, allowing `LineageDatasetFacet` on output datasets in a RunEvent alongside `LineageJobFacet` on the job, with clear merge/precedence rules.
 
 When this restriction is relaxed, a separate lineage-type attribute (runtime vs static) may be needed to disambiguate the semantics of a lineage facet that appears outside its "natural" event type. 
 For instance, a LineageDatasetFacet on an output dataset within a RunEvent could be either "this is what I observed during this run" or "this is the static definition of this dataset" — an explicit attribute would resolve the ambiguity.

--- a/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageProposal.md
@@ -8,15 +8,18 @@
 
 ## Problem Statement
 
-OpenLineage's current model captures lineage through two mechanisms: `inputs`/`outputs` arrays on Run and Job events, and `ColumnLineageDatasetFacet` (CLL) for column-level detail on individual outputs. Most integrations today (Spark, dbt, Flink) emit one output per job, so the implicit assumption that all inputs feed all outputs happens to be correct — dataset-level lineage works fine.
+TODO: bit more positive sentiment here. We will support more use cases due to this proposal.
+
+OpenLineage's current model captures lineage through two mechanisms: `inputs`/`outputs` arrays on Run and Job events, and `ColumnLineageDatasetFacet` (CLL - Column-Level Lineage) for column-level detail on individual outputs. Most integrations today (Spark, dbt, Flink) emit one output per job, so the implicit assumption that all inputs feed all outputs happens to be correct — dataset-level lineage works fine.
 
 The problem appears when a single job reads and writes multiple independent datasets. The model infers the cartesian product of inputs x outputs: reading A,B and writing C,D produces four edges, even if the real flow is only A -> C and B -> D. In some cases, this makes it difficult to express a bulk ETL job processing 10 independent tables without artificially splitting it into separate jobs. CLL can resolve this at column granularity, but many integrations know "Table A feeds Table C" without column-level detail — and without CLL, the only fallback is the cartesian product.
 
 Beyond this gap, the current model cannot express several common patterns:
 
 - **Dataset-to-dataset derivation** — no mechanism for views, aliases, or manually documented lineage without an intermediate job
-- **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level lineage for some outputs and column-level for others in the same event
 - **Job-to-job data flow** — no way to express that one job feeds data to another without an intermediate dataset (e.g., non-materialized views, stored procedures calling functions, in-memory data passing)
+- **Mixed granularity** — CLL is all-or-nothing per output; no way to provide dataset-level lineage for some outputs and column-level for others in the same event.
+- **Job-to-dataset and dataset-to-job data flows - TODO**
 
 ## Goals
 
@@ -24,26 +27,31 @@ Create a unified lineage structure that handles all the cases outlined above —
 
 ## Proposed Solution
 
+The general idea is to model the relationships explicitly; rather than implicitly; following and expanding on the ColumnLevelLineageDatasetFacet.
+
 We introduce three new facets — **LineageRunFacet**, **LineageJobFacet**, and **LineageDatasetFacet** — each carrying explicit lineage information and each restricted (by spec text, not JSON Schema) to a single event type:
 
-| Facet | Entity it lives on | Allowed event type | Semantics |
-|---|---|---|---|
-| `LineageRunFacet` | Run | RunEvent only | Observed data flow during this specific run |
-| `LineageJobFacet` | Job | JobEvent only | Declared/static data flow for this job definition |
-| `LineageDatasetFacet` | Dataset | DatasetEvent only | Structural derivation of this dataset (views, aliases, manual docs) |
+
+| Facet                 | Entity it lives on | Allowed event type | Semantics                                                           |
+| --------------------- | ------------------ | ------------------ | ------------------------------------------------------------------- |
+| `LineageRunFacet`     | Run                | RunEvent only      | Observed data flow during this specific run                         |
+| `LineageJobFacet`     | Job                | JobEvent only      | Declared/static data flow for this job definition                   |
+| `LineageDatasetFacet` | Dataset            | DatasetEvent only  | Structural derivation of this dataset (views, aliases, manual docs) |
+
 
 **Why the one-facet-per-event-type restriction?** If a RunEvent carried both a LineageRunFacet (on the run) and LineageDatasetFacet (on output datasets), the semantics would be ambiguous — which takes precedence? Do they merge? Rather than define complex interaction rules, we disallow the combination entirely. Each event type has exactly one place where lineage lives.
 
-This restriction may be relaxed in a future version with clear type-of-lineage or hierarchy semantics defined (see [Future Evolution](#future-evolution)).
+This restriction may be relaxed in a future version if we define the semantics of that behavior (see [Future Evolution](#future-evolution)).
 
 **LineageDatasetFacet** is the natural one. It sits on an output dataset and describes what feeds into that specific dataset — the same position as CLL. The target entity is implicit (the dataset the facet is attached to). This is a direct evolution of CLL.
 
-**LineageRunFacet** and **LineageJobFacet** are the pragmatic ones. They sit on the run/job entity but describe relationships between other entities (datasets). This is unusual for a facet — normally a facet describes properties of the entity it's on. But it works because the event type provides the semantic frame: "during this run, data flowed this way" or "this job is designed to move data this way."
-
+**LineageRunFacet** and **LineageJobFacet** are the pragmatic ones. They sit on the run/job entity but describe relationships between other entities (datasets). This is not the usual way for a facet — normally a facet describes properties of the entity it's on. But it works because the event type provides the frame on which the event is one: "during this run, data flowed this way" or "this job is designed to move data this way." This information is also used in the Sinks/Generators section below - we know they live in the context of some dataset.
 
 ## Proposed Schema
 
 The proposed facet and shared type schemas are defined in more details in [ExplicitLineageSchema.md](ExplicitLineageSchema.md).
+
+There are special cases that need additional explanation and defined semantics:
 
 ### Sinks: jobs that consume data without a tracked output
 
@@ -55,7 +63,7 @@ inputs: [transactions]
 outputs: []
 ```
 
-The dataset-to-job relationship is implicit in the event boundary: `transactions` is consumed by the event's job because it appears in `inputs` and does not feed any tracked output dataset in the lineage facet. We intentionally do not add a `LineageJobEntry` for `fraud_detector`; that would duplicate information already carried by the event's `job` field.
+The dataset-to-job relationship is implicit in the event: `transactions` is consumed by the event's job because it appears in `inputs` and does not feed any tracked output dataset in the lineage facet. We intentionally do not add a `LineageJobEntry` for `fraud_detector`; that would duplicate information already carried by the event's `job` field.
 
 ```
 transactions (DATASET) ──> fraud_detector (JOB)
@@ -108,6 +116,8 @@ An explicit job-involving chain is data flowing through a job that cannot be rec
 dag_a.task_3 (JOB) ──> dag_b.task_1 (JOB)
 ```
 
+TODO: explain that we standarize from the point of "output" - we are describing the current job's inputs
+
 Either or both jobs may live in a different namespace from the event's own job, so the explicit `(namespace, name)` on `LineageJobEntry` and `LineageJobInput` is load-bearing — these chains cannot be reconstructed from the event's surrounding job field alone. The same applies to a chain that ends in a dataset after an explicit upstream job, such as `dag_a.task_3 (JOB) -> output_table (DATASET)`: the upstream job identity is not the event's own job and must remain expressible as a `LineageJobInput`.
 
 `runId` is OPTIONAL on both ends. On a `JobEvent`, it should be omitted: declared lineage describes the job definition, not a specific execution. On a `RunEvent`, it MAY be populated to bind the chain to specific upstream/downstream executions when the producer can identify them (e.g. when an orchestrator knows which run of `dag_a.task_3` fed this run of `dag_b.task_1`).
@@ -138,23 +148,29 @@ What is lost is the partitioning of the handoff: that `dataset_4` depends on the
 
 ## Granularity Matrix
 
+TODO: This is not clear at all
+
 The combination of target type, source type, and field presence on either end enables all granularity levels in one table:
 
-| Target type | Source type | Source field? | Meaning | Example |
-|---|---|---|---|---|
-| DATASET (entity-level) | DATASET | No | Dataset-level lineage | `output_table <- input_table` |
-| DATASET (entity-level) | DATASET | Yes | Dataset-wide operation (e.g., GROUP BY) | `output_table <- input.group_by_col` |
-| DATASET (per field) | DATASET | Yes | Column-level lineage | `output.total <- input.amount` |
-| DATASET (per field) | DATASET | No | Partial column lineage (source column unknown) | `output.region <- lookup_table` |
-| DATASET | JOB (identified) | — | Dataset produced from an explicitly identified upstream job | `output_table <- dag_a.task_3` |
-| DATASET (per field) | JOB (identity-less = own job) | — | Field produced by the event's own job, with transformation detail and no tracked upstream | `extracted_data.total <- sum() by own job` |
-| JOB | DATASET | No | Explicit target job consumes entire dataset | `dag_b.task_1 <- transactions` |
-| JOB | DATASET | Yes | Explicit target job consumes specific columns | `dag_b.task_1 <- transactions.amount` |
-| JOB | JOB | — | Job-to-job chain (no intermediate dataset) | `dag_b.task_1 <- dag_a.task_3` |
+
+| Target type            | Source type                   | Source field? | Meaning                                                                                   | Example                                    |
+| ---------------------- | ----------------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
+| DATASET (entity-level) | DATASET                       | No            | Dataset-level lineage                                                                     | `output_table <- input_table`              |
+| DATASET (entity-level) | DATASET                       | Yes           | Dataset-wide operation (e.g., GROUP BY)                                                   | `output_table <- input.group_by_col`       |
+| DATASET (per field)    | DATASET                       | Yes           | Column-level lineage                                                                      | `output.total <- input.amount`             |
+| DATASET (per field)    | DATASET                       | No            | Partial column lineage (source column unknown)                                            | `output.region <- lookup_table`            |
+| DATASET                | JOB (identified)              | —             | Dataset produced from an explicitly identified upstream job                               | `output_table <- dag_a.task_3`             |
+| DATASET (per field)    | JOB (identity-less = own job) | —             | Field produced by the event's own job, with transformation detail and no tracked upstream | `extracted_data.total <- sum() by own job` |
+| JOB                    | DATASET                       | No            | Explicit target job consumes entire dataset                                               | `dag_b.task_1 <- transactions`             |
+| JOB                    | DATASET                       | Yes           | Explicit target job consumes specific columns                                             | `dag_b.task_1 <- transactions.amount`      |
+| JOB                    | JOB                           | —             | Job-to-job chain (no intermediate dataset)                                                | `dag_b.task_1 <- dag_a.task_3`             |
+
 
 The ordinary sink and generator relationships for the event's own job are outside this matrix because they are not represented as explicit facet entries. They are represented by event membership: dangling `inputs` are consumed by the event's job, and dangling `outputs` are produced by the event's job.
 
 ## Precedence Rules
+
+TODO: Why are we talking about this here
 
 1. **If a lineage facet is present on the event**, it is the complete picture of explicit lineage between tracked entities for that event. Consumers should derive dataset-to-dataset, column-level, and explicit job-involving edges from the facet and should not infer additional dataset-to-dataset edges from `inputs`/`outputs` arrays or CLL facets.
 2. **The event's own job remains implicit**. Even when a lineage facet is present, `inputs`/`outputs` still define the boundary of the event's job. Input datasets that are not referenced by any lineage entry are consumed directly by the event's job. Output datasets that are not described by any lineage entry are produced directly by the event's job. These implicit job-boundary relationships do not create a cartesian product between inputs and outputs.
@@ -166,28 +182,23 @@ The ordinary sink and generator relationships for the event's own job are outsid
 These constraints are documented in spec text rather than enforced by JSON Schema. They are intentionally conservative — motivated by keeping lineage cohesive within a single event and avoiding the need to define interaction/precedence rules between multiple lineage facets. Any of these restrictions may be relaxed in a future version if use cases emerge; the current goal is to keep the initial proposal simple and unambiguous.
 
 1. **One lineage facet per event**: A single event MUST NOT carry more than one type of lineage facet. A RunEvent uses LineageRunFacet; a JobEvent uses LineageJobFacet; a DatasetEvent uses LineageDatasetFacet. Mixing them is forbidden.
-
 2. **Event type restriction**: LineageRunFacet MUST only appear on RunEvent. LineageJobFacet MUST only appear on JobEvent. LineageDatasetFacet MUST only appear on DatasetEvent.
 
-3. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets, the fallback for older consumers, and the source of implicit event-job boundary relationships for dangling inputs/outputs.
+TODO: reconsider only LineageJobFacet vs LineageRunFacet. The lineage should be a relatively "static" property - not change every run. 
 
-4. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
+1. **Producers MUST include datasets referenced in lineage facets in the event's inputs/outputs arrays** when applicable. These arrays are the carrier for dataset facets, the fallback for older consumers, and the source of implicit event-job boundary relationships for dangling inputs/outputs.
+2. **Absence of lineage facet**: When no lineage facet is present on an event, the existing behavior applies unchanged — lineage is derived from CLL on output datasets if available, otherwise from the cartesian product of inputs x outputs.
+3. At least one of `inputs` or `fields` SHOULD be present on a LineageDatasetEntry (or on LineageDatasetFacet directly). For LineageJobEntry, `inputs` SHOULD be present.
+4. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
+5. A **dangling input** is an input dataset in the event `inputs` array that is not referenced as a source by any lineage entry. It is interpreted as data consumed directly by the event's job without a tracked output dataset. A **dangling output** is an output dataset in the event `outputs` array that is not represented as a lineage target. It is interpreted as data produced directly by the event's job without a tracked input dataset.
+6. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
+7. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
+8. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
 
-5. At least one of `inputs` or `fields` SHOULD be present on a LineageDatasetEntry (or on LineageDatasetFacet directly). For LineageJobEntry, `inputs` SHOULD be present.
+TODO: Semantics should follow event types - behave differently based on event, not facets
 
-6. An **empty `inputs: []` array is semantically meaningful**: "this entity has no upstream source" (distinct from the entity not appearing in lineage at all).
-
-7. A **dangling input** is an input dataset in the event `inputs` array that is not referenced as a source by any lineage entry. It is interpreted as data consumed directly by the event's job without a tracked output dataset. A **dangling output** is an output dataset in the event `outputs` array that is not represented as a lineage target. It is interpreted as data produced directly by the event's job without a tracked input dataset.
-
-8. Lineage entries and inputs do NOT carry a `facets` property. Facets belong on the entities they describe (Dataset, Run, Job), not on lineage edges.
-
-9. **On RunEvent**: LineageRunFacet follows existing OpenLineage **accumulative semantics** — each event adds to the lineage picture for the run. Consumers merge lineage entries across events for the same `runId`.
-
-10. **On DatasetEvent and JobEvent**: lineage facets use **replace semantics** — the latest event's lineage is the complete picture for that entity.
-
-11. **`type: JOB` semantics**: A `LineageJobEntry` (target) MUST identify the job by `(namespace, name)`. A `LineageJobInput` (source) identifies the job by `(namespace, name)` when both are present; either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. A `LineageJobInput` is **not** used to restate that the event's own job consumes event inputs or produces event outputs at dataset granularity — that remains implicit via event membership.
-
-    **Identity-less `LineageJobInput` (the event's own job)**: A `LineageJobInput` MAY omit both `namespace` and `name`, in which case it resolves to the event's own job. This form exists only to attach **field-level and/or transformation detail** to data produced by the implicit job (the generator case) — detail that event membership alone cannot carry. It MUST NOT be used as a top-level entity-level input to restate the implicit dataset-level edge. A producer MUST emit `namespace` and `name` together or omit them together.
+1. `**type: JOB` semantics**: A `LineageJobEntry` (target) MUST identify the job by `(namespace, name)`. A `LineageJobInput` (source) identifies the job by `(namespace, name)` when both are present; either job MAY differ from the event's own job and from other jobs in the same lineage chain (e.g., for cross-namespace job-to-job-to-dataset chains). `runId` is OPTIONAL: on `RunEvent` it MAY be populated to bind the edge to a specific execution; on `JobEvent` it SHOULD be omitted, since declared lineage is execution-agnostic. Job-involving lineage expresses **data flow only**; control-flow / scheduling dependencies remain in `JobDependenciesRunFacet`, and containment remains in `ParentRunFacet`. A `LineageJobInput` is **not** used to restate that the event's own job consumes event inputs or produces event outputs at dataset granularity — that remains implicit via event membership.
+  **Identity-less `LineageJobInput` (the event's own job)**: A `LineageJobInput` MAY omit both `namespace` and `name`, in which case it resolves to the event's own job. This form exists only to attach **field-level and/or transformation detail** to data produced by the implicit job (the generator case) — detail that event membership alone cannot carry. It MUST NOT be used as a top-level entity-level input to restate the implicit dataset-level edge. A producer MUST emit `namespace` and `name` together or omit them together.
 
 ## Interaction with Existing Features
 
@@ -231,21 +242,25 @@ The translation happens transparently in the client library's event emission pat
 
 **CLL -> Lineage (lossless):**
 
-| CLL structure | Lineage facet equivalent |
-|---|---|
-| `fields.{col}.inputFields[i]` | `fields.{col}.inputs[i]` with `field` on source |
-| `dataset[i]` (GROUP BY, FILTER) | Top-level `inputs[i]` with `field` on source |
-| Target dataset identity | Implicit — same dataset the facet is on |
+
+| CLL structure                   | Lineage facet equivalent                        |
+| ------------------------------- | ----------------------------------------------- |
+| `fields.{col}.inputFields[i]`   | `fields.{col}.inputs[i]` with `field` on source |
+| `dataset[i]` (GROUP BY, FILTER) | Top-level `inputs[i]` with `field` on source    |
+| Target dataset identity         | Implicit — same dataset the facet is on         |
+
 
 **Lineage -> CLL (lossy):**
 
-| Lineage facet structure | CLL mapping | Loss |
-|---|---|---|
-| Entity-level inputs (no field on source) | dropped | CLL has no dataset-level concept |
-| Entity-level inputs (field on source) | -> `dataset[]` array | None |
-| `fields.{col}.inputs` (field on source) | -> `fields.{col}.inputFields` | None |
-| `fields.{col}.inputs` (no field on source) | dropped | CLL requires field on source |
-| `fields.{col}.inputs` (identity-less JOB source, transformations only) | dropped | CLL has no notion of a field produced by the job with no dataset source |
+
+| Lineage facet structure                                                | CLL mapping                   | Loss                                                                    |
+| ---------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------- |
+| Entity-level inputs (no field on source)                               | dropped                       | CLL has no dataset-level concept                                        |
+| Entity-level inputs (field on source)                                  | -> `dataset[]` array          | None                                                                    |
+| `fields.{col}.inputs` (field on source)                                | -> `fields.{col}.inputFields` | None                                                                    |
+| `fields.{col}.inputs` (no field on source)                             | dropped                       | CLL requires field on source                                            |
+| `fields.{col}.inputs` (identity-less JOB source, transformations only) | dropped                       | CLL has no notion of a field produced by the job with no dataset source |
+
 
 For LineageRunFacet/LineageJobFacet: extract entries by target dataset, generate a CLL facet per output dataset, attach to the corresponding output in `outputs[]`. Same lossy mapping as above.
 
@@ -275,12 +290,14 @@ This translation is lossless — CLL is a strict subset of what lineage facets c
 openlineage.lineage.compatibility = none | legacy | modern | both
 ```
 
-| Mode | Producer emits | Client generates | Use case |
-|---|---|---|---|
-| `none` | Whatever it wants | Nothing | Full control, no magic |
-| `legacy` | Lineage facets | inputs/outputs/CLL | New producer, old consumers |
-| `modern` | inputs/outputs/CLL | Lineage facets | Old producer, new consumers |
-| `both` | Either or both | Whichever is missing | Transition period — everything works |
+
+| Mode     | Producer emits     | Client generates     | Use case                             |
+| -------- | ------------------ | -------------------- | ------------------------------------ |
+| `none`   | Whatever it wants  | Nothing              | Full control, no magic               |
+| `legacy` | Lineage facets     | inputs/outputs/CLL   | New producer, old consumers          |
+| `modern` | inputs/outputs/CLL | Lineage facets       | Old producer, new consumers          |
+| `both`   | Either or both     | Whichever is missing | Transition period — everything works |
+
 
 **Default during transition**: `both`.
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
@@ -34,6 +34,8 @@ The natural facet. Lives on datasets in DatasetEvent. The target entity is impli
 
 ## LineageRunFacet (RunFacet)
 
+TODO: remove
+
 Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail.
 
 ```json
@@ -79,6 +81,8 @@ Lives on the job object in JobEvent. Same structure as LineageRunFacet.
 ## Shared Types
 
 ### LineageEntry (discriminated union)
+
+TODO: when LineageJobFacet coalesces to LineageRunFacet, we don't need this
 
 Used by LineageRunFacet and LineageJobFacet. Each entry describes ONE target entity and what feeds into it. The `type` field discriminates between dataset targets and job targets. Dataset targets may be fed by datasets or by explicit upstream jobs; job targets may be fed by datasets or jobs when the target job must be identified independently from the event's own job:
 
@@ -138,19 +142,13 @@ A lineage target that is a dataset. Supports both entity-level and column-level 
 
 A lineage target that is a job. Used when the target job must be identified explicitly, such as **job-to-job chains** or other cross-job handoffs with no intermediate tracked dataset. It is not used to model the ordinary sink case for the event's own job; that is represented by input datasets that appear in the event `inputs` array but do not feed any tracked output dataset. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
 
+When we describe current job, we don't 
+
 ```json
 "LineageJobEntry": {
   "type": "object",
   "description": "Describes data flowing into a target job. Used when the target job must be identified explicitly.",
   "properties": {
-    "namespace": {
-      "type": "string",
-      "description": "The namespace of the target job"
-    },
-    "name": {
-      "type": "string",
-      "description": "The name of the target job"
-    },
     "type": {
       "type": "string",
       "enum": ["JOB"],
@@ -169,7 +167,7 @@ A lineage target that is a job. Used when the target job must be identified expl
       }
     }
   },
-  "required": ["namespace", "name", "type"]
+  "required": ["type"]
 }
 ```
 
@@ -249,7 +247,7 @@ A source input that is a dataset. Supports optional field reference and transfor
 
 A source input that is a job. Used when data comes from an explicitly identified job without an intermediate tracked dataset, including `JOB → JOB` and `JOB → DATASET` chains. Supports an optional `runId` to tie to a specific execution, and optional `transformations` describing how the job produced the data.
 
-**`namespace` and `name` are OPTIONAL.** When both are omitted, the source job is implicitly the **event's own job** — the job carried in the event's `job` field. This is the home for field-level and transformation detail on data produced by the implicit job (the generator case): a target field can name the current job as its source and attach `transformations` without that job having to be restated as an explicit entity. When `namespace`/`name` are present, they identify a different, explicitly tracked job (the `JOB → JOB` / `JOB → DATASET` chain case).
+`**namespace` and `name` are OPTIONAL.** When both are omitted, the source job is implicitly the **event's own job** — the job carried in the event's `job` field. This is the home for field-level and transformation detail on data produced by the implicit job (the generator case): a target field can name the current job as its source and attach `transformations` without that job having to be restated as an explicit entity. When `namespace`/`name` are present, they identify a different, explicitly tracked job (the `JOB → JOB` / `JOB → DATASET` chain case).
 
 ```json
 "LineageJobInput": {
@@ -272,7 +270,7 @@ A source input that is a job. Used when data comes from an explicitly identified
     "runId": {
       "type": "string",
       "format": "uuid",
-      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution. When the source is the event's own job, this MAY repeat the event's own runId."
+      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution."
     },
     "transformations": {
       "type": "array",
@@ -287,6 +285,8 @@ A source input that is a job. Used when data comes from an explicitly identified
 ```
 
 > Either both `namespace` and `name` are present (an explicitly identified job) or both are absent (the event's own job). A producer SHOULD NOT emit one without the other.
+
+TODO: explain that when refering to current job, we are inferring current namespace/name/runId from the job on the top-level event
 
 ### LineageTransformation
 
@@ -314,3 +314,4 @@ Reuses the existing CLL transformation structure:
   "required": ["type"]
 }
 ```
+

--- a/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
@@ -1,0 +1,305 @@
+# Explicit Lineage: Proposed Schema
+
+This file contains the proposed schema details for [ExplicitLineageProposal.md](ExplicitLineageProposal.md).
+
+## LineageDatasetFacet (DatasetFacet)
+
+The natural facet. Lives on datasets in DatasetEvent. The target entity is implicit — it's the dataset the facet is attached to.
+
+```json
+"LineageDatasetFacet": {
+  "type": "object",
+  "description": "Explicit lineage for this dataset. Describes which source entities feed into it, at entity and/or column granularity. Supersedes ColumnLineageDatasetFacet.",
+  "allOf": [{ "$ref": "#/$defs/DatasetFacet" }],
+  "properties": {
+    "inputs": {
+      "type": "array",
+      "description": "Dataset-level source inputs. When a source includes a 'field' property, it represents a dataset-wide operation (e.g., GROUP BY) where that source column affects the entire target dataset.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    },
+    "fields": {
+      "type": "object",
+      "description": "Column-level lineage. Maps target field names to their source inputs.",
+      "additionalProperties": {
+        "$ref": "#/$defs/LineageFieldEntry"
+      }
+    }
+  }
+}
+```
+
+> Note: no `namespace`, `name`, or `type` on this facet — the target is the dataset it's attached to.
+
+## LineageRunFacet (RunFacet)
+
+Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail.
+
+```json
+"LineageRunFacet": {
+  "type": "object",
+  "description": "Explicit lineage observed during this run. Describes data flow between entities at entity and/or column granularity.",
+  "allOf": [{ "$ref": "#/$defs/RunFacet" }],
+  "properties": {
+    "entries": {
+      "type": "array",
+      "description": "Lineage entries describing data flow observed during this run.",
+      "items": {
+        "$ref": "#/$defs/LineageEntry"
+      }
+    }
+  },
+  "required": ["entries"]
+}
+```
+
+## LineageJobFacet (JobFacet)
+
+Lives on the job object in JobEvent. Same structure as LineageRunFacet.
+
+```json
+"LineageJobFacet": {
+  "type": "object",
+  "description": "Explicit lineage declared for this job definition. Describes designed/static data flow at entity and/or column granularity.",
+  "allOf": [{ "$ref": "#/$defs/JobFacet" }],
+  "properties": {
+    "entries": {
+      "type": "array",
+      "description": "Lineage entries describing data flow designed for this job.",
+      "items": {
+        "$ref": "#/$defs/LineageEntry"
+      }
+    }
+  },
+  "required": ["entries"]
+}
+```
+
+## Shared Types
+
+### LineageEntry (discriminated union)
+
+Used by LineageRunFacet and LineageJobFacet. Each entry describes ONE target entity and what feeds into it. The `type` field discriminates between dataset targets and job targets. Dataset targets may be fed by datasets or by explicit upstream jobs; job targets may be fed by datasets or jobs when the target job must be identified independently from the event's own job:
+
+```json
+"LineageEntry": {
+  "oneOf": [
+    { "$ref": "#/$defs/LineageDatasetEntry" },
+    { "$ref": "#/$defs/LineageJobEntry" }
+  ]
+}
+```
+
+The `enum` constraint on each subtype's `type` field (`"DATASET"` or `"JOB"`) ensures only one branch can match during validation.
+
+### LineageDatasetEntry
+
+A lineage target that is a dataset. Supports both entity-level and column-level lineage from source entities:
+
+```json
+"LineageDatasetEntry": {
+  "type": "object",
+  "description": "Describes data flowing into a target dataset from source entities, at entity and/or column granularity.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the target dataset"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the target dataset"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["DATASET"],
+      "description": "Must be DATASET"
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Entity-level source inputs. Each item is a LineageInput (dataset or job).",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    },
+    "fields": {
+      "type": "object",
+      "description": "Column-level lineage. Maps target field names to their source inputs.",
+      "additionalProperties": {
+        "$ref": "#/$defs/LineageFieldEntry"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+### LineageJobEntry
+
+A lineage target that is a job. Used when the target job must be identified explicitly, such as **job-to-job chains** or other cross-job handoffs with no intermediate tracked dataset. It is not used to model the ordinary sink case for the event's own job; that is represented by input datasets that appear in the event `inputs` array but do not feed any tracked output dataset. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
+
+```json
+"LineageJobEntry": {
+  "type": "object",
+  "description": "Describes data flowing into a target job. Used when the target job must be identified explicitly.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the target job"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the target job"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["JOB"],
+      "description": "Must be JOB"
+    },
+    "runId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. The specific run ID of the target job, when the lineage is tied to a particular execution."
+    },
+    "inputs": {
+      "type": "array",
+      "description": "Source inputs feeding into this job.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+### LineageFieldEntry
+
+```json
+"LineageFieldEntry": {
+  "type": "object",
+  "description": "Column-level lineage for a single target field.",
+  "properties": {
+    "inputs": {
+      "type": "array",
+      "description": "Source entities and/or fields that feed into this target field.",
+      "items": {
+        "$ref": "#/$defs/LineageInput"
+      }
+    }
+  },
+  "required": ["inputs"]
+}
+```
+
+### LineageInput (discriminated union)
+
+A source entity that feeds data into a lineage target. The `type` field discriminates between dataset sources and job sources:
+
+```json
+"LineageInput": {
+  "oneOf": [
+    { "$ref": "#/$defs/LineageDatasetInput" },
+    { "$ref": "#/$defs/LineageJobInput" }
+  ]
+}
+```
+
+Same pattern — the `enum` on each subtype's `type` field disambiguates.
+
+### LineageDatasetInput
+
+A source input that is a dataset. Supports optional field reference and transformations:
+
+```json
+"LineageDatasetInput": {
+  "type": "object",
+  "description": "A source dataset that feeds data into a lineage target.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the source dataset"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the source dataset"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["DATASET"],
+      "description": "Must be DATASET"
+    },
+    "field": {
+      "type": "string",
+      "description": "The specific field/column of the source dataset. Optional — when omitted at column level, means 'source column unknown'."
+    },
+    "transformations": {
+      "type": "array",
+      "description": "Transformations applied to the source data. Same structure as ColumnLineageDatasetFacet.",
+      "items": {
+        "$ref": "#/$defs/LineageTransformation"
+      }
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+### LineageJobInput
+
+A source input that is a job. Used when data comes from an explicitly identified job without an intermediate tracked dataset, including `JOB → JOB` and `JOB → DATASET` chains. Supports an optional `runId` to tie to a specific execution:
+
+```json
+"LineageJobInput": {
+  "type": "object",
+  "description": "A source job that feeds data into a lineage target. Used when data comes from another job without an intermediate tracked dataset.",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the source job"
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the source job"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["JOB"],
+      "description": "Must be JOB"
+    },
+    "runId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution."
+    }
+  },
+  "required": ["namespace", "name", "type"]
+}
+```
+
+### LineageTransformation
+
+Reuses the existing CLL transformation structure:
+
+```json
+"LineageTransformation": {
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "DIRECT or INDIRECT"
+    },
+    "subtype": {
+      "type": "string",
+      "description": "E.g., IDENTITY, AGGREGATION, FILTER, JOIN, etc."
+    },
+    "description": {
+      "type": "string"
+    },
+    "masking": {
+      "type": "boolean"
+    }
+  },
+  "required": ["type"]
+}
+```

--- a/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
@@ -32,45 +32,31 @@ The natural facet. Lives on datasets in DatasetEvent. The target entity is impli
 
 > Note: no `namespace`, `name`, or `type` on this facet — the target is the dataset it's attached to.
 
-## LineageRunFacet (RunFacet)
-
-TODO: remove
-
-Lives on the run object in RunEvent. Contains an array of `LineageEntry` objects, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail.
-
-```json
-"LineageRunFacet": {
-  "type": "object",
-  "description": "Explicit lineage observed during this run. Describes data flow between entities at entity and/or column granularity.",
-  "allOf": [{ "$ref": "#/$defs/RunFacet" }],
-  "properties": {
-    "entries": {
-      "type": "array",
-      "description": "Lineage entries describing data flow observed during this run.",
-      "items": {
-        "$ref": "#/$defs/LineageEntry"
-      }
-    }
-  },
-  "required": ["entries"]
-}
-```
-
 ## LineageJobFacet (JobFacet)
 
-Lives on the job object in JobEvent. Same structure as LineageRunFacet.
+The primary lineage facet. It is a **JobFacet**, so it lives on the `job` object — which is present on both `RunEvent` and `JobEvent`. There is no separate run-level lineage facet: lineage is treated as a property of the *job*, not of each individual run.
+
+It contains an array of entries, each identifying a target entity explicitly by namespace, name, and type, along with its source inputs and optional column-level detail. Each entry is a `LineageDatasetEntry` or a `LineageJobEntry`.
+
+The same facet is used on both event types; only the *interpretation* differs, keyed by the event type it rides on (see the semantics section of the proposal):
+
+- On a **JobEvent**, it describes the job's declared/static data flow, using **replace** semantics (the latest event is the complete picture).
+- On a **RunEvent**, it describes data flow observed during that run, using OpenLineage's usual **accumulative** run semantics, and MAY bind edges to specific executions via the optional `runId` on job-typed entries/inputs.
 
 ```json
 "LineageJobFacet": {
   "type": "object",
-  "description": "Explicit lineage declared for this job definition. Describes designed/static data flow at entity and/or column granularity.",
+  "description": "Explicit lineage for a job. Describes data flow between entities at entity and/or column granularity. On a JobEvent it is the job's declared/static lineage; on a RunEvent it is lineage observed during that run. Supersedes ColumnLineageDatasetFacet for job-scoped lineage.",
   "allOf": [{ "$ref": "#/$defs/JobFacet" }],
   "properties": {
     "entries": {
       "type": "array",
-      "description": "Lineage entries describing data flow designed for this job.",
+      "description": "Lineage entries describing data flow for this job. Each entry describes ONE target entity and what feeds into it. The 'type' field discriminates between dataset targets and job targets: dataset targets may be fed by datasets or by explicit upstream jobs; job targets may be fed by datasets or jobs when the target job must be identified independently from the event's own job.",
       "items": {
-        "$ref": "#/$defs/LineageEntry"
+        "oneOf": [
+          { "$ref": "#/$defs/LineageDatasetEntry" },
+          { "$ref": "#/$defs/LineageJobEntry" }
+        ]
       }
     }
   },
@@ -80,22 +66,7 @@ Lives on the job object in JobEvent. Same structure as LineageRunFacet.
 
 ## Shared Types
 
-### LineageEntry (discriminated union)
-
-TODO: when LineageJobFacet coalesces to LineageRunFacet, we don't need this
-
-Used by LineageRunFacet and LineageJobFacet. Each entry describes ONE target entity and what feeds into it. The `type` field discriminates between dataset targets and job targets. Dataset targets may be fed by datasets or by explicit upstream jobs; job targets may be fed by datasets or jobs when the target job must be identified independently from the event's own job:
-
-```json
-"LineageEntry": {
-  "oneOf": [
-    { "$ref": "#/$defs/LineageDatasetEntry" },
-    { "$ref": "#/$defs/LineageJobEntry" }
-  ]
-}
-```
-
-The `enum` constraint on each subtype's `type` field (`"DATASET"` or `"JOB"`) ensures only one branch can match during validation.
+Entries in `LineageJobFacet.entries` are a discriminated union of `LineageDatasetEntry` and `LineageJobEntry`. The `enum` constraint on each subtype's `type` field (`"DATASET"` or `"JOB"`) ensures only one branch can match during validation.
 
 ### LineageDatasetEntry
 
@@ -140,15 +111,26 @@ A lineage target that is a dataset. Supports both entity-level and column-level 
 
 ### LineageJobEntry
 
-A lineage target that is a job. Used when the target job must be identified explicitly, such as **job-to-job chains** or other cross-job handoffs with no intermediate tracked dataset. It is not used to model the ordinary sink case for the event's own job; that is represented by input datasets that appear in the event `inputs` array but do not feed any tracked output dataset. Does not support column-level lineage (`fields`), but supports an optional `runId` to tie to a specific execution:
+A lineage target that is a job. It has two forms, set by whether `namespace` and `name` are present:
 
-When we describe current job, we don't 
+- with `namespace` and `name`: another job, identified explicitly. This is the job-to-job chain case, where a job hands data to another job with no intermediate tracked dataset.
+- without `namespace` or `name`: the event's own job. Use this only to add transformation detail for the sink case, where a job consumes data but writes no tracked dataset to hang that detail on. Its identity comes from the event's top-level `job` (and `run` on a RunEvent).
+
+Emit `namespace` and `name` together or omit both. It supports an optional `runId` to tie it to a specific run:
 
 ```json
 "LineageJobEntry": {
   "type": "object",
-  "description": "Describes data flowing into a target job. Used when the target job must be identified explicitly.",
+  "description": "Describes data flowing into a target job. With namespace and name, it identifies another job explicitly (a job-to-job chain). Without them, the target is the event's own job, used only to add transformation detail for the sink case.",
   "properties": {
+    "namespace": {
+      "type": "string",
+      "description": "The namespace of the target job. Omit together with 'name' to mean the event's own job."
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the target job. Omit together with 'namespace' to mean the event's own job."
+    },
     "type": {
       "type": "string",
       "enum": ["JOB"],
@@ -286,7 +268,7 @@ A source input that is a job. Used when data comes from an explicitly identified
 
 > Either both `namespace` and `name` are present (an explicitly identified job) or both are absent (the event's own job). A producer SHOULD NOT emit one without the other.
 
-TODO: explain that when refering to current job, we are inferring current namespace/name/runId from the job on the top-level event
+When both are absent, the source job is the event's own job. A consumer resolves its `namespace` and `name` from the top-level event's `job`, and its run from the top-level event's `run` on a RunEvent. This is why those fields are omitted rather than repeated: the event already carries them, and restating them risks drift.
 
 ### LineageTransformation
 

--- a/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
+++ b/proposals/explicit_lineage_facet/ExplicitLineageSchema.md
@@ -117,7 +117,7 @@ A lineage target that is a dataset. Supports both entity-level and column-level 
     },
     "inputs": {
       "type": "array",
-      "description": "Entity-level source inputs. Each item is a LineageInput (dataset or job).",
+      "description": "Entity-level inputs feeding this target dataset. Each item is a LineageInput (dataset or job). When an input includes a 'field' property, it represents a dataset-wide operation (e.g., GROUP BY) where that input's column affects the entire target dataset.",
       "items": {
         "$ref": "#/$defs/LineageInput"
       }
@@ -247,20 +247,22 @@ A source input that is a dataset. Supports optional field reference and transfor
 
 ### LineageJobInput
 
-A source input that is a job. Used when data comes from an explicitly identified job without an intermediate tracked dataset, including `JOB → JOB` and `JOB → DATASET` chains. Supports an optional `runId` to tie to a specific execution:
+A source input that is a job. Used when data comes from an explicitly identified job without an intermediate tracked dataset, including `JOB → JOB` and `JOB → DATASET` chains. Supports an optional `runId` to tie to a specific execution, and optional `transformations` describing how the job produced the data.
+
+**`namespace` and `name` are OPTIONAL.** When both are omitted, the source job is implicitly the **event's own job** — the job carried in the event's `job` field. This is the home for field-level and transformation detail on data produced by the implicit job (the generator case): a target field can name the current job as its source and attach `transformations` without that job having to be restated as an explicit entity. When `namespace`/`name` are present, they identify a different, explicitly tracked job (the `JOB → JOB` / `JOB → DATASET` chain case).
 
 ```json
 "LineageJobInput": {
   "type": "object",
-  "description": "A source job that feeds data into a lineage target. Used when data comes from another job without an intermediate tracked dataset.",
+  "description": "A source job that feeds data into a lineage target. Used when data comes from another job without an intermediate tracked dataset. When namespace/name are omitted, the source is the event's own job.",
   "properties": {
     "namespace": {
       "type": "string",
-      "description": "The namespace of the source job"
+      "description": "The namespace of the source job. When omitted together with 'name', the source is the event's own job."
     },
     "name": {
       "type": "string",
-      "description": "The name of the source job"
+      "description": "The name of the source job. When omitted together with 'namespace', the source is the event's own job."
     },
     "type": {
       "type": "string",
@@ -270,12 +272,21 @@ A source input that is a job. Used when data comes from an explicitly identified
     "runId": {
       "type": "string",
       "format": "uuid",
-      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution."
+      "description": "Optional. The specific run ID of the source job, when the lineage is tied to a particular execution. When the source is the event's own job, this MAY repeat the event's own runId."
+    },
+    "transformations": {
+      "type": "array",
+      "description": "Transformations applied by the source job to produce the data.",
+      "items": {
+        "$ref": "#/$defs/LineageTransformation"
+      }
     }
   },
-  "required": ["namespace", "name", "type"]
+  "required": ["type"]
 }
 ```
+
+> Either both `namespace` and `name` are present (an explicitly identified job) or both are absent (the event's own job). A producer SHOULD NOT emit one without the other.
 
 ### LineageTransformation
 


### PR DESCRIPTION
## Problem
OpenLineage infers dataset lineage from the cartesian product of a run's inputs × outputs. A job reading {A,B} and writing {C,D} produces 4 edges — even when the real flow is A→C and B→D only. The spurious edges aren't always a problem at small scale, but they compound on bulk ETL jobs where many independent tables are processed together, making impact analysis and compliance audits harder to rely on.

```mermaid
flowchart LR
    subgraph Current["Current spec (cartesian product)"]
      direction LR
      A1[Table A] --> C1[Table C]
      A1 -.->|false positive| D1[Table D]
      B1[Table B] -.->|false positive| C1
      B1 --> D1
    end
    subgraph Proposed["Explicit lineage"]
      direction LR
      A2[Table A] --> C2[Table C]
      B2[Table B] --> D2[Table D]
    end
```

`ColumnLineageDatasetFacet` solves this at column granularity, but leaves a gap at dataset granularity, and the current model can't express dataset-to-dataset derivation (views, aliases) or mixed granularity.

## Proposal
Adds two documents under `proposals/explicit_lineage_facet/`:

- **ExplicitLineageProposal.md** — full spec for three new facets, one per event type:

```mermaid
flowchart LR
    RE[RunEvent] --> RF["run.facets.lineage<br/>LineageRunFacet<br/><i>observed flow during run</i>"]
    JE[JobEvent] --> JF["job.facets.lineage<br/>LineageJobFacet<br/><i>declared flow for job</i>"]
    DE[DatasetEvent] --> DF["dataset.facets.lineage<br/>LineageDatasetFacet<br/><i>structural derivation</i>"]
```

Each entry explicitly maps a target entity to its source inputs at entity and/or column granularity, via a discriminated union on `type`:

```mermaid
classDiagram
    class LineageEntry { <<oneOf>> }
    class LineageDatasetEntry {
      namespace, name
      type = DATASET
      inputs: LineageInput[]
      fields: map~string, LineageFieldEntry~
    }
    class LineageJobEntry {
      namespace, name
      type = JOB
      runId?
      inputs: LineageInput[]
    }
    class LineageInput { <<oneOf>> }
    class LineageDatasetInput {
      namespace, name, type=DATASET
      field?
      transformations[]
    }
    class LineageJobInput {
      namespace, name, type=JOB
      runId?
    }
    LineageEntry <|-- LineageDatasetEntry
    LineageEntry <|-- LineageJobEntry
    LineageDatasetEntry --> LineageInput
    LineageJobEntry --> LineageInput
    LineageInput <|-- LineageDatasetInput
    LineageInput <|-- LineageJobInput
```

Limited `type: JOB` support for sink/generator cases now; extensible to full job-to-job later. Intended to eventually supersede `ColumnLineageDatasetFacet`.

- **ExplicitLineageAdoptionGuideline.md** — producer/consumer adoption guide.

## Compatibility & Migration
New `openlineage.lineage.compatibility = both` setting auto-generates the legacy `inputs`/`outputs`/CLL from the new facets, so existing consumers keep working. No coordination required, no core model changes (facets only).

```mermaid
flowchart LR
    P1["Phase 1<br/>Producers emit both<br/>(compatibility = both)"] --> P2["Phase 2<br/>Consumers add<br/>new-facet support"] --> P3["Phase 3<br/>Deprecate old<br/>format + CLL"]
```

## Related
Tracks #4359.

