### PR TITLE
spark: fix PathUtils.reconstructDefaultLocation malformed URI

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -141,7 +141,7 @@ public class PathUtils {
     }
 
     // /warehouse/mydb.db/mytable
-    return new Path(warehouse, database + ".db", name);
+    return new Path(new Path(warehouse, database + ".db"), name);
   }
 
   public static Optional<URI> getMetastoreUri(SparkContext context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -444,4 +444,37 @@ class PathUtilsTest {
     // name
     assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
+
+  @Test
+  void testReconstructDefaultLocationWithS3Path() {
+    assertThat(
+            PathUtils.reconstructDefaultLocation(
+                    "s3://bucket/prefix", new String[] {"spark_catalog", "database"}, "table")
+                .toString())
+        .isEqualTo("s3://bucket/prefix/database.db/table");
+    assertThat(
+            PathUtils.reconstructDefaultLocation(
+                    "s3://bucket", new String[] {"spark_catalog", "database"}, "table")
+                .toString())
+        .isEqualTo("s3://bucket/database.db/table");
+    assertThat(
+            PathUtils.reconstructDefaultLocation(
+                    "hdfs://namenode:8020/warehouse", new String[] {"spark_catalog", "db"}, "table")
+                .toString())
+        .isEqualTo("hdfs://namenode:8020/warehouse/db.db/table");
+    assertThat(
+            PathUtils.reconstructDefaultLocation(
+                    "s3://bucket/prefix", new String[] {"spark_catalog", "default"}, "table")
+                .toString())
+        .isEqualTo("s3://bucket/prefix/table");
+    assertThat(
+            PathUtils.reconstructDefaultLocation(
+                    "s3://bucket/prefix", new String[] {"database"}, "table")
+                .toString())
+        .isEqualTo("s3://bucket/prefix/database.db/table");
+    assertThat(
+            PathUtils.reconstructDefaultLocation("s3://bucket/prefix", new String[] {}, "table")
+                .toString())
+        .isEqualTo("s3://bucket/prefix/table");
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/OpenLineage/OpenLineage/issues/4414

## Problem

`PathUtils.reconstructDefaultLocation()` uses the 3-argument `Path(String, String, String)` constructor, which is `Path(scheme, authority, path)` — not `Path(parent, child, grandchild)` as intended.

When the warehouse location is an S3 path with a sub-path (e.g., `s3://bucket/prefix`), this produces a malformed URI:

```
s3://bucket/prefix://database.db./table_name
```

Which throws:
```
java.lang.IllegalArgumentException: java.net.URISyntaxException:
Relative path in absolute URI: s3://bucket/prefix://database.db./table_name
```

This crashes the output dataset builder, resulting in zero lineage events for the entire Spark application.

## Fix

Replaced the 3-argument `Path` constructor with chained 2-argument constructors:

```java
// Before (broken)
return new Path(warehouse, database + ".db", name);

// After (fixed)
return new Path(new Path(warehouse, database + ".db"), name);
```
This correctly produces s3://bucket/prefix/database.db/table_name.

# Testing
Added [testReconstructDefaultLocationWithS3Path](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) covering:

- [X] S3 paths with sub-paths (the bug scenario)
- [X] S3 paths without sub-paths
- [X] HDFS paths with sub-paths
- [X] Default database (no .db suffix)
- [X] Single and empty namespace arrays