### PR TITLE
spec: add GcpBigQueryRoutineJobFacet

### DIFF
--- a/spec/registry/gcp/bigquery/facets/GcpBigQueryRoutineJobFacet.json
+++ b/spec/registry/gcp/bigquery/facets/GcpBigQueryRoutineJobFacet.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json",
+  "$defs": {
+    "GcpBigQueryRoutineJobFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "projectId": {
+              "description": "GCP project ID containing the routine",
+              "type": "string"
+            },
+            "datasetId": {
+              "description": "BigQuery dataset containing the routine",
+              "type": "string"
+            },
+            "routineId": {
+              "description": "Name of the routine (stored procedure or user-defined function)",
+              "type": "string"
+            },
+            "routineType": {
+              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type`. Optional — omit when unknown at emit time",
+              "type": "string",
+              "enum": ["PROCEDURE", "SCALAR_FUNCTION", "TABLE_VALUED_FUNCTION", "AGGREGATE_FUNCTION"]
+            }
+          },
+          "required": ["projectId", "datasetId", "routineId"],
+          "additionalProperties": true
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "gcp_bigquery_routine_job": {
+      "$ref": "#/$defs/GcpBigQueryRoutineJobFacet"
+    }
+  }
+}

--- a/spec/registry/gcp/bigquery/facets/GcpBigQueryRoutineJobFacet.json
+++ b/spec/registry/gcp/bigquery/facets/GcpBigQueryRoutineJobFacet.json
@@ -23,9 +23,8 @@
               "type": "string"
             },
             "routineType": {
-              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type`. Optional — omit when unknown at emit time",
-              "type": "string",
-              "enum": ["PROCEDURE", "SCALAR_FUNCTION", "TABLE_VALUED_FUNCTION", "AGGREGATE_FUNCTION"]
+              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type` (`PROCEDURE`, `SCALAR_FUNCTION`, `TABLE_VALUED_FUNCTION`, `AGGREGATE_FUNCTION`, etc.)",
+              "type": "string"
             }
           },
           "required": ["projectId", "datasetId", "routineId"],

--- a/spec/registry/gcp/bigquery/registry.json
+++ b/spec/registry/gcp/bigquery/registry.json
@@ -1,0 +1,6 @@
+{
+  "producer": {
+    "root_doc_URL": "https://cloud.google.com/bigquery/docs/routines",
+    "produced_facets": ["ol:gcp:bigquery:GcpBigQueryRoutineJobFacet.json"]
+  }
+}

--- a/website/static/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json
+++ b/website/static/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openlineage.io/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json",
+  "$defs": {
+    "GcpBigQueryRoutineJobFacet": {
+      "allOf": [
+        {
+          "$ref": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/JobFacet"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "projectId": {
+              "description": "GCP project ID containing the routine",
+              "type": "string"
+            },
+            "datasetId": {
+              "description": "BigQuery dataset containing the routine",
+              "type": "string"
+            },
+            "routineId": {
+              "description": "Name of the routine (stored procedure or user-defined function)",
+              "type": "string"
+            },
+            "routineType": {
+              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type`. Optional — omit when unknown at emit time",
+              "type": "string",
+              "enum": ["PROCEDURE", "SCALAR_FUNCTION", "TABLE_VALUED_FUNCTION", "AGGREGATE_FUNCTION"]
+            }
+          },
+          "required": ["projectId", "datasetId", "routineId"],
+          "additionalProperties": true
+        }
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "gcp_bigquery_routine_job": {
+      "$ref": "#/$defs/GcpBigQueryRoutineJobFacet"
+    }
+  }
+}

--- a/website/static/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json
+++ b/website/static/spec/facets/1-0-0/GcpBigQueryRoutineJobFacet.json
@@ -23,9 +23,8 @@
               "type": "string"
             },
             "routineType": {
-              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type`. Optional — omit when unknown at emit time",
-              "type": "string",
-              "enum": ["PROCEDURE", "SCALAR_FUNCTION", "TABLE_VALUED_FUNCTION", "AGGREGATE_FUNCTION"]
+              "description": "BigQuery routine type as reported by `INFORMATION_SCHEMA.ROUTINES.routine_type` (`PROCEDURE`, `SCALAR_FUNCTION`, `TABLE_VALUED_FUNCTION`, `AGGREGATE_FUNCTION`, etc.)",
+              "type": "string"
             }
           },
           "required": ["projectId", "datasetId", "routineId"],


### PR DESCRIPTION
closes: #4562 

### One-line summary for changelog:
Add `GcpBigQueryRoutineJobFacet` to identify the BigQuery routine (stored procedure or user-defined function) invoked by an OpenLineage job.

### Meaningful description

OpenLineage events emitted from Airflow tasks that invoke BigQuery routines (stored procedures, scalar/table/aggregate UDFs) currently lose the identity of the called routine. For `BigQueryInsertJobOperator` with a `CALL ...` query, the existing extractor walks the parent SCRIPT job and aggregates child input/output datasets but the routine reference itself is dropped (see #773); for non-Google operators (e.g., a `PythonOperator` wrapping `bigquery.Client().query("CALL ...")`) there is no routine information in the event at all. This blocks consumers from building an `AirflowTask → BigQueryRoutine → Table` relationship.

This PR adds a new GCP registry job facet `GcpBigQueryRoutineJobFacet` under `spec/registry/gcp/bigquery/facets/`, following the same shape as the existing `GcpComposerJobFacet` and `GcpDataprocRunFacet`. The facet carries `projectId`, `datasetId`, `routineId` (required) — matching BigQuery's REST API `RoutineReference` shape, which uniquely identifies a routine since BigQuery does not support overloading. Optional `routineType` mirrors the `INFORMATION_SCHEMA.ROUTINES.routine_type` enum (`PROCEDURE`, `SCALAR_FUNCTION`, `TABLE_VALUED_FUNCTION`, `AGGREGATE_FUNCTION`) so consumers can distinguish stored procedures from UDFs.

Modeled as a `JobFacet` because the invoked routine is part of the job's definition (it doesn't vary per run), consistent with `JobTypeJobFacet` and `SourceCodeJobFacet`. A `RunFacet` variant can be added later if a generic-dispatch operator pattern emerges where the routine varies per run.

Spec-only addition — no core spec changes, no producer-side integration in this PR. Follow-up will populate the facet from `BigQueryInsertJobOperator` in `apache-airflow-providers-google`; custom-operator users can populate it via an OL Airflow extractor. Extending `BigQueryJobRunFacet` was considered and rejected — that facet lives in the Airflow Google provider repo and carries dynamic run metrics, not static job identity, so coupling routine identity to it would prevent non-Airflow producers from emitting routine info.

### Checklist
- [x] AI was used in creating this PR
