### PR TITLE
fix(spark/test): make drop table lifecycle state assertion actually fail on mismatch

### DIFF
--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
@@ -85,11 +85,11 @@ class DropTableCommandVisitorTest {
         .hasFieldOrPropertyWithValue("namespace", "file");
 
     assertThat(
-        datasets
-            .get(0)
-            .getFacets()
-            .getLifecycleStateChange()
-            .getLifecycleStateChange()
-            .equals(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP));
+            datasets
+                .get(0)
+                .getFacets()
+                .getLifecycleStateChange()
+                .getLifecycleStateChange())
+        .isEqualTo(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
   }
 }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/lifecycle/plan/DropTableCommandVisitorTest.java
@@ -84,12 +84,7 @@ class DropTableCommandVisitorTest {
         .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/drop_table")
         .hasFieldOrPropertyWithValue("namespace", "file");
 
-    assertThat(
-            datasets
-                .get(0)
-                .getFacets()
-                .getLifecycleStateChange()
-                .getLifecycleStateChange())
+    assertThat(datasets.get(0).getFacets().getLifecycleStateChange().getLifecycleStateChange())
         .isEqualTo(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2143

In `DropTableCommandVisitorTest.testDropCommand()`, the final assertion was:

```java
assertThat(
    datasets.get(0).getFacets()
        .getLifecycleStateChange()
        .getLifecycleStateChange()
        .equals(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP));
```

`assertThat(boolean)` creates an `AbstractBooleanAssert` but **never calls `.isTrue()`**, so the assertion was a silent no-op — the test passed regardless of whether the lifecycle state was actually `DROP`.

## Fix

Replace with idiomatic AssertJ:

```java
assertThat(
        datasets.get(0).getFacets()
            .getLifecycleStateChange()
            .getLifecycleStateChange())
    .isEqualTo(OpenLineage.LifecycleStateChangeDatasetFacet.LifecycleStateChange.DROP);
```

This directly asserts on the enum value and will fail with a clear message if the lifecycle state is wrong or null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)