### PR TITLE
expose failure counts and thresholds on dbt test facets

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -81,6 +81,21 @@ class UnsupportedDbtCommand(Exception):
     pass
 
 
+def expected_from_test_config(config: dict | None, severity: str | None) -> str:
+    """Translate dbt's ``error_if``/``warn_if`` threshold into the spec's ``expected`` value.
+
+    dbt's default is ``"!= 0"`` (any failing row trips the test) — semantically the
+    expected count is 0. A non-default threshold like ``"> 10"`` is carried through
+    so a consumer can distinguish "expected zero failures, got N" from "expected at
+    most 10 failures, got N".
+    """
+    threshold_key = "warn_if" if (severity or "").lower() == "warn" else "error_if"
+    threshold = (config or {}).get(threshold_key)
+    if threshold is None or "".join(str(threshold).split()) == "!=0":
+        return "0"
+    return str(threshold)
+
+
 @attr.define
 class ModelNode:
     # in reality Literal["model", "test", "snapshot", "source", "seed"]
@@ -535,6 +550,13 @@ class DbtArtifactProcessor:
             severity=severity,
         )
 
+        # dbt reports the count of violating rows as `failures` in run_results.json.
+        # `expected` mirrors the test's error_if/warn_if threshold (default "!= 0" → "0").
+        failures = run.get("failures")
+        if failures is not None:
+            obj.actual = str(failures)
+            obj.expected = expected_from_test_config(config, severity)
+
         if not inputs:
             obj.type = test_metadata["name"] if test_metadata else "singular"
             obj.content = (
@@ -584,12 +606,18 @@ class DbtArtifactProcessor:
             if severity:
                 severity = severity.lower()
 
+            failures = run.get("failures")
+            actual = str(failures) if failures is not None else None
+            expected = expected_from_test_config(config, severity) if failures is not None else None
+
             assertions[model_node].append(
                 data_quality_assertions_dataset.Assertion(
                     assertion=name,
                     success=True if run["status"] == "pass" else False,
                     column=get_from_nullable_chain(node_columns, ["kwargs", "column_name"]),
                     severity=severity,
+                    actual=actual,
+                    expected=expected,
                 )
             )
 

--- a/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
+++ b/integration/common/src/openlineage/common/provider/dbt/structured_logs.py
@@ -36,6 +36,7 @@ from openlineage.common.provider.dbt.local import DbtLocalArtifactProcessor
 from openlineage.common.provider.dbt.processor import (
     ModelNode,
     UnsupportedDbtCommand,
+    expected_from_test_config,
 )
 from openlineage.common.provider.dbt.utils import (
     DBT_LOG_FILE_MAX_BYTES,
@@ -494,7 +495,11 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
             config = test_node.get("config", {})
             severity = (config.get("severity") or "error").lower()
 
-            if assertion := self._get_assertion(node_unique_id, success):
+            # Structured-log NodeFinished events name the count `num_failures`
+            # (run_results.json calls the same value `failures`).
+            num_failures = (event["data"].get("run_result") or {}).get("num_failures")
+
+            if assertion := self._get_assertion(node_unique_id, success, num_failures):
                 assertion_facet = dq.DataQualityAssertionsDatasetFacet(assertions=[assertion])
                 inputs = []
                 for attached_dataset in self._get_attached_datasets(node_unique_id):
@@ -521,6 +526,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
                 test_obj.contentType = "sql"
                 if desc := test_node.get("description"):
                     test_obj.description = desc
+                if num_failures is not None:
+                    test_obj.actual = str(num_failures)
+                    test_obj.expected = expected_from_test_config(config, severity)
                 run_facets["test"] = test_run.TestRunFacet(tests=[test_obj])
 
         if extraction_error := self._get_extraction_error_facet(node_unique_id):
@@ -563,7 +571,9 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         ]
 
     @handle_keyerror
-    def _get_assertion(self, node_id: str, success: bool) -> dq.Assertion | None:
+    def _get_assertion(
+        self, node_id: str, success: bool, num_failures: int | None = None
+    ) -> dq.Assertion | None:
         manifest_test_node = self.compiled_manifest["nodes"][node_id]
         test_metadata = manifest_test_node.get("test_metadata")
         if test_metadata:
@@ -581,11 +591,16 @@ class DbtStructuredLogsProcessor(DbtLocalArtifactProcessor):
         if severity:
             severity = severity.lower()
 
+        actual = str(num_failures) if num_failures is not None else None
+        expected = expected_from_test_config(config, severity) if num_failures is not None else None
+
         return dq.Assertion(
             assertion=name,
             success=success,
             column=column,
             severity=severity,
+            actual=actual,
+            expected=expected,
         )
 
     def _parse_sql_query_event(self, event) -> RunEvent:

--- a/integration/common/tests/dbt/build/result.json
+++ b/integration/common/tests/dbt/build/result.json
@@ -151,17 +151,23 @@
                             {
                                 "column": "id",
                                 "assertion": "expect_column_median_to_be_between",
-                                "success": true
+                                "success": true,
+                                "actual": "0",
+                                "expected": "0"
                             },
                             {
                                 "column": "id",
                                 "assertion": "expect_column_quantile_values_to_be_between",
-                                "success": true
+                                "success": true,
+                                "actual": "0",
+                                "expected": "0"
                             },
                             {
                                 "column": "id",
                                 "assertion": "unique",
-                                "success": true
+                                "success": true,
+                                "actual": "0",
+                                "expected": "0"
                             }
                         ]
                     }

