### PR TITLE
dbt: use correct name for fabric adapter

### DIFF
--- a/integration/common/src/openlineage/common/provider/dbt/processor.py
+++ b/integration/common/src/openlineage/common/provider/dbt/processor.py
@@ -60,7 +60,7 @@ class Adapter(Enum):
     TRINO = "trino"
     GLUE = "glue"
     CLICKHOUSE = "clickhouse"
-    FABRIC_WAREHOUSE = "fabric"
+    FABRIC = "fabric"
 
     @staticmethod
     def adapters() -> str:
@@ -889,7 +889,7 @@ class DbtArtifactProcessor:
             return f"databricks://{profile['host']}"
         elif self.adapter_type == Adapter.SQLSERVER:
             return f"mssql://{profile['server']}:{profile['port']}"
-        elif self.adapter_type == Adapter.FABRIC_WAREHOUSE:
+        elif self.adapter_type == Adapter.FABRIC:
             if "port" in profile:
                 return f"fabric-warehouse://{profile['server']}:{profile['port']}"
             return f"fabric-warehouse://{profile['server']}"

--- a/integration/common/tests/dbt/test_processor.py
+++ b/integration/common/tests/dbt/test_processor.py
@@ -59,7 +59,7 @@ def dbt_artifact_processor():
         ("job_id", Adapter.BIGQUERY, "bigquery", {}),  # BigQuery
         (
             "query_id",
-            Adapter.FABRIC_WAREHOUSE,
+            Adapter.FABRIC,
             "fabric-warehouse://myworkspace.datawarehouse.fabric.microsoft.com",
             {"server": "myworkspace.datawarehouse.fabric.microsoft.com"},
         ),  # Microsoft Fabric Warehouse
@@ -124,7 +124,7 @@ def test_get_query_id_missing_adapter_response(dbt_artifact_processor, run_resul
 
 
 def test_fabric_warehouse_namespace_with_port(dbt_artifact_processor):
-    dbt_artifact_processor.adapter_type = Adapter.FABRIC_WAREHOUSE
+    dbt_artifact_processor.adapter_type = Adapter.FABRIC
     dbt_artifact_processor.extract_dataset_namespace(
         {"server": "myworkspace.datawarehouse.fabric.microsoft.com", "port": 1433}
     )
@@ -133,6 +133,13 @@ def test_fabric_warehouse_namespace_with_port(dbt_artifact_processor):
         dbt_artifact_processor.dataset_namespace
         == "fabric-warehouse://myworkspace.datawarehouse.fabric.microsoft.com:1433"
     )
+
+
+def test_extract_adapter_type_fabric(dbt_artifact_processor):
+    # dbt-fabric profiles use `type: fabric`; the enum name must match so
+    # `Adapter[type.upper()]` resolves it without NotImplementedError.
+    dbt_artifact_processor.extract_adapter_type({"type": "fabric"})
+    assert dbt_artifact_processor.adapter_type == Adapter.FABRIC
 
 
 class TestParseSeverity:


### PR DESCRIPTION
`extract_adapter_type` uses `Adapter[profile["type"].upper()]`

This means enum name needs to match the dbt adapter type name. 

The PR changes enum name, while leaving `fabric-warehouse` OL namespace.

### Checklist
- [ ] AI was used in creating this PR
