### PR TITLE
fix(spark): use 2-arg Path constructor in reconstructDefaultLocation to avoid malformed URI

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -141,7 +141,7 @@ public class PathUtils {
     }
 
     // /warehouse/mydb.db/mytable
-    return new Path(warehouse, database + ".db", name);
+    return new Path(new Path(warehouse, database + ".db"), name);
   }
 
   public static Optional<URI> getMetastoreUri(SparkContext context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -444,4 +444,20 @@ class PathUtilsTest {
     // name
     assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
+
+  @Test
+  void testReconstructDefaultLocationS3WarehouseProducesValidUri() {
+    // Regression test for https://github.com/OpenLineage/OpenLineage/issues/4414
+    // The 3-arg Path(scheme, authority, path) constructor was mistakenly used, producing
+    // a malformed URI like "s3://warehouse/mydb.db" instead of
+    // "s3://my-bucket/warehouse/mydb.db/mytable".
+    Path result =
+        PathUtils.reconstructDefaultLocation(
+            "s3://my-bucket/warehouse", new String[] {"mydb"}, "mytable");
+
+    assertThat(result.toUri().getScheme()).isEqualTo("s3");
+    assertThat(result.toUri().getAuthority()).isEqualTo("my-bucket");
+    assertThat(result.toUri().getPath()).isEqualTo("/warehouse/mydb.db/mytable");
+    assertThat(result.toString()).isEqualTo("s3://my-bucket/warehouse/mydb.db/mytable");
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #4414

The 3-argument Hadoop `Path(String scheme, String authority, String path)` constructor was mistakenly used in `PathUtils.reconstructDefaultLocation()`. This constructor interprets its three arguments as URI components (scheme, authority, path), so when the warehouse value is an S3 URI like `s3://my-bucket/warehouse`:

- `scheme` → `"s3://my-bucket/warehouse"` (entire URI treated as scheme — wrong)
- `authority` → `"mydb.db"` (treated as host)
- `path` → `"mytable"`

This produced a completely wrong URI such as `s3://mydb.db/mytable` instead of the expected `s3://my-bucket/warehouse/mydb.db/mytable`.

## Fix

Replace with the 2-argument `Path(Path parent, String child)` constructor which correctly concatenates path segments:

```java
// Before (broken)
return new Path(warehouse, database + ".db", name);

// After (correct)
return new Path(new Path(warehouse, database + ".db"), name);
```

## Test

Added `testReconstructDefaultLocationS3WarehouseProducesValidUri` to `PathUtilsTest` that verifies the scheme, authority, and path components of the resulting URI are all correct when the warehouse is an S3 URI with a sub-prefix.