### PR TITLE
dbt: propagate root parent through dbt-run wrapper to child events

### DIFF
--- a/integration/dbt/src/openlineage/dbt/__init__.py
+++ b/integration/dbt/src/openlineage/dbt/__init__.py
@@ -301,10 +301,26 @@ def consume_local_artifacts(
         parent_run_metadata=parent_run_metadata,
     )
 
+    # Carry the root parent through to per-node events so backends can stitch the full
+    # orchestrator → dbt-run → node chain. Without this, child events get root=None.
+    if parent_run_metadata:
+        root_parent_run_id = parent_run_metadata.root_parent_run_id or parent_run_metadata.run_id
+        root_parent_job_name = parent_run_metadata.root_parent_job_name or parent_run_metadata.job_name
+        root_parent_job_namespace = (
+            parent_run_metadata.root_parent_job_namespace or parent_run_metadata.job_namespace
+        )
+    else:
+        root_parent_run_id = start_event.run.runId
+        root_parent_job_name = start_event.job.name
+        root_parent_job_namespace = start_event.job.namespace
+
     dbt_run_metadata = ParentRunMetadata(
         run_id=start_event.run.runId,
         job_name=start_event.job.name,
         job_namespace=start_event.job.namespace,
+        root_parent_run_id=root_parent_run_id,
+        root_parent_job_name=root_parent_job_name,
+        root_parent_job_namespace=root_parent_job_namespace,
     )
     # Set parent run metadata to use it as parent run facet
     processor.dbt_run_metadata = dbt_run_metadata

