### PR TITLE
fix race condition in dbt parsing

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -58,7 +58,6 @@ from openlineage.common.utils import (
     add_command_line_args,
     add_or_replace_command_line_option,
     get_from_nullable_chain,
-    has_lines,
 )
 
 
@@ -141,6 +140,7 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
 
         # will be populated when some dbt events are collected
         self._compiled_manifest: dict = {}
+        self._dbt_started_at: float | None = None
         self._dbt_version: str | None = None
         self._dbt_invocation_id: str | None = None
         self._dbt_log_file: TextIO | None = None
@@ -190,6 +190,18 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         if self._compiled_manifest != {}:
             return self._compiled_manifest
         elif os.path.isfile(self.manifest_path):
+            if self._dbt_started_at is not None:
+                mtime = os.path.getmtime(self.manifest_path)
+                # Allow 2s tolerance for coarse filesystem mtime granularity.
+                if mtime < self._dbt_started_at - 2.0:
+                    self.logger.warning(
+                        "manifest.json at %s predates this dbt invocation (mtime=%.1f, started=%.1f); "
+                        "skipping load to avoid stale dataset identities",
+                        self.manifest_path,
+                        mtime,
+                        self._dbt_started_at,
+                    )
+                    return {}
             self._compiled_manifest = self.load_metadata(self.manifest_path, list(range(2, 13)), self.logger)
             manifest_data = self._validate_manifest_integrity()
             self.logger.debug(manifest_data)
@@ -257,6 +269,13 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             end_event = self._parse_command_completed_event(dbt_event)
             self.received_dbt_command_completed = True
             return end_event
+
+        elif dbt_event_name == "ArtifactWritten":
+            # dbt >= 1.9 emits this after writing each artifact. Load the manifest as soon as
+            # dbt confirms it wrote a fresh one so we don't have to wait until the first NodeStart.
+            if dbt_event.get("data", {}).get("artifact_type") == "WritableManifest":
+                _ = self.compiled_manifest
+            return None
 
         if get_node_unique_id(dbt_event) is None:
             return None
@@ -814,8 +833,8 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         last_size = os.stat(self.dbt_log_file_path).st_size
         self.logger.debug("Running dbt command: %s", " ".join(dbt_command_line))
 
+        self._dbt_started_at = time.time()
         process = subprocess.Popen(dbt_command_line, stdout=sys.stdout, stderr=sys.stderr, text=True)
-        parse_manifest = True
         last_log = datetime.datetime.now()
 
         try:
@@ -823,11 +842,6 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                 if (datetime.datetime.now() - last_log) >= datetime.timedelta(seconds=10):
                     self.logger.debug("dbt process is still running: waiting for logs to appear")
                     last_log = datetime.datetime.now()
-                if parse_manifest and has_lines(self._dbt_log_file) > 0:  # type: ignore[arg-type]
-                    # Load the manifest as soon as it exists
-                    self.compiled_manifest
-                    parse_manifest = False
-                    self.logger.debug("Parsed manifest file")
 
                 current_size = os.stat(self.dbt_log_file_path).st_size
                 if current_size > last_size:

--- a/integration/common/tests/dbt/structured_logs/test_structured_logs.py
+++ b/integration/common/tests/dbt/structured_logs/test_structured_logs.py
@@ -1053,6 +1053,98 @@ def test_validate_manifest_integrity_empty_manifest(caplog):
     assert "Manifest integrity check failed" not in caplog.text
 
 