--- a/integration/common/tests/dbt/no_test_metadata/result.json
+++ b/integration/common/tests/dbt/no_test_metadata/result.json
@@ -79,13 +79,17 @@
                                 "assertion": "unique_customers_customer_id",
                                 "success": false,
                                 "column": null,
-                                "severity": "error"
+                                "severity": "error",
+                                "actual": "1",
+                                "expected": "0"
                             },
                             {
                                 "assertion": "not_null_customers_customer_id",
                                 "success": false,
                                 "column": null,
-                                "severity": "error"
+                                "severity": "error",
+                                "actual": "Test failure",
+                                "expected": "0"
                             }
                         ]
                     }
@@ -674,13 +678,17 @@
                                 "assertion": "unique_customers_customer_id",
                                 "success": false,
                                 "column": null,
-                                "severity": "error"
+                                "severity": "error",
+                                "actual": "1",
+                                "expected": "0"
                             },
                             {
                                 "assertion": "not_null_customers_customer_id",
                                 "success": false,
                                 "column": null,
-                                "severity": "error"
+                                "severity": "error",
+                                "actual": "Test failure",
+                                "expected": "0"
                             }
                         ]
                     }

--- a/integration/common/tests/dbt/singular_test/result.json
+++ b/integration/common/tests/dbt/singular_test/result.json
@@ -16,8 +16,8 @@
               "severity": "error",
               "type": "singular",
               "description": "Ensures all order amounts are positive.",
-              "expected": null,
-              "actual": null,
+              "expected": "0",
+              "actual": "0",
               "content": "select * from my_schema.orders where amount < 0",
               "contentType": "sql",
               "params": {}
@@ -114,8 +114,8 @@
               "severity": "warn",
               "type": "singular",
               "description": null,
-              "expected": null,
-              "actual": null,
+              "expected": "0",
+              "actual": "5",
               "content": "select * from my_schema.orders where amount not between 0 and 10000",
               "contentType": "sql",
               "params": {}
@@ -212,8 +212,8 @@
               "severity": "error",
               "type": "singular",
               "description": "Ensures all order amounts are positive.",
-              "expected": null,
-              "actual": null,
+              "expected": "0",
+              "actual": "0",
               "content": "select * from my_schema.orders where amount < 0",
               "contentType": "sql",
               "params": {}
@@ -310,8 +310,8 @@
               "severity": "warn",
               "type": "singular",
               "description": null,
-              "expected": null,
-              "actual": null,
+              "expected": "0",
+              "actual": "5",
               "content": "select * from my_schema.orders where amount not between 0 and 10000",
               "contentType": "sql",
               "params": {}

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -258,25 +258,33 @@
                 "column": "id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "second_id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "unique",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "second_id",
                 "assertion": "unique",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               }
             ]
           }
@@ -338,13 +346,17 @@
                 "column": "id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "unique",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               }
             ]
           }
@@ -407,13 +419,17 @@
                 "column": "id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "unique",
                 "success": false,
-                "severity": "error"
+                "severity": "error",
+                "actual": "1",
+                "expected": "0"
               }
             ]
           }
@@ -477,31 +493,41 @@
                 "column": "id",
                 "assertion": "expect_column_quantile_values_to_be_between",
                 "success": false,
-                "severity": "error"
+                "severity": "error",
+                "actual": "6",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "expect_column_median_to_be_between",
                 "success": false,
-                "severity": "error"
+                "severity": "error",
+                "actual": "6",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "expect_column_values_to_not_be_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
                 "assertion": "unique",
                 "success": false,
-                "severity": "error"
+                "severity": "error",
+                "actual": "1",
+                "expected": "0"
               }
             ]
           }
@@ -565,7 +591,9 @@
                 "column": "id",
                 "assertion": "not_null",
                 "success": true,
-                "severity": "error"
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               }
             ]
           }

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -299,3 +299,105 @@ class TestParseSingularTests:
         assert assertion.assertion == "assert_no_future_dates"
         assert assertion.success is True
         assert assertion.column is None
