### PR TITLE
Python: Remove deprecated dbt attributes in integration/common

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -430,8 +430,7 @@ class DbtArtifactProcessor:
                             namespace=namespace,
                             name=name,
                             inputFacets=dataset_facets,
-                            # TODO: remove this next release
-                            facets=dataset_facets,  # type: ignore
+
                         )
                     ],
                     None,


### PR DESCRIPTION
Removes deprecated facets kwarg and dbt_version_facet in common python dbt processor. They have passed their deprecation period.