### PR TITLE
spark: improve handling raw path files and Hive partitioning

### DIFF
--- a/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
+++ b/integration/spark/app/src/main/java/io/openlineage/spark/agent/lifecycle/RddExecutionContext.java
@@ -555,7 +555,8 @@ class RddExecutionContext implements ExecutionContext {
 
   protected List<DatasetIdentifier> findInputs(Set<RDD<?>> rdds) {
     log.debug("find Inputs within RddExecutionContext {}", rdds);
-    return PlanUtils.findDatasetIdentifiers(rdds.stream().collect(Collectors.toList())).stream()
+    return PlanUtils.findDatasetIdentifiers(rdds.stream().collect(Collectors.toList()), olContext)
+        .stream()
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }

--- a/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
+++ b/integration/spark/app/src/test/java/io/openlineage/spark/agent/ArgumentParserTest.java
@@ -351,6 +351,16 @@ class ArgumentParserTest {
   }
 
   @Test
+  void testNormalizeHiveStylePartitioningConfiguration() {
+    SparkConf sparkConf =
+        new SparkConf().set("spark.openlineage.normalizeHiveStylePartitioning", "false");
+
+    SparkOpenLineageConfig config = ArgumentParser.parse(sparkConf);
+
+    assertThat(config.getNormalizeHiveStylePartitioning()).isFalse();
+  }
+
+  @Test
   void testNodeFilterConfiguration() {
     SparkConf sparkConf =
         new SparkConf()

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
@@ -9,11 +9,13 @@ import io.openlineage.client.OpenLineage;
 import io.openlineage.client.OpenLineage.InputDataset;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.AbstractInputDatasetBuilder;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,7 +57,9 @@ public class HadoopRDDInputDatasetBuilder extends AbstractInputDatasetBuilder<RD
     List<URI> result = new ArrayList<>();
     Path[] inputPaths = getInputPaths(rdd);
     if (inputPaths != null) {
-      for (Path path : inputPaths) {
+      for (Path path :
+          PlanUtils.getDirectoryPaths(
+              Arrays.asList(inputPaths), rdd.sparkContext().hadoopConfiguration())) {
         result.add(getDatasetUri(path.toUri()));
       }
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
@@ -59,7 +59,7 @@ public class HadoopRDDInputDatasetBuilder extends AbstractInputDatasetBuilder<RD
     if (inputPaths != null) {
       for (Path path :
           PlanUtils.getDirectoryPaths(
-              Arrays.asList(inputPaths), rdd.sparkContext().hadoopConfiguration())) {
+              Arrays.asList(inputPaths), rdd.sparkContext().hadoopConfiguration(), context)) {
         result.add(getDatasetUri(path.toUri()));
       }
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilder.java
@@ -58,8 +58,10 @@ public class HadoopRDDInputDatasetBuilder extends AbstractInputDatasetBuilder<RD
     Path[] inputPaths = getInputPaths(rdd);
     if (inputPaths != null) {
       for (Path path :
-          PlanUtils.getDirectoryPaths(
-              Arrays.asList(inputPaths), rdd.sparkContext().hadoopConfiguration(), context)) {
+          PathUtils.getDirectoryPaths(
+              Arrays.asList(inputPaths),
+              rdd.sparkContext().hadoopConfiguration(),
+              PlanUtils.isHiveStylePartitioningNormalizationEnabled(context))) {
         result.add(getDatasetUri(path.toUri()));
       }
     }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/AbstractRDDNodeVisitor.java
@@ -39,7 +39,7 @@ public abstract class AbstractRDDNodeVisitor<T extends LogicalPlan, D extends Op
   }
 
   protected List<D> findInputDatasets(List<RDD<?>> fileRdds, StructType schema) {
-    return PlanUtils.findDatasetIdentifiers(fileRdds).stream()
+    return PlanUtils.findDatasetIdentifiers(fileRdds, context).stream()
         // TODO- refactor this to return a single partitioned dataset based on static
         // static partitions in the relation
         .map(

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -8,6 +8,7 @@ package io.openlineage.spark.agent.lifecycle.plan;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.PathUtils;
+import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.QueryPlanVisitor;
 import java.util.Collections;
@@ -68,6 +69,14 @@ public class InsertIntoHadoopFsRelationVisitor
           PathUtils.fromCatalogTable(
               command.catalogTable().get(), context.getSparkSession().get(), command.outputPath()));
     }
-    return Optional.of(PathUtils.fromPath(command.outputPath()));
+    return Optional.of(command.outputPath())
+        .map(
+            path -> {
+              if (PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)) {
+                return PlanUtils.normalizeHiveStylePartitioning(path);
+              }
+              return path;
+            })
+        .map(PathUtils::fromPath);
   }
 }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitor.java
@@ -73,7 +73,7 @@ public class InsertIntoHadoopFsRelationVisitor
         .map(
             path -> {
               if (PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)) {
-                return PlanUtils.normalizeHiveStylePartitioning(path);
+                return PathUtils.normalizeHiveStylePartitioning(path);
               }
               return path;
             })

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -234,7 +234,11 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                           relation.schema(),
                           datasetFacetsBuilder));
                 } else {
-                  return PlanUtils.getDirectoryPaths(rootPaths, hadoopConfig, context).stream()
+                  return PathUtils.getDirectoryPaths(
+                          rootPaths,
+                          hadoopConfig,
+                          PlanUtils.isHiveStylePartitioningNormalizationEnabled(context))
+                      .stream()
                       .map(
                           p -> {
                             // TODO- refactor this to return a single partitioned dataset based on

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -214,6 +215,15 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                               .build());
                 }
 
+                Optional<Path> partitionedDatasetRoot = getPartitionedDatasetRoot(relation);
+                if (partitionedDatasetRoot.isPresent()) {
+                  return Collections.singletonList(
+                      datasetFactory.getDataset(
+                          partitionedDatasetRoot.get().toUri(),
+                          relation.schema(),
+                          datasetFacetsBuilder));
+                }
+
                 Collection<Path> rootPaths =
                     ScalaConversionUtils.fromSeq(relation.location().rootPaths());
 
@@ -266,6 +276,26 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
         return inputDatasets;
       }
     }