+
+
+class TestParseFailures:
+    """Tests for failure-count extraction in parse_assertions (generic tests)."""
+
+    @pytest.fixture
+    def processor(self):
+        processor = DbtArtifactProcessor(
+            producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            job_namespace="test-namespace",
+        )
+        processor.manifest_version = 11  # Use version < 12 for test_metadata path
+        return processor
+
+    def test_warning_test_with_nine_failures(self, processor):
+        """Mirrors the dbt-test-env scenario: accepted_values test with severity=warn, failures=9."""
+        nodes = {
+            "test.project.accepted_values_country": {
+                "test_metadata": {
+                    "name": "accepted_values",
+                    "kwargs": {"column_name": "country", "values": ["USA", "Canada"]},
+                },
+                "config": {"severity": "warn"},
+            }
+        }
+        manifest = {
+            "parent_map": {
+                "test.project.accepted_values_country": ["model.project.stg_customers"],
+            }
+        }
+        run_results = {
+            "results": [
+                {
+                    "unique_id": "test.project.accepted_values_country",
+                    "status": "warn",
+                    "failures": 9,
+                }
+            ]
+        }
+        context = DbtRunContext(manifest=manifest, run_results=run_results)
+
+        assertion = processor.parse_assertions(context, nodes)["model.project.stg_customers"][0]
+
+        assert assertion.success is False  # status="warn" is not "pass"
+        assert assertion.actual == "9"
+        assert assertion.expected == "0"
+
+    def test_passing_test_surfaces_zero_failures(self, processor):
+        """Passing tests still report the count; surfacing 0 makes the metric uniformly queryable."""
+        nodes = {
+            "test.project.unique_id": {
+                "test_metadata": {"name": "unique", "kwargs": {"column_name": "id"}},
+                "config": {"severity": "error"},
+            }
+        }
+        manifest = {"parent_map": {"test.project.unique_id": ["model.project.my_model"]}}
+        run_results = {"results": [{"unique_id": "test.project.unique_id", "status": "pass", "failures": 0}]}
+        context = DbtRunContext(manifest=manifest, run_results=run_results)
+
+        assertion = processor.parse_assertions(context, nodes)["model.project.my_model"][0]
+
+        assert assertion.success is True
+        assert assertion.actual == "0"
+        assert assertion.expected == "0"
+
+    def test_custom_threshold_carried_through_to_expected(self, processor):
+        """When error_if/warn_if is non-default, the threshold expression is preserved in `expected`."""
+        nodes = {
+            "test.project.row_count": {
+                "test_metadata": {"name": "row_count", "kwargs": {}},
+                "config": {"severity": "warn", "warn_if": "> 100"},
+            }
+        }
+        manifest = {"parent_map": {"test.project.row_count": ["model.project.my_model"]}}
+        run_results = {"results": [{"unique_id": "test.project.row_count", "status": "pass", "failures": 50}]}
+        context = DbtRunContext(manifest=manifest, run_results=run_results)
+
+        assertion = processor.parse_assertions(context, nodes)["model.project.my_model"][0]
+
+        assert assertion.actual == "50"
+        assert assertion.expected == "> 100"
+
+    def test_missing_failures_field_falls_back_to_none(self, processor):
+        """Older dbt versions or runtime errors may not report failures; both fields stay None."""
+        nodes = {
+            "test.project.unique_id": {
+                "test_metadata": {"name": "unique", "kwargs": {"column_name": "id"}},
+                "config": {"severity": "error"},
+            }
+        }
+        manifest = {"parent_map": {"test.project.unique_id": ["model.project.my_model"]}}
+        run_results = {
+            "results": [
+                {"unique_id": "test.project.unique_id", "status": "pass"}  # no "failures" key
+            ]
+        }
+        context = DbtRunContext(manifest=manifest, run_results=run_results)
+
+        assertion = processor.parse_assertions(context, nodes)["model.project.my_model"][0]
+
+        assert assertion.actual is None
+        assert assertion.expected is None


### PR DESCRIPTION
The dbt integration emits `DataQualityAssertionsDatasetFacet` and `TestRunFacet` for every dbt test, but neither populated `actual` or `expected` — even though dbt's `run_results.json` (file-based path) carries a `failures` row count and structured-log `NodeFinished` events carry the same value as `num_failures`. 

This PR threads that count through to `actual` (always emitted, including `0` for passing tests, so the metric is uniformly queryable) and maps `expected` to the test's `error_if`/`warn_if` threshold based on severity — defaulting to `"0"` when the threshold is the dbt default `"!= 0"` and carrying non-default expressions like `"> 10"` through verbatim, so consumers can distinguish "expected zero failures, got N" from "passed within configured tolerance." The fields stay `None` when dbt didn't report a count (older dbt versions, runtime errors). 

### Checklist
- [x] AI was used in creating this PR - Claude Code
