### PR TITLE
spark: fix Kafka SASL bootstrap namespace

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaBootstrapServerResolver.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/KafkaBootstrapServerResolver.java
@@ -7,22 +7,27 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class KafkaBootstrapServerResolver {
+  private static final Pattern KAFKA_PROTOCOL_PREFIX =
+      Pattern.compile("^[A-Za-z][A-Za-z0-9_+.-]*://");
+
   static String resolve(Optional<String> bootstrapServersOpt) {
     String server =
         bootstrapServersOpt
-            .map(
-                str -> {
-                  if (!str.matches("\\w+://.*")) {
-                    return "PLAINTEXT://" + str;
-                  } else {
-                    return str;
-                  }
-                })
-            .map(str -> URI.create(str.split(",")[0]))
+            .map(str -> str.split(",")[0].trim())
+            .map(KafkaBootstrapServerResolver::stripKafkaProtocol)
+            .map(endpoint -> URI.create("kafka://" + endpoint))
             .map(uri -> uri.getHost() + ":" + uri.getPort())
             .orElse("");
     return "kafka://" + server;
+  }
+
+  private static String stripKafkaProtocol(String endpoint) {
+    if (KAFKA_PROTOCOL_PREFIX.matcher(endpoint).find()) {
+      return endpoint.substring(endpoint.indexOf("://") + 3);
+    }
+    return endpoint;
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KafkaBootstrapServerResolverTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/KafkaBootstrapServerResolverTest.java
@@ -1,0 +1,35 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class KafkaBootstrapServerResolverTest {
+  @Test
+  void resolvesPlainBootstrapServer() {
+    assertEquals(
+        "kafka://broker.example.com:9092",
+        KafkaBootstrapServerResolver.resolve(Optional.of("broker.example.com:9092")));
+  }
+
+  @Test
+  void resolvesSecureBootstrapServerWithUnderscoreProtocol() {
+    assertEquals(
+        "kafka://broker.example.com:9093",
+        KafkaBootstrapServerResolver.resolve(Optional.of("SASL_SSL://broker.example.com:9093")));
+  }
+
+  @Test
+  void resolvesFirstBootstrapServer() {
+    assertEquals(
+        "kafka://broker-one.example.com:9092",
+        KafkaBootstrapServerResolver.resolve(
+            Optional.of("SASL_SSL://broker-one.example.com:9092,broker-two.example.com:9092")));
+  }
+}


### PR DESCRIPTION
### Problem

Spark Kafka lineage derives the dataset namespace from the first configured bootstrap server. Secure Kafka values such as SASL_SSL://broker.example.com:9093 include a Kafka protocol name with an underscore, which java.net.URI does not accept as a URI scheme. That can produce an invalid namespace like kafka://null:-1.

### Changes

- Strip Kafka protocol prefixes before URI parsing.
- Parse the broker endpoint with a stable kafka:// URI prefix.
- Add regression coverage for plaintext, SASL_SSL, and comma-separated bootstrap server values.

Fixes #4534

### Tests

- git diff --check
- Not run: ./gradlew.bat :shared:test --tests io.openlineage.spark.agent.lifecycle.plan.KafkaBootstrapServerResolverTest because this environment does not have JAVA_HOME or java on PATH.