+  }
+
+  private Optional<Path> getPartitionedDatasetRoot(HadoopFsRelation relation) {
+    if (relation.partitionSchema() == null || relation.partitionSchema().fields().length == 0) {
+      return Optional.empty();
+    }
+    return getBasePath(relation);
+  }
+
+  private Optional<Path> getBasePath(HadoopFsRelation relation) {
+    if (relation.options() == null) {
+      return Optional.empty();
+    }
+    Map<String, String> options = ScalaConversionUtils.fromMap(relation.options());
+    return options.entrySet().stream()
+        .filter(entry -> "basePath".equalsIgnoreCase(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .filter(value -> value != null && !value.isEmpty())
+        .findFirst()
+        .map(Path::new);
   }
 
   @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilder.java
@@ -234,7 +234,7 @@ public class LogicalRelationDatasetBuilder<D extends OpenLineage.Dataset>
                           relation.schema(),
                           datasetFacetsBuilder));
                 } else {
-                  return PlanUtils.getDirectoryPaths(rootPaths, hadoopConfig).stream()
+                  return PlanUtils.getDirectoryPaths(rootPaths, hadoopConfig, context).stream()
                       .map(
                           p -> {
                             // TODO- refactor this to return a single partitioned dataset based on

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -8,7 +8,12 @@ package io.openlineage.spark.agent.util;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +39,81 @@ public class PathUtils {
 
   public static DatasetIdentifier fromURI(URI location) {
     return FilesystemDatasetUtils.fromLocation(location);
+  }
+
+  public static List<Path> getDirectoryPaths(
+      Collection<Path> paths, Configuration hadoopConf, boolean normalizeHiveStylePartitioning) {
+    LinkedHashSet<Path> normalizedPaths = new LinkedHashSet<>();
+    for (Path path : paths) {
+      Path directoryPath = getDirectoryPath(path, hadoopConf);
+      if (normalizeHiveStylePartitioning) {
+        directoryPath = normalizeHiveStylePartitioning(directoryPath);
+      }
+      if (directoryPath != null && !normalizedPaths.contains(directoryPath)) {
+        normalizedPaths.add(directoryPath);
+      }
+    }
+    return new ArrayList<>(normalizedPaths);
+  }
+
+  private static Path getDirectoryPath(Path p, Configuration hadoopConf) {
+    if (hasGlobPattern(p)) {
+      return getPathBeforeGlob(p);
+    }
+
+    try {
+      if (p.getFileSystem(hadoopConf).getFileStatus(p).isFile()) {
+        return p.getParent();
+      }
+      return p;
+    } catch (IOException e) {
+      log.warn("Unable to get file system for path: {}", e.getMessage());
+      return p;
+    }
+  }
+
+  private static boolean hasGlobPattern(Path path) {
+    String value = path.toString();
+    return value.contains("*")
+        || value.contains("?")
+        || value.contains("{")
+        || value.contains("}")
+        || value.contains("[")
+        || value.contains("]");
+  }
+
+  private static Path getPathBeforeGlob(Path path) {
+    String value = path.toString();
+    Path current = path;
+    while (current != null && hasGlobPattern(current)) {
+      current = current.getParent();
+    }
+
+    if (current == null) {
+      log.warn("Unable to determine non-glob parent for path: {}", value);
+      return path;
+    }
+    return current;
+  }
+
+  public static Path normalizeHiveStylePartitioning(Path path) {
+    Path current = path;
+    while (current != null && isHivePartitionPath(current.getName())) {
+      Path parent = current.getParent();
+      if (parent == null) {
+        return path;
+      }
+      current = parent;
+    }
+    return current == null ? path : current;
+  }
+
+  private static boolean isHivePartitionPath(String pathName) {
+    int firstEquals = pathName.indexOf('=');
+    return firstEquals > 0
+        && firstEquals == pathName.lastIndexOf('=')
+        && pathName.substring(0, firstEquals).matches("[A-Za-z_][A-Za-z0-9_]*")
+        && firstEquals < pathName.length() - 1;
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PathUtils.java
@@ -12,9 +12,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -44,31 +48,71 @@ public class PathUtils {
   public static List<Path> getDirectoryPaths(
       Collection<Path> paths, Configuration hadoopConf, boolean normalizeHiveStylePartitioning) {
     LinkedHashSet<Path> normalizedPaths = new LinkedHashSet<>();
-    for (Path path : paths) {
-      Path directoryPath = getDirectoryPath(path, hadoopConf);
+    for (Path path : collapsePathsWithSameParent(paths)) {
+      if (hasNormalizedAncestor(normalizedPaths, path)) {
+        continue;
+      }
+
+      Optional<Path> directoryPath = getDirectoryPath(path, hadoopConf);
       if (normalizeHiveStylePartitioning) {
-        directoryPath = normalizeHiveStylePartitioning(directoryPath);
+        directoryPath = directoryPath.map(PathUtils::normalizeHiveStylePartitioning);
       }
-      if (directoryPath != null && !normalizedPaths.contains(directoryPath)) {
-        normalizedPaths.add(directoryPath);
-      }
+      directoryPath.ifPresent(normalizedPaths::add);
     }
     return new ArrayList<>(normalizedPaths);
   }
 
-  private static Path getDirectoryPath(Path p, Configuration hadoopConf) {
+  private static List<Path> collapsePathsWithSameParent(Collection<Path> paths) {
+    if (paths.size() <= 1) {
+      return new ArrayList<>(paths);
+    }
+
+    Map<Path, Long> parentCounts =
+        paths.stream()
+            .map(Path::getParent)
+            .filter(parent -> parent != null)
+            .collect(
+                Collectors.groupingBy(parent -> parent, LinkedHashMap::new, Collectors.counting()));
+
+    List<Path> collapsedPaths = new ArrayList<>();
+    Set<Path> emittedParents = new LinkedHashSet<>();
+    for (Path path : paths) {
+      Path parent = path.getParent();
+      if (parent != null && parentCounts.getOrDefault(parent, 0L) > 1) {
+        if (emittedParents.add(parent)) {
+          collapsedPaths.add(parent);
+        }
+      } else {
+        collapsedPaths.add(path);
+      }
+    }
+    return collapsedPaths;
+  }
+
+  private static boolean hasNormalizedAncestor(Set<Path> normalizedPaths, Path path) {
+    Path current = path.getParent();
+    while (current != null) {
+      if (normalizedPaths.contains(current)) {
+        return true;
+      }
+      current = current.getParent();
+    }
+    return false;
+  }
+
+  private static Optional<Path> getDirectoryPath(Path p, Configuration hadoopConf) {
     if (hasGlobPattern(p)) {
       return getPathBeforeGlob(p);
     }
 
     try {
       if (p.getFileSystem(hadoopConf).getFileStatus(p).isFile()) {
-        return p.getParent();
+        return Optional.ofNullable(p.getParent());
       }
-      return p;
+      return Optional.of(p);
     } catch (IOException e) {
-      log.warn("Unable to get file system for path: {}", e.getMessage());
-      return p;
+      log.warn("Unable to get file status for path: {}", p, e);
+      return Optional.of(p);
     }
   }
 
@@ -82,7 +126,7 @@ public class PathUtils {
         || value.contains("]");
   }
 
-  private static Path getPathBeforeGlob(Path path) {
+  private static Optional<Path> getPathBeforeGlob(Path path) {
     String value = path.toString();
     Path current = path;
     while (current != null && hasGlobPattern(current)) {
@@ -91,9 +135,9 @@ public class PathUtils {
 
     if (current == null) {
       log.warn("Unable to determine non-glob parent for path: {}", value);
-      return path;
+      return Optional.empty();
     }
-    return current;
+    return Optional.of(current);
   }
 
   public static Path normalizeHiveStylePartitioning(Path path) {

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -277,16 +277,6 @@ public class PlanUtils {
     return Optional.ofNullable(context)
         .map(OpenLineageContext::getOpenLineageConfig)
         .map(config -> config.getNormalizeHiveStylePartitioning())
-        .orElseGet(() -> isHiveStylePartitioningNormalizationEnabledInSparkConf(context));
-  }
-
-  private static boolean isHiveStylePartitioningNormalizationEnabledInSparkConf(
-      OpenLineageContext context) {
-    return Optional.ofNullable(context)
-        .flatMap(OpenLineageContext::getSparkContext)
-        .map(sparkContext -> sparkContext.getConf())
-        .filter(Objects::nonNull)
-        .map(conf -> conf.getBoolean(SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, true))
         .orElse(true);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -12,13 +12,10 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.naming.NameNormalizer;
-import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -267,28 +264,13 @@ public class PlanUtils {
    * @return
    */
   public static List<Path> getDirectoryPaths(Collection<Path> paths, Configuration hadoopConf) {
-    return getDirectoryPaths(paths, hadoopConf, false);
+    return PathUtils.getDirectoryPaths(paths, hadoopConf, false);
   }
 
   public static List<Path> getDirectoryPaths(
       Collection<Path> paths, Configuration hadoopConf, OpenLineageContext context) {
-    return getDirectoryPaths(
+    return PathUtils.getDirectoryPaths(
         paths, hadoopConf, isHiveStylePartitioningNormalizationEnabled(context));
-  }
-
-  private static List<Path> getDirectoryPaths(
-      Collection<Path> paths, Configuration hadoopConf, boolean normalizeHiveStylePartitioning) {
-    LinkedHashSet<Path> normalizedPaths = new LinkedHashSet<>();
-    for (Path path : paths) {
-      Path directoryPath = PlanUtils.getDirectoryPath(path, hadoopConf);
-      if (normalizeHiveStylePartitioning) {
-        directoryPath = normalizeHiveStylePartitioning(directoryPath);
-      }
-      if (directoryPath != null && !normalizedPaths.contains(directoryPath)) {
-        normalizedPaths.add(directoryPath);
-      }
-    }
-    return new ArrayList<>(normalizedPaths);
   }
 
   public static boolean isHiveStylePartitioningNormalizationEnabled(OpenLineageContext context) {
@@ -306,67 +288,6 @@ public class PlanUtils {
         .filter(Objects::nonNull)
         .map(conf -> conf.getBoolean(SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, true))
         .orElse(true);
-  }
-
-  private static Path getDirectoryPath(Path p, Configuration hadoopConf) {
-    if (hasGlobPattern(p)) {
-      return getPathBeforeGlob(p);
-    }
-
-    try {
-      if (p.getFileSystem(hadoopConf).getFileStatus(p).isFile()) {
-        return p.getParent();
-      } else {
-        return p;
-      }
-    } catch (IOException e) {
-      log.warn("Unable to get file system for path: {}", e.getMessage());
-      return p;
-    }
-  }
-
-  private static boolean hasGlobPattern(Path path) {
-    String value = path.toString();
-    return value.contains("*")
-        || value.contains("?")
-        || value.contains("{")
-        || value.contains("}")
-        || value.contains("[")
-        || value.contains("]");
-  }
-
-  private static Path getPathBeforeGlob(Path path) {
-    String value = path.toString();
-    Path current = path;
-    while (current != null && hasGlobPattern(current)) {
-      current = current.getParent();
-    }
-
-    if (current == null) {
-      log.warn("Unable to determine non-glob parent for path: {}", value);
-      return path;
-    }
-    return current;
-  }
-
-  public static Path normalizeHiveStylePartitioning(Path path) {
-    Path current = path;
-    while (current != null && isHivePartitionPath(current.getName())) {
-      Path parent = current.getParent();
-      if (parent == null) {
-        return path;
-      }
-      current = parent;
-    }
-    return current == null ? path : current;
-  }
-
-  private static boolean isHivePartitionPath(String pathName) {
-    int firstEquals = pathName.indexOf('=');
-    return firstEquals > 0
-        && firstEquals == pathName.lastIndexOf('=')
-        && pathName.substring(0, firstEquals).matches("[A-Za-z_][A-Za-z0-9_]*")
-        && firstEquals < pathName.length() - 1;
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -43,8 +43,8 @@ import scala.PartialFunction$;
  */
 @Slf4j
 public class PlanUtils {
-  public static final String SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING =
-      "spark.openlineage.dataset.normalizeHiveStylePartitioning";
+  public static final String SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING =
+      "spark.openlineage.normalizeHiveStylePartitioning";
 
   /**
    * Given a list of {@link PartialFunction}s merge to produce a single function that will test the
@@ -292,13 +292,19 @@ public class PlanUtils {
   }
 
   public static boolean isHiveStylePartitioningNormalizationEnabled(OpenLineageContext context) {
-    return context
-        .getSparkContext()
+    return Optional.ofNullable(context)
+        .map(OpenLineageContext::getOpenLineageConfig)
+        .map(config -> config.getNormalizeHiveStylePartitioning())
+        .orElseGet(() -> isHiveStylePartitioningNormalizationEnabledInSparkConf(context));
+  }
+
+  private static boolean isHiveStylePartitioningNormalizationEnabledInSparkConf(
+      OpenLineageContext context) {
+    return Optional.ofNullable(context)
+        .flatMap(OpenLineageContext::getSparkContext)
         .map(sparkContext -> sparkContext.getConf())
         .filter(Objects::nonNull)
-        .map(
-            conf ->
-                conf.getBoolean(SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING, true))
+        .map(conf -> conf.getBoolean(SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, true))
         .orElse(true);
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.ArrayType;
@@ -40,9 +38,6 @@ import scala.PartialFunction$;
  */
 @Slf4j
 public class PlanUtils {
-  public static final String SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING =
-      "spark.openlineage.normalizeHiveStylePartitioning";
-
   /**
    * Given a list of {@link PartialFunction}s merge to produce a single function that will test the
    * input against each function one by one until a match is found or {@link
@@ -254,25 +249,6 @@ public class PlanUtils {
         .build();
   }
 
-  /**
-   * Given a list of paths, it collects list of data location directories. For each path, a parent
-   * directory is taken and list of distinct locations is returned. Operation is optimized to check
-   * for each path if it was already added to the list of normalized paths.
-   *
-   * @param paths
-   * @param hadoopConf
-   * @return
-   */
-  public static List<Path> getDirectoryPaths(Collection<Path> paths, Configuration hadoopConf) {
-    return PathUtils.getDirectoryPaths(paths, hadoopConf, false);
-  }
-
-  public static List<Path> getDirectoryPaths(
-      Collection<Path> paths, Configuration hadoopConf, OpenLineageContext context) {
-    return PathUtils.getDirectoryPaths(
-        paths, hadoopConf, isHiveStylePartitioningNormalizationEnabled(context));
-  }
-
   public static boolean isHiveStylePartitioningNormalizationEnabled(OpenLineageContext context) {
     return Optional.ofNullable(context)
         .map(OpenLineageContext::getOpenLineageConfig)
@@ -288,8 +264,20 @@ public class PlanUtils {
    * @return
    */
   public static List<DatasetIdentifier> findDatasetIdentifiers(List<RDD<?>> rdds) {
+    return findDatasetIdentifiers(rdds, false);
+  }
+
+  public static List<DatasetIdentifier> findDatasetIdentifiers(
+      List<RDD<?>> rdds, OpenLineageContext context) {
+    return findDatasetIdentifiers(rdds, isHiveStylePartitioningNormalizationEnabled(context));
+  }
+
+  private static List<DatasetIdentifier> findDatasetIdentifiers(
+      List<RDD<?>> rdds, boolean normalizeHiveStylePartitioning) {
     return rdds.stream()
-        .flatMap(RddDatasetInfoExtractor::findDatasetIdentifiers)
+        .flatMap(
+            rdd ->
+                RddDatasetInfoExtractor.findDatasetIdentifiers(rdd, normalizeHiveStylePartitioning))
         .distinct()
         .collect(Collectors.toList());
   }

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -10,6 +10,7 @@ import static io.openlineage.spark.agent.util.ScalaConversionUtils.asJavaOptiona
 import io.openlineage.client.OpenLineage;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.naming.NameNormalizer;
 import java.io.IOException;
 import java.net.URI;
@@ -42,6 +43,9 @@ import scala.PartialFunction$;
  */
 @Slf4j
 public class PlanUtils {
+  public static final String SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING =
+      "spark.openlineage.dataset.normalizeHiveStylePartitioning";
+
   /**
    * Given a list of {@link PartialFunction}s merge to produce a single function that will test the
    * input against each function one by one until a match is found or {@link
@@ -263,14 +267,39 @@ public class PlanUtils {
    * @return
    */
   public static List<Path> getDirectoryPaths(Collection<Path> paths, Configuration hadoopConf) {
+    return getDirectoryPaths(paths, hadoopConf, false);
+  }
+
+  public static List<Path> getDirectoryPaths(
+      Collection<Path> paths, Configuration hadoopConf, OpenLineageContext context) {
+    return getDirectoryPaths(
+        paths, hadoopConf, isHiveStylePartitioningNormalizationEnabled(context));
+  }
+
+  private static List<Path> getDirectoryPaths(
+      Collection<Path> paths, Configuration hadoopConf, boolean normalizeHiveStylePartitioning) {
     LinkedHashSet<Path> normalizedPaths = new LinkedHashSet<>();
     for (Path path : paths) {
       Path directoryPath = PlanUtils.getDirectoryPath(path, hadoopConf);
+      if (normalizeHiveStylePartitioning) {
+        directoryPath = normalizeHiveStylePartitioning(directoryPath);
+      }
       if (directoryPath != null && !normalizedPaths.contains(directoryPath)) {
         normalizedPaths.add(directoryPath);
       }
     }
     return new ArrayList<>(normalizedPaths);
+  }
+
+  public static boolean isHiveStylePartitioningNormalizationEnabled(OpenLineageContext context) {
+    return context
+        .getSparkContext()
+        .map(sparkContext -> sparkContext.getConf())
+        .filter(Objects::nonNull)
+        .map(
+            conf ->
+                conf.getBoolean(SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING, true))
+        .orElse(true);
   }
 
   private static Path getDirectoryPath(Path p, Configuration hadoopConf) {
@@ -312,6 +341,26 @@ public class PlanUtils {
       return path;
     }
     return current;
+  }
+
+  public static Path normalizeHiveStylePartitioning(Path path) {
+    Path current = path;
+    while (current != null && isHivePartitionPath(current.getName())) {
+      Path parent = current.getParent();
+      if (parent == null) {
+        return path;
+      }
+      current = parent;
+    }
+    return current == null ? path : current;
+  }
+
+  private static boolean isHivePartitionPath(String pathName) {
+    int firstEquals = pathName.indexOf('=');
+    return firstEquals > 0
+        && firstEquals == pathName.lastIndexOf('=')
+        && pathName.substring(0, firstEquals).matches("[A-Za-z_][A-Za-z0-9_]*")
+        && firstEquals < pathName.length() - 1;
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/PlanUtils.java
@@ -265,17 +265,19 @@ public class PlanUtils {
   public static List<Path> getDirectoryPaths(Collection<Path> paths, Configuration hadoopConf) {
     LinkedHashSet<Path> normalizedPaths = new LinkedHashSet<>();
     for (Path path : paths) {
-      // check if the root path is already contained in normalized Paths
-      Path parent = path.getParent();
-      if (parent != null && !normalizedPaths.contains(parent)) {
-        // if not, add new path to normalized paths -> call getDirectoryPath
-        normalizedPaths.add(PlanUtils.getDirectoryPath(path, hadoopConf));
+      Path directoryPath = PlanUtils.getDirectoryPath(path, hadoopConf);
+      if (directoryPath != null && !normalizedPaths.contains(directoryPath)) {
+        normalizedPaths.add(directoryPath);
       }
     }
     return new ArrayList<>(normalizedPaths);
   }
 
   private static Path getDirectoryPath(Path p, Configuration hadoopConf) {
+    if (hasGlobPattern(p)) {
+      return getPathBeforeGlob(p);
+    }
+
     try {
       if (p.getFileSystem(hadoopConf).getFileStatus(p).isFile()) {
         return p.getParent();
@@ -286,6 +288,30 @@ public class PlanUtils {
       log.warn("Unable to get file system for path: {}", e.getMessage());
       return p;
     }
+  }
+
+  private static boolean hasGlobPattern(Path path) {
+    String value = path.toString();
+    return value.contains("*")
+        || value.contains("?")
+        || value.contains("{")
+        || value.contains("}")
+        || value.contains("[")
+        || value.contains("]");
+  }
+
+  private static Path getPathBeforeGlob(Path path) {
+    String value = path.toString();
+    Path current = path;
+    while (current != null && hasGlobPattern(current)) {
+      current = current.getParent();
+    }
+
+    if (current == null) {
+      log.warn("Unable to determine non-glob parent for path: {}", value);
+      return path;
+    }
+    return current;
   }
 
   /**

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddDatasetInfoExtractor.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/RddDatasetInfoExtractor.java
@@ -50,12 +50,17 @@ import scala.collection.mutable.ArrayBuffer;
 public class RddDatasetInfoExtractor {
 
   public static Stream<DatasetIdentifier> findDatasetIdentifiers(RDD<?> rdd) {
+    return findDatasetIdentifiers(rdd, false);
+  }
+
+  public static Stream<DatasetIdentifier> findDatasetIdentifiers(
+      RDD<?> rdd, boolean normalizeHiveStylePartitioning) {
     return Stream.<RddDatasetIdentifierExtractor>of(
-            new HadoopRDDExtractor(),
+            new HadoopRDDExtractor(normalizeHiveStylePartitioning),
             new FileScanRDDExtractor(),
-            new MapPartitionsRDDExtractor(),
-            new UnionRddExctractor(),
-            new NewHadoopRDDExtractor(),
+            new MapPartitionsRDDExtractor(normalizeHiveStylePartitioning),
+            new UnionRddExctractor(normalizeHiveStylePartitioning),
+            new NewHadoopRDDExtractor(normalizeHiveStylePartitioning),
             new ParallelCollectionRDDExtractor(),
             new DataSourceRDDExtractor())
         .filter(e -> e.isDefinedAt(rdd))
@@ -73,6 +78,12 @@ public class RddDatasetInfoExtractor {
   }
 
   static class UnionRddExctractor implements RddDatasetIdentifierExtractor<UnionRDD<?>> {
+    private final boolean normalizeHiveStylePartitioning;
+
+    UnionRddExctractor(boolean normalizeHiveStylePartitioning) {
+      this.normalizeHiveStylePartitioning = normalizeHiveStylePartitioning;
+    }
+
     @Override
     public boolean isDefinedAt(Object rdd) {
       return rdd instanceof UnionRDD;
@@ -81,7 +92,10 @@ public class RddDatasetInfoExtractor {
     @Override
     public Stream<DatasetIdentifier> extract(UnionRDD<?> rdd) {
       return ScalaConversionUtils.fromSeq(rdd.rdds()).stream()
-          .flatMap(RddDatasetInfoExtractor::findDatasetIdentifiers);
+          .flatMap(
+              child ->
+                  RddDatasetInfoExtractor.findDatasetIdentifiers(
+                      child, normalizeHiveStylePartitioning));
     }
   }
 
@@ -99,6 +113,12 @@ public class RddDatasetInfoExtractor {
   }
 
   static class HadoopRDDExtractor implements RddDatasetIdentifierExtractor<HadoopRDD<?, ?>> {
+    private final boolean normalizeHiveStylePartitioning;
+
+    HadoopRDDExtractor(boolean normalizeHiveStylePartitioning) {
+      this.normalizeHiveStylePartitioning = normalizeHiveStylePartitioning;
+    }
+
     @Override
     public boolean isDefinedAt(Object rdd) {
       return rdd instanceof HadoopRDD;
@@ -113,12 +133,20 @@ public class RddDatasetInfoExtractor {
         log.debug("Hadoop RDD input paths {}", Arrays.toString(inputPaths));
         log.debug("Hadoop RDD job conf {}", rdd.getJobConf());
       }
-      return PlanUtils.getDirectoryPaths(Arrays.asList(inputPaths), hadoopConf).stream()
+      return PathUtils.getDirectoryPaths(
+              Arrays.asList(inputPaths), hadoopConf, normalizeHiveStylePartitioning)
+          .stream()
           .map(PathUtils::fromPath);
     }
   }
 
   static class NewHadoopRDDExtractor implements RddDatasetIdentifierExtractor<NewHadoopRDD<?, ?>> {
+    private final boolean normalizeHiveStylePartitioning;
+
+    NewHadoopRDDExtractor(boolean normalizeHiveStylePartitioning) {
+      this.normalizeHiveStylePartitioning = normalizeHiveStylePartitioning;
+    }
+
     @Override
     public boolean isDefinedAt(Object rdd) {
       return rdd instanceof NewHadoopRDD;
@@ -131,7 +159,9 @@ public class RddDatasetInfoExtractor {
             org.apache.hadoop.mapreduce.lib.input.FileInputFormat.getInputPaths(
                 new Job(rdd.getConf()));
 
-        return PlanUtils.getDirectoryPaths(Arrays.asList(inputPaths), rdd.getConf()).stream()
+        return PathUtils.getDirectoryPaths(
+                Arrays.asList(inputPaths), rdd.getConf(), normalizeHiveStylePartitioning)
+            .stream()
             .map(PathUtils::fromPath);
       } catch (IOException e) {
         log.error("Openlineage spark agent could not get input paths", e);
@@ -142,6 +172,11 @@ public class RddDatasetInfoExtractor {
 
   static class MapPartitionsRDDExtractor
       implements RddDatasetIdentifierExtractor<MapPartitionsRDD<?, ?>> {
+    private final boolean normalizeHiveStylePartitioning;
+
+    MapPartitionsRDDExtractor(boolean normalizeHiveStylePartitioning) {
+      this.normalizeHiveStylePartitioning = normalizeHiveStylePartitioning;
+    }
 
     @Override
     public boolean isDefinedAt(Object rdd) {
@@ -153,7 +188,7 @@ public class RddDatasetInfoExtractor {
       if (log.isDebugEnabled()) {
         log.debug("Parent RDD: {}", rdd.prev());
       }
-      return findDatasetIdentifiers(rdd.prev());
+      return findDatasetIdentifiers(rdd.prev(), normalizeHiveStylePartitioning);
     }
   }
 

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -144,11 +144,8 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     return columnLineageConfig;
   }
 
-  public Boolean getNormalizeHiveStylePartitioning() {
-    if (normalizeHiveStylePartitioning == null) {
-      normalizeHiveStylePartitioning = true;
-    }
-    return normalizeHiveStylePartitioning;
+  public boolean getNormalizeHiveStylePartitioning() {
+    return normalizeHiveStylePartitioning == null ? true : normalizeHiveStylePartitioning;
   }
 
   @Getter

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -144,6 +144,13 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     return columnLineageConfig;
   }
 
+  public Boolean getNormalizeHiveStylePartitioning() {
+    if (normalizeHiveStylePartitioning == null) {
+      normalizeHiveStylePartitioning = true;
+    }
+    return normalizeHiveStylePartitioning;
+  }
+
   @Getter
   @Setter
   @ToString

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/api/SparkOpenLineageConfig.java
@@ -63,6 +63,8 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
   @JsonProperty("timeout")
   private TimeoutConfig timeoutConfig;
 
+  private Boolean normalizeHiveStylePartitioning;
+
   public SparkOpenLineageConfig(
       String namespace,
       String parentJobName,
@@ -84,7 +86,8 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
       ColumnLineageConfig columnLineageConfig,
       VendorsConfig vendors,
       FilterConfig filterConfig,
-      RunConfig run) {
+      RunConfig run,
+      Boolean normalizeHiveStylePartitioning) {
     super(transportConfig, facetsConfig, datasetConfig, circuitBreaker, metricsConfig, run, job);
     this.namespace = namespace;
     this.parentJobName = parentJobName;
@@ -100,6 +103,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
     this.columnLineageConfig = columnLineageConfig;
     this.vendors = vendors;
     this.filterConfig = filterConfig;
+    this.normalizeHiveStylePartitioning = normalizeHiveStylePartitioning;
   }
 
   @Override
@@ -194,6 +198,7 @@ public class SparkOpenLineageConfig extends OpenLineageConfig<SparkOpenLineageCo
         mergePropertyWith(columnLineageConfig, other.columnLineageConfig),
         mergePropertyWith(vendors, other.vendors),
         mergePropertyWith(filterConfig, other.filterConfig),
-        mergePropertyWith(runConfig, other.runConfig));
+        mergePropertyWith(runConfig, other.runConfig),
+        mergePropertyWith(normalizeHiveStylePartitioning, other.normalizeHiveStylePartitioning));
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
@@ -9,11 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.rdd.RDD;
 import org.junit.jupiter.api.Test;
@@ -27,8 +30,16 @@ class HadoopRDDInputDatasetBuilderTest {
     RDD<?> rdd = mock(RDD.class);
     when(rdd.sparkContext()).thenReturn(sparkContext);
 
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf())
+        .thenReturn(
+            new SparkConf()
+                .set(
+                    PlanUtils.SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
+
     HadoopRDDInputDatasetBuilder builder =
-        new HadoopRDDInputDatasetBuilder(mock(OpenLineageContext.class)) {
+        new HadoopRDDInputDatasetBuilder(context) {
           @Override
           protected Path[] getInputPaths(RDD<?> rdd) {
             return new Path[] {new Path("s3://bucket/table/dt=20260516/*.parquet")};
@@ -37,6 +48,6 @@ class HadoopRDDInputDatasetBuilderTest {
 
     List<URI> inputs = builder.findInputs(rdd);
 
-    assertThat(inputs).containsExactly(URI.create("s3://bucket/table/dt=20260516"));
+    assertThat(inputs).containsExactly(URI.create("s3://bucket/table"));
   }
 }

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
@@ -35,8 +35,7 @@ class HadoopRDDInputDatasetBuilderTest {
     when(sparkContext.getConf())
         .thenReturn(
             new SparkConf()
-                .set(
-                    PlanUtils.SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
+                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
 
     HadoopRDDInputDatasetBuilder builder =
         new HadoopRDDInputDatasetBuilder(context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
@@ -9,14 +9,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.rdd.RDD;
 import org.junit.jupiter.api.Test;
@@ -31,11 +29,7 @@ class HadoopRDDInputDatasetBuilderTest {
     when(rdd.sparkContext()).thenReturn(sparkContext);
 
     OpenLineageContext context = mock(OpenLineageContext.class);
-    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
-    when(sparkContext.getConf())
-        .thenReturn(
-            new SparkConf()
-                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
+    when(context.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
 
     HadoopRDDInputDatasetBuilder builder =
         new HadoopRDDInputDatasetBuilder(context) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/HadoopRDDInputDatasetBuilderTest.java
@@ -1,0 +1,42 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkContext;
+import org.apache.spark.rdd.RDD;
+import org.junit.jupiter.api.Test;
+
+class HadoopRDDInputDatasetBuilderTest {
+  @Test
+  void findInputsNormalizesInputPathsToDirectoriesAndRemovesGlobs() {
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(sparkContext.hadoopConfiguration()).thenReturn(new Configuration());
+
+    RDD<?> rdd = mock(RDD.class);
+    when(rdd.sparkContext()).thenReturn(sparkContext);
+
+    HadoopRDDInputDatasetBuilder builder =
+        new HadoopRDDInputDatasetBuilder(mock(OpenLineageContext.class)) {
+          @Override
+          protected Path[] getInputPaths(RDD<?> rdd) {
+            return new Path[] {new Path("s3://bucket/table/dt=20260516/*.parquet")};
+          }
+        };
+
+    List<URI> inputs = builder.findInputs(rdd);
+
+    assertThat(inputs).containsExactly(URI.create("s3://bucket/table/dt=20260516"));
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitorTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/InsertIntoHadoopFsRelationVisitorTest.java
@@ -1,0 +1,56 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand;
+import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+class InsertIntoHadoopFsRelationVisitorTest {
+  @Test
+  void applyNormalizesHiveStylePartitionedOutputPathWhenEnabled() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkSession sparkSession = mock(SparkSession.class);
+    SparkOpenLineageConfig config = new SparkOpenLineageConfig();
+    config.setNormalizeHiveStylePartitioning(true);
+
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI));
+    when(context.getOpenLineageConfig()).thenReturn(config);
+    when(context.getSparkSession()).thenReturn(Optional.of(sparkSession));
+
+    LogicalPlan query = mock(LogicalPlan.class);
+    when(query.schema()).thenReturn(new StructType().add("id", StringType$.MODULE$));
+
+    InsertIntoHadoopFsRelationCommand command = mock(InsertIntoHadoopFsRelationCommand.class);
+    when(command.catalogTable()).thenReturn(Option.empty());
+    when(command.outputPath()).thenReturn(new Path("s3://bucket/table/dt=20260516"));
+    when(command.query()).thenReturn(query);
+    when(command.mode()).thenReturn(SaveMode.Append);
+
+    List<OpenLineage.OutputDataset> datasets =
+        new InsertIntoHadoopFsRelationVisitor(context).apply(command);
+
+    assertThat(datasets).hasSize(1);
+    assertThat(datasets.get(0).getNamespace()).isEqualTo("s3://bucket");
+    assertThat(datasets.get(0).getName()).isEqualTo("table");
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -180,6 +180,34 @@ class LogicalRelationDatasetBuilderTest {
   }
 
   @Test
+  void testApplyForPartitionedHadoopFsRelationWithBasePath() {
+    HadoopFsRelation hadoopFsRelation = mock(HadoopFsRelation.class);
+    LogicalRelation logicalRelation = mock(LogicalRelation.class);
+    Configuration hadoopConfig = mock(Configuration.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    SessionState sessionState = mock(SessionState.class);
+
+    when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
+    when(openLineageContext.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(openLineageContext.getSparkSession()).thenReturn(Optional.of(session));
+    when(session.sessionState()).thenReturn(sessionState);
+    when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
+    when(hadoopFsRelation.options())
+        .thenReturn(
+            ScalaConversionUtils.fromJavaMap(Collections.singletonMap("basePath", "/tmp/table")));
+    when(hadoopFsRelation.partitionSchema())
+        .thenReturn(new StructType().add("dt", StringType$.MODULE$));
+    when(hadoopFsRelation.schema()).thenReturn(new StructType().add("id", StringType$.MODULE$));
+
+    List<OpenLineage.Dataset> datasets =
+        builder.apply(mock(SparkListenerEvent.class), logicalRelation);
+
+    assertEquals(1, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals("/tmp/table", ds.getName());
+  }
+
+  @Test
   void testApplyForSingleFileHadoopFsRelation() throws IOException, URISyntaxException {
     HadoopFsRelation hadoopFsRelation = mock(HadoopFsRelation.class);
     LogicalRelation logicalRelation = mock(LogicalRelation.class);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -7,6 +7,8 @@ package io.openlineage.spark.agent.lifecycle.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -17,7 +19,7 @@ import io.openlineage.client.OpenLineage.OutputDataset;
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
-import io.openlineage.spark.agent.util.PlanUtils;
+import io.openlineage.spark.agent.util.PathUtils;
 import io.openlineage.spark.agent.util.ScalaConversionUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
@@ -160,6 +162,7 @@ class LogicalRelationDatasetBuilderTest {
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
+    when(hadoopFsRelation.schema()).thenReturn(new StructType().add("id", StringType$.MODULE$));
     when(fileIndex.rootPaths())
         .thenReturn(
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(
@@ -167,9 +170,12 @@ class LogicalRelationDatasetBuilderTest {
                 .asScala()
                 .toSeq());
 
-    try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
-      when(PlanUtils.getDirectoryPaths(
-              any(Collection.class), any(Configuration.class), any(OpenLineageContext.class)))
+    try (MockedStatic<PathUtils> mocked = mockStatic(PathUtils.class, CALLS_REAL_METHODS)) {
+      mocked
+          .when(
+              () ->
+                  PathUtils.getDirectoryPaths(
+                      any(Collection.class), any(Configuration.class), anyBoolean()))
           .thenReturn(Collections.singletonList(new Path("/tmp")));
 
       List<OpenLineage.Dataset> datasets =
@@ -228,19 +234,18 @@ class LogicalRelationDatasetBuilderTest {
     when(session.sessionState()).thenReturn(sessionState);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
+    when(hadoopFsRelation.schema()).thenReturn(new StructType().add("id", StringType$.MODULE$));
     when(fileIndex.rootPaths())
         .thenReturn(
             scala.collection.JavaConverters.collectionAsScalaIterableConverter(Arrays.asList(p))
                 .asScala()
                 .toSeq());
 
-    try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
-      List<OpenLineage.Dataset> datasets =
-          builder.apply(mock(SparkListenerEvent.class), logicalRelation);
-      assertEquals(1, datasets.size());
-      OpenLineage.Dataset ds = datasets.get(0);
-      assertEquals("/tmp/path.csv", ds.getName());
-    }
+    List<OpenLineage.Dataset> datasets =
+        builder.apply(mock(SparkListenerEvent.class), logicalRelation);
+    assertEquals(1, datasets.size());
+    OpenLineage.Dataset ds = datasets.get(0);
+    assertEquals("/tmp/path.csv", ds.getName());
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -168,7 +168,8 @@ class LogicalRelationDatasetBuilderTest {
                 .toSeq());
 
     try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
-      when(PlanUtils.getDirectoryPaths(any(Collection.class), any(Configuration.class)))
+      when(PlanUtils.getDirectoryPaths(
+              any(Collection.class), any(Configuration.class), any(OpenLineageContext.class)))
           .thenReturn(Collections.singletonList(new Path("/tmp")));
 
       List<OpenLineage.Dataset> datasets =

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -25,6 +26,8 @@ import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.apache.spark.sql.internal.SessionState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.MockedStatic;
 import scala.Option;
@@ -62,6 +65,80 @@ class PathUtilsTest {
 
     when(sparkSession.sessionState()).thenReturn(sessionState);
     when(sessionState.catalog()).thenReturn(sessionCatalog);
+  }
+
+  @Test
+  void testGetDirectoryPathsRemovesTrailingGlob() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
+                new Configuration(),
+                false))
+        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
+  }
+
+  @Test
+  void testGetDirectoryPathsUsesNonGlobAncestor() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/*/*/rates.parquet")),
+                new Configuration(),
+                false))
+        .containsExactly(new Path("s3://bucket/table"));
+  }
+
+  @Test
+  void testGetDirectoryPathsNormalizesHiveStylePartitioningWhenEnabled() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Collections.singletonList(
+                    new Path("s3://bucket/table/dt=20260516/hour=13/*.parquet")),
+                new Configuration(),
+                true))
+        .containsExactly(new Path("s3://bucket/table"));
+  }
+
+  @Test
+  void testGetDirectoryPathsDoesNotNormalizeHiveStylePartitioningWhenDisabled() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
+                new Configuration(),
+                false))
+        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "s3://bucket/table/dt=20260516, s3://bucket/table",
+    "s3://bucket/table/_dt=20260516, s3://bucket/table",
+    "s3://bucket/table/d_t1=20260516, s3://bucket/table",
+    "s3://bucket/table/dt=20260516/hour=13, s3://bucket/table"
+  })
+  void testNormalizeHiveStylePartitioningWithValidPartitionSegments(String input, String expected) {
+    assertThat(PathUtils.normalizeHiveStylePartitioning(new Path(input)))
+        .isEqualTo(new Path(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "s3://bucket/table/=20260516",
+    "s3://bucket/table/1dt=20260516",
+    "s3://bucket/table/dt=",
+    "s3://bucket/table/d-t=20260516",
+    "s3://bucket/table/ts=1-id=6-uuid=f"
+  })
+  void testNormalizeHiveStylePartitioningWithInvalidPartitionSegments(String input) {
+    assertThat(PathUtils.normalizeHiveStylePartitioning(new Path(input)))
+        .isEqualTo(new Path(input));
+  }
+
+  @Test
+  void testNormalizeHiveStylePartitioningDoesNotNormalizeCompoundEqualsSuffix() {
+    assertThat(
+            PathUtils.normalizeHiveStylePartitioning(
+                new Path("s3://bucket/table/ts=1-id=6-uuid=f")))
+        .isEqualTo(new Path("s3://bucket/table/ts=1-id=6-uuid=f"));
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PathUtilsTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -88,6 +89,26 @@ class PathUtilsTest {
   }
 
   @Test
+  void testGetDirectoryPathsSkipsPathWhenAncestorAlreadyAdded() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Arrays.asList(new Path("/root"), new Path("/root/sub/file.parquet")),
+                new Configuration(),
+                false))
+        .containsExactly(new Path("/root"));
+  }
+
+  @Test
+  void testGetDirectoryPathsCollapsesPathsWithSameParent() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Arrays.asList(new Path("/root/file1.parquet"), new Path("/root/file2.parquet")),
+                new Configuration(),
+                false))
+        .containsExactly(new Path("/root"));
+  }
+
+  @Test
   void testGetDirectoryPathsNormalizesHiveStylePartitioningWhenEnabled() {
     assertThat(
             PathUtils.getDirectoryPaths(
@@ -108,12 +129,23 @@ class PathUtilsTest {
         .containsExactly(new Path("s3://bucket/table/dt=20260516"));
   }
 
+  @Test
+  void testGetDirectoryPathsDoesNotNormalizeHiveStylePartitioningInMiddleOfPath() {
+    assertThat(
+            PathUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/data/*.parquet")),
+                new Configuration(),
+                true))
+        .containsExactly(new Path("s3://bucket/table/dt=20260516/data"));
+  }
+
   @ParameterizedTest
   @CsvSource({
     "s3://bucket/table/dt=20260516, s3://bucket/table",
     "s3://bucket/table/_dt=20260516, s3://bucket/table",
     "s3://bucket/table/d_t1=20260516, s3://bucket/table",
-    "s3://bucket/table/dt=20260516/hour=13, s3://bucket/table"
+    "s3://bucket/table/dt=20260516/hour=13, s3://bucket/table",
+    "s3://some/table/col1=1/col2=2, s3://some/table"
   })
   void testNormalizeHiveStylePartitioningWithValidPartitionSegments(String input, String expected) {
     assertThat(PathUtils.normalizeHiveStylePartitioning(new Path(input)))

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -11,10 +11,14 @@ import static org.mockito.Mockito.when;
 
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.api.OpenLineageContext;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.IntegerType$;
@@ -22,6 +26,8 @@ import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PlanUtilsTest {
@@ -41,6 +47,88 @@ class PlanUtilsTest {
                 Collections.singletonList(new Path("s3://bucket/table/*/*/rates.parquet")),
                 new Configuration()))
         .containsExactly(new Path("s3://bucket/table"));
+  }
+
+  @Test
+  void testGetDirectoryPathsNormalizesHiveStylePartitioningWhenEnabled() {
+    assertThat(
+            PlanUtils.getDirectoryPaths(
+                Collections.singletonList(
+                    new Path("s3://bucket/table/dt=20260516/hour=13/*.parquet")),
+                new Configuration(),
+                contextWithHiveStylePartitioningNormalization(true)))
+        .containsExactly(new Path("s3://bucket/table"));
+  }
+
+  @Test
+  void testGetDirectoryPathsNormalizesHiveStylePartitioningByDefault() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf()).thenReturn(new SparkConf());
+
+    assertThat(
+            PlanUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
+                new Configuration(),
+                context))
+        .containsExactly(new Path("s3://bucket/table"));
+  }
+
+  @Test
+  void testGetDirectoryPathsDoesNotNormalizeHiveStylePartitioningWhenDisabled() {
+    assertThat(
+            PlanUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
+                new Configuration(),
+                contextWithHiveStylePartitioningNormalization(false)))
+        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "s3://bucket/table/dt=20260516, s3://bucket/table",
+    "s3://bucket/table/_dt=20260516, s3://bucket/table",
+    "s3://bucket/table/d_t1=20260516, s3://bucket/table",
+    "s3://bucket/table/dt=20260516/hour=13, s3://bucket/table"
+  })
+  void testNormalizeHiveStylePartitioningWithValidPartitionSegments(String input, String expected) {
+    assertThat(PlanUtils.normalizeHiveStylePartitioning(new Path(input)))
+        .isEqualTo(new Path(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "s3://bucket/table/=20260516",
+    "s3://bucket/table/1dt=20260516",
+    "s3://bucket/table/dt=",
+    "s3://bucket/table/d-t=20260516",
+    "s3://bucket/table/ts=1-id=6-uuid=f"
+  })
+  void testNormalizeHiveStylePartitioningWithInvalidPartitionSegments(String input) {
+    assertThat(PlanUtils.normalizeHiveStylePartitioning(new Path(input)))
+        .isEqualTo(new Path(input));
+  }
+
+  @Test
+  void testNormalizeHiveStylePartitioningDoesNotNormalizeCompoundEqualsSuffix() {
+    assertThat(
+            PlanUtils.normalizeHiveStylePartitioning(
+                new Path("s3://bucket/table/ts=1-id=6-uuid=f")))
+        .isEqualTo(new Path("s3://bucket/table/ts=1-id=6-uuid=f"));
+  }
+
+  private OpenLineageContext contextWithHiveStylePartitioningNormalization(boolean enabled) {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    SparkConf sparkConf =
+        new SparkConf()
+            .set(
+                PlanUtils.SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING,
+                String.valueOf(enabled));
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    return context;
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -12,6 +12,9 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
 import java.util.Arrays;
+import java.util.Collections;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.IntegerType$;
@@ -22,6 +25,24 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PlanUtilsTest {
+  @Test
+  void testGetDirectoryPathsRemovesTrailingGlob() {
+    assertThat(
+            PlanUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
+                new Configuration()))
+        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
+  }
+
+  @Test
+  void testGetDirectoryPathsUsesNonGlobAncestor() {
+    assertThat(
+            PlanUtils.getDirectoryPaths(
+                Collections.singletonList(new Path("s3://bucket/table/*/*/rates.parquet")),
+                new Configuration()))
+        .containsExactly(new Path("s3://bucket/table"));
+  }
+
   @Test
   void testSchemaFacetFlat() {
     OpenLineage openLineage = new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI);

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -15,11 +15,8 @@ import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.IntegerType$;
@@ -44,9 +41,7 @@ class PlanUtilsTest {
   @Test
   void testGetDirectoryPathsNormalizesHiveStylePartitioningByDefault() {
     OpenLineageContext context = mock(OpenLineageContext.class);
-    SparkContext sparkContext = mock(SparkContext.class);
-    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
-    when(sparkContext.getConf()).thenReturn(new SparkConf());
+    when(context.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
 
     assertThat(
             PlanUtils.getDirectoryPaths(
@@ -67,29 +62,11 @@ class PlanUtilsTest {
   }
 
   @Test
-  void testOpenLineageConfigTakesPrecedenceOverSparkConf() {
-    OpenLineageContext context = contextWithHiveStylePartitioningNormalization(false);
-    SparkContext sparkContext = mock(SparkContext.class);
-    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
-    when(sparkContext.getConf())
-        .thenReturn(
-            new SparkConf()
-                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
-
-    assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isFalse();
-  }
-
-  @Test
-  void testSparkConfIsUsedAsFallbackForHiveStylePartitioningNormalization() {
-    OpenLineageContext context = mock(OpenLineageContext.class);
-    SparkContext sparkContext = mock(SparkContext.class);
-    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
-    when(sparkContext.getConf())
-        .thenReturn(
-            new SparkConf()
-                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "false"));
-
-    assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isFalse();
+  void testOpenLineageConfigControlsHiveStylePartitioningNormalization() {
+    assertThat(
+            PlanUtils.isHiveStylePartitioningNormalizationEnabled(
+                contextWithHiveStylePartitioningNormalization(false)))
+        .isFalse();
   }
 
   private OpenLineageContext contextWithHiveStylePartitioningNormalization(boolean enabled) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -14,9 +14,6 @@ import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
-import java.util.Collections;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.IntegerType$;
@@ -28,37 +25,11 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PlanUtilsTest {
   @Test
-  void testGetDirectoryPathsNormalizesHiveStylePartitioningWhenEnabled() {
-    assertThat(
-            PlanUtils.getDirectoryPaths(
-                Collections.singletonList(
-                    new Path("s3://bucket/table/dt=20260516/hour=13/*.parquet")),
-                new Configuration(),
-                contextWithHiveStylePartitioningNormalization(true)))
-        .containsExactly(new Path("s3://bucket/table"));
-  }
-
-  @Test
-  void testGetDirectoryPathsNormalizesHiveStylePartitioningByDefault() {
+  void testHiveStylePartitioningNormalizationEnabledByDefault() {
     OpenLineageContext context = mock(OpenLineageContext.class);
     when(context.getOpenLineageConfig()).thenReturn(new SparkOpenLineageConfig());
 
-    assertThat(
-            PlanUtils.getDirectoryPaths(
-                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
-                new Configuration(),
-                context))
-        .containsExactly(new Path("s3://bucket/table"));
-  }
-
-  @Test
-  void testGetDirectoryPathsDoesNotNormalizeHiveStylePartitioningWhenDisabled() {
-    assertThat(
-            PlanUtils.getDirectoryPaths(
-                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
-                new Configuration(),
-                contextWithHiveStylePartitioningNormalization(false)))
-        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
+    assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isTrue();
   }
 
   @Test

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -27,29 +27,9 @@ import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PlanUtilsTest {
-  @Test
-  void testGetDirectoryPathsRemovesTrailingGlob() {
-    assertThat(
-            PlanUtils.getDirectoryPaths(
-                Collections.singletonList(new Path("s3://bucket/table/dt=20260516/*.parquet")),
-                new Configuration()))
-        .containsExactly(new Path("s3://bucket/table/dt=20260516"));
-  }
-
-  @Test
-  void testGetDirectoryPathsUsesNonGlobAncestor() {
-    assertThat(
-            PlanUtils.getDirectoryPaths(
-                Collections.singletonList(new Path("s3://bucket/table/*/*/rates.parquet")),
-                new Configuration()))
-        .containsExactly(new Path("s3://bucket/table"));
-  }
-
   @Test
   void testGetDirectoryPathsNormalizesHiveStylePartitioningWhenEnabled() {
     assertThat(
@@ -110,39 +90,6 @@ class PlanUtilsTest {
                 .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "false"));
 
     assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isFalse();
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "s3://bucket/table/dt=20260516, s3://bucket/table",
-    "s3://bucket/table/_dt=20260516, s3://bucket/table",
-    "s3://bucket/table/d_t1=20260516, s3://bucket/table",
-    "s3://bucket/table/dt=20260516/hour=13, s3://bucket/table"
-  })
-  void testNormalizeHiveStylePartitioningWithValidPartitionSegments(String input, String expected) {
-    assertThat(PlanUtils.normalizeHiveStylePartitioning(new Path(input)))
-        .isEqualTo(new Path(expected));
-  }
-
-  @ParameterizedTest
-  @CsvSource({
-    "s3://bucket/table/=20260516",
-    "s3://bucket/table/1dt=20260516",
-    "s3://bucket/table/dt=",
-    "s3://bucket/table/d-t=20260516",
-    "s3://bucket/table/ts=1-id=6-uuid=f"
-  })
-  void testNormalizeHiveStylePartitioningWithInvalidPartitionSegments(String input) {
-    assertThat(PlanUtils.normalizeHiveStylePartitioning(new Path(input)))
-        .isEqualTo(new Path(input));
-  }
-
-  @Test
-  void testNormalizeHiveStylePartitioningDoesNotNormalizeCompoundEqualsSuffix() {
-    assertThat(
-            PlanUtils.normalizeHiveStylePartitioning(
-                new Path("s3://bucket/table/ts=1-id=6-uuid=f")))
-        .isEqualTo(new Path("s3://bucket/table/ts=1-id=6-uuid=f"));
   }
 
   private OpenLineageContext contextWithHiveStylePartitioningNormalization(boolean enabled) {

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/PlanUtilsTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import io.openlineage.client.OpenLineage;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -85,6 +86,32 @@ class PlanUtilsTest {
         .containsExactly(new Path("s3://bucket/table/dt=20260516"));
   }
 
+  @Test
+  void testOpenLineageConfigTakesPrecedenceOverSparkConf() {
+    OpenLineageContext context = contextWithHiveStylePartitioningNormalization(false);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf())
+        .thenReturn(
+            new SparkConf()
+                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "true"));
+
+    assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isFalse();
+  }
+
+  @Test
+  void testSparkConfIsUsedAsFallbackForHiveStylePartitioningNormalization() {
+    OpenLineageContext context = mock(OpenLineageContext.class);
+    SparkContext sparkContext = mock(SparkContext.class);
+    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
+    when(sparkContext.getConf())
+        .thenReturn(
+            new SparkConf()
+                .set(PlanUtils.SPARK_OPENLINEAGE_NORMALIZE_HIVE_STYLE_PARTITIONING, "false"));
+
+    assertThat(PlanUtils.isHiveStylePartitioningNormalizationEnabled(context)).isFalse();
+  }
+
   @ParameterizedTest
   @CsvSource({
     "s3://bucket/table/dt=20260516, s3://bucket/table",
@@ -120,14 +147,9 @@ class PlanUtilsTest {
 
   private OpenLineageContext contextWithHiveStylePartitioningNormalization(boolean enabled) {
     OpenLineageContext context = mock(OpenLineageContext.class);
-    SparkContext sparkContext = mock(SparkContext.class);
-    SparkConf sparkConf =
-        new SparkConf()
-            .set(
-                PlanUtils.SPARK_OPENLINEAGE_DATASET_NORMALIZE_HIVE_STYLE_PARTITIONING,
-                String.valueOf(enabled));
-    when(context.getSparkContext()).thenReturn(Optional.of(sparkContext));
-    when(sparkContext.getConf()).thenReturn(sparkConf);
+    SparkOpenLineageConfig config = new SparkOpenLineageConfig();
+    config.setNormalizeHiveStylePartitioning(enabled);
+    when(context.getOpenLineageConfig()).thenReturn(config);
     return context;
   }
 

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -98,7 +98,7 @@ class LogicalRelationDatasetBuilderTest {
 
     try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PlanUtils.getDirectoryPaths(any(), eq(hadoopConfig)))
+        when(PlanUtils.getDirectoryPaths(any(), eq(hadoopConfig), any(OpenLineageContext.class)))
             .thenReturn(Collections.singletonList(new Path("/tmp")));
         when(DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(logicalRelation))
             .thenReturn(Optional.of(SOME_VERSION));

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/LogicalRelationDatasetBuilderTest.java
@@ -7,7 +7,8 @@ package io.openlineage.spark3.agent.lifecycle.plan;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -18,7 +19,6 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.Versions;
 import io.openlineage.spark.agent.lifecycle.SparkOpenLineageExtensionVisitorWrapper;
 import io.openlineage.spark.agent.util.PathUtils;
-import io.openlineage.spark.agent.util.PlanUtils;
 import io.openlineage.spark.api.DatasetFactory;
 import io.openlineage.spark.api.OpenLineageContext;
 import io.openlineage.spark3.agent.utils.DatasetVersionDatasetFacetUtils;
@@ -87,6 +87,7 @@ class LogicalRelationDatasetBuilderTest {
     when(logicalRelation.relation()).thenReturn(hadoopFsRelation);
     when(sessionState.newHadoopConfWithOptions(any())).thenReturn(hadoopConfig);
     when(hadoopFsRelation.location()).thenReturn(fileIndex);
+    when(hadoopFsRelation.schema()).thenReturn(new StructType().add("id", StringType$.MODULE$));
 
     when(fileIndex.rootPaths())
         .thenReturn(
@@ -96,9 +97,10 @@ class LogicalRelationDatasetBuilderTest {
     when(openLineage.newDatasetFacetsBuilder()).thenReturn(new OpenLineage.DatasetFacetsBuilder());
     when(openLineage.newDatasetVersionDatasetFacet(SOME_VERSION)).thenReturn(facet);
 
-    try (MockedStatic mocked = mockStatic(PlanUtils.class)) {
+    try (MockedStatic<PathUtils> mocked = mockStatic(PathUtils.class, CALLS_REAL_METHODS)) {
       try (MockedStatic mockedFacetUtils = mockStatic(DatasetVersionDatasetFacetUtils.class)) {
-        when(PlanUtils.getDirectoryPaths(any(), eq(hadoopConfig), any(OpenLineageContext.class)))
+        mocked
+            .when(() -> PathUtils.getDirectoryPaths(any(), any(Configuration.class), anyBoolean()))
             .thenReturn(Collections.singletonList(new Path("/tmp")));
         when(DatasetVersionDatasetFacetUtils.extractVersionFromLogicalRelation(logicalRelation))
             .thenReturn(Optional.of(SOME_VERSION));


### PR DESCRIPTION
AI description:

This PR improves dataset naming for Spark file-based lineage when jobs read or write partitioned raw files. Spark users often work with Parquet/CSV paths that point at a selected partition or file pattern, such as `s3://bucket/table/dt=20260516/*.parquet`, even though the logical dataset is the parent table directory. Previously, OpenLineage could emit the partition path or literal glob as the dataset name, causing lineage graphs to fragment across timestamped or partition-specific paths.

The change normalizes file paths before creating dataset identifiers. Literal glob selectors are resolved to the nearest stable directory, and Hive-style partition segments such as `dt=20260516/hour=13` are stripped by default so the emitted dataset is the table/root path. This behavior is configurable with `spark.openlineage.normalizeHiveStylePartitioning`, which defaults to `true` and can be set to `false` to preserve the previous partition-path behavior.

This normalization is applied across SQL file relations, Hadoop RDD inputs, and `InsertIntoHadoopFsRelationCommand` outputs. The implementation also uses Spark’s explicit `basePath` metadata for partitioned `HadoopFsRelation`s, so reads of selected partitions with a declared dataset root emit the stable root dataset.


### Checklist
- [x] AI was used in creating this PR - Pi/gpt-5.5