+##################
+# Stale manifest resilience tests
+##################
+
+
+def _make_processor():
+    return DbtStructuredLogsProcessor(
+        producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        job_namespace="dbt-test-namespace",
+        project_dir=CURRENT_DIR,
+        target="postgres",
+        dbt_command_line=["dbt", "run", "..."],
+    )
+
+
+def test_artifact_written_triggers_manifest_load(monkeypatch):
+    """ArtifactWritten with WritableManifest causes compiled_manifest to be populated."""
+    processor = _make_processor()
+    processor.manifest_path = CURRENT_DIR + "/postgres/run/target/manifest.json"
+    # No _dbt_started_at set — mtime guard is skipped, simulating ArtifactWritten path.
+
+    artifact_written_event = json.dumps(
+        {
+            "data": {"artifact_path": processor.manifest_path, "artifact_type": "WritableManifest"},
+            "info": {"name": "ArtifactWritten", "invocation_id": "abc", "ts": "2024-01-01T00:00:00Z"},
+        }
+    )
+
+    # Simulate MainReportVersion first so dbt_run_metadata is set up.
+    main_report = json.dumps(
+        {
+            "data": {"version": "=1.10.0", "log_version": 3},
+            "info": {"name": "MainReportVersion", "invocation_id": "abc", "ts": "2024-01-01T00:00:00Z"},
+        }
+    )
+
+    def parsed(self):
+        self.received_dbt_command_completed = True
+        return [main_report, artifact_written_event]
+
+    monkeypatch.setattr(
+        "openlineage.common.provider.dbt.structured_logs.DbtStructuredLogsProcessor._run_dbt_command",
+        parsed,
+    )
+
+    list(processor.parse())
+
+    assert processor._compiled_manifest != {}
+    assert "nodes" in processor._compiled_manifest
+
+
+def test_stale_manifest_mtime_guard_warns_and_skips(caplog, monkeypatch, tmp_path):
+    """compiled_manifest returns {} and warns when manifest mtime predates dbt start."""
+    import os
+    import shutil
+
+    processor = _make_processor()
+
+    # Write a manifest file then backdate its mtime.
+    stale_manifest = tmp_path / "manifest.json"
+    shutil.copy(CURRENT_DIR + "/postgres/run/target/manifest.json", stale_manifest)
+    old_time = 1000.0  # Unix epoch + 1000s — definitely older than any real run
+    os.utime(stale_manifest, (old_time, old_time))
+
+    processor.manifest_path = str(stale_manifest)
+    processor._dbt_started_at = old_time + 100.0  # started well after manifest was written
+
+    result = processor.compiled_manifest
+
+    assert result == {}
+    assert "predates this dbt invocation" in caplog.text
+
+
+def test_fresh_manifest_mtime_guard_loads_normally(monkeypatch, tmp_path):
+    """compiled_manifest loads normally when manifest mtime is after dbt start."""
+    import shutil
+    import time as time_mod
+
+    processor = _make_processor()
+
+    fresh_manifest = tmp_path / "manifest.json"
+    shutil.copy(CURRENT_DIR + "/postgres/run/target/manifest.json", fresh_manifest)
+
+    processor.manifest_path = str(fresh_manifest)
+    processor._dbt_started_at = time_mod.time() - 60.0  # started 60s ago; manifest is newer
+
+    result = processor.compiled_manifest
+
+    assert result != {}
+    assert "nodes" in result
+
+
 def test_validate_manifest_integrity_missing_sections(caplog):
     """Test validation with manifest missing key sections."""
     processor = DbtStructuredLogsProcessor(


### PR DESCRIPTION
The `--consume-structured-logs` path was loading `manifest.json` eagerly the moment dbt's log file had any content — before dbt's parse phase finished writing a fresh manifest. This meant a leftover `target/manifest.json` from a prior invocation (different env vars, killed task, CI artifact cache) would silently poison all dataset identities for the entire run.

This PR fixes the root cause by removing the eager load entirely. For dbt ≥ 1.9, we instead subscribe to the `ArtifactWritten` structured log event (`artifact_type: WritableManifest`) and load the manifest exactly when dbt signals it just wrote a fresh one. For older dbt versions without that event, the manifest loads lazily on the first `NodeStart` handler call — which is inherently safe because dbt's parse phase, and therefore the manifest write, always completes before any node execution events are emitted.

As a third layer of defense, `compiled_manifest` now compares the file's modification time against the recorded process start time and logs a loud warning (skipping the load) if the manifest predates the current invocation by more than 2 seconds. This catches any future scenario where the ordering assumptions above break — such as `--no-write-json` being forced externally or dbt crashing mid-parse.

### Checklist
- [x] AI was used in creating this PR - yes, Claude Code
