### PR TITLE
dbt: emit FAIL on aggregate test event when assertions failed

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -385,18 +385,19 @@ class DbtArtifactProcessor:
 
         events = DbtEvents()
         manifest_nodes = {**context.manifest["nodes"], **context.manifest["sources"]}
-        for name, node in manifest_nodes.items():
-            if name.startswith("model."):
+        for unique_id, node in manifest_nodes.items():
+            if unique_id.startswith("model."):
                 node_type = "model"
-            elif name.startswith("source."):
+            elif unique_id.startswith("source."):
                 node_type = "source"
             else:
                 continue
-            if len(assertions[name]) == 0:
+            node_assertions = assertions[unique_id]
+            if len(node_assertions) == 0:
                 continue
 
             assertion_facet = data_quality_assertions_dataset.DataQualityAssertionsDatasetFacet(
-                assertions=assertions[name]
+                assertions=node_assertions
             )
 
             namespace, name, _, _ = self.extract_dataset_data(
@@ -433,9 +434,17 @@ class DbtArtifactProcessor:
 
             run_id = str(generate_new_uuid())
             dataset_facets: dict[str, InputDatasetFacet] = {"dataQualityAssertions": assertion_facet}
+            # The aggregate per-model test event is FAIL when any of its assertions failed.
+            # Warn-severity failures count as success so they don't block the pipeline,
+            # mirroring dbt's own success/failure semantics.
+            status = (
+                "success"
+                if all(a.success or (a.severity or "").lower() == "warn" for a in node_assertions)
+                else "error"
+            )
             events.add(
                 self.to_openlineage_events(
-                    "success",
+                    status,
                     started_at,
                     completed_at,
                     self.get_run(run_id=run_id, run_facets=run_facets),

--- a/integration/common/tests/dbt/no_test_metadata/result.json
+++ b/integration/common/tests/dbt/no_test_metadata/result.json
@@ -603,105 +603,6 @@
         "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
         "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
         "run": {
-            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
-            "facets": {
-                "dbt_version": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-                    "version": "1.8.5"
-                },
-                "processing_engine": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
-                    "name": "dbt",
-                    "version": "1.8.5",
-                    "openlineageAdapterVersion": "{{ any(result) }}"
-                },
-                "parent": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
-                    "run": {
-                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
-                    },
-                    "job": {
-                        "namespace": "dbt",
-                        "name": "dbt-job-name"
-                    }
-                }
-            }
-        },
-        "job": {
-            "namespace": "dbt-test-namespace",
-            "name": "DEMO_DB.public.jaffle_shop.customers.test",
-            "facets": {
-                "jobType": {
-                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
-                    "_deleted": null,
-                    "processingType": "BATCH",
-                    "integration": "DBT",
-                    "jobType": "TEST"
-                }
-            }
-        },
-        "eventType": "COMPLETE",
-        "inputs": [
-            {
-                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
-                "name": "DEMO_DB.public.customers",
-                "facets": {
-                    "dataQualityAssertions": {
-                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                        "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
-                        "assertions": [
-                            {
-                                "assertion": "unique_customers_customer_id",
-                                "success": false,
-                                "column": null,
-                                "severity": "error"
-                            },
-                            {
-                                "assertion": "not_null_customers_customer_id",
-                                "success": false,
-                                "column": null,
-                                "severity": "error"
-                            }
-                        ]
-                    }
-                },
-                "inputFacets": {
-                    "dataQualityAssertions": {
-                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-                        "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
-                        "assertions": [
-                            {
-                                "assertion": "unique_customers_customer_id",
-                                "success": false,
-                                "column": null,
-                                "severity": "error",
-                                "actual": "1",
-                                "expected": "0"
-                            },
-                            {
-                                "assertion": "not_null_customers_customer_id",
-                                "success": false,
-                                "column": null,
-                                "severity": "error",
-                                "actual": "Test failure",
-                                "expected": "0"
-                            }
-                        ]
-                    }
-                }
-            }
-        ],
-        "outputs": []
-    },
-    {
-        "eventTime": "2021-08-25T11:00:25.277467+00:00",
-        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
-        "run": {
             "runId": "1a69c0a7-04bb-408b-980e-cbbfb1831ef7",
             "facets": {
                 "dbt_version": {
@@ -1189,6 +1090,105 @@
                                 "success": true,
                                 "column": null,
                                 "severity": "error"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "outputs": []
+    },
+    {
+        "eventTime": "2021-08-25T11:00:25.277467+00:00",
+        "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+        "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+        "run": {
+            "runId": "6edf42ed-d8d0-454a-b819-d09b9067ff99",
+            "facets": {
+                "dbt_version": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+                    "version": "1.8.5"
+                },
+                "processing_engine": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+                    "name": "dbt",
+                    "version": "1.8.5",
+                    "openlineageAdapterVersion": "{{ any(result) }}"
+                },
+                "parent": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
+                    "run": {
+                        "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+                    },
+                    "job": {
+                        "namespace": "dbt",
+                        "name": "dbt-job-name"
+                    }
+                }
+            }
+        },
+        "job": {
+            "namespace": "dbt-test-namespace",
+            "name": "DEMO_DB.public.jaffle_shop.customers.test",
+            "facets": {
+                "jobType": {
+                    "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+                    "_deleted": null,
+                    "processingType": "BATCH",
+                    "integration": "DBT",
+                    "jobType": "TEST"
+                }
+            }
+        },
+        "eventType": "FAIL",
+        "inputs": [
+            {
+                "namespace": "snowflake://ASDF1234.eu-central-1.aws",
+                "name": "DEMO_DB.public.customers",
+                "facets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null,
+                                "severity": "error"
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null,
+                                "severity": "error"
+                            }
+                        ]
+                    }
+                },
+                "inputFacets": {
+                    "dataQualityAssertions": {
+                        "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+                        "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+                        "assertions": [
+                            {
+                                "assertion": "unique_customers_customer_id",
+                                "success": false,
+                                "column": null,
+                                "severity": "error",
+                                "actual": "1",
+                                "expected": "0"
+                            },
+                            {
+                                "assertion": "not_null_customers_customer_id",
+                                "success": false,
+                                "column": null,
+                                "severity": "error",
+                                "actual": "Test failure",
+                                "expected": "0"
                             }
                         ]
                     }

--- a/integration/common/tests/dbt/test/result.json
+++ b/integration/common/tests/dbt/test/result.json
@@ -422,6 +422,72 @@
                 "severity": "error",
                 "actual": "0",
                 "expected": "0"
+              }
+            ]
+          }
+        },
+        "name": "random-gcp-project.dbt_test2.source_table",
+        "namespace": "bigquery"
+      }
+    ],
+    "job": {
+      "facets": {},
+      "name": "random-gcp-project.dbt_test2.source.dbt_bigquery_test.dbt_test2.source_table.test",
+      "namespace": "dbt-test-namespace"
+    },
+    "outputs": [],
+    "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+    "run": {
+      "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3",
+      "facets": {
+        "parent": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
+          "job": {
+            "name": "dbt-job-name",
+            "namespace": "dbt"
+          },
+          "run": {
+            "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
+          }
+        },
+        "dbt_version": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
+          "version": "0.21.0"
+        },
+        "processing_engine": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
+          "name": "dbt",
+          "version": "0.21.0",
+          "openlineageAdapterVersion": "{{ any(result) }}"
+        },
+        "dbt_run": {
+          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-run-run-facet.json",
+          "invocation_id": "9adc7020-c784-4179-a4e3-e3c4ffb3b09c"
+        }
+      }
+    }
+  },
+  {
+    "eventTime": "2021-08-25T11:00:25.277467+00:00",
+    "eventType": "FAIL",
+    "inputs": [
+      {
+        "inputFacets": {
+          "dataQualityAssertions": {
+            "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
+            "assertions": [
+              {
+                "column": "id",
+                "assertion": "not_null",
+                "success": true,
+                "severity": "error",
+                "actual": "0",
+                "expected": "0"
               },
               {
                 "column": "id",
@@ -481,7 +547,7 @@
   },
   {
     "eventTime": "2021-08-25T11:00:25.277467+00:00",
-    "eventType": "COMPLETE",
+    "eventType": "FAIL",
     "inputs": [
       {
         "inputFacets": {
@@ -545,72 +611,6 @@
     "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
     "run": {
       "runId": "c11f2efd-4415-45fc-8081-10d2aaa594d2",
-      "facets": {
-        "parent": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ParentRunFacet.json#/$defs/ParentRunFacet",
-          "job": {
-            "name": "dbt-job-name",
-            "namespace": "dbt"
-          },
-          "run": {
-            "runId": "f99310b4-3c3c-1a1a-2b2b-c1b95c24ff11"
-          }
-        },
-        "dbt_version": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-version-run-facet.json",
-          "version": "0.21.0"
-        },
-        "processing_engine": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-          "_schemaURL": "https://openlineage.io/spec/facets/1-1-1/ProcessingEngineRunFacet.json#/$defs/ProcessingEngineRunFacet",
-          "name": "dbt",
-          "version": "0.21.0",
-          "openlineageAdapterVersion": "{{ any(result) }}"
-        },
-        "dbt_run": {
-          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-          "_schemaURL": "https://github.com/OpenLineage/OpenLineage/tree/main/integration/common/openlineage/schema/dbt-run-run-facet.json",
-          "invocation_id": "9adc7020-c784-4179-a4e3-e3c4ffb3b09c"
-        }
-      }
-    }
-  },
-  {
-    "eventTime": "2021-08-25T11:00:25.277467+00:00",
-    "eventType": "COMPLETE",
-    "inputs": [
-      {
-        "inputFacets": {
-          "dataQualityAssertions": {
-            "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-            "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DataQualityAssertionsDatasetFacet.json#/$defs/DataQualityAssertionsDatasetFacet",
-            "assertions": [
-              {
-                "column": "id",
-                "assertion": "not_null",
-                "success": true,
-                "severity": "error",
-                "actual": "0",
-                "expected": "0"
-              }
-            ]
-          }
-        },
-        "name": "random-gcp-project.dbt_test2.source_table",
-        "namespace": "bigquery"
-      }
-    ],
-    "job": {
-      "facets": {},
-      "name": "random-gcp-project.dbt_test2.source.dbt_bigquery_test.dbt_test2.source_table.test",
-      "namespace": "dbt-test-namespace"
-    },
-    "outputs": [],
-    "producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
-    "run": {
-      "runId": "b901441a-7b4a-4a97-aa61-a200106b3ce3",
       "facets": {
         "parent": {
           "_producer": "https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -401,3 +401,93 @@ class TestParseFailures:
 
         assert assertion.actual is None
         assert assertion.expected is None
+
+
+class TestAggregateTestEventStatus:
+    """Per-model aggregate test job emits FAIL when an error-severity assertion failed,
+    and COMPLETE when all assertions passed or only warn-severity ones failed.
+
+    Regression: legacy ``processor.parse_test`` previously hardcoded status="success",
+    so failing tests were emitted as COMPLETE."""
+
+    @pytest.fixture
+    def processor(self):
+        p = DbtArtifactProcessor(
+            producer="https://github.com/OpenLineage/OpenLineage/tree/0.0.1/integration/dbt",
+            job_namespace="ns",
+        )
+        p.manifest_version = 11
+        p.command = "test"
+        p.dataset_namespace = "snowflake://acct"
+        p.dbt_run_run_facet = MagicMock(return_value={})
+        return p
+
+    @staticmethod
+    def _ctx(test_results):
+        manifest = {
+            "nodes": {
+                "model.project.my_model": {
+                    "database": "DB",
+                    "schema": "SCH",
+                    "alias": "my_model",
+                    "unique_id": "model.project.my_model",
+                    "columns": {},
+                },
+            },
+            "sources": {},
+            "parent_map": {
+                f"test.project.t{i}": ["model.project.my_model"] for i in range(len(test_results))
+            },
+        }
+        run_results = {"results": test_results}
+        nodes = {
+            f"test.project.t{i}": {
+                "name": f"t{i}",
+                "test_metadata": {"name": f"t{i}", "kwargs": {"column_name": "id"}},
+                "config": {"severity": severity},
+            }
+            for i, (severity, _status) in enumerate([(r["_severity"], r["status"]) for r in test_results])
+        }
+        # remove the synthetic _severity key from results so they look like real run_results
+        for r in test_results:
+            r.pop("_severity", None)
+        return DbtRunContext(manifest=manifest, run_results=run_results, catalog=None), nodes
+
+    def _event_types(self, processor, test_results):
+        ctx, nodes = self._ctx(test_results)
+        events = processor.parse_test(ctx, nodes)
+        return [e.eventType.value for e in events.starts + events.completes + events.fails]
+
+    def test_all_pass_emits_complete(self, processor):
+        results = [
+            {"unique_id": "test.project.t0", "status": "pass", "_severity": "error"},
+        ]
+        assert self._event_types(processor, results) == ["START", "COMPLETE"]
+
+    def test_error_severity_failure_emits_fail(self, processor):
+        results = [
+            {"unique_id": "test.project.t0", "status": "fail", "failures": 3, "_severity": "error"},
+        ]
+        assert self._event_types(processor, results) == ["START", "FAIL"]
+
+    def test_warn_severity_failure_emits_complete(self, processor):
+        # dbt itself doesn't fail the run on warn-severity test failures, so the
+        # aggregate test job stays COMPLETE — mirroring CommandCompleted.success=true.
+        results = [
+            {"unique_id": "test.project.t0", "status": "warn", "failures": 3, "_severity": "warn"},
+        ]
+        assert self._event_types(processor, results) == ["START", "COMPLETE"]
+
+    def test_mixed_pass_and_warn_failure_emits_complete(self, processor):
+        results = [
+            {"unique_id": "test.project.t0", "status": "pass", "_severity": "error"},
+            {"unique_id": "test.project.t1", "status": "warn", "failures": 1, "_severity": "warn"},
+        ]
+        assert self._event_types(processor, results) == ["START", "COMPLETE"]
+
+    def test_mixed_error_and_warn_failure_emits_fail(self, processor):
+        results = [
+            {"unique_id": "test.project.t0", "status": "fail", "failures": 1, "_severity": "error"},
+            {"unique_id": "test.project.t1", "status": "warn", "failures": 1, "_severity": "warn"},
+        ]
+        assert self._event_types(processor, results) == ["START", "FAIL"]


### PR DESCRIPTION
The legacy `consume_local_artifacts` path builds one aggregate run event per model that has assertions attached. The status passed to `to_openlineage_events` was hardcoded to "success", so the wrapper emitted a START → COMPLETE pair even when the embedded DataQualityAssertions facet showed `success: false, severity: error`.

Compute the status from the assertions instead: FAIL if any error-severity assertion failed, COMPLETE otherwise. Warn-severity failures stay COMPLETE to mirror dbt's own success/failure semantics — `CommandCompleted.success` also stays true on warn.

### Checklist
- [x] AI was used in creating this PR
