### PR TITLE
fix(dbt): guard against None node_unique_id in get_job_type()

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/utils.py
+++ b/integration/common/src/openlineage/common/provider/dbt/utils.py
@@ -169,6 +169,8 @@ def get_job_type(event) -> str | None:
         return "SQL"
     elif node_type in ("MainReportVersion", "CommandCompleted"):
         return "JOB"
+    elif node_unique_id is None:
+        return None
     elif node_unique_id.startswith("model."):
         return "MODEL"
     elif node_unique_id.startswith("snapshot."):

--- a/integration/common/tests/test_utils.py
+++ b/integration/common/tests/test_utils.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2026 contributors to the OpenLineage project
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from openlineage.common.provider.dbt.utils import CONSUME_STRUCTURED_LOGS_COMMAND_OPTION
+from openlineage.common.provider.dbt.utils import CONSUME_STRUCTURED_LOGS_COMMAND_OPTION, get_job_type
 from openlineage.common.utils import (
     IncrementalFileReader,
     add_command_line_arg,
@@ -196,3 +196,48 @@ def test_incremental_file_reader(incremental_reads, expected_lines):
         actual_lines_read.append(line)
 
     assert expected_lines == actual_lines_read
+
+
+def _make_event(node_name: str, node_unique_id: str | None = None) -> dict:
+    """Helper to build a minimal dbt structured-log event for get_job_type tests."""
+    event: dict = {"info": {"name": node_name}, "data": {}}
+    if node_unique_id is not None:
+        event["data"]["node_info"] = {"unique_id": node_unique_id}
+    return event
+
+
+@pytest.mark.parametrize(
+    "node_name, node_unique_id, expected",
+    [
+        ("SQLQuery", None, "SQL"),
+        ("SQLQuery", "model.project.my_model", "SQL"),
+        ("MainReportVersion", None, "JOB"),
+        ("CommandCompleted", None, "JOB"),
+        # None guard: should return None instead of raising AttributeError
+        ("NodeStart", None, None),
+        ("NodeFinished", None, None),
+        # Valid unique_id prefixes
+        ("NodeFinished", "model.project.my_model", "MODEL"),
+        ("NodeFinished", "snapshot.project.my_snapshot", "SNAPSHOT"),
+        ("NodeFinished", "seed.project.my_seed", "SEED"),
+        ("NodeFinished", "test.project.my_test", "TEST"),
+        # Unknown prefix should return None
+        ("NodeFinished", "source.project.my_source", None),
+    ],
+    ids=[
+        "sql_query_no_uid",
+        "sql_query_with_uid",
+        "main_report_version",
+        "command_completed",
+        "node_start_none_uid",
+        "node_finished_none_uid",
+        "model_prefix",
+        "snapshot_prefix",
+        "seed_prefix",
+        "test_prefix",
+        "unknown_prefix",
+    ],
+)
+def test_get_job_type(node_name, node_unique_id, expected):
+    event = _make_event(node_name, node_unique_id)
+    assert get_job_type(event) == expected


### PR DESCRIPTION
## Summary

Fixes #4488

The `get_job_type()` helper in `integration/common/src/openlineage/common/provider/dbt/utils.py` calls `.startswith()` on `node_unique_id` without first checking if it is `None`.

`node_unique_id` is retrieved via `get_from_nullable_chain()`, which returns `None` when `node_info.unique_id` is absent from the event. This causes a crash:

```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

## Changes

- **`utils.py`**: Added an early-exit `elif node_unique_id is None: return None` guard before the `.startswith()` calls.
- **`test_utils.py`**: Added a parametrized `test_get_job_type` suite (11 cases) covering the None guard, all known `node_type` names (`SQLQuery`, `MainReportVersion`, `CommandCompleted`), all valid `unique_id` prefixes (`model.`, `snapshot.`, `seed.`, `test.`), and an unknown prefix.

## Type of change

- [x] Bug fix (non-breaking)
- [x] New tests added
