### PR TITLE
fix(client/java): MySqlJdbcExtractor incorrectly includes URL database in qualified table names

### DIFF
--- a/client/java/src/main/java/io/openlineage/client/utils/jdbc/MySqlJdbcExtractor.java
+++ b/client/java/src/main/java/io/openlineage/client/utils/jdbc/MySqlJdbcExtractor.java
@@ -6,12 +6,14 @@
 package io.openlineage.client.utils.jdbc;
 
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Properties;
 
 public class MySqlJdbcExtractor implements JdbcExtractor {
   // https://dev.mysql.com/doc/connector-j/en/connector-j-reference-jdbc-url-format.html
 
   private static final String PROTOCOL_PART = "^[\\w+:]+://";
+  private static final int MIN_QUALIFIED_TABLE_NAME_PARTS = 2;
 
   private JdbcExtractor delegate() {
     return new OverridingJdbcExtractor("mysql", "3306");
@@ -26,6 +28,24 @@ public class MySqlJdbcExtractor implements JdbcExtractor {
   public JdbcLocation extract(String rawUri, Properties properties) throws URISyntaxException {
     // Schema could be 'mysql', 'mysql:part', 'mysql+srv:part'. Convert it to 'mysql'
     String normalizedUri = rawUri.replaceFirst(PROTOCOL_PART, "mysql://");
-    return delegate().extract(normalizedUri, properties);
+
+    JdbcLocation location = delegate().extract(normalizedUri, properties);
+
+    // In MySQL, DATABASE and SCHEMA are synonyms (no 3-level structure)
+    // Override toName() to handle qualified vs unqualified table names
+    return new JdbcLocation(
+        location.getScheme(),
+        location.getAuthority(),
+        location.getInstance(),
+        location.getDatabase()) {
+      @Override
+      public String toName(List<String> parts) {
+        if (parts.size() >= MIN_QUALIFIED_TABLE_NAME_PARTS) {
+          return String.join(".", parts);
+        }
+        // Otherwise, use default behavior (add URL database)
+        return super.toName(parts);
+      }
+    };
   }
 }

--- a/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
+++ b/client/java/src/test/java/io/openlineage/client/utils/jdbc/JdbcDatasetUtilsTestForMySql.java
@@ -69,11 +69,19 @@ class JdbcDatasetUtilsTestForMySql {
 
   @Test
   void testGetDatasetIdentifierWithDatabase() {
+    // Qualified table name: explicit database overrides URL database
     assertThat(
             JdbcDatasetUtils.getDatasetIdentifier(
                 "jdbc:mysql://hostname/mydb", "schema.table1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "mysql://hostname:3306")
-        .hasFieldOrPropertyWithValue("name", "mydb.schema.table1");
+        .hasFieldOrPropertyWithValue("name", "schema.table1");
+
+    // Unqualified table name: URL database is used
+    assertThat(
+            JdbcDatasetUtils.getDatasetIdentifier(
+                "jdbc:mysql://hostname/mydb", "table1", new Properties()))
+        .hasFieldOrPropertyWithValue("namespace", "mysql://hostname:3306")
+        .hasFieldOrPropertyWithValue("name", "mydb.table1");
   }
 
   @Test
@@ -124,7 +132,7 @@ class JdbcDatasetUtilsTestForMySql {
             JdbcDatasetUtils.getDatasetIdentifier(
                 "JDBC:MYSQL://TEST.HOST.COM/MYDB", "SCHEMA.TABLE1", new Properties()))
         .hasFieldOrPropertyWithValue("namespace", "mysql://test.host.com:3306")
-        .hasFieldOrPropertyWithValue("name", "MYDB.SCHEMA.TABLE1");
+        .hasFieldOrPropertyWithValue("name", "SCHEMA.TABLE1");
   }
 
   @Test


### PR DESCRIPTION

In MySQL, DATABASE and SCHEMA are synonyms. When a table name is qualified (e.g., schema.table1), the explicit database name takes precedence over the URL database, which should be excluded.

related: #4496


### One-line summary for changelog:

Fix MySqlJdbcExtractor to exclude URL database from qualified table names.


### Meaningful description

MySqlJdbcExtractor incorrectly prepends the URL database to qualified table names, creating invalid 3-level identifiers like `mydb.schema.table1`. In MySQL, DATABASE and SCHEMA are synonyms (not separate concepts like PostgreSQL).

Clear the database field from JdbcLocation after extraction, similar to the ClickHouse fix. When a table is referenced as `schema.table1`, the `schema` part is already the database name and should not be prefixed with the URL database.
