### PR TITLE
fix(python): read config files as utf-8

### DIFF
--- a/client/python/src/openlineage/client/client.py
+++ b/client/python/src/openlineage/client/client.py
@@ -291,7 +291,7 @@ class OpenLineageClient:
     @staticmethod
     def _get_config_file_content(config_path: str) -> dict[str, Any]:
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config: dict[str, Any] | None = yaml.safe_load(f)
                 if not config:
                     log.error("Empty OpenLineage config file: `%s`", config_path)

--- a/client/python/tests/test_client.py
+++ b/client/python/tests/test_client.py
@@ -370,6 +370,26 @@ def test_get_config_file_content(root: Path) -> None:
     }
 
 
+def test_get_config_file_content_reads_utf8(
+    tmp_path: Path,
+    mocker: MockerFixture,
+) -> None:
+    config_path = tmp_path / "openlineage.yml"
+    config_path.write_text("transport:\n  type: console\nmetadata: café\n", encoding="utf-8")
+    real_open = open
+
+    def open_with_ascii_default(file, mode="r", *args, **kwargs):
+        if "b" not in mode and kwargs.get("encoding") is None:
+            kwargs["encoding"] = "ascii"
+        return real_open(file, mode, *args, **kwargs)
+
+    mocker.patch("builtins.open", side_effect=open_with_ascii_default)
+
+    result = OpenLineageClient._get_config_file_content(str(config_path))  # noqa: SLF001
+
+    assert result == {"transport": {"type": "console"}, "metadata": "café"}
+
+
 @patch("yaml.safe_load", return_value=None)
 def test_get_config_file_content_empty(mock_yaml) -> None:  # noqa: ARG001
     result = OpenLineageClient._get_config_file_content("empty.yml")  # noqa: SLF001


### PR DESCRIPTION
﻿## Summary

- read Python client YAML config files with explicit UTF-8 decoding
- add a regression test that simulates a non-UTF-8 platform default encoding

## Issue

Fixes #4507

## Tests

- `uv run pytest tests/test_client.py -k "get_config_file_content"`
- `uv run ruff check src/openlineage/client/client.py tests/test_client.py`
