### PR TITLE
client/java/transports-kinesis: upgrade Kinesis Producer Library to 1.0.7

### DIFF
--- a/client/java/transports-kinesis/README.md
+++ b/client/java/transports-kinesis/README.md
@@ -24,7 +24,7 @@ To use this transport in your project, you need to include the following depende
 - `streamName` - the streamName of the Kinesis. Required.
 - `region` - the region of the Kinesis. Required.
 - `roleArn` - the roleArn which is allowed to read/write to Kinesis stream. Optional.
-- `properties` - a dictionary that contains a [Kinesis allowed properties](https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties). Optional.
+- `properties` - a dictionary that contains a [Kinesis allowed properties](https://github.com/awslabs/amazon-kinesis-producer/blob/v1.0.7/java/amazon-kinesis-producer-sample/default_config.properties). Optional.
 
 #### Behavior
 

--- a/client/java/transports-kinesis/build.gradle
+++ b/client/java/transports-kinesis/build.gradle
@@ -18,11 +18,13 @@ plugins {
 }
 
 ext {
-    projectDescription = "GcpLineage OpenLineage transport library"
+    projectDescription = "Kinesis OpenLineage transport library"
 }
 
 dependencies {
-    implementation("com.amazonaws:amazon-kinesis-producer:0.15.12")
+    implementation("software.amazon.kinesis:amazon-kinesis-producer:1.0.7")
+    implementation("software.amazon.awssdk:sts:2.44.3")
+    implementation("software.amazon.awssdk:auth:2.44.3")
 }
 
 apply from: '../transports.build.gradle'

--- a/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisConfig.java
+++ b/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisConfig.java
@@ -24,7 +24,7 @@ public final class KinesisConfig implements TransportConfig, MergeConfig<Kinesis
   @Getter @Setter private String roleArn;
 
   // check
-  // https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer-sample/default_config.properties
+  // https://github.com/awslabs/amazon-kinesis-producer/blob/v1.0.7/java/amazon-kinesis-producer-sample/default_config.properties
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   @Getter
   @Setter

--- a/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisTransport.java
+++ b/client/java/transports-kinesis/src/main/java/io/openlineage/client/transports/kinesis/KinesisTransport.java
@@ -5,11 +5,6 @@
 
 package io.openlineage.client.transports.kinesis;
 
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import com.amazonaws.services.kinesis.producer.UserRecord;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -22,11 +17,21 @@ import java.util.concurrent.Executors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
+import software.amazon.kinesis.producer.UserRecord;
+import software.amazon.kinesis.producer.UserRecordResult;
 
 @Slf4j
 public class KinesisTransport extends Transport {
   private final String streamName;
   private final String region;
+
   private final String roleArn;
 
   private final KinesisProducer producer;
@@ -50,8 +55,16 @@ public class KinesisTransport extends Transport {
         KinesisProducerConfiguration.fromProperties(kinesisConfig.getProperties());
     config.setRegion(this.region);
     if (StringUtils.isNotBlank(roleArn)) {
-      config.setCredentialsProvider(
-          new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, "OLProducer").build());
+      AwsCredentialsProvider credentialsProvider =
+          StsAssumeRoleCredentialsProvider.builder()
+              .stsClient(StsClient.builder().region(Region.of(this.region)).build())
+              .refreshRequest(
+                  AssumeRoleRequest.builder()
+                      .roleArn(roleArn)
+                      .roleSessionName("OLProducer")
+                      .build())
+              .build();
+      config.setCredentialsProvider(credentialsProvider);
     }
     this.producer = new KinesisProducer(config);
     this.listeningExecutor = Executors.newSingleThreadExecutor();

--- a/client/java/transports-kinesis/src/test/java/io/openlineage/client/transports/kinesis/KinesisTransportTest.java
+++ b/client/java/transports-kinesis/src/test/java/io/openlineage/client/transports/kinesis/KinesisTransportTest.java
@@ -9,8 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.UserRecord;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineageClient;
@@ -25,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.UserRecord;
 
 class KinesisTransportTest {
   @Test


### PR DESCRIPTION
### One-line summary for changelog:
upgrades the Amazon Kinesis Producer Library (KPL) from version 0.15.12 to 1.0.7 and updates the AWS SDK dependencies to maintain compatibility.

### Meaningful description
- **Kinesis Producer Library**: `com.amazonaws:amazon-kinesis-producer:0.15.12` → `software.amazon.kinesis:amazon-kinesis-producer:1.0.7`
- **AWS SDK Dependencies**: Updated


### Checklist
- [x] AI was used in creating this PR