### PR TITLE
fix(python): detect github pull request head refs

### DIFF
--- a/client/python/src/openlineage/client/git.py
+++ b/client/python/src/openlineage/client/git.py
@@ -148,10 +148,11 @@ def get_ci_pr_number() -> str | None:
     if gitlab_mr_iid:
         return gitlab_mr_iid
 
-    # GitHub Actions: GITHUB_REF is "refs/pull/{number}/merge" for pull_request events
+    # GitHub Actions: GITHUB_REF can be "refs/pull/{number}/merge" or
+    # "refs/pull/{number}/head" for pull request refs.
     github_ref = os.getenv("GITHUB_REF")
     if github_ref:
-        match = re.match(r"refs/pull/(\d+)/merge", github_ref)
+        match = re.match(r"refs/pull/(\d+)/(?:merge|head)", github_ref)
         if match:
             return match.group(1)
 

--- a/client/python/tests/test_source_code_location.py
+++ b/client/python/tests/test_source_code_location.py
@@ -548,6 +548,10 @@ class TestGetCiPrNumber:
     def test_github_actions_pull_request(self):
         assert get_ci_pr_number() == "42"
 
+    @patch.dict("os.environ", {"GITHUB_REF": "refs/pull/42/head"}, clear=True)
+    def test_github_actions_pull_request_head_ref(self):
+        assert get_ci_pr_number() == "42"
+
     @patch.dict("os.environ", {"GITHUB_REF": "refs/heads/main"}, clear=True)
     def test_github_actions_push_returns_none(self):
         assert get_ci_pr_number() is None


### PR DESCRIPTION
﻿## Summary

- detect GitHub pull request refs that use the `refs/pull/<number>/head` form
- keep existing detection for `refs/pull/<number>/merge`
- add a regression test for the head ref form

## Issue

Fixes #4560

## Tests

- `uv run pytest tests/test_source_code_location.py -k "GetCiPrNumber"`
- `uv run ruff check src/openlineage/client/git.py tests/test_source_code_location.py`
