### PR TITLE
spark: map sqlserver to MsSqlDialect

### DIFF
--- a/integration/sql/impl/src/dialect.rs
+++ b/integration/sql/impl/src/dialect.rs
@@ -41,6 +41,7 @@ pub fn get_dialect(name: &str) -> &'static dyn CanonicalDialect {
         "hive" => &HiveDialect {},
         "mysql" => &MySqlDialect {},
         "mssql" => &MsSqlDialect {},
+        "sqlserver" => &MsSqlDialect {},
         "sqlite" => &SQLiteDialect {},
         "ansi" => &AnsiDialect {},
         "generic" => &GenericDialect,
@@ -53,5 +54,19 @@ pub fn get_generic_dialect(name: Option<String>) -> &'static dyn CanonicalDialec
         get_dialect(d.as_str())
     } else {
         &GenericDialect
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_dialect;
+    use sqlparser::dialect::MsSqlDialect;
+
+    #[test]
+    fn sqlserver_alias_uses_mssql_dialect() {
+        let dialect = get_dialect("sqlserver");
+
+        assert!(dialect.as_base().is::<MsSqlDialect>());
+        assert_eq!(dialect.canonical_name("[Alias]"), Some("Alias"));
     }
 }

--- a/integration/sql/impl/src/dialect.rs
+++ b/integration/sql/impl/src/dialect.rs
@@ -56,17 +56,3 @@ pub fn get_generic_dialect(name: Option<String>) -> &'static dyn CanonicalDialec
         &GenericDialect
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::get_dialect;
-    use sqlparser::dialect::MsSqlDialect;
-
-    #[test]
-    fn sqlserver_alias_uses_mssql_dialect() {
-        let dialect = get_dialect("sqlserver");
-
-        assert!(dialect.as_base().is::<MsSqlDialect>());
-        assert_eq!(dialect.canonical_name("[Alias]"), Some("Alias"));
-    }
-}

--- a/integration/sql/impl/tests/table_lineage/tests_select.rs
+++ b/integration/sql/impl/tests/table_lineage/tests_select.rs
@@ -130,6 +130,19 @@ fn select_redshift() {
 }
 
 #[test]
+fn select_sqlserver() {
+    assert_eq!(
+        test_sql_dialect("SELECT [col1] FROM [test_schema].[test_table]", "sqlserver")
+            .unwrap()
+            .table_lineage,
+        TableLineage {
+            in_tables: tables(vec!["[test_schema].[test_table]"]),
+            out_tables: vec![]
+        }
+    )
+}
+
+#[test]
 fn select_with_table_generator() {
     assert_eq!(
         test_sql(


### PR DESCRIPTION
closes: #4550

### One-line summary for changelog:
Map Spark JDBC `sqlserver` URLs to `MsSqlDialect` so SQL Server queries with bracketed identifiers parse correctly during lineage extraction.

### Meaningful description
Spark extracts the SQL dialect name from JDBC URLs, so a SQL Server connection like `jdbc:sqlserver://...` is passed through as `sqlserver`.

The SQL integration only recognized `mssql`, which meant SQL Server queries using T-SQL bracketed identifiers such as `[col]` and `[schema].[table]` fell back to `GenericDialect` and produced parsing errors during lineage extraction.

This change adds `sqlserver` as an alias for `MsSqlDialect` in the SQL dialect mapping and adds a regression test in `integration/sql/impl/tests/table_lineage/tests_select.rs` covering a bracketed SQL Server `SELECT`.

Validated with `cargo test` and `cargo fmt --check` in `integration/sql/impl`.

### Checklist
- [x] AI was used in creating this PR