### PR TITLE
spark: add iceberg s3 tables catalog support for v2 path

### DIFF
--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/AwsUtils.java
@@ -11,7 +11,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Optional;
-import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.conf.Configuration;
@@ -30,7 +29,6 @@ public class AwsUtils {
   private static final String SPARK_SQL_CATALOG_PREFIX = "spark.sql.catalog.";
   private static final String GLUE_CATALOG_SUFFIX = "GlueCatalog";
 
-  @SneakyThrows
   public static Optional<String> getGlueArn(SparkConf sparkConf, Configuration hadoopConf) {
     if (isHiveUsingGlue(sparkConf, hadoopConf) || isIcebergUsingGlue(sparkConf)) {
       return awsRegion()
@@ -71,11 +69,17 @@ public class AwsUtils {
     Optional<String> glueJobAccountId =
         SparkConfUtils.findSparkConfigKey(sparkConf, "spark.glue.accountId");
     if (glueJobAccountId.isPresent()) {
-      log.debug("Using [spark.glue.account] property [{}] as catalog ID.", glueJobAccountId.get());
+      log.debug(
+          "Using [spark.glue.accountId] property [{}] as catalog ID.", glueJobAccountId.get());
       return glueJobAccountId;
     } else {
       log.debug("Fetching current account ID to use as the catalog ID.");
-      return Optional.of(AwsAccountIdFetcher.getAccountId());
+      try {
+        return Optional.ofNullable(AwsAccountIdFetcher.getAccountId());
+      } catch (Exception e) {
+        log.warn("Unable to retrieve AWS account ID to build Glue catalog ARN.", e);
+        return Optional.empty();
+      }
     }
   }
 
@@ -108,7 +112,7 @@ public class AwsUtils {
     return hadoopPropertyCatalogId;
   }
 
-  private static @NotNull Optional<String> awsRegion() {
+  static @NotNull Optional<String> awsRegion() {
     // First, try environment variables
     Optional<String> envRegion =
         Optional.ofNullable(System.getenv("AWS_DEFAULT_REGION"))
@@ -175,7 +179,7 @@ public class AwsUtils {
         }
       }
     } catch (Exception e) {
-      log.debug("Could not retrieve region from EC2 metadata service: {}", e.getMessage());
+      log.debug("Could not retrieve region from EC2 metadata service", e);
     } finally {
       if (tokenConnection != null) {
         tokenConnection.disconnect();

--- a/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/S3TablesUtils.java
+++ b/integration/spark/shared/src/main/java/io/openlineage/spark/agent/util/S3TablesUtils.java
@@ -1,0 +1,216 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Value;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+
+/**
+ * Utilities for detecting and building dataset identifiers for AWS S3 Tables. S3 Tables can be
+ * reached from Spark in several configurations (native {@code S3TablesCatalog}, Iceberg REST
+ * pointing at the S3 Tables endpoint, Iceberg REST pointing at the Glue Iceberg endpoint with S3
+ * Tables federation, and Iceberg {@code GlueCatalog} against the federated catalog). This utility
+ * builds an {@code arn:aws:s3tables:<region>:<account>:bucket/<bucket-name>} identifier instead of
+ * exposing internal catalog implementation details.
+ */
+@Slf4j
+@UtilityClass
+public class S3TablesUtils {
+  private static final String CATALOG_IMPL_KEY = "catalog-impl";
+  private static final String WAREHOUSE_KEY = "warehouse";
+  private static final String URI_KEY = "uri";
+  private static final String GLUE_ID_KEY = "glue.id";
+  private static final String SIGNING_NAME_KEY = "signing-name";
+  private static final String REST_SIGNING_NAME_KEY = "rest.signing-name";
+
+  private static final String S3TABLES_CATALOG_SUFFIX = "S3TablesCatalog";
+  private static final String GLUE_CATALOG_SUFFIX = "GlueCatalog";
+  private static final String S3TABLES_ARN_PREFIX = "arn:aws:s3tables:";
+  private static final Pattern FEDERATION_ID = Pattern.compile("^(\\d+):s3tablescatalog/(.+)$");
+  private static final Pattern S3TABLES_ARN =
+      Pattern.compile("^arn:aws:s3tables:([^:]+):([^:]+):bucket/(.+)$");
+  private static final Pattern S3TABLES_HOST =
+      Pattern.compile("^s3tables\\.[^.]+\\.amazonaws\\.com$");
+
+  /** Bucket info extracted from a warehouse / glue.id property. */
+  @Value
+  private static class BucketInfo {
+    Optional<String> region;
+    Optional<String> account;
+    String bucketName;
+  }
+
+  /**
+   * Returns true if the given per-catalog config (already stripped of {@code
+   * spark.sql.catalog.<name>.} prefix) looks like an S3 Tables catalog.
+   */
+  public static boolean matchesS3TablesCatalogConfig(Map<String, String> catalogConf) {
+    if (catalogConf == null || catalogConf.isEmpty()) {
+      return false;
+    }
+    String impl = catalogConf.get(CATALOG_IMPL_KEY);
+    if (impl != null && impl.endsWith(S3TABLES_CATALOG_SUFFIX)) {
+      return true;
+    }
+
+    String warehouse = catalogConf.get(WAREHOUSE_KEY);
+    if (warehouse != null) {
+      if (warehouse.startsWith(S3TABLES_ARN_PREFIX)) {
+        return true;
+      }
+      if (FEDERATION_ID.matcher(warehouse).matches()) {
+        return true;
+      }
+    }
+
+    if (impl != null && impl.endsWith(GLUE_CATALOG_SUFFIX)) {
+      String glueId = catalogConf.get(GLUE_ID_KEY);
+      if (glueId != null && FEDERATION_ID.matcher(glueId).matches()) {
+        return true;
+      }
+    }
+
+    String uri = catalogConf.get(URI_KEY);
+    if (uri != null) {
+      try {
+        URI parsed = URI.create(uri);
+        if (parsed.getHost() != null && S3TABLES_HOST.matcher(parsed.getHost()).matches()) {
+          return true;
+        }
+      } catch (IllegalArgumentException ignored) {
+        // not a valid URI
+      }
+    }
+
+    String signing =
+        catalogConf.getOrDefault(REST_SIGNING_NAME_KEY, catalogConf.get(SIGNING_NAME_KEY));
+    if ("s3tables".equalsIgnoreCase(signing)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Builds an S3 Tables ARN namespace (full ARN when bucket name is recoverable, account-level
+   * otherwise) from a per-catalog config.
+   */
+  public static String buildS3TablesArnFromCatalogConf(
+      SparkConf sparkConf, Configuration hadoopConf, Map<String, String> catalogConf) {
+    Optional<BucketInfo> info = extractBucketFromCatalogConf(catalogConf);
+    return composeArn(sparkConf, hadoopConf, info);
+  }
+
+  // ----- internals -----
+
+  private static Optional<BucketInfo> extractBucketFromCatalogConf(Map<String, String> conf) {
+    if (conf == null) {
+      return Optional.empty();
+    }
+    Optional<BucketInfo> fromFederation = parseFederationId(conf.get(GLUE_ID_KEY));
+    if (fromFederation.isPresent()) {
+      return fromFederation;
+    }
+    String warehouse = conf.get(WAREHOUSE_KEY);
+    Optional<BucketInfo> fromWarehouseFederation = parseFederationId(warehouse);
+    if (fromWarehouseFederation.isPresent()) {
+      return fromWarehouseFederation;
+    }
+    Optional<BucketInfo> fromArn = parseS3TablesArn(warehouse);
+    if (fromArn.isPresent()) {
+      return fromArn;
+    }
+    return Optional.empty();
+  }
+
+  private static String composeArn(
+      SparkConf sparkConf, Configuration hadoopConf, Optional<BucketInfo> info) {
+    Optional<String> resolvedRegion = info.flatMap(b -> b.region);
+    if (!resolvedRegion.isPresent()) {
+      resolvedRegion = AwsUtils.awsRegion();
+    }
+    if (!resolvedRegion.isPresent()) {
+      log.warn("Unable to resolve AWS region for S3 Tables namespace; using 'unknown'.");
+    }
+
+    Optional<String> resolvedAccount = info.flatMap(b -> b.account);
+    if (!resolvedAccount.isPresent()) {
+      resolvedAccount = resolveAccountId(sparkConf, hadoopConf);
+    }
+    if (!resolvedAccount.isPresent()) {
+      log.warn("Unable to resolve AWS account ID for S3 Tables namespace; using 'unknown'.");
+    }
+
+    String prefix =
+        S3TABLES_ARN_PREFIX
+            + resolvedRegion.orElse("unknown")
+            + ":"
+            + resolvedAccount.orElse("unknown");
+    return info.map(b -> prefix + ":bucket/" + b.bucketName).orElse(prefix);
+  }
+
+  private static Optional<String> resolveAccountId(SparkConf sparkConf, Configuration hadoopConf) {
+    // Mirror the order AwsUtils.getGlueCatalogId uses: explicit catalog id wins, then EMR/Glue job
+    // account, then STS. Keeps behavior consistent across V1/V2 paths and avoids a network call in
+    // test environments that set the account explicitly.
+    if (sparkConf != null) {
+      Optional<String> explicit =
+          SparkConfUtils.findSparkConfigKey(sparkConf, "hive.metastore.glue.catalogid");
+      if (explicit.isPresent()) {
+        return explicit;
+      }
+      Optional<String> glueJob =
+          SparkConfUtils.findSparkConfigKey(sparkConf, "spark.glue.accountId");
+      if (glueJob.isPresent()) {
+        return glueJob;
+      }
+    }
+    if (hadoopConf != null) {
+      Optional<String> hadoopExplicit =
+          SparkConfUtils.findHadoopConfigKey(hadoopConf, "hive.metastore.glue.catalogid");
+      if (hadoopExplicit.isPresent()) {
+        return hadoopExplicit;
+      }
+    }
+    try {
+      return Optional.ofNullable(AwsAccountIdFetcher.getAccountId());
+    } catch (Exception e) {
+      log.debug("Could not retrieve AWS account ID", e);
+      return Optional.empty();
+    }
+  }
+
+  private static Optional<BucketInfo> parseFederationId(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    Matcher m = FEDERATION_ID.matcher(value);
+    if (m.matches()) {
+      return Optional.of(new BucketInfo(Optional.empty(), Optional.of(m.group(1)), m.group(2)));
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<BucketInfo> parseS3TablesArn(String value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    Matcher m = S3TABLES_ARN.matcher(value);
+    if (m.matches()) {
+      return Optional.of(
+          new BucketInfo(Optional.of(m.group(1)), Optional.of(m.group(2)), m.group(3)));
+    }
+    return Optional.empty();
+  }
+}

--- a/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/S3TablesUtilsTest.java
+++ b/integration/spark/shared/src/test/java/io/openlineage/spark/agent/util/S3TablesUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.mockito.MockedStatic;
+
+class S3TablesUtilsTest {
+  private static final String CATALOG_IMPL = "catalog-impl";
+  private static final String WAREHOUSE = "warehouse";
+  private static final String HIVE_METASTORE_GLUE_CATALOG_ID = "hive.metastore.glue.catalogid";
+
+  @Test
+  void matchesS3TablesCatalogConfig_ModeA_S3TablesCatalogImpl() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(CATALOG_IMPL, "software.amazon.s3tables.iceberg.S3TablesCatalog");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_S3TablesArnWarehouse() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(WAREHOUSE, "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_ModeB_RestEndpoint() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put("type", "rest");
+    conf.put("uri", "https://s3tables.eu-central-1.amazonaws.com/iceberg");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_ModeB_SigningName() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put("signing-name", "s3tables");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_ModeC_FederationWarehouse() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put("type", "rest");
+    conf.put(WAREHOUSE, "557690578487:s3tablescatalog/my-bucket");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_ModeD_GlueImplPlusFederationId() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(CATALOG_IMPL, "org.apache.iceberg.aws.glue.GlueCatalog");
+    conf.put("glue.id", "557690578487:s3tablescatalog/my-bucket");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isTrue();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_PlainGlue_DoesNotMatch() {
+    Map<String, String> conf = new HashMap<>();
+    conf.put(CATALOG_IMPL, "org.apache.iceberg.aws.glue.GlueCatalog");
+    conf.put(WAREHOUSE, "s3://my-glue-warehouse/");
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(conf)).isFalse();
+  }
+
+  @Test
+  void matchesS3TablesCatalogConfig_EmptyConf_DoesNotMatch() {
+    assertThat(S3TablesUtils.matchesS3TablesCatalogConfig(new HashMap<>())).isFalse();
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void buildS3TablesArnFromCatalogConf_PrefersWarehouseArn() {
+    SparkConf sparkConf = new SparkConf();
+    Configuration hadoopConf = new Configuration();
+    Map<String, String> catalogConf = new HashMap<>();
+    catalogConf.put(WAREHOUSE, "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket");
+    catalogConf.put(CATALOG_IMPL, "software.amazon.s3tables.iceberg.S3TablesCatalog");
+
+    String arn = S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf);
+    assertThat(arn).isEqualTo("arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket");
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void buildS3TablesArnFromCatalogConf_PrefersGlueIdOverWarehouse() {
+    SparkConf sparkConf = new SparkConf();
+    Configuration hadoopConf = new Configuration();
+    Map<String, String> catalogConf = new HashMap<>();
+    catalogConf.put(CATALOG_IMPL, "org.apache.iceberg.aws.glue.GlueCatalog");
+    catalogConf.put("glue.id", "557690578487:s3tablescatalog/federated-bucket");
+    catalogConf.put(WAREHOUSE, "s3://some-other/warehouse/");
+
+    String arn = S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf);
+    assertThat(arn).isEqualTo("arn:aws:s3tables:eu-central-1:557690578487:bucket/federated-bucket");
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void buildS3TablesArnFromCatalogConf_AccountFallbackOrder() {
+    Map<String, String> catalogConf = new HashMap<>();
+
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set(HIVE_METASTORE_GLUE_CATALOG_ID, "111111111111");
+    sparkConf.set("spark.glue.accountId", "222222222222");
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set(HIVE_METASTORE_GLUE_CATALOG_ID, "333333333333");
+
+    assertThat(S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf))
+        .isEqualTo("arn:aws:s3tables:eu-central-1:111111111111");
+
+    sparkConf.remove(HIVE_METASTORE_GLUE_CATALOG_ID);
+    assertThat(S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf))
+        .isEqualTo("arn:aws:s3tables:eu-central-1:222222222222");
+
+    sparkConf.remove("spark.glue.accountId");
+    assertThat(S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf))
+        .isEqualTo("arn:aws:s3tables:eu-central-1:333333333333");
+
+    hadoopConf.unset(HIVE_METASTORE_GLUE_CATALOG_ID);
+    try (MockedStatic<AwsAccountIdFetcher> mocked = mockStatic(AwsAccountIdFetcher.class)) {
+      mocked.when(AwsAccountIdFetcher::getAccountId).thenReturn("444444444444");
+      assertThat(S3TablesUtils.buildS3TablesArnFromCatalogConf(sparkConf, hadoopConf, catalogConf))
+          .isEqualTo("arn:aws:s3tables:eu-central-1:444444444444");
+    }
+  }
+}

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/BaseCatalogTypeHandler.java
@@ -24,6 +24,24 @@ abstract class BaseCatalogTypeHandler {
   abstract Optional<DatasetIdentifier> getIdentifier(
       SparkSession session, Map<String, String> catalogConf, String table);
 
+  String getFacetType(Map<String, String> catalogConf) {
+    return Optional.ofNullable(catalogConf.get(IcebergHandler.TYPE)).orElse(getType());
+  }
+
+  /**
+   * Optionally supply the primary {@link DatasetIdentifier} directly, bypassing the default
+   * table-location-based identity in {@code IcebergHandler.getDatasetIdentifier}. Handlers like S3
+   * Tables override this so the user-facing identity matches the catalog (e.g. {@code
+   * arn:aws:s3tables:...}) rather than an opaque physical bucket URI.
+   */
+  Optional<DatasetIdentifier> getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      String catalogName) {
+    return Optional.empty();
+  }
+
   Path defaultTableLocation(Path warehouseLocation, Identifier identifier) {
     // namespace1.namespace2.table -> /warehouseLocation/namespace1/namespace2/table
     String[] namespace = identifier.namespace();

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/GlueCatalogTypeHandler.java
@@ -10,6 +10,7 @@ import static io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg.Iceberg
 
 import io.openlineage.client.utils.DatasetIdentifier;
 import io.openlineage.spark.agent.util.AwsUtils;
+import io.openlineage.spark.agent.util.S3TablesUtils;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +27,21 @@ class GlueCatalogTypeHandler extends BaseCatalogTypeHandler {
 
   @Override
   boolean matchesCatalogType(Map<String, String> catalogConf) {
-    return catalogConf.containsKey(CATALOG_IMPL)
-        && catalogConf.get(CATALOG_IMPL).endsWith("GlueCatalog");
+    boolean glueImpl =
+        catalogConf.containsKey(CATALOG_IMPL)
+            && catalogConf.get(CATALOG_IMPL).endsWith("GlueCatalog");
+    if (!glueImpl) {
+      return false;
+    }
+    // S3 Tables can be accessed through GlueCatalog federation. Those configs must be handled by
+    // S3TablesCatalogTypeHandler regardless of handler ordering.
+    if (S3TablesUtils.matchesS3TablesCatalogConfig(catalogConf)) {
+      log.warn(
+          "Catalog has catalog-impl=GlueCatalog with S3 Tables federation signals. "
+              + "Treating as non-Glue so S3 Tables lineage identity is preserved.");
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/IcebergHandler.java
@@ -49,6 +49,10 @@ public class IcebergHandler implements CatalogHandler {
     this.context = context;
     this.catalogTypeHandlers =
         Arrays.asList(
+            // S3TablesCatalogTypeHandler must run first: its warehouse-ARN and glue.id signals
+            // must override the suffix-based matches in GlueCatalogTypeHandler and the type=rest
+            // match in RestCatalogTypeHandler when the underlying catalog is S3 Tables.
+            new S3TablesCatalogTypeHandler(),
             new NessieCatalogTypeHandler(),
             new GlueCatalogTypeHandler(),
             new RestCatalogTypeHandler(),
@@ -89,7 +93,7 @@ public class IcebergHandler implements CatalogHandler {
     }
     Map<String, String> conf = catalogConf.get();
     BaseCatalogTypeHandler catalogTypeHandler = getCatalogTypeHandler(conf);
-    String catalogType = Optional.ofNullable(conf.get(TYPE)).orElse(catalogTypeHandler.getType());
+    String catalogType = catalogTypeHandler.getFacetType(conf);
 
     OpenLineage.CatalogDatasetFacetBuilder builder =
         context
@@ -153,6 +157,24 @@ public class IcebergHandler implements CatalogHandler {
         ICEBERG_PATH_IDENTIFIER_CLASS_NAME.equals(identifier.getClass().getName());
     Optional<Table> table = getIcebergTable(tableCatalog, identifier);
     Optional<Path> maybeTableLocation = table.map(tbl -> new Path(tbl.location()));
+
+    // S3 Tables identity comes from catalog config and the logical Spark identifier, not
+    // table.location(). Build it before path-based fallback so NoSuchTableException paths
+    // (for example, create-like operations) can still produce a stable dataset name.
+    Optional<DatasetIdentifier> primaryOverride =
+        catalogTypeHandler.getPrimaryIdentifier(session, catalogConf, identifier, catalogName);
+    if (primaryOverride.isPresent()) {
+      DatasetIdentifier di = primaryOverride.get();
+      maybeTableLocation.ifPresent(
+          loc -> {
+            String authority = loc.toUri().getAuthority();
+            if (authority != null) {
+              di.withSymlink("/", "s3://" + authority, SymlinkType.LOCATION);
+            }
+          });
+      return di;
+    }
+
     Optional<DatasetIdentifier> maybeSymlink = Optional.empty();
     if (isDefaultIcebergCatalog && lacksWarehouseProperty && isPathIdentifier) {
       if (log.isDebugEnabled()) {

--- a/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
+++ b/integration/spark/spark3/src/main/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/iceberg/S3TablesCatalogTypeHandler.java
@@ -1,0 +1,74 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark3.agent.lifecycle.plan.catalog.iceberg;
+
+import io.openlineage.client.utils.DatasetIdentifier;
+import io.openlineage.spark.agent.util.S3TablesUtils;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+/**
+ * Handles S3 Tables catalogs configured as native {@code S3TablesCatalog}, REST catalogs pointing
+ * at the S3 Tables endpoint/signing name, REST catalogs using Glue federation IDs, and {@code
+ * GlueCatalog} configured with an S3 Tables federation ID.
+ */
+class S3TablesCatalogTypeHandler extends BaseCatalogTypeHandler {
+
+  private static final String S3TABLES_CATALOG_TYPE = "s3tables";
+
+  @Override
+  String getType() {
+    return S3TABLES_CATALOG_TYPE;
+  }
+
+  @Override
+  boolean matchesCatalogType(Map<String, String> catalogConf) {
+    return S3TablesUtils.matchesS3TablesCatalogConfig(catalogConf);
+  }
+
+  @Override
+  String getFacetType(Map<String, String> catalogConf) {
+    return getType();
+  }
+
+  @Override
+  Optional<DatasetIdentifier> getPrimaryIdentifier(
+      SparkSession session,
+      Map<String, String> catalogConf,
+      Identifier identifier,
+      String catalogName) {
+    // S3 Tables data lives in AWS-managed physical buckets such as s3://...--table-s3.
+    // That path is an implementation detail; lineage should use the user-facing S3 Tables
+    // ARN plus the logical Spark catalog/namespace/table name.
+    String[] namespace = identifier.namespace();
+    StringBuilder nameBuilder = new StringBuilder(catalogName);
+    for (String ns : namespace) {
+      nameBuilder.append('.').append(ns);
+    }
+    nameBuilder.append('.').append(identifier.name());
+
+    SparkContext ctx = session.sparkContext();
+    String ns =
+        S3TablesUtils.buildS3TablesArnFromCatalogConf(
+            ctx.getConf(), ctx.hadoopConfiguration(), catalogConf);
+    return Optional.of(new DatasetIdentifier(nameBuilder.toString(), ns));
+  }
+
+  @Override
+  Optional<DatasetIdentifier> getIdentifier(
+      SparkSession session, Map<String, String> catalogConf, String table) {
+    // Kept for back-compat with the existing symlink dispatch in IcebergHandler;
+    // not normally reached because getPrimaryIdentifier short-circuits the path.
+    SparkContext ctx = session.sparkContext();
+    String namespace =
+        S3TablesUtils.buildS3TablesArnFromCatalogConf(
+            ctx.getConf(), ctx.hadoopConfiguration(), catalogConf);
+    return Optional.of(new DatasetIdentifier(table, namespace));
+  }
+}

--- a/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
+++ b/integration/spark/spark3/src/test/java/io/openlineage/spark3/agent/lifecycle/plan/catalog/IcebergHandlerTest.java
@@ -889,4 +889,191 @@ class IcebergHandlerTest {
         .hasFieldOrPropertyWithValue("namespace", "file")
         .hasFieldOrPropertyWithValue("name", "/tmp/warehouse/database/table");
   }
+
+  @Test
+  @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void testGetDatasetIdentifierForS3TablesGlueCatalogWarehouseArn() {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.s3tablescatalog.catalog-impl",
+                "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.s3tablescatalog.warehouse",
+                "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    Identifier identifier = Identifier.of(new String[] {"it_al_prod"}, "tbpiani");
+
+    when(sparkCatalog.name()).thenReturn("s3tablescatalog");
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue(
+            "namespace", "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket")
+        .hasFieldOrPropertyWithValue("name", "s3tablescatalog.it_al_prod.tbpiani");
+    assertThat(datasetIdentifier.getSymlinks()).isEmpty();
+  }
+
+  @Test
+  void testGetS3TablesCatalogData() {
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    when(context.getSparkSession()).thenReturn(Optional.of(sparkSession));
+    when(context.getOpenLineage()).thenReturn(new OpenLineage(URI.create("http://localhost")));
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkCatalog.name()).thenReturn("s3tablescatalog");
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map3(
+                "spark.sql.catalog.s3tablescatalog.type",
+                "rest",
+                "spark.sql.catalog.s3tablescatalog.warehouse",
+                "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket",
+                "spark.sql.catalog.s3tablescatalog.uri",
+                "https://s3tables.eu-central-1.amazonaws.com/iceberg"));
+
+    Optional<CatalogHandler.CatalogWithAdditionalFacets> catalogDatasetFacet =
+        icebergHandler.getCatalogDatasetFacet(sparkCatalog, new HashMap<>());
+    assertTrue(catalogDatasetFacet.isPresent());
+
+    OpenLineage.CatalogDatasetFacet facet = catalogDatasetFacet.get().getCatalogDatasetFacet();
+
+    assertEquals("s3tablescatalog", facet.getName());
+    assertEquals("s3tables", facet.getType());
+    assertEquals(
+        "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket", facet.getWarehouseUri());
+    assertEquals("https://s3tables.eu-central-1.amazonaws.com/iceberg", facet.getMetadataUri());
+    assertEquals("iceberg", facet.getFramework());
+  }
+
+  @Test
+  @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void testGetDatasetIdentifierForS3TablesNativeCatalog() {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.s3tablescatalog.catalog-impl",
+                "software.amazon.s3tables.iceberg.S3TablesCatalog",
+                "spark.sql.catalog.s3tablescatalog.warehouse",
+                "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"it_al_prod"}, "tbpiani");
+
+    when(sparkCatalog.name()).thenReturn("s3tablescatalog");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location())
+        .thenReturn("s3://abcd1234ef56--table-s3/data/00000-0-abcd.parquet");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue(
+            "namespace", "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket")
+        .hasFieldOrPropertyWithValue("name", "s3tablescatalog.it_al_prod.tbpiani");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "/")
+        .hasFieldOrPropertyWithValue("namespace", "s3://abcd1234ef56--table-s3")
+        .hasFieldOrPropertyWithValue("type", DatasetIdentifier.SymlinkType.LOCATION);
+  }
+
+  @Test
+  @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void testGetDatasetIdentifierForS3TablesGlueFederation_DropsGlueSymlink() {
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    sparkConf.set("spark.glue.accountId", "557690578487");
+    hadoopConf.set(
+        "hive.metastore.client.factory.class",
+        "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory");
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.s3tablescatalog.catalog-impl",
+                "org.apache.iceberg.aws.glue.GlueCatalog",
+                "spark.sql.catalog.s3tablescatalog.glue.id",
+                "557690578487:s3tablescatalog/my-bucket"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    SparkTable sparkTable = mock(SparkTable.class, RETURNS_DEEP_STUBS);
+    Identifier identifier = Identifier.of(new String[] {"it_al_prod"}, "tbpiani");
+
+    when(sparkCatalog.name()).thenReturn("s3tablescatalog");
+    when(sparkCatalog.loadTable(identifier)).thenReturn(sparkTable);
+    when(sparkTable.table().location()).thenReturn("s3://abcd1234ef56--table-s3");
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    // No arn:aws:glue anywhere — S3 Tables handler matched first because of the glue.id federation
+    // signal.
+    assertThat(datasetIdentifier.getNamespace()).doesNotContain("arn:aws:glue");
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue(
+            "namespace", "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket")
+        .hasFieldOrPropertyWithValue("name", "s3tablescatalog.it_al_prod.tbpiani");
+
+    assertThat(datasetIdentifier.getSymlinks())
+        .allSatisfy(symlink -> assertThat(symlink.getNamespace()).doesNotContain("arn:aws:glue"));
+  }
+
+  @Test
+  @SneakyThrows
+  @SetEnvironmentVariable(key = "AWS_DEFAULT_REGION", value = "eu-central-1")
+  void testGetDatasetIdentifierForS3Tables_MissingTable_NoException() {
+    // Regression for the empty inputs/outputs case: the target of a MERGE INTO that doesn't yet
+    // exist should still produce an identifier built from catalog/namespace/table + warehouse ARN.
+    when(sparkSession.conf()).thenReturn(runtimeConfig);
+    when(sparkContext.getConf()).thenReturn(sparkConf);
+    when(sparkContext.hadoopConfiguration()).thenReturn(hadoopConf);
+    when(sparkSession.sparkContext()).thenReturn(sparkContext);
+    when(runtimeConfig.getAll())
+        .thenReturn(
+            new Map.Map2<>(
+                "spark.sql.catalog.s3tablescatalog.type",
+                "rest",
+                "spark.sql.catalog.s3tablescatalog.warehouse",
+                "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket"));
+
+    SparkCatalog sparkCatalog = mock(SparkCatalog.class);
+    Identifier identifier =
+        Identifier.of(new String[] {"it_al_prod_red_alleanza_allnet"}, "tbstatt");
+
+    when(sparkCatalog.name()).thenReturn("s3tablescatalog");
+    when(sparkCatalog.loadTable(identifier)).thenThrow(new NoSuchTableException(identifier));
+
+    DatasetIdentifier datasetIdentifier =
+        icebergHandler.getDatasetIdentifier(
+            sparkSession, sparkCatalog, identifier, new HashMap<>());
+
+    assertThat(datasetIdentifier)
+        .hasFieldOrPropertyWithValue(
+            "namespace", "arn:aws:s3tables:eu-central-1:557690578487:bucket/my-bucket")
+        .hasFieldOrPropertyWithValue(
+            "name", "s3tablescatalog.it_al_prod_red_alleanza_allnet.tbstatt");
+    // No LOCATION symlink because table.location() couldn't be resolved.
+    assertThat(datasetIdentifier.getSymlinks()).isEmpty();
+  }
 }


### PR DESCRIPTION
Currently, when using S3 tables, in some cases Spark integration wrongly attaches symlinks to Glue tables; especially for cases where Glue libs are present and metastore is configured to Glue catalog. It happens since we're falling back to Glue broadly, basing on heuristics like metastore config. 

This solves this issue by providing explicit support for S3 Tables.

### Checklist
- [ ] AI was used in creating this PR
