### PR TITLE
hive: bump testcontainers to 1.21.4 to fix Docker API mismatch on CI

### DIFF
--- a/integration/hive/hive-openlineage-hook/build.gradle
+++ b/integration/hive/hive-openlineage-hook/build.gradle
@@ -35,7 +35,7 @@ ext {
     hiveVersion = '3.1.3'
     hadoopVersion = '2.10.2'
     postgresqlVersion = '42.7.5'
-    testcontainersVersion = '1.20.4'
+    testcontainersVersion = '1.21.4'
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

The `integration-test-integration-hive` job on `main` is failing with:

```
Could not find a valid Docker environment.
UnixSocketClientProviderStrategy: failed with exception BadRequestException
(Status 400: {"message":"client version 1.32 is too old.
 Minimum supported API version is 1.40, please upgrade your client to a newer version"})
```

Testcontainers `1.20.x` defaults to Docker API `1.32` during its initial socket strategy ping. The Docker daemon shipped in CircleCI's `ubuntu-2404:current` image now requires API ≥ `1.40`, so the daemon rejects the ping before any container is started, and both `ColumnLevelLineageTests` and `TableLevelLineageTests` fail at `initializationError`.

This bumps the Hive integration's testcontainers version to `1.21.4`, matching the version already used by the Flink and Spark integrations. `1.21.x` uses a newer default API version that the modern daemon accepts.