### PR TITLE
flink: extract generic schema and config facet visitors

### DIFF
--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/listener/OpenLineageJobStatusChangedListenerFactory.java
@@ -7,7 +7,9 @@ package io.openlineage.flink.listener;
 
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.visitor.Flink2VisitorFactory;
+import io.openlineage.flink.visitor.facet.ConfigFacetVisitor;
 import io.openlineage.flink.visitor.facet.DatasetFacetVisitor;
+import io.openlineage.flink.visitor.facet.SchemaFacetVisitor;
 import io.openlineage.flink.visitor.facet.TableLineageFacetVisitor;
 import io.openlineage.flink.visitor.facet.TypeDatasetFacetVisitor;
 import io.openlineage.flink.visitor.identifier.DatasetIdentifierVisitor;
@@ -37,7 +39,10 @@ public class OpenLineageJobStatusChangedListenerFactory implements JobStatusChan
       @Override
       public Collection<DatasetFacetVisitor> loadDatasetFacetVisitors(OpenLineageContext context) {
         return Arrays.asList(
-            new TypeDatasetFacetVisitor(context), new TableLineageFacetVisitor(context));
+            new TypeDatasetFacetVisitor(context),
+            new TableLineageFacetVisitor(context),
+            new ConfigFacetVisitor(context),
+            new SchemaFacetVisitor(context));
       }
 
       @Override

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/ConfigFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/ConfigFacetVisitor.java
@@ -1,0 +1,46 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+/**
+ * Extracts {@link DatasetConfigFacet} from any dataset. This handles both Table API and DataStream
+ * API connectors that provide config facets via Flink's lineage API.
+ */
+public class ConfigFacetVisitor implements DatasetFacetVisitor {
+
+  private final OpenLineageContext context;
+
+  public ConfigFacetVisitor(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean isDefinedAt(LineageDatasetWithIdentifier dataset) {
+    return dataset.getFlinkDataset().facets().values().stream()
+        .anyMatch(f -> f instanceof DatasetConfigFacet);
+  }
+
+  @Override
+  public void apply(LineageDatasetWithIdentifier dataset, DatasetFacetsBuilder builder) {
+    for (LineageDatasetFacet facet : dataset.getFlinkDataset().facets().values()) {
+      if (facet instanceof DatasetConfigFacet) {
+        OpenLineage.DefaultDatasetFacet datasetFacet =
+            (OpenLineage.DefaultDatasetFacet) context.getOpenLineage().newDatasetFacet();
+        datasetFacet.getAdditionalProperties().putAll(((DatasetConfigFacet) facet).config());
+        builder.put(facet.name(), datasetFacet);
+      } else if (facet instanceof OpenLineage.DatasetFacet) {
+        builder.put(facet.name(), (OpenLineage.DatasetFacet) facet);
+      }
+    }
+  }
+}

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/SchemaFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/SchemaFacetVisitor.java
@@ -1,0 +1,59 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import io.openlineage.flink.wrapper.TableLineageDatasetWrapper;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+/**
+ * Extracts {@link DatasetSchemaFacet} from any dataset that provides it via Flink's lineage API.
+ */
+public class SchemaFacetVisitor implements DatasetFacetVisitor {
+
+  private final OpenLineageContext context;
+
+  public SchemaFacetVisitor(OpenLineageContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public boolean isDefinedAt(LineageDatasetWithIdentifier dataset) {
+    if (new TableLineageDatasetWrapper(dataset.getFlinkDataset()).isTableLineageDataset()) {
+      return false;
+    }
+
+    return dataset.getFlinkDataset().facets().values().stream()
+        .anyMatch(f -> f instanceof DatasetSchemaFacet);
+  }
+
+  @Override
+  public void apply(LineageDatasetWithIdentifier dataset, DatasetFacetsBuilder builder) {
+    for (LineageDatasetFacet facet : dataset.getFlinkDataset().facets().values()) {
+      if (facet instanceof DatasetSchemaFacet) {
+        DatasetSchemaFacet schemaFacet = (DatasetSchemaFacet) facet;
+        List<SchemaDatasetFacetFields> fields =
+            schemaFacet.fields().values().stream()
+                .map(
+                    f ->
+                        context
+                            .getOpenLineage()
+                            .newSchemaDatasetFacetFieldsBuilder()
+                            .name(f.name())
+                            .type(String.valueOf(f.type()))
+                            .build())
+                .collect(Collectors.toList());
+        builder.schema(context.getOpenLineage().newSchemaDatasetFacet(fields));
+      }
+    }
+  }
+}

--- a/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
+++ b/integration/flink/flink2/src/main/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitor.java
@@ -5,7 +5,6 @@
 
 package io.openlineage.flink.visitor.facet;
 
-import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.flink.api.OpenLineageContext;
@@ -14,9 +13,7 @@ import io.openlineage.flink.wrapper.TableLineageDatasetWrapper;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
-import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 
@@ -37,18 +34,6 @@ public class TableLineageFacetVisitor implements DatasetFacetVisitor {
   @Override
   public void apply(LineageDatasetWithIdentifier dataset, DatasetFacetsBuilder builder) {
     buildSchemaFacet(dataset.getFlinkDataset(), builder);
-    buildConfigFacet(dataset.getFlinkDataset(), builder);
-  }
-
-  private void buildConfigFacet(LineageDataset flinkDataset, DatasetFacetsBuilder builder) {
-    for (LineageDatasetFacet facet : flinkDataset.facets().values()) {
-      if (facet instanceof DatasetConfigFacet) {
-        OpenLineage.DefaultDatasetFacet datasetFacet =
-            (OpenLineage.DefaultDatasetFacet) context.getOpenLineage().newDatasetFacet();
-        datasetFacet.getAdditionalProperties().putAll(((DatasetConfigFacet) facet).config());
-        builder.put(facet.name(), datasetFacet);
-      }
-    }
   }
 
   private void buildSchemaFacet(LineageDataset flinkDataset, DatasetFacetsBuilder builder) {

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/ConfigFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/ConfigFacetVisitorTest.java
@@ -1,0 +1,65 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacet;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.OpenLineage.DefaultDatasetFacet;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.client.Versions;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import java.util.Map;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ConfigFacetVisitor}. */
+class ConfigFacetVisitorTest {
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  ConfigFacetVisitor visitor = new ConfigFacetVisitor(context);
+  OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+  LineageDataset flinkDataset = mock(LineageDataset.class);
+  LineageDatasetWithIdentifier dataset = mock(LineageDatasetWithIdentifier.class);
+
+  @Test
+  void testIsDefinedAt() {
+    when(dataset.getFlinkDataset()).thenReturn(flinkDataset);
+    when(flinkDataset.facets()).thenReturn(Map.of("facet", mock(LineageDatasetFacet.class)));
+
+    assertThat(visitor.isDefinedAt(dataset)).isFalse();
+
+    when(flinkDataset.facets()).thenReturn(Map.of("config", mock(DatasetConfigFacet.class)));
+
+    assertThat(visitor.isDefinedAt(dataset)).isTrue();
+  }
+
+  @Test
+  void testApplyWithConfigFacet() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+    when(dataset.getFlinkDataset()).thenReturn(flinkDataset);
+    DatasetFacetsBuilder facetsBuilder = openLineage.newDatasetFacetsBuilder();
+
+    DatasetConfigFacet configFacet = mock(DatasetConfigFacet.class);
+    when(configFacet.name()).thenReturn("config");
+    when(configFacet.config()).thenReturn(Map.of("key1", "value1", "key2", "value2"));
+    when(flinkDataset.facets()).thenReturn(Map.of("config", configFacet));
+
+    visitor.apply(dataset, facetsBuilder);
+
+    Map<String, DatasetFacet> additionalProps = facetsBuilder.build().getAdditionalProperties();
+    DefaultDatasetFacet resultFacet = (DefaultDatasetFacet) additionalProps.get("config");
+
+    assertThat(resultFacet).isNotNull();
+    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key1", "value1");
+    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key2", "value2");
+  }
+}

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/SchemaFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/SchemaFacetVisitorTest.java
@@ -1,0 +1,111 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.flink.visitor.facet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
+import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
+import io.openlineage.flink.api.OpenLineageContext;
+import io.openlineage.flink.client.Versions;
+import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaField;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.table.planner.lineage.TableLineageDataset;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SchemaFacetVisitor}. */
+class SchemaFacetVisitorTest {
+  OpenLineageContext context = mock(OpenLineageContext.class);
+  SchemaFacetVisitor visitor = new SchemaFacetVisitor(context);
+  OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
+  LineageDataset flinkDataset = mock(LineageDataset.class);
+  LineageDatasetWithIdentifier dataset = mock(LineageDatasetWithIdentifier.class);
+
+  @Test
+  void testIsDefinedAt() {
+    when(dataset.getFlinkDataset()).thenReturn(flinkDataset);
+    when(flinkDataset.facets()).thenReturn(Map.of("facet", mock(LineageDatasetFacet.class)));
+
+    assertThat(visitor.isDefinedAt(dataset)).isFalse();
+
+    when(flinkDataset.facets()).thenReturn(Map.of("schema", new TestingDatasetSchemaFacet()));
+
+    assertThat(visitor.isDefinedAt(dataset)).isTrue();
+
+    TableLineageDataset tableDataset = mock(TableLineageDataset.class);
+    when(dataset.getFlinkDataset()).thenReturn(tableDataset);
+    when(tableDataset.facets()).thenReturn(Map.of("schema", new TestingDatasetSchemaFacet()));
+
+    assertThat(visitor.isDefinedAt(dataset)).isFalse();
+  }
+
+  @Test
+  void testApply() {
+    when(context.getOpenLineage()).thenReturn(openLineage);
+    when(dataset.getFlinkDataset()).thenReturn(flinkDataset);
+    DatasetFacetsBuilder facetsBuilder = openLineage.newDatasetFacetsBuilder();
+
+    TestingDatasetSchemaFacet schemaFacet = new TestingDatasetSchemaFacet();
+    schemaFacet.fields.put("fieldA", new TestingDatasetSchemaField("fieldA", "STRING"));
+    schemaFacet.fields.put("fieldB", new TestingDatasetSchemaField("fieldB", "BIGINT"));
+    when(flinkDataset.facets()).thenReturn(Map.of("schema", schemaFacet));
+
+    visitor.apply(dataset, facetsBuilder);
+
+    List<SchemaDatasetFacetFields> fields = facetsBuilder.build().getSchema().getFields();
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0))
+        .hasFieldOrPropertyWithValue("name", "fieldA")
+        .hasFieldOrPropertyWithValue("type", "STRING");
+    assertThat(fields.get(1))
+        .hasFieldOrPropertyWithValue("name", "fieldB")
+        .hasFieldOrPropertyWithValue("type", "BIGINT");
+  }
+
+  private static class TestingDatasetSchemaFacet implements DatasetSchemaFacet {
+    private final Map<String, DatasetSchemaField<String>> fields = new LinkedHashMap<>();
+
+    @Override
+    public String name() {
+      return "schema";
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> Map<String, DatasetSchemaField<T>> fields() {
+      return (Map) fields;
+    }
+  }
+
+  private static class TestingDatasetSchemaField implements DatasetSchemaField<String> {
+    private final String name;
+    private final String type;
+
+    private TestingDatasetSchemaField(String name, String type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String type() {
+      return type;
+    }
+  }
+}

--- a/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitorTest.java
+++ b/integration/flink/flink2/src/test/java/io/openlineage/flink/visitor/facet/TableLineageFacetVisitorTest.java
@@ -10,20 +10,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
-import io.openlineage.client.OpenLineage.DatasetFacet;
 import io.openlineage.client.OpenLineage.DatasetFacetsBuilder;
-import io.openlineage.client.OpenLineage.DefaultDatasetFacet;
 import io.openlineage.client.OpenLineage.SchemaDatasetFacetFields;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.flink.api.OpenLineageContext;
 import io.openlineage.flink.client.Versions;
 import io.openlineage.flink.converter.LineageDatasetWithIdentifier;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
-import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import java.util.Optional;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
 import org.apache.flink.table.planner.lineage.TableLineageDataset;
@@ -39,11 +33,12 @@ class TableLineageFacetVisitorTest {
   OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);
 
   @Test
-  void testApply() {
+  void testApplyBuildsSchemaAndDocumentationFacets() {
     when(context.getOpenLineage()).thenReturn(openLineage);
     DatasetFacetsBuilder facetsBuilder = openLineage.newDatasetFacetsBuilder();
     Schema schema = mock(Schema.class);
     when(table.table().getUnresolvedSchema()).thenReturn(schema);
+    when(table.table().getDescription()).thenReturn(Optional.of("table description"));
     DataType dataType1 = mock(DataType.class);
     DataType dataType2 = mock(DataType.class);
     when(dataType1.toString()).thenReturn("type1");
@@ -51,7 +46,7 @@ class TableLineageFacetVisitorTest {
 
     when(schema.getColumns())
         .thenReturn(
-            Arrays.asList(
+            List.of(
                 new UnresolvedPhysicalColumn("col_a", dataType1),
                 new UnresolvedPhysicalColumn("col_b", dataType2)));
 
@@ -68,36 +63,24 @@ class TableLineageFacetVisitorTest {
     assertThat(fields.get(1))
         .hasFieldOrPropertyWithValue("name", "col_b")
         .hasFieldOrPropertyWithValue("type", "type2");
+    assertThat(facetsBuilder.build().getDocumentation())
+        .hasFieldOrPropertyWithValue("description", "table description");
   }
 
   @Test
-  void testApplyWithConfigFacet() {
+  void testApplyWithoutTableDescriptionDoesNotBuildDocumentationFacet() {
     when(context.getOpenLineage()).thenReturn(openLineage);
     DatasetFacetsBuilder facetsBuilder = openLineage.newDatasetFacetsBuilder();
     Schema schema = mock(Schema.class);
     when(table.table().getUnresolvedSchema()).thenReturn(schema);
-    when(schema.getColumns()).thenReturn(Arrays.asList());
-
-    DatasetConfigFacet configFacet = mock(DatasetConfigFacet.class);
-    when(configFacet.name()).thenReturn("config");
-    Map<String, String> config = new HashMap<>();
-    config.put("key1", "value1");
-    config.put("key2", "value2");
-    when(configFacet.config()).thenReturn(config);
-
-    Map<String, LineageDatasetFacet> facets = new HashMap<>();
-    facets.put("config", configFacet);
-    when(table.facets()).thenReturn(facets);
+    when(schema.getColumns()).thenReturn(List.of());
+    when(table.table().getDescription()).thenReturn(Optional.empty());
 
     visitor.apply(
         new LineageDatasetWithIdentifier(new DatasetIdentifier("namespace", "name"), table),
         facetsBuilder);
 
-    Map<String, DatasetFacet> additionalProps = facetsBuilder.build().getAdditionalProperties();
-    DefaultDatasetFacet resultFacet = (DefaultDatasetFacet) additionalProps.get("config");
-
-    assertThat(resultFacet).isNotNull();
-    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key1", "value1");
-    assertThat(resultFacet.getAdditionalProperties()).containsEntry("key2", "value2");
+    assertThat(facetsBuilder.build().getSchema().getFields()).isEmpty();
+    assertThat(facetsBuilder.build().getDocumentation()).isNull();
   }
 }


### PR DESCRIPTION
### Problem

Flink 2 lineage datasets outside the Table API, such as DataStream API connector datasets, can expose schema and config metadata through Flink lineage facets. The OpenLineage listener previously handled config extraction only inside `TableLineageFacetVisitor`, which meant this metadata was not handled for non-table dataset APIs.

### Changes

- Add `ConfigFacetVisitor` to extract `DatasetConfigFacet` from any Flink lineage dataset.
- Add `SchemaFacetVisitor` to extract generic `DatasetSchemaFacet` from non-Table datasets.
- Keep Table API schema extraction in `TableLineageFacetVisitor`, where it can use `CatalogBaseTable` and preserve table-specific schema behavior.
- Register the new facet visitors in the Flink 2 listener factory.
- Add unit tests for config facet extraction, schema facet extraction, and Table API schema/documentation handling.