--- a/integration/dbt/src/openlineage/dbt/__init__.py
+++ b/integration/dbt/src/openlineage/dbt/__init__.py
@@ -303,12 +303,22 @@ def consume_local_artifacts(
 
     # Carry the root parent through to per-node events so backends can stitch the full
     # orchestrator → dbt-run → node chain. Without this, child events get root=None.
+    # All three root fields must be present together; partial data falls back to the
+    # immediate parent to avoid mixing fields from different runs/jobs.
     if parent_run_metadata:
-        root_parent_run_id = parent_run_metadata.root_parent_run_id or parent_run_metadata.run_id
-        root_parent_job_name = parent_run_metadata.root_parent_job_name or parent_run_metadata.job_name
-        root_parent_job_namespace = (
-            parent_run_metadata.root_parent_job_namespace or parent_run_metadata.job_namespace
+        root_all_present = (
+            parent_run_metadata.root_parent_run_id
+            and parent_run_metadata.root_parent_job_name
+            and parent_run_metadata.root_parent_job_namespace
         )
+        if root_all_present:
+            root_parent_run_id = parent_run_metadata.root_parent_run_id
+            root_parent_job_name = parent_run_metadata.root_parent_job_name
+            root_parent_job_namespace = parent_run_metadata.root_parent_job_namespace
+        else:
+            root_parent_run_id = parent_run_metadata.run_id
+            root_parent_job_name = parent_run_metadata.job_name
+            root_parent_job_namespace = parent_run_metadata.job_namespace
     else:
         root_parent_run_id = start_event.run.runId
         root_parent_job_name = start_event.job.name

--- a/integration/dbt/tests/test_main.py
+++ b/integration/dbt/tests/test_main.py
@@ -211,3 +211,74 @@ def test_consume_local_artifacts_root_when_no_external_parent(monkeypatch):
     assert md.root_parent_run_id == md.run_id
     assert md.root_parent_job_name == md.job_name
     assert md.root_parent_job_namespace == md.job_namespace
+
+
+def test_consume_local_artifacts_explicit_root_different_from_parent(monkeypatch):
+    """When OPENLINEAGE_ROOT_PARENT_ID is provided and distinct from the immediate
+    parent, child events must use root values — not parent values — for the root field."""
+    from openlineage.dbt import consume_local_artifacts
+
+    parent_namespace = "airflow"
+    parent_job = "airflow-dag.task"
+    parent_run_id = "aaaaaaaa-0000-0000-0000-000000000001"
+    root_namespace = "prefect"
+    root_job = "root-flow"
+    root_run_id = "bbbbbbbb-0000-0000-0000-000000000002"
+    env = {
+        "OPENLINEAGE_NAMESPACE": "dbt",
+        "OPENLINEAGE_PARENT_ID": f"{parent_namespace}/{parent_job}/{parent_run_id}",
+        "OPENLINEAGE_ROOT_PARENT_ID": f"{root_namespace}/{root_job}/{root_run_id}",
+    }
+    processor = _setup_local_artifacts_mocks(monkeypatch, env)
+
+    consume_local_artifacts(
+        args=["dbt", "run"],
+        target=None,
+        target_path=None,
+        project_dir="./",
+        profile_name=None,
+        model_selector=None,
+        models=[],
+    )
+
+    md = processor.dbt_run_metadata
+    # Root must reflect the explicit root, not the immediate parent.
+    assert md.root_parent_run_id == root_run_id
+    assert md.root_parent_job_name == root_job
+    assert md.root_parent_job_namespace == root_namespace
+    # Immediate parent stays as-is.
+    assert md.run_id != root_run_id
+    assert md.job_name != root_job
+
+
+def test_consume_local_artifacts_partial_root_falls_back_to_parent(monkeypatch):
+    """When OPENLINEAGE_ROOT_PARENT_ID is malformed (not all three identifiers
+    present), root info must not be partially applied — it should fall back
+    entirely to the immediate parent values."""
+    from openlineage.dbt import consume_local_artifacts
+
+    parent_namespace = "airflow"
+    parent_job = "airflow-dag.task"
+    parent_run_id = "cccccccc-0000-0000-0000-000000000003"
+    env = {
+        "OPENLINEAGE_NAMESPACE": "dbt",
+        "OPENLINEAGE_PARENT_ID": f"{parent_namespace}/{parent_job}/{parent_run_id}",
+        "OPENLINEAGE_ROOT_PARENT_ID": "invalid-not-three-parts",
+    }
+    processor = _setup_local_artifacts_mocks(monkeypatch, env)
+
+    consume_local_artifacts(
+        args=["dbt", "run"],
+        target=None,
+        target_path=None,
+        project_dir="./",
+        profile_name=None,
+        model_selector=None,
+        models=[],
+    )
+
+    md = processor.dbt_run_metadata
+    # Partial root data must not bleed into result; fall back to the parent entirely.
+    assert md.root_parent_run_id == parent_run_id
+    assert md.root_parent_job_name == parent_job
+    assert md.root_parent_job_namespace == parent_namespace

--- a/integration/dbt/tests/test_main.py
+++ b/integration/dbt/tests/test_main.py
@@ -132,3 +132,82 @@ def test_consume_structured_logs(command_line, os_envs, function_kwargs, monkeyp
         selector=function_kwargs["model_selector"],
         openlineage_job_name=None,
     )
+
+
+def _setup_local_artifacts_mocks(monkeypatch, env):
+    """Wire up just enough mocks to drive consume_local_artifacts() up to the
+    point where it sets ``processor.dbt_run_metadata``."""
+    monkeypatch.setattr("os.environ", env)
+    mock_processor = mock.MagicMock()
+    mock_processor.parse.return_value.events.return_value = []
+    mock_processor.run_result_path = "/nonexistent/run_results.json"
+    mock_processor.job_name = "dbt-job-name"
+    monkeypatch.setattr(
+        "openlineage.dbt.DbtLocalArtifactProcessor", mock.MagicMock(return_value=mock_processor)
+    )
+    monkeypatch.setattr("openlineage.dbt.OpenLineageClient", mock.MagicMock())
+
+    process_mock = mock.MagicMock()
+    process_mock.__enter__ = mock.MagicMock(return_value=process_mock)
+    process_mock.__exit__ = mock.MagicMock(return_value=None)
+    process_mock.wait.return_value = 0
+    monkeypatch.setattr("openlineage.dbt.subprocess.Popen", mock.MagicMock(return_value=process_mock))
+
+    return mock_processor
+
+
+def test_consume_local_artifacts_propagates_root_parent_metadata(monkeypatch):
+    """Regression: child node events must keep the orchestrator's root parent so
+    backends can stitch the full Airflow → dbt-run → node lineage chain."""
+    from openlineage.dbt import consume_local_artifacts
+
+    parent_namespace = "airflow"
+    parent_job = "airflow-dag.task"
+    parent_run_id = "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+    env = {
+        "OPENLINEAGE_NAMESPACE": "dbt",
+        "OPENLINEAGE_PARENT_ID": f"{parent_namespace}/{parent_job}/{parent_run_id}",
+    }
+    processor = _setup_local_artifacts_mocks(monkeypatch, env)
+
+    consume_local_artifacts(
+        args=["dbt", "run"],
+        target=None,
+        target_path=None,
+        project_dir="./",
+        profile_name=None,
+        model_selector=None,
+        models=[],
+    )
+
+    # Child events use processor.dbt_run_metadata as their parent facet — root must
+    # point at the orchestrator that started us, not be left blank.
+    md = processor.dbt_run_metadata
+    assert md.root_parent_run_id == parent_run_id
+    assert md.root_parent_job_name == parent_job
+    assert md.root_parent_job_namespace == parent_namespace
+
+
+def test_consume_local_artifacts_root_when_no_external_parent(monkeypatch):
+    """When no orchestrator wraps dbt-ol, the dbt run is itself the root —
+    so child events get root pointing at the dbt-run wrapper."""
+    from openlineage.dbt import consume_local_artifacts
+
+    env = {"OPENLINEAGE_NAMESPACE": "dbt"}  # no OPENLINEAGE_PARENT_ID
+    processor = _setup_local_artifacts_mocks(monkeypatch, env)
+
+    consume_local_artifacts(
+        args=["dbt", "run"],
+        target=None,
+        target_path=None,
+        project_dir="./",
+        profile_name=None,
+        model_selector=None,
+        models=[],
+    )
+
+    md = processor.dbt_run_metadata
+    # Root falls back to the wrapper's own start event.
+    assert md.root_parent_run_id == md.run_id
+    assert md.root_parent_job_name == md.job_name
+    assert md.root_parent_job_namespace == md.job_namespace


### PR DESCRIPTION
The legacy `consume_local_artifacts` path constructs `dbt_run_metadata` without `root_parent_*` fields, so every per-node event uses `self._dbt_run_metadata.to_openlineage()` and ends up with `root=None` in its parent facet. 


### Checklist
- [x] AI was used in creating this PR