### PR TITLE
spark: make iceberg catalog identifiers optional

### DIFF
--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -20,7 +21,7 @@ abstract class BaseCatalogTypeHandler {
 
   abstract boolean matchesCatalogType(Map<String, String> catalogConf);
 
-  abstract DatasetIdentifier getIdentifier(
+  abstract Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table);
 
   Path defaultTableLocation(Path warehouseLocation, Identifier identifier) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BigQueryMetastoreCatalogTypeHandler.java
@@ -12,6 +12,7 @@ import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.spark.sql.SparkSession;
@@ -31,10 +32,11 @@ class BigQueryMetastoreCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
-    return FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table);
+    return Optional.of(
+        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table));
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
@@ -12,9 +12,11 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.AwsUtils;
 import java.util.Map;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SparkSession;
 
+@Slf4j
 class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
@@ -29,12 +31,14 @@ class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
   }
 
   @Override
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     SparkContext sparkContext = session.sparkContext();
     Optional<String> arn =
         AwsUtils.getGlueArn(sparkContext.getConf(), sparkContext.hadoopConfiguration());
-    return arn.map(s -> new DatasetIdentifier(GLUE_TABLE_PREFIX + table.replace(".", "/"), s))
-        .orElse(null);
+    if (!arn.isPresent()) {
+      log.warn("Glue catalog ARN is unavailable; omitting Glue table symlink for table {}.", table);
+    }
+    return arn.map(s -> new DatasetIdentifier(GLUE_TABLE_PREFIX + table.replace(".", "/"), s));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HadoopCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HadoopCatalogTypeHandler.java
@@ -10,6 +10,7 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.client.utils.filesystem.FilesystemDatasetUtils;
 import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
@@ -33,9 +34,10 @@ class HadoopCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String warehouseLocation = catalogConf.get(CatalogProperties.WAREHOUSE_LOCATION);
-    return FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table);
+    return Optional.of(
+        FilesystemDatasetUtils.fromLocationAndName(new Path(warehouseLocation).toUri(), table));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/HiveCatalogTypeHandler.java
@@ -13,6 +13,7 @@ import io.openlineage.spark.agent.util.SparkConfUtils;
 import io.openlineage.spark3.agent.lifecycle.plan.catalog.MissingDatasetIdentifierCatalogException;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.CatalogProperties;
@@ -35,7 +36,7 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     URI metastoreUri;
     String confUri = catalogConf.get(CatalogProperties.URI);
@@ -46,6 +47,7 @@ class HiveCatalogTypeHandler extends BaseCatalogTypeHandler {
     } else {
       metastoreUri = new URI(confUri);
     }
-    return new DatasetIdentifier(table, PathUtils.prepareHiveUri(metastoreUri).toString());
+    return Optional.of(
+        new DatasetIdentifier(table, PathUtils.prepareHiveUri(metastoreUri).toString()));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -170,8 +170,7 @@ public class IcebergHandler implements CatalogHandler {
             catalogName);
       }
       String tableName = identifier.toString();
-      maybeSymlink =
-          Optional.ofNullable(catalogTypeHandler.getIdentifier(session, catalogConf, tableName));
+      maybeSymlink = catalogTypeHandler.getIdentifier(session, catalogConf, tableName);
     }
 
     if (!maybeTableLocation.isPresent() && warehouseLocation == null) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/NessieCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/NessieCatalogTypeHandler.java
@@ -10,6 +10,7 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.CatalogProperties;
@@ -32,11 +33,11 @@ class NessieCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     log.debug("Getting identifier for nessie");
     String confUri = catalogConf.get(CatalogProperties.URI);
     String uri = new URI(confUri).toString();
-    return new DatasetIdentifier(table, uri);
+    return Optional.of(new DatasetIdentifier(table, uri));
   }
 }

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/RestCatalogTypeHandler.java
@@ -12,6 +12,7 @@ import io.openlineage.client.utils.DatasetIdentifier;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.CatalogProperties;
@@ -37,11 +38,11 @@ class RestCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   @SneakyThrows
-  DatasetIdentifier getIdentifier(
+  Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table) {
     String confUri = catalogConf.get(CatalogProperties.URI);
     String uri = new URI(confUri).toString();
-    return new DatasetIdentifier(table, uri);
+    return Optional.of(new DatasetIdentifier(table, uri));
   }
 
   @Override

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -298,6 +298,39 @@ class IcebergHandlerTest {
         .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.TABLE);
   }
 
+  @Test
+  @SneakyThrows
+  void testGetDatasetIdentifierForGlueWithoutArnOmitsSymlink() {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.test.catalog-impl",
+                "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.test.warehouse",
+                "/tmp/warehouse"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"database"}, "table");
+
+    when(sparkCatalog.name()).thenReturn("test");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("file:/tmp/warehouse/database/table");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue("namespace", "file")
+        .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
+    assertThat(datasetIdentifier.getSymlinks()).isEmpty();
+  }
+
   private static Stream<Arguments> missingTableOptions() {
     return Stream.of(
         Arguments.of(Identifier.of(new String[] {}, "table"), "table", "/tmp/iceberg/table"),


### PR DESCRIPTION
Sometimes the `getIdentifier` can return nullable values, this uses Optional to make the contract more explicit

### Checklist
- [x] AI was used in creating this PR
