### PR TITLE
feat(spec): AgentAttributionRunFacet for agent-produced lineage events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/OpenLineage/OpenLineage/compare/1.46.0...HEAD)
 
+### Added
+
+* **Spec: Add AgentAttributionRunFacet for agent-produced lineage events** [`#4409`](https://github.com/OpenLineage/OpenLineage/issues/4409) [@aeoess](https://github.com/aeoess)
+  *Add `AgentAttributionRunFacet` JSON Schema carrying the agent's identifier and the governance attestation (covenant) that was in force at execution time. The `covenantInEffect.digest` provides tamper-evident reference to the signed policy; the `type` is an open enum with `governance_attestation` as the vendor-agnostic reference value; `additionalProperties: true` is scoped to the `covenantInEffect` sub-object so implementations can add vendor-specific fields without facet version bumps.*
+
 ## [1.46.0](https://github.com/OpenLineage/OpenLineage/compare/1.45.0...1.46.0)
 
 ### Added

--- a/client/python/redact_fields.yml
+++ b/client/python/redact_fields.yml
@@ -304,3 +304,9 @@
       redact_fields: []
     - class_name: HierarchyDatasetFacetLevel
       redact_fields: []
+- module: agent_attribution_run
+  classes:
+    - class_name: AgentAttributionRunFacet
+      redact_fields: []
+    - class_name: CovenantInEffect
+      redact_fields: []

--- a/client/python/src/openlineage/client/facet_v2.py
+++ b/client/python/src/openlineage/client/facet_v2.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openlineage.client.generated import (
+    agent_attribution_run,
     base_subset_dataset,
     catalog_dataset,
     column_lineage_dataset,
@@ -60,6 +61,7 @@ __all__ = [
     "OutputDatasetFacet",
     "RunFacet",
     "set_producer",
+    "agent_attribution_run",
     "base_subset_dataset",
     "catalog_dataset",
     "column_lineage_dataset",

--- a/client/python/src/openlineage/client/generated/agent_attribution_run.py
+++ b/client/python/src/openlineage/client/generated/agent_attribution_run.py
@@ -1,0 +1,113 @@
+# Copyright 2018-2026 contributors to the OpenLineage project
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import attr
+from openlineage.client.generated.base import RunFacet
+from openlineage.client.utils import RedactMixin
+
+
+@attr.define
+class AgentAttributionRunFacet(RunFacet):
+    agentId: str  # noqa: N815
+    """
+    The identifier of the agent that executed this run. It is recommended to define this as a URN or
+    DID. For example did:aps:z6Mk..., did:web:agent.example.com, agent:foo
+
+    Example: did:aps:z6MkTestAgent001
+    """
+    covenantInEffect: CovenantInEffect  # noqa: N815
+    """
+    The governance attestation that was in force at execution time. The digest is the hash of the signed
+    attestation bytes; the type indicates which governance framework emitted it. Consumers verify the
+    digest against a resolvable attestation to confirm what the agent was allowed to do during this run.
+    """
+    accessedAt: str | None = attr.field(default=None)  # noqa: N815
+    """The timestamp at which the agent accessed the input data source. ISO 8601 UTC."""
+
+    @staticmethod
+    def _get_schema() -> str:
+        return "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json#/$defs/AgentAttributionRunFacet"
+
+    @accessedAt.validator
+    def accessedat_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        from dateutil import parser
+
+        parser.isoparse(value)
+        if "t" not in value.lower():
+            # make sure date-time contains time
+            msg = f"Parsed date-time has to contain time: {value}"
+            raise ValueError(msg)
+
+
+@attr.define
+class CovenantInEffect(RedactMixin):
+    """
+    The governance attestation that was in force at execution time. The digest is the hash of the signed
+    attestation bytes; the type indicates which governance framework emitted it. Consumers verify the
+    digest against a resolvable attestation to confirm what the agent was allowed to do during this run.
+    """
+
+    digest: str
+    """
+    Hash of the governance attestation that was in force at execution time. SHA-256 by default; the
+    algorithm can be declared explicitly in the digestAlgorithm field or prefixed in the value (e.g.
+    sha256:abc...).
+
+    Example: sha256:3c9e9d2c6b7e8a1f4d5c6b7a8f9e0d1c2b3a4f5e6d7c8b9a0f1e2d3c4b5a6978
+    """
+    type: str  # noqa: A003
+    """
+    The governance signal type. Open enum; vendor-agnostic reference value is 'governance_attestation'.
+    Implementers MAY emit a vendor-specific string as long as the digest remains a hash of a signed
+    object that a compliance consumer can resolve and verify.
+
+    Example: governance_attestation
+    """
+    digestAlgorithm: str | None = "sha-256"  # noqa: N815
+    """
+    The hash algorithm used to compute the digest. Defaults to sha-256 if omitted.
+
+    Example: sha-256
+    """
+    resolver: str | None = attr.field(default=None)
+    """
+    Optional URL or DID of the signed attestation from which the digest is computed. When present, a
+    compliance consumer MAY fetch the resolved object and verify the hash matches the digest. Absence of
+    a resolver is acceptable; the digest alone is sufficient for tamper-evidence.
+
+    Example: https://gateway.example.com/api/v1/public/trust/agent001
+    """
+
+    def with_additional_properties(self, **kwargs: Any) -> "CovenantInEffect":
+        """Add additional properties to updated class instance."""
+        current_attrs = [a.name for a in attr.fields(self.__class__)]
+
+        new_class = attr.make_class(
+            self.__class__.__name__,
+            {k: attr.field(default=None) for k in kwargs if k not in current_attrs},
+            bases=(self.__class__,),
+        )
+        new_class.__module__ = self.__class__.__module__
+        attrs = attr.fields(self.__class__)
+        for a in attrs:
+            if not a.init:
+                continue
+            attr_name = a.name  # To deal with private attributes.
+            init_name = a.alias
+            if init_name not in kwargs:
+                kwargs[init_name] = getattr(self, attr_name)
+        return cast(CovenantInEffect, new_class(**kwargs))
+
+    @resolver.validator
+    def resolver_check(self, attribute: str, value: str) -> None:  # noqa: ARG002
+        if value is None:
+            return
+        from urllib.parse import urlparse
+
+        urlparse(value)

--- a/spec/facets/AgentAttributionRunFacet.json
+++ b/spec/facets/AgentAttributionRunFacet.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+  "$defs": {
+    "AgentAttributionRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "agentId": {
+              "description": "The identifier of the agent that executed this run. It is recommended to define this as a URN or DID. For example did:aps:z6Mk..., did:web:agent.example.com, agent:foo",
+              "type": "string",
+              "example": "did:aps:z6MkTestAgent001"
+            },
+            "accessedAt": {
+              "description": "The timestamp at which the agent accessed the input data source. ISO 8601 UTC.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "covenantInEffect": {
+              "description": "The governance attestation that was in force at execution time. The digest is the hash of the signed attestation bytes; the type indicates which governance framework emitted it. Consumers verify the digest against a resolvable attestation to confirm what the agent was allowed to do during this run.",
+              "type": "object",
+              "properties": {
+                "digest": {
+                  "description": "Hash of the governance attestation that was in force at execution time. SHA-256 by default; the algorithm can be declared explicitly in the digestAlgorithm field or prefixed in the value (e.g. sha256:abc...).",
+                  "type": "string",
+                  "example": "sha256:3c9e9d2c6b7e8a1f4d5c6b7a8f9e0d1c2b3a4f5e6d7c8b9a0f1e2d3c4b5a6978"
+                },
+                "digestAlgorithm": {
+                  "description": "The hash algorithm used to compute the digest. Defaults to sha-256 if omitted.",
+                  "type": "string",
+                  "default": "sha-256",
+                  "example": "sha-256"
+                },
+                "type": {
+                  "description": "The governance signal type. Open enum; vendor-agnostic reference value is 'governance_attestation'. Implementers MAY emit a vendor-specific string as long as the digest remains a hash of a signed object that a compliance consumer can resolve and verify.",
+                  "type": "string",
+                  "example": "governance_attestation"
+                },
+                "resolver": {
+                  "description": "Optional URL or DID of the signed attestation from which the digest is computed. When present, a compliance consumer MAY fetch the resolved object and verify the hash matches the digest. Absence of a resolver is acceptable; the digest alone is sufficient for tamper-evidence.",
+                  "type": "string",
+                  "format": "uri",
+                  "example": "https://gateway.example.com/api/v1/public/trust/agent001"
+                }
+              },
+              "required": ["digest", "type"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["agentId", "covenantInEffect"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "agentAttribution": {
+      "$ref": "#/$defs/AgentAttributionRunFacet"
+    }
+  }
+}

--- a/spec/tests/AgentAttributionRunFacet/1.json
+++ b/spec/tests/AgentAttributionRunFacet/1.json
@@ -1,0 +1,14 @@
+{
+  "agentAttribution": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/main/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+    "agentId": "did:example:agent:001",
+    "accessedAt": "2026-04-21T15:44:22.000Z",
+    "covenantInEffect": {
+      "digest": "sha256:3c9e9d2c6b7e8a1f4d5c6b7a8f9e0d1c2b3a4f5e6d7c8b9a0f1e2d3c4b5a6978",
+      "digestAlgorithm": "sha-256",
+      "type": "governance_attestation",
+      "resolver": "https://example.com/api/v1/public/trust/agent001"
+    }
+  }
+}

--- a/spec/tests/AgentAttributionRunFacet/2.json
+++ b/spec/tests/AgentAttributionRunFacet/2.json
@@ -1,0 +1,18 @@
+{
+  "agentAttribution": {
+    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/main/client",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+    "agentId": "did:example:agent:scribe-42",
+    "accessedAt": "2026-04-21T14:29:12.000Z",
+    "covenantInEffect": {
+      "digest": "sha256:7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b",
+      "type": "vendor_specific_covenant",
+      "resolver": "https://example.com/api/v1/covenants/cov-a8f3b2",
+      "authorizationHash": "sha256:0a5bc9a9941286da6bb365d6a25ea5412fa014583e2b99cb1ccc92af556f580a",
+      "authorizationSignature": "APRQxuV0SOorX-Bol50NWtLdltqbw_uhFAyKs-i1WhhNUZdssauZkuDrhykQG2_i53dVybydSQc06dRt2EBQBQ",
+      "resultHash": "sha256:0fbdb588d8d7f25af779424b9238628fd25489af125a446e4daeb7257ec555ea",
+      "resultSignature": "R-yd0OJxVB01-cnSoDir-SeGOt3WBsb57OyZgBMzt_KxNDij-NDFANSvEBRDuCKjo1N3cv4zyh6-9w3zeGhACw",
+      "signerKeyId": "did:example:agent:scribe-42#key-ed25519-1"
+    }
+  }
+}

--- a/website/docs/spec/facets/run-facets/agent_attribution.md
+++ b/website/docs/spec/facets/run-facets/agent_attribution.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 11
+---
+
+# Agent Attribution Facet
+
+The `AgentAttributionRunFacet` captures information about the autonomous agent that executed a run, along with the governance attestation (covenant) that was in force at execution time. Agent-produced lineage events need two run-scoped properties that existing facets don't cover cleanly: the agent's identifier and a tamper-evident reference to the policy the agent was operating under.
+
+- `agentId`: The identifier of the agent that executed this run. Recommended as a URN or DID (e.g. `did:example:agent:001`, `did:web:agent.example.com`).
+- `accessedAt`: The timestamp at which the agent accessed the input data source.
+- `covenantInEffect`: The governance attestation that was in force at execution time, carried as a digest so compliance consumers can verify what the agent was authorized to do during this run.
+  - `digest` (required): Hash of the signed attestation bytes. SHA-256 by default; the algorithm can be declared explicitly in `digestAlgorithm` or prefixed in the value (e.g. `sha256:abc...`).
+  - `digestAlgorithm` (optional, default `sha-256`): The hash algorithm used to compute the digest.
+  - `type` (required): The governance signal type. Open enum; the vendor-agnostic reference value is `governance_attestation`. Implementations MAY emit a vendor-specific string as long as the digest remains a hash of a signed object a compliance consumer can resolve.
+  - `resolver` (optional): URL or DID of the signed attestation from which the digest is computed. Absence is acceptable; the digest alone is sufficient for tamper-evidence (supporting air-gapped or non-public compliance stores).
+
+`covenantInEffect` allows `additionalProperties: true` scoped to the sub-object, so implementations can add vendor-specific fields (enforcement outcome, reason codes, bilateral receipt hashes, signatures, signer key ID, reviewer chain, etc.) without needing a facet version bump.
+
+Example:
+
+```json
+{
+    ...
+    "run": {
+        "facets": {
+            "agentAttribution": {
+                "_producer": "https://github.com/OpenLineage/OpenLineage/tree/main/client",
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+                "agentId": "did:example:agent:001",
+                "accessedAt": "2026-04-21T15:44:22.000Z",
+                "covenantInEffect": {
+                    "digest": "sha256:3c9e9d2c6b7e8a1f4d5c6b7a8f9e0d1c2b3a4f5e6d7c8b9a0f1e2d3c4b5a6978",
+                    "digestAlgorithm": "sha-256",
+                    "type": "governance_attestation",
+                    "resolver": "https://example.com/api/v1/public/trust/agent001"
+                }
+            }
+        }
+    }
+    ...
+}
+```
+
+Example with vendor extensions (bilateral receipt — pre-execution authorization hash + post-execution result hash, both signed by the same agent key):
+
+```json
+{
+    ...
+    "run": {
+        "facets": {
+            "agentAttribution": {
+                "_producer": "https://github.com/OpenLineage/OpenLineage/tree/main/client",
+                "_schemaURL": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+                "agentId": "did:example:agent:scribe-42",
+                "accessedAt": "2026-04-21T14:29:12.000Z",
+                "covenantInEffect": {
+                    "digest": "sha256:7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b",
+                    "type": "vendor_specific_covenant",
+                    "resolver": "https://example.com/api/v1/covenants/cov-a8f3b2",
+                    "authorizationHash": "sha256:0a5bc9a9941286da6bb365d6a25ea5412fa014583e2b99cb1ccc92af556f580a",
+                    "authorizationSignature": "APRQxuV0SOorX-Bol50NWtLdltqbw_uhFAyKs-i1WhhNUZdssauZkuDrhykQG2_i53dVybydSQc06dRt2EBQBQ",
+                    "resultHash": "sha256:0fbdb588d8d7f25af779424b9238628fd25489af125a446e4daeb7257ec555ea",
+                    "resultSignature": "R-yd0OJxVB01-cnSoDir-SeGOt3WBsb57OyZgBMzt_KxNDij-NDFANSvEBRDuCKjo1N3cv4zyh6-9w3zeGhACw",
+                    "signerKeyId": "did:example:agent:scribe-42#key-ed25519-1"
+                }
+            }
+        }
+    }
+    ...
+}
+```
+
+The facet specification can be found [here](https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json).

--- a/website/static/spec/facets/1-0-0/AgentAttributionRunFacet.json
+++ b/website/static/spec/facets/1-0-0/AgentAttributionRunFacet.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/AgentAttributionRunFacet.json",
+  "$defs": {
+    "AgentAttributionRunFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "agentId": {
+              "description": "The identifier of the agent that executed this run. It is recommended to define this as a URN or DID. For example did:aps:z6Mk..., did:web:agent.example.com, agent:foo",
+              "type": "string",
+              "example": "did:aps:z6MkTestAgent001"
+            },
+            "accessedAt": {
+              "description": "The timestamp at which the agent accessed the input data source. ISO 8601 UTC.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "covenantInEffect": {
+              "description": "The governance attestation that was in force at execution time. The digest is the hash of the signed attestation bytes; the type indicates which governance framework emitted it. Consumers verify the digest against a resolvable attestation to confirm what the agent was allowed to do during this run.",
+              "type": "object",
+              "properties": {
+                "digest": {
+                  "description": "Hash of the governance attestation that was in force at execution time. SHA-256 by default; the algorithm can be declared explicitly in the digestAlgorithm field or prefixed in the value (e.g. sha256:abc...).",
+                  "type": "string",
+                  "example": "sha256:3c9e9d2c6b7e8a1f4d5c6b7a8f9e0d1c2b3a4f5e6d7c8b9a0f1e2d3c4b5a6978"
+                },
+                "digestAlgorithm": {
+                  "description": "The hash algorithm used to compute the digest. Defaults to sha-256 if omitted.",
+                  "type": "string",
+                  "default": "sha-256",
+                  "example": "sha-256"
+                },
+                "type": {
+                  "description": "The governance signal type. Open enum; vendor-agnostic reference value is 'governance_attestation'. Implementers MAY emit a vendor-specific string as long as the digest remains a hash of a signed object that a compliance consumer can resolve and verify.",
+                  "type": "string",
+                  "example": "governance_attestation"
+                },
+                "resolver": {
+                  "description": "Optional URL or DID of the signed attestation from which the digest is computed. When present, a compliance consumer MAY fetch the resolved object and verify the hash matches the digest. Absence of a resolver is acceptable; the digest alone is sufficient for tamper-evidence.",
+                  "type": "string",
+                  "format": "uri",
+                  "example": "https://gateway.example.com/api/v1/public/trust/agent001"
+                }
+              },
+              "required": ["digest", "type"],
+              "additionalProperties": true
+            }
+          },
+          "required": ["agentId", "covenantInEffect"]
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "agentAttribution": {
+      "$ref": "#/$defs/AgentAttributionRunFacet"
+    }
+  }
+}


### PR DESCRIPTION
Closes #4409.

Adds the `AgentAttributionRunFacet` for OpenLineage events produced by autonomous agents — carrying the agent's identifier and the governance attestation (covenant) that was in force at execution time.

## Why

Agent-produced lineage events need two run-scoped properties that existing facets don't cover cleanly:

1. **Agent identity** — which agent process emitted this run. Recommended as a URN or DID (`did:aps:...`, `did:web:...`, etc.).
2. **Governance covenant** — the policy or attestation the agent was operating under at run time, carried as a tamper-evident digest so downstream compliance consumers can verify what the agent was authorized to do.

This extends the design discussion in #4409. The facet is vendor-agnostic: `covenantInEffect.type` is an open enum with `governance_attestation` as the reference canonical value; implementers MAY emit vendor-specific strings as long as the digest remains a hash of a signed object a compliance consumer can resolve.

## What's in

- `spec/facets/AgentAttributionRunFacet.json` — the facet schema (Draft 2020-12, `allOf` + RunFacet base).
- `spec/tests/AgentAttributionRunFacet/{1,2}.json` — two test vectors: minimal shape and a shape exercising the `covenantInEffect` vendor-extension slot with a bilateral receipt (pre/post-execution hashes + signatures).
- `website/docs/spec/facets/run-facets/agent_attribution.md` — documentation page with design notes and two worked examples.
- `CHANGELOG.md` entry under `[Unreleased] → Added`.
- `client/python` regeneration — new `generated/agent_attribution_run.py`, `facet_v2.py` import + re-export, and `redact_fields.yml` registration.

## Design decisions

1. **RunFacet, not DatasetFacet.** Agent identity + covenant are run-scoped. Per-input/output data hashes stay on existing dataset facets.
2. **`digest` required, `resolver` optional.** Tamper-evidence comes from the digest alone; a resolver URL is helpful but not required, supporting air-gapped compliance stores.
3. **`covenantInEffect.type` is an open enum.** Vendor-agnostic reference value is `governance_attestation`; vendor-specific strings are fine.
4. **`covenantInEffect.additionalProperties: true`.** Scoped to the sub-object so implementations can add vendor-specific fields without facet version bumps.
5. **`digestAlgorithm` defaults to `sha-256`.** Explicit field when needed, implied when absent. Forward-compatible for BLAKE3 / SHA3-256.

## Cross-implementation validation

`digest` = JCS-canonicalized(signed attestation) → SHA-256. This path has been cross-verified between two independent implementations (TypeScript and Python) producing byte-identical digests on three test vectors.

## Ask

Review welcome. @arian-gogani has been close to the design discussion in #4409 and has offered to leave a co-signal review on this PR.
