### PR TITLE
flink: add ClickHouse JDBC support

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/ClickHouseJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/ClickHouseJdbcExtractor.java
@@ -1,0 +1,59 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Implementation of {@link JdbcExtractor} for ClickHouse.
+ *
+ * @see <a href="https://clickhouse.com/docs/en/integrations/java#jdbc-driver">ClickHouse JDBC
+ *     Driver</a>
+ */
+public class ClickHouseJdbcExtractor implements JdbcExtractor {
+
+  private static final int MIN_QUALIFIED_TABLE_NAME_PARTS = 2;
+
+  private JdbcExtractor delegate() {
+    return new OverridingJdbcExtractor("clickhouse", "8123");
+  }
+
+  @Override
+  public boolean isDefinedAt(String jdbcUri) {
+    // Support both 'ch' and 'clickhouse' schemes
+    return jdbcUri.startsWith("ch:") || jdbcUri.startsWith("clickhouse:");
+  }
+
+  @Override
+  public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
+    // Normalize scheme and remove protocol prefix (similar to how PostgreSQL removes SSL info)
+    String normalizedUri =
+        rawUri
+            .replaceFirst("^ch:", "clickhouse:")
+            .replaceFirst("^clickhouse:(https?|grpc)://", "clickhouse://");
+
+    JdbcLocation location = delegate().extract(normalizedUri, properties);
+
+    // In ClickHouse, DATABASE and SCHEMA are synonyms (no 3-level structure)
+    // Override toName() to handle qualified vs unqualified table names
+    return new JdbcLocation(
+        location.getScheme(),
+        location.getAuthority(),
+        location.getInstance(),
+        location.getDatabase()) {
+      @Override
+      public String toName(List<String> parts) {
+        if (parts.size() >= MIN_QUALIFIED_TABLE_NAME_PARTS) {
+          return String.join(".", parts);
+        }
+        // Otherwise, use default behavior (add URL database)
+        return super.toName(parts);
+      }
+    };
+  }
+}

--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtils.java
@@ -27,6 +27,7 @@ public class JdbcDatasetUtils {
     new Db2JdbcExtractor(),
     new TrinoJdbcExtractor(),
     new OceanBaseJdbcExtractor(),
+    new ClickHouseJdbcExtractor(),
     new GenericJdbcExtractor()
   };
 

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForClickHouse.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForClickHouse.java
@@ -1,0 +1,143 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.client.utils.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+class JdbcDatasetUtilsTestForClickHouse {
+  @Test
+  void testGetDatasetIdentifierWithHost() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithPort() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://test-host.com:9000", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:9000")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithDatabase() {
+    // Qualified table name: explicit database overrides URL database
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://test-host.com:8123/mydb", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    // Unqualified table name: URL database is used
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://test-host.com:8123/mydb", "table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "mydb.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithMultipleHosts() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://test-host.com,test-host2.com",
+                "schema.table1",
+                new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "clickhouse://test-host.com:8123,test-host2.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIP() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://198.51.100.1", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://198.51.100.1:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithMultipleIPs() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://198.51.100.1,198.51.100.2", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue(
+            "namespace", "clickhouse://198.51.100.1:8123,198.51.100.2:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithIPv6() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:clickhouse://[2001:db8::1]", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://[2001:db8::1]:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChScheme() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch://test-host.com", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChSchemeAndPort() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch://test-host.com:9000", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:9000")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChSchemeAndDatabase() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch://test-host.com:8123/mydb", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChHttpProtocol() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch:http://test-host.com:8123", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8123")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChHttpsProtocol() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch:https://test-host.com:8443", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:8443")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+
+  @Test
+  void testGetDatasetIdentifierWithChGrpcProtocol() {
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:ch:grpc://test-host.com:9100", "schema.table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "clickhouse://test-host.com:9100")
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+  }
+}


### PR DESCRIPTION
Add ClickHouseJdbcExtractor for parsing ClickHouse JDBC URLs.

related: #4494

### One-line summary for changelog:
Add ClickHouse JDBC support with ClickHouseJdbcExtractor

### Meaningful description
Adds `ClickHouseJdbcExtractor` to enable lineage tracking for ClickHouse JDBC connections. This allows OpenLineage to parse ClickHouse JDBC URLs and extract proper dataset namespaces and names. 

  **Implementation:** 
  - Supports both `jdbc:clickhouse://` and `jdbc:ch://` URL schemes 
  - Removes protocol prefixes (http/https/grpc) from namespace following OpenLineage conventions
    - ClickHouse JDBC supports protocol-specific URLs like `jdbc:ch:https://host:8443`
    - OpenLineage extracts only physical location (host:port), removing protocol info
    - This follows the same pattern as PostgreSQL extractor removing SSL info 
  - Default port: 8123