### PR TITLE
spark: fix PathUtils.reconstructDefaultLocation malformed URI for S3 paths

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -141,7 +141,7 @@ public class PathUtils {
     }
 
     // /warehouse/mydb.db/mytable
-    return new Path(warehouse, database + ".db", name);
+    return new Path(new Path(warehouse, database + ".db"), name);
   }
 
   public static Optional<URI> getMetastoreUri(SparkContext context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -444,4 +444,29 @@ class PathUtilsTest {
     // name
     assertThat(datasetIdentifier.getSymlinks()).hasSize(0);
   }
+
+  @Test
+  void testReconstructDefaultLocationWithS3Warehouse() {
+    // Regression test for https://github.com/OpenLineage/OpenLineage/issues/4414
+    // The 3-argument Path constructor Path(scheme, authority, path) was incorrectly used,
+    // producing malformed URIs like s3://bucket/prefix://database.db./table when the
+    // warehouse is an S3 path. Chained 2-argument constructors must be used instead.
+    Path result =
+        PathUtils.reconstructDefaultLocation("s3://bucket/prefix", new String[] {"mydb"}, "mytable");
+    assertThat(result.toString()).isEqualTo("s3://bucket/prefix/mydb.db/mytable");
+  }
+
+  @Test
+  void testReconstructDefaultLocationWithDefaultDb() {
+    Path result =
+        PathUtils.reconstructDefaultLocation("s3://bucket/prefix", new String[] {"default"}, "mytable");
+    assertThat(result.toString()).isEqualTo("s3://bucket/prefix/mytable");
+  }
+
+  @Test
+  void testReconstructDefaultLocationWithLocalPath() {
+    Path result =
+        PathUtils.reconstructDefaultLocation("/warehouse", new String[] {"mydb"}, "mytable");
+    assertThat(result.toString()).isEqualTo("/warehouse/mydb.db/mytable");
+  }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -452,14 +452,16 @@ class PathUtilsTest {
     // producing malformed URIs like s3://bucket/prefix://database.db./table when the
     // warehouse is an S3 path. Chained 2-argument constructors must be used instead.
     Path result =
-        PathUtils.reconstructDefaultLocation("s3://bucket/prefix", new String[] {"mydb"}, "mytable");
+        PathUtils.reconstructDefaultLocation(
+            "s3://bucket/prefix", new String[] {"mydb"}, "mytable");
     assertThat(result.toString()).isEqualTo("s3://bucket/prefix/mydb.db/mytable");
   }
 
   @Test
   void testReconstructDefaultLocationWithDefaultDb() {
     Path result =
-        PathUtils.reconstructDefaultLocation("s3://bucket/prefix", new String[] {"default"}, "mytable");
+        PathUtils.reconstructDefaultLocation(
+            "s3://bucket/prefix", new String[] {"default"}, "mytable");
     assertThat(result.toString()).isEqualTo("s3://bucket/prefix/mytable");
   }
 


### PR DESCRIPTION
## Summary

Fixes #4414

`PathUtils.reconstructDefaultLocation` used Hadoop's 3-argument `Path` constructor incorrectly:

```java
// Before — wrong: Path(scheme, authority, path) not hierarchical path building
new Path(warehouse, database + ".db", name)
```

When `warehouse` is an S3 URI like `s3://bucket/prefix`, the 3-argument constructor interprets its arguments as `(scheme, authority, path)`, producing the malformed URI:

```
s3://bucket/prefix://database.db./table_name
```

This throws `IllegalArgumentException: Relative path in absolute URI` and silently drops all lineage events for the job.

## Fix

Chain 2-argument `Path` constructors to build the path hierarchically:

```java
// After — correct: builds s3://bucket/prefix/database.db/table_name
new Path(new Path(warehouse, database + ".db"), name)
```

## Tests

Added three test cases to `PathUtilsTest`:
- `testReconstructDefaultLocationWithS3Warehouse` — the exact bug scenario (S3 warehouse with sub-path prefix)
- `testReconstructDefaultLocationWithDefaultDb` — default database skips the `.db` segment
- `testReconstructDefaultLocationWithLocalPath` — local filesystem path still works correctly

## Checklist

- [x] One-line fix in `PathUtils.java`
- [x] Three regression tests added to `PathUtilsTest.java`
- [x] `Signed-off-by` included (DCO)

---

> ⚠️ **AI Disclosure** — This pull request was generated with AI assistance (Claude Code). The fix and tests were reviewed for correctness before submission.