### PR TITLE
dbt: Handle missing "description" key in `DbtArtifactProcessor.extract_dataset_data()` for dbt-fusion support

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -747,7 +747,7 @@ class DbtArtifactProcessor:
                 ),
             }
 
-            documentation = node.metadata_node["description"]
+            documentation = node.metadata_node.get("description", "")
             if documentation:
                 facets["documentation"] = documentation_dataset.DocumentationDatasetFacet(
                     description=documentation


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please review our [contribution guidelines](https://github.com/OpenLineage/OpenLineage/blob/main/CONTRIBUTING.md).

If your contribution relates to an existing issue, reference it using one of the following formats:
closes: #ISSUE
related: #ISSUE
-->

### One-line summary for changelog:
<!-- Concise, informative sentence to help future readers understand the change. -->
Fix `KeyError` raised in `extract_dataset_data()` when processing dbt-fusion manifests where source nodes omit the `"description"` key when no description is specified.

### Meaningful description
<!-- Brief description of the problem, solution and alternatives considered. -->
**Problem**
When using dbt-fusion, source nodes in `manifest.json` omit the `"description"` key entirely when no description is defined in the schema YAML. dbt-core always writes `"description": ""` as a placeholder, so this was never an issue before.

In `DbtArtifactProcessor.extract_dataset_data()`, [this line](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L750) performs a hard dict access on this key. 

When processing a dbt-fusion manifest, this raises `KeyError` for any source node without a description. The error propagates out of the [`node_to_dataset()` list comprehension](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L358) in `parse_execution()` , gets re-raised as [`ValueError`](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L606) by [`to_openlineage_events()`](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L490), and causes the entire `DbtArtifactProcessor.parse()` call to fail - meaning no lineage events are emitted for that task at all.

**Solution**
Use `.get()` with an empty string default.

This is safe because `documentation` is only used to conditionally add a [`DocumentationDatasetFacet`](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L752) - an empty string is already handled by [`if documentation:`](https://github.com/OpenLineage/OpenLineage/blob/f7464dd13927d996c7e39b59f4048079b92558e6/integration/common/src/openlineage/common/provider/dbt/processor.py#L751), so no facet is added. Additionally the behavior is unchanged for dbt-core manifests.

### Checklist
- [ ] AI was used in creating this PR